### PR TITLE
chore: change recommended Visual Studio Code stylelint extension (#21)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -19,7 +19,7 @@
     // code style + formatting
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
-    "shinnn.stylelint",
+    "hex-ci.stylelint-plus",
     "ms-vscode.vscode-typescript-tslint-plugin",
     // testing
     "orta.vscode-jest",


### PR DESCRIPTION
- previously recommended extension was removed, using most active fork now

closes #21