### PR TITLE
fix: always write apiToken cookie as it is a functional cookie

### DIFF
--- a/src/app/core/services/cookies/cookies.service.spec.ts
+++ b/src/app/core/services/cookies/cookies.service.spec.ts
@@ -1,7 +1,7 @@
 import { PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CookiesService as ForeignCookiesService } from '@ngx-utils/cookies';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify } from 'ts-mockito';
 
 import { CookiesService } from './cookies.service';
 
@@ -29,44 +29,19 @@ describe('Cookies Service', () => {
     verify(foreignCookiesServiceMock.get('dummy')).once();
   });
 
-  describe('when cookieLaw was not yet accepted', () => {
-    it('should call remove of underlying implementation', done => {
-      setTimeout(() => {
-        cookiesService.remove('dummy');
-        verify(foreignCookiesServiceMock.remove('dummy')).once();
-        done();
-      }, 2000);
-    });
-
-    it('should not call put of underlying implementation', done => {
-      setTimeout(() => {
-        cookiesService.put('dummy', 'value');
-        verify(foreignCookiesServiceMock.put(anything(), anything())).never();
-        verify(foreignCookiesServiceMock.put(anything(), anything(), anything())).never();
-        done();
-      }, 2000);
-    });
+  it('should call remove of underlying implementation', done => {
+    setTimeout(() => {
+      cookiesService.remove('dummy');
+      verify(foreignCookiesServiceMock.remove('dummy')).once();
+      done();
+    }, 2000);
   });
 
-  describe('when cookieLaw was accepted', () => {
-    beforeEach(() => {
-      when(foreignCookiesServiceMock.get('cookieLawSeen')).thenReturn('true');
-    });
-
-    it('should call remove of underlying implementation', done => {
-      setTimeout(() => {
-        cookiesService.remove('dummy');
-        verify(foreignCookiesServiceMock.remove('dummy')).once();
-        done();
-      }, 2000);
-    });
-
-    it('should call put of underlying implementation', done => {
-      setTimeout(() => {
-        cookiesService.put('dummy', 'value');
-        verify(foreignCookiesServiceMock.put('dummy', anything(), anything())).once();
-        done();
-      }, 2000);
-    });
+  it('should call put of underlying implementation', done => {
+    setTimeout(() => {
+      cookiesService.put('dummy', 'value');
+      verify(foreignCookiesServiceMock.put('dummy', anything(), anything())).once();
+      done();
+    }, 2000);
   });
 });

--- a/src/app/core/services/cookies/cookies.service.ts
+++ b/src/app/core/services/cookies/cookies.service.ts
@@ -2,14 +2,12 @@ import { isPlatformBrowser } from '@angular/common';
 import { ApplicationRef, Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { CookiesOptions, CookiesService as ForeignCookiesService } from '@ngx-utils/cookies';
 import { ReplaySubject, timer } from 'rxjs';
-import { distinct, map, switchMap, take, tap } from 'rxjs/operators';
+import { distinct, map, switchMap, take } from 'rxjs/operators';
 
 import { whenTruthy } from 'ish-core/utils/operators';
 
 @Injectable({ providedIn: 'root' })
 export class CookiesService {
-  private cookieLawSeen: boolean;
-
   cookieLawSeen$ = new ReplaySubject<boolean>(1);
 
   constructor(
@@ -25,8 +23,7 @@ export class CookiesService {
           switchMap(() =>
             timer(0, 1000).pipe(
               map(() => this.cookiesService.get('cookieLawSeen') === 'true'),
-              distinct(),
-              tap(cookieLawSeen => (this.cookieLawSeen = cookieLawSeen))
+              distinct()
             )
           )
         )
@@ -45,8 +42,6 @@ export class CookiesService {
   }
 
   put(key: string, value: string, options?: CookiesOptions) {
-    if (this.cookieLawSeen) {
-      this.cookiesService.put(key, value, options);
-    }
+    this.cookiesService.put(key, value, options);
   }
 }

--- a/src/app/core/store/restore/restore.effects.spec.ts
+++ b/src/app/core/store/restore/restore.effects.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, combineReducers } from '@ngrx/store';
 import { cold } from 'jest-marbles';
-import { Observable, ReplaySubject, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { anyString, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { Order } from 'ish-core/models/order/order.model';
@@ -28,12 +28,9 @@ describe('Restore Effects', () => {
   let actions$: Observable<Action>;
   let cookiesServiceMock: CookiesService;
   let store$: TestStore;
-  let cookieLawSubject$: ReplaySubject<boolean>;
 
   beforeEach(() => {
     cookiesServiceMock = mock(CookiesService);
-    cookieLawSubject$ = new ReplaySubject(1);
-    when(cookiesServiceMock.cookieLawSeen$).thenReturn(cookieLawSubject$);
 
     TestBed.configureTestingModule({
       imports: [
@@ -118,10 +115,6 @@ describe('Restore Effects', () => {
   });
 
   describe('saveAPITokenToCookie$', () => {
-    beforeEach(() => {
-      cookieLawSubject$.next(true);
-    });
-
     it('should not save token when neither basket nor user nor order is available', () => {
       store$.dispatch(new SetAPIToken({ apiToken: 'dummy' }));
 
@@ -197,9 +190,7 @@ describe('Restore Effects', () => {
   });
 
   describe('logOutUserIfTokenVanishes$', () => {
-    it('should log out user when token is not available and cookie law was accepted', done => {
-      cookieLawSubject$.next(true);
-
+    it('should log out user when token is not available', done => {
       store$.dispatch(new LoginUserSuccess({ user: { email: 'test@intershop.de' } as User, customer: undefined }));
 
       restoreEffects.logOutUserIfTokenVanishes$.subscribe(
@@ -211,23 +202,10 @@ describe('Restore Effects', () => {
         fail
       );
     });
-
-    it('should do nothing when cookie law was not yet accepted', done => {
-      cookieLawSubject$.next(false);
-
-      store$.dispatch(new LoginUserSuccess({ user: { email: 'test@intershop.de' } as User, customer: undefined }));
-
-      restoreEffects.logOutUserIfTokenVanishes$.subscribe(fail, fail, fail);
-
-      // terminate checking
-      setTimeout(done, 3000);
-    });
   });
 
   describe('removeAnonymousBasketIfTokenVanishes$', () => {
-    it('should remove basket when token is not available and cookie law was accepted', done => {
-      cookieLawSubject$.next(true);
-
+    it('should remove basket when token is not available', done => {
       store$.dispatch(new LoadBasketSuccess({ basket: BasketMockData.getBasket() }));
 
       restoreEffects.removeAnonymousBasketIfTokenVanishes$.subscribe({
@@ -239,20 +217,7 @@ describe('Restore Effects', () => {
       });
     });
 
-    it('should do nothing when cookie law was not yet accepted', done => {
-      cookieLawSubject$.next(false);
-
-      store$.dispatch(new LoadBasketSuccess({ basket: BasketMockData.getBasket() }));
-
-      restoreEffects.removeAnonymousBasketIfTokenVanishes$.subscribe(fail, fail, fail);
-
-      // terminate checking
-      setTimeout(done, 3000);
-    });
-
     it('should do nothing when user is available', done => {
-      cookieLawSubject$.next(true);
-
       store$.dispatch(new LoginUserSuccess({ user: { email: 'test@intershop.de' } as User, customer: undefined }));
       store$.dispatch(new LoadBasketSuccess({ basket: BasketMockData.getBasket() }));
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


- [x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [x] application / infrastructure changes
- [ ] Other... Please describe:


## What Is the Current Behavior?
Currently the functional cookie keeping the apiToken for later user or basket recovery is only saved when the cookie banner was accepted. This way however one cannot complete a checkout with redirect successfully.

Issue Number: 
no issue reported, yet

## What Is the New Behavior?
Functional cookies are always written, which should not cause legal issues, if there is a remark in the policy.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other Information
