### PR TITLE
fix: load quote-requests on login and page refresh

### DIFF
--- a/src/app/extensions/quoting/store/quote-request/quote-request.effects.spec.ts
+++ b/src/app/extensions/quoting/store/quote-request/quote-request.effects.spec.ts
@@ -24,7 +24,7 @@ import { ApplyConfiguration } from 'ish-core/store/configuration';
 import { configurationReducer } from 'ish-core/store/configuration/configuration.reducer';
 import { LoadProductIfNotLoaded } from 'ish-core/store/shopping/products';
 import { shoppingReducers } from 'ish-core/store/shopping/shopping-store.module';
-import { LoadCompanyUserSuccess, LoginUserSuccess } from 'ish-core/store/user';
+import { LoadCompanyUser, LoadCompanyUserSuccess, LoginUserSuccess } from 'ish-core/store/user';
 import { userReducer } from 'ish-core/store/user/user.reducer';
 import { ngrxTesting } from 'ish-core/utils/dev/ngrx-testing';
 
@@ -1036,6 +1036,23 @@ describe('Quote Request Effects', () => {
 
       actions$ = hot('a--b--a', { a: selectQuoteRequestAction, b: loadQuoteRequestSuccessAction });
       expect(effects.loadQuoteRequestItemsAfterSelectQuoteRequest$).toBeObservable(cold('---a--a', { a: expected }));
+    });
+  });
+
+  describe('loadQuoteRequestsOnLogin', () => {
+    beforeEach(() => {
+      store$.dispatch(
+        new LoginUserSuccess({
+          customer: {} as Customer,
+          user: {} as User,
+        })
+      );
+    });
+    it('should fire LoadQuoteRequests if getLoggedInCustomer selector streams true.', () => {
+      actions$ = hot('a', { a: new LoadCompanyUser() });
+      expect(effects.loadQuoteRequestsOnLogin$).toBeObservable(
+        cold('(a|)', { a: new quoteRequestActions.LoadQuoteRequests() })
+      );
     });
   });
 });

--- a/src/app/extensions/quoting/store/quote-request/quote-request.effects.ts
+++ b/src/app/extensions/quoting/store/quote-request/quote-request.effects.ts
@@ -27,7 +27,7 @@ import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-updat
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { getCurrentBasket } from 'ish-core/store/checkout/basket';
 import { LoadProductIfNotLoaded } from 'ish-core/store/shopping/products';
-import { UserActionTypes, getUserAuthorized } from 'ish-core/store/user';
+import { UserActionTypes, getLoggedInCustomer, getUserAuthorized } from 'ish-core/store/user';
 import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 
 import { QuoteRequest } from '../../models/quote-request/quote-request.model';
@@ -368,6 +368,14 @@ export class QuoteRequestEffects {
   ]).pipe(
     filter(([quoteId]) => !!quoteId),
     map(([quoteId]) => new actions.LoadQuoteRequestItems({ id: quoteId }))
+  );
+
+  @Effect()
+  loadQuoteRequestsOnLogin$ = this.store.pipe(
+    select(getLoggedInCustomer),
+    whenTruthy(),
+    first(),
+    mapTo(new actions.LoadQuoteRequests())
   );
 
   /**


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


- [ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] application / infrastructure changes
- [ ] Other... Please describe:


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

quote-requests currently loaded in components (quote-widget.container.ts & quote-list-page.container.ts)


## What Is the New Behavior?

quote-requests should load on login and/or page-refresh (F5)

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

