### PR TITLE
fix: save quote request from modal links to my account

### DIFF
--- a/e2e/cypress/integration/pages/account/quote-list.page.ts
+++ b/e2e/cypress/integration/pages/account/quote-list.page.ts
@@ -10,7 +10,7 @@ export class QuoteListPage {
   }
 
   goToQuoteDetailLink(id: string) {
-    cy.get(`a[href="/account/quote/${id}"]`)
+    cy.get(`a[href="/account/quote-request/${id}"], a[href="/account/quote/${id}"]`)
       .first()
       .click();
   }

--- a/e2e/cypress/integration/pages/header.module.ts
+++ b/e2e/cypress/integration/pages/header.module.ts
@@ -36,7 +36,7 @@ export class HeaderModule {
   }
 
   get myAccountLink() {
-    return cy.get('[data-testing-id="user-status-desktop"] [data-testing-id="link-myaccount"]');
+    return cy.get('[data-testing-id="link-myaccount"]:visible');
   }
 
   goToMyAccount() {

--- a/e2e/cypress/integration/pages/shopping/quote-request.dialog.ts
+++ b/e2e/cypress/integration/pages/shopping/quote-request.dialog.ts
@@ -1,9 +1,20 @@
+import { waitLoadingEnd } from '../../framework';
+import { MyAccountPage } from '../account/my-account.page';
+import { QuoteListPage } from '../account/quote-list.page';
+import { HeaderModule } from '../header.module';
+
 export class QuoteRequestDialog {
   readonly tag = 'ish-product-add-to-quote-dialog';
 
+  readonly header = new HeaderModule();
+  readonly myAccountPage = new MyAccountPage();
+  readonly quoteListPage = new QuoteListPage();
+
   private saveQuoteRequestButton = () => cy.get('[data-testing-id="saveQuoteRequest"]');
   private submitQuoteRequestButton = () => cy.get('[data-testing-id="submitQuoteRequest"]');
+  private hideButton = () => cy.get('.close');
   private quantityInput = () => cy.get('[data-testing-id="quantity"]');
+  private quoteId = () => cy.get('[data-testing-id="quoteId"]');
 
   saveQuoteRequest() {
     this.saveQuoteRequestButton().click();
@@ -15,5 +26,28 @@ export class QuoteRequestDialog {
 
   setQuantity(quantity: number) {
     this.quantityInput().type(quantity.toString());
+  }
+
+  hide() {
+    this.hideButton().click();
+  }
+
+  gotoQuoteDetail() {
+    this.quoteId().then(x => {
+      const id = x.attr('data-quote-id');
+      this.hide();
+      this.header.goToMyAccount();
+      this.myAccountPage.navigateToQuoting();
+      waitLoadingEnd();
+      this.quoteListPage.goToQuoteDetailLink(id);
+    });
+  }
+
+  get productId() {
+    return cy.get('[itemprop="sku"]');
+  }
+
+  get quoteState() {
+    return cy.get('ish-quote-state');
   }
 }

--- a/e2e/cypress/integration/specs/quoting/quote-handling.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/quoting/quote-handling.b2b.e2e-spec.ts
@@ -49,7 +49,7 @@ describe('Quote Handling', () => {
       page.addProductToQuoteRequest();
     });
     at(QuoteRequestDialog, dialog => {
-      dialog.saveQuoteRequest();
+      dialog.gotoQuoteDetail();
     });
     at(QuoteDetailPage, page => {
       page.totalPrice.should('contain', _.product.price * quantity);
@@ -62,7 +62,7 @@ describe('Quote Handling', () => {
     at(CategoryPage, page => page.gotoSubCategory(_.categoryId));
     at(FamilyPage, page => page.productList.addProductToQuoteRequest(_.product.sku));
     at(QuoteRequestDialog, dialog => {
-      dialog.saveQuoteRequest();
+      dialog.gotoQuoteDetail();
     });
     at(QuoteDetailPage, page => {
       page.totalPrice.should('contain', _.product.price);

--- a/src/app/core/facades/message.facade.ts
+++ b/src/app/core/facades/message.facade.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+
+import {
+  ErrorMessage,
+  InfoMessage,
+  MessagesPayloadType,
+  SuccessMessage,
+  WarningMessage,
+} from 'ish-core/store/messages';
+
+@Injectable({ providedIn: 'root' })
+export class MessageFacade {
+  constructor(private store: Store<{}>) {}
+
+  info(data: MessagesPayloadType) {
+    this.store.dispatch(new InfoMessage(data));
+  }
+
+  error(data: MessagesPayloadType) {
+    this.store.dispatch(new ErrorMessage(data));
+  }
+
+  warn(data: MessagesPayloadType) {
+    this.store.dispatch(new WarningMessage(data));
+  }
+
+  success(data: MessagesPayloadType) {
+    this.store.dispatch(new SuccessMessage(data));
+  }
+}

--- a/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.html
+++ b/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.html
@@ -22,7 +22,9 @@
             'quote.edit.unsubmitted.quote_no.label' | translate
           }}</label>
           <div class="col-8 col-md-9 col-xl-10">
-            <p class="form-control-plaintext">{{ quote.number }}</p>
+            <p class="form-control-plaintext" data-testing-id="quoteId" [attr.data-quote-id]="quote.id">
+              {{ quote.number }}
+            </p>
           </div>
         </div>
 
@@ -85,7 +87,6 @@
       <div>
         <button
           *ngIf="quote"
-          [routerLink]="'/account/quote-request/' + quote.id"
           type="submit"
           class="btn btn-secondary"
           [disabled]="!quote"

--- a/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.spec.ts
+++ b/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.spec.ts
@@ -7,6 +7,7 @@ import { MockComponent } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
+import { MessageFacade } from 'ish-core/facades/message.facade';
 import { LineItemListComponent } from 'ish-shared/components/basket/line-item-list/line-item-list.component';
 import { LoadingComponent } from 'ish-shared/components/common/loading/loading.component';
 import { InputComponent } from 'ish-shared/forms/components/input/input.component';
@@ -21,9 +22,11 @@ describe('Product Add To Quote Dialog Component', () => {
   let fixture: ComponentFixture<ProductAddToQuoteDialogComponent>;
   let element: HTMLElement;
   let quotingFacade: QuotingFacade;
+  let messageFacade: MessageFacade;
 
   beforeEach(async(() => {
     quotingFacade = mock(QuotingFacade);
+    messageFacade = mock(MessageFacade);
 
     TestBed.configureTestingModule({
       imports: [ReactiveFormsModule, RouterTestingModule, TranslateModule.forRoot()],
@@ -34,7 +37,11 @@ describe('Product Add To Quote Dialog Component', () => {
         MockComponent(QuoteStateComponent),
         ProductAddToQuoteDialogComponent,
       ],
-      providers: [NgbActiveModal, { provide: QuotingFacade, useFactory: () => instance(quotingFacade) }],
+      providers: [
+        NgbActiveModal,
+        { provide: QuotingFacade, useFactory: () => instance(quotingFacade) },
+        { provide: MessageFacade, useFactory: () => instance(messageFacade) },
+      ],
     }).compileComponents();
   }));
 

--- a/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.ts
+++ b/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.ts
@@ -4,6 +4,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilKeyChanged, filter, take, takeUntil } from 'rxjs/operators';
 
+import { MessageFacade } from 'ish-core/facades/message.facade';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { whenTruthy } from 'ish-core/utils/operators';
 
@@ -23,7 +24,11 @@ export class ProductAddToQuoteDialogComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject();
 
-  constructor(public ngbActiveModal: NgbActiveModal, private quotingFacade: QuotingFacade) {
+  constructor(
+    public ngbActiveModal: NgbActiveModal,
+    private quotingFacade: QuotingFacade,
+    private messageFacade: MessageFacade
+  ) {
     this.form = new FormGroup({
       displayName: new FormControl(undefined, [Validators.maxLength(255)]),
       description: new FormControl(undefined, []),
@@ -133,7 +138,16 @@ export class ProductAddToQuoteDialogComponent implements OnInit, OnDestroy {
       displayName: this.form.value.displayName,
       description: this.form.value.description,
     });
+
+    this.messageFacade.success({
+      message: 'quote.edit.saved.your_quote_request_has_been_saved.text',
+      messageParams: {
+        0: this.form.value.displayName,
+      },
+    });
+
     this.hide();
+    return false;
   }
 
   /**

--- a/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.html
+++ b/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.html
@@ -33,7 +33,7 @@
   </div>
 
   <div *ngIf="displaySavedMessage$ | async" data-testing-id="success-message" class="alert alert-success alert-fade">
-    {{ 'quote.edit.saved.your_quote_request_has_been_saved.text' | translate }}
+    {{ 'quote.edit.saved.your_quote_request_has_been_saved.text' | translate: { '0': displayName } }}
   </div>
 
   <div *ngIf="error" role="alert" class="alert alert-danger">{{ error.status }}: {{ error.error }}</div>

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -2503,7 +2503,7 @@
   "quote.edit.unsubmitted.provide_comment.text": "Fügen Sie ihrer Preisanfrage einen Kommentar hinzu.",
   "quote.edit.unsubmitted.seller_comment.label": "Kommentar des Anbieters:",
   "quote.edit.submitted.your_quote_request_has_been_submitted.text": "Ihre Preisanfrage wurde am {{0}} gesendet. Sie werden per E-Mail über ein Angebot informiert.",
-  "quote.edit.saved.your_quote_request_has_been_saved.text": "Ihre Preisanfrage wurde gespeichert.",
+  "quote.edit.saved.your_quote_request_has_been_saved.text": "Ihre Preisanfrage \"{{0}}\" wurde gespeichert.",
   "quote.edit.submitted.your_quote_expired.text": "Ihr Preisangebot ist am {{0}} {{1}} abgelaufen.",
   "quote.edit.back_to_shopping.link": "Weiter einkaufen",
   "quote.edit.back_to_quotes.link": "Zurück zu Preisangeboten",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -2503,7 +2503,7 @@
   "quote.edit.unsubmitted.provide_comment.text": "Provide a comment for your quote request",
   "quote.edit.unsubmitted.seller_comment.label": "Seller Comment:",
   "quote.edit.submitted.your_quote_request_has_been_submitted.text": "Your quote request has been submitted at {{0}}. You will be informed about a quotation via e-mail.",
-  "quote.edit.saved.your_quote_request_has_been_saved.text": "Your quote request has been saved.",
+  "quote.edit.saved.your_quote_request_has_been_saved.text": "Your quote request \"{{0}}\" has been saved.",
   "quote.edit.submitted.your_quote_expired.text": "Your quote expired at {{0}} {{1}}.",
   "quote.edit.back_to_shopping.link": "Back to Shopping",
   "quote.edit.back_to_quotes.link": "Back to Quotes",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -2502,7 +2502,7 @@
   "quote.edit.unsubmitted.provide_comment.text": "Entrez un commentaire pour votre demande de devis",
   "quote.edit.unsubmitted.seller_comment.label": "Commentaire du vendeur :",
   "quote.edit.submitted.your_quote_request_has_been_submitted.text": "Votre demande de devis a été soumise à {{0}}. Vous serez informé sur votre demande de devis par courriel.",
-  "quote.edit.saved.your_quote_request_has_been_saved.text": "Votre demande de devis a été enregistrée.",
+  "quote.edit.saved.your_quote_request_has_been_saved.text": "Votre demande de devis \"{{0}}\" a été enregistrée.",
   "quote.edit.submitted.your_quote_expired.text": "Votre devis a expiré à {{0}} {{1}}.",
   "quote.edit.back_to_shopping.link": "Retour au magasin",
   "quote.edit.back_to_quotes.link": "Retour aux devis",


### PR DESCRIPTION
## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

"Save Quote Request" within a quote request modal dialog links to quote request details in my account area. The user loses his context.

(Issue Number: ISREST-940)

## What Is the New Behavior?

Click on "Save Quote Request" - closes modal and display success toast "Your quote request [name] has been saved." Then the user can continue shopping and easily adding another product to this quote request.

## Does this PR Introduce a Breaking Change?
[x] No

