### PR TITLE
fix: wrong alignment of forgot password link (ISREST-937)

### DIFF
--- a/src/app/shared/forms/containers/login-form/login-form.container.html
+++ b/src/app/shared/forms/containers/login-form/login-form.container.html
@@ -59,7 +59,7 @@
         {{ 'account.signin.button.label' | translate }}
       </button>
     </div>
-    <div [ngClass]="forgotPasswordClass || ''">
+    <div [ngClass]="forgotPasswordClass || 'col-md-auto pl-md-0'">
       <a class="btn btn-link" [routerLink]="'/forgotPassword'">{{ 'account.send_password.heading' | translate }}</a>
     </div>
   </div>

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -657,7 +657,7 @@
   "account.security_question.maiden_name.text": "Quel est le nom de jeune fille de votre mère ?",
   "account.security_question.pet_name.text": "Comment s'appelle votre animal domestique ?",
   "account.security_question.street_name.text": "Dans quelle rue avez-vous vécu pendant votre enfance ?",
-  "account.send_password.heading": "Vous avez oublié votre mot de passe ?",
+  "account.send_password.heading": "Mot de passe oublié ?",
   "account.send_password.message": "Un e-mail contenant un lien a été envoyé à votre adresse e-mail. Veuillez suivre ce lien pour modifier votre mot de passe.",
   "account.signin.button.label": "Se connecter",
   "account.submit.button.label": "OK",


### PR DESCRIPTION
## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] application / infrastructure changes
- [ ] Other... Please describe:


## What Is the Current Behavior?
Alignment of forgot password link is wrong for mobile view and in case of french localization also for tablet view.

Issue Number: ISREST-937

## What Is the New Behavior?
Alignment of forgot password link is correct for mobile view and french localization.

## Does this PR Introduce a Breaking Change?
- [ ] Yes
- [x] No
