### PR TITLE
refactor: componentize address forms on checkout address step

### DIFF
--- a/src/app/core/facades/checkout.facade.ts
+++ b/src/app/core/facades/checkout.facade.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Store, select } from '@ngrx/store';
+import { Store, createSelector, select } from '@ngrx/store';
 import { merge } from 'rxjs';
 import { map, switchMap, take, tap } from 'rxjs/operators';
 
@@ -7,6 +7,7 @@ import { Address } from 'ish-core/models/address/address.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
+import { getAllAddresses } from 'ish-core/store/addresses';
 import {
   AddPromotionCodeToBasket,
   AssignBasketAddress,
@@ -26,14 +27,18 @@ import {
   getBasketEligibleShippingMethods,
   getBasketError,
   getBasketInfo,
+  getBasketInvoiceAddress,
   getBasketLastTimeProductAdded,
   getBasketLoading,
   getBasketPromotionError,
+  getBasketShippingAddress,
   getBasketValidationResults,
   getCurrentBasket,
+  isBasketInvoiceAndShippingAddressEqual,
 } from 'ish-core/store/checkout/basket';
 import { getCheckoutStep } from 'ish-core/store/checkout/viewconf';
 import { CreateOrder, getOrdersError, getSelectedOrder } from 'ish-core/store/orders';
+import { getLoggedInUser } from 'ish-core/store/user';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 // tslint:disable:member-ordering
@@ -114,16 +119,35 @@ export class CheckoutFacade {
   }
 
   // ADDRESSES
-  assignBasketAddress(body: { addressId: string; scope: 'invoice' | 'shipping' | 'any' }) {
-    this.store.dispatch(new AssignBasketAddress({ addressId: body.addressId, scope: body.scope }));
+  basketInvoiceAddress$ = this.store.pipe(select(getBasketInvoiceAddress));
+  basketShippingAddress$ = this.store.pipe(select(getBasketShippingAddress));
+  basketInvoiceAndShippingAddressEqual$ = this.store.pipe(select(isBasketInvoiceAndShippingAddressEqual));
+  basketShippingAddressDeletable$ = this.store.pipe(
+    select(
+      createSelector(
+        getLoggedInUser,
+        getAllAddresses,
+        getBasketShippingAddress,
+        (user, addresses, shippingAddress): boolean =>
+          !!shippingAddress &&
+          !!user &&
+          addresses.length > 1 &&
+          (!user.preferredInvoiceToAddressUrn || user.preferredInvoiceToAddressUrn !== shippingAddress.urn) &&
+          (!user.preferredShipToAddressUrn || user.preferredShipToAddressUrn !== shippingAddress.urn)
+      )
+    )
+  );
+
+  assignBasketAddress(addressId: string, scope: 'invoice' | 'shipping' | 'any') {
+    this.store.dispatch(new AssignBasketAddress({ addressId, scope }));
   }
 
-  createBasketAddress(body: { address: Address; scope: 'invoice' | 'shipping' | 'any' }) {
-    if (!body || !body.address || !body.scope) {
+  createBasketAddress(address: Address, scope: 'invoice' | 'shipping' | 'any') {
+    if (!address || !scope) {
       return;
     }
 
-    this.store.dispatch(new CreateBasketAddress({ address: body.address, scope: body.scope }));
+    this.store.dispatch(new CreateBasketAddress({ address, scope }));
   }
 
   updateBasketAddress(address: Address) {

--- a/src/app/core/models/address/address.helper.spec.ts
+++ b/src/app/core/models/address/address.helper.spec.ts
@@ -8,10 +8,15 @@ describe('Address Helper', () => {
     using(
       [
         { add1: undefined, add2: undefined, expected: false },
-        { add1: { id: '1' } as Address, add2: undefined, expected: false },
-        { add1: undefined, add2: { id: '1' } as Address, expected: false },
+        { add1: { urn: '1' } as Address, add2: undefined, expected: false },
+        { add1: undefined, add2: { urn: '1' } as Address, expected: false },
+        { add1: { urn: '1' } as Address, add2: { urn: '2' } as Address, expected: false },
+        { add1: { urn: '1' } as Address, add2: { urn: '1' } as Address, expected: true },
         { add1: { id: '1' } as Address, add2: { id: '2' } as Address, expected: false },
         { add1: { id: '1' } as Address, add2: { id: '1' } as Address, expected: true },
+        { add1: { urn: '1', id: '1' } as Address, add2: { urn: '2', id: '1' } as Address, expected: false },
+        { add1: { urn: '1', id: '1' } as Address, add2: { urn: '1', id: '1' } as Address, expected: true },
+        { add1: { urn: '1', id: '1' } as Address, add2: { urn: '1', id: '2' } as Address, expected: true },
       ],
       slice => {
         it(`should yield ${slice.expected} when comparing ${JSON.stringify(slice.add1)} and ${JSON.stringify(

--- a/src/app/core/models/address/address.helper.ts
+++ b/src/app/core/models/address/address.helper.ts
@@ -2,6 +2,13 @@ import { Address } from './address.model';
 
 export class AddressHelper {
   static equal(add1: Address, add2: Address): boolean {
-    return !!add1 && !!add2 && add1.id === add2.id;
+    if (!add1 || !add2) {
+      return false;
+    }
+    if (add1.urn && add2.urn) {
+      return add1.urn === add2.urn;
+    }
+    // fallback to id if urn is not set
+    return add1.id === add2.id;
   }
 }

--- a/src/app/core/store/checkout/basket/basket.selectors.ts
+++ b/src/app/core/store/checkout/basket/basket.selectors.ts
@@ -1,5 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import { createSelector, createSelectorFactory, defaultMemoize } from '@ngrx/store';
+import { isEqual } from 'lodash-es';
 
+import { AddressHelper } from 'ish-core/models/address/address.helper';
 import { BasketValidationResultType } from 'ish-core/models/basket-validation/basket-validation.model';
 import { BasketView, createBasketView } from 'ish-core/models/basket/basket.model';
 import { getCheckoutState } from 'ish-core/store/checkout/checkout-store';
@@ -95,4 +97,18 @@ export const getBasketEligibleShippingMethods = createSelector(
 export const getBasketEligiblePaymentMethods = createSelector(
   getBasketState,
   basket => basket.eligiblePaymentMethods
+);
+
+export const getBasketInvoiceAddress = createSelectorFactory(projector =>
+  defaultMemoize(projector, undefined, isEqual)
+)(getCurrentBasket, basket => basket && basket.invoiceToAddress);
+
+export const getBasketShippingAddress = createSelectorFactory(projector =>
+  defaultMemoize(projector, undefined, isEqual)
+)(getCurrentBasket, basket => basket && basket.commonShipToAddress);
+
+export const isBasketInvoiceAndShippingAddressEqual = createSelector(
+  getBasketInvoiceAddress,
+  getBasketShippingAddress,
+  AddressHelper.equal
 );

--- a/src/app/core/utils/dev/html-query-utils.ts
+++ b/src/app/core/utils/dev/html-query-utils.ts
@@ -1,3 +1,6 @@
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
 function getAllElementTagsRecursively(el: Element): string[] {
   const returnList = [];
   returnList.push(el.tagName);
@@ -23,6 +26,13 @@ export function findAllIshElements(el: HTMLElement): string[] {
   }
 
   return returnList.sort();
+}
+
+export function findAllDataTestingIDs(fixture: ComponentFixture<unknown>) {
+  return fixture.debugElement
+    .queryAll(By.css('[data-testing-id]'))
+    .map(el => el.attributes['data-testing-id'])
+    .sort();
 }
 
 export function createDocumentFromHTML(html: string): HTMLDocument {

--- a/src/app/pages/account-addresses/account-addresses-page.module.ts
+++ b/src/app/pages/account-addresses/account-addresses-page.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { AddressFormsSharedModule } from 'ish-shared/address-forms/address-forms.module';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { AccountAddressesPageContainerComponent } from './account-addresses-page.container';
@@ -9,7 +8,7 @@ import { AccountAddressesComponent } from './components/account-addresses/accoun
 
 const routes: Routes = [{ path: '', component: AccountAddressesPageContainerComponent }];
 @NgModule({
-  imports: [AddressFormsSharedModule, RouterModule.forChild(routes), SharedModule],
+  imports: [RouterModule.forChild(routes), SharedModule],
   declarations: [AccountAddressesComponent, AccountAddressesPageContainerComponent],
 })
 export class AccountAddressesPageModule {}

--- a/src/app/pages/checkout-address/checkout-address-page.container.html
+++ b/src/app/pages/checkout-address/checkout-address-page.container.html
@@ -8,14 +8,8 @@
     >
       <h1>{{ 'checkout.addresses.heading' | translate }}</h1>
       <ish-checkout-address
-        [currentUser]="currentUser$ | async"
         [basket]="basket"
-        [addresses]="addresses$ | async"
         [error]="(basketError$ | async) || (addressesError$ | async)"
-        (assignAddressToBasket)="assignAddressToBasket($event)"
-        (updateAddress)="updateAddress($event)"
-        (createAddress)="createAddress($event)"
-        (deleteShippingAddress)="deleteCustomerAddress($event)"
         (nextStep)="nextStep()"
       ></ish-checkout-address>
     </ng-container>
@@ -25,7 +19,6 @@
       <ish-checkout-address-anonymous
         [basket]="basket"
         [error]="(basketError$ | async) || (addressesError$ | async)"
-        (createBasketAddress)="createAddress($event)"
         (nextStep)="nextStep()"
       ></ish-checkout-address-anonymous>
     </ng-template>

--- a/src/app/pages/checkout-address/checkout-address-page.container.ts
+++ b/src/app/pages/checkout-address/checkout-address-page.container.ts
@@ -5,7 +5,6 @@ import { filter, first, map, take } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
-import { Address } from 'ish-core/models/address/address.model';
 import { BasketView } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
@@ -24,7 +23,6 @@ export class CheckoutAddressPageContainerComponent implements OnInit {
   basket$: Observable<BasketView>;
   basketError$: Observable<HttpError>;
   basketLoading$: Observable<boolean>;
-  addresses$: Observable<Address[]>;
   addressesError$: Observable<HttpError>;
   addressesLoading$: Observable<boolean>;
   currentUser$: Observable<User>;
@@ -40,7 +38,6 @@ export class CheckoutAddressPageContainerComponent implements OnInit {
     this.basket$ = this.checkoutFacade.basket$;
     this.basketError$ = this.checkoutFacade.basketError$;
     this.basketLoading$ = this.checkoutFacade.basketLoading$;
-    this.addresses$ = this.accountFacade.addresses$();
     this.addressesError$ = this.accountFacade.addressesError$;
     this.addressesLoading$ = this.accountFacade.addressesLoading$;
     this.currentUser$ = this.accountFacade.user$;
@@ -59,34 +56,6 @@ export class CheckoutAddressPageContainerComponent implements OnInit {
         take(1)
       )
       .subscribe(() => this.router.navigate(['/basket']));
-  }
-
-  /**
-   * Assigns another address as basket invoice and/or shipping address
-   */
-  assignAddressToBasket(body: { addressId: string; scope: 'invoice' | 'shipping' | 'any' }) {
-    this.checkoutFacade.assignBasketAddress(body);
-  }
-
-  /**
-   * creates address and assigns it to basket
-   */
-  createAddress(body: { address: Address; scope: 'invoice' | 'shipping' | 'any' }) {
-    this.checkoutFacade.createBasketAddress(body);
-  }
-
-  /**
-   * Updates an address which is assigned to basket
-   */
-  updateAddress(address: Address) {
-    this.checkoutFacade.updateBasketAddress(address);
-  }
-
-  /**
-   * Deletes a customer address which is assigned to basket
-   */
-  deleteCustomerAddress(addressId: string) {
-    this.checkoutFacade.deleteBasketAddress(addressId);
   }
 
   /**

--- a/src/app/pages/checkout-address/checkout-address-page.module.ts
+++ b/src/app/pages/checkout-address/checkout-address-page.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 
-import { AddressFormsSharedModule } from 'ish-shared/address-forms/address-forms.module';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { CheckoutAddressPageContainerComponent } from './checkout-address-page.container';
@@ -8,7 +7,7 @@ import { CheckoutAddressAnonymousComponent } from './components/checkout-address
 import { CheckoutAddressComponent } from './components/checkout-address/checkout-address.component';
 
 @NgModule({
-  imports: [AddressFormsSharedModule, SharedModule],
+  imports: [SharedModule],
   declarations: [CheckoutAddressAnonymousComponent, CheckoutAddressComponent, CheckoutAddressPageContainerComponent],
 })
 export class CheckoutAddressPageModule {

--- a/src/app/pages/checkout-address/components/checkout-address-anonymous/checkout-address-anonymous.component.ts
+++ b/src/app/pages/checkout-address/components/checkout-address-anonymous/checkout-address-anonymous.component.ts
@@ -9,12 +9,11 @@ import {
   Output,
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
 import { CustomValidators } from 'ng2-validation';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { Address } from 'ish-core/models/address/address.model';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
@@ -39,7 +38,6 @@ export class CheckoutAddressAnonymousComponent implements OnChanges, OnInit, OnD
   @Input() basket: Basket;
   @Input() error: HttpError;
 
-  @Output() createBasketAddress = new EventEmitter<{ address: Address; scope: 'invoice' | 'shipping' | 'any' }>();
   @Output() nextStep = new EventEmitter<void>();
 
   form: FormGroup;
@@ -51,7 +49,7 @@ export class CheckoutAddressAnonymousComponent implements OnChanges, OnInit, OnD
 
   private destroy$ = new Subject();
 
-  constructor(private router: Router, private fb: FormBuilder) {}
+  constructor(private checkoutFacade: CheckoutFacade, private fb: FormBuilder) {}
 
   ngOnInit() {
     // create address form for basket addresses
@@ -129,10 +127,10 @@ export class CheckoutAddressAnonymousComponent implements OnChanges, OnInit, OnD
         : this.shippingAddressForm.get('address').value;
 
     if (shippingAddress) {
-      this.createBasketAddress.emit({ address: invoiceAddress, scope: 'invoice' });
-      this.createBasketAddress.emit({ address: shippingAddress, scope: 'shipping' });
+      this.checkoutFacade.createBasketAddress(invoiceAddress, 'invoice');
+      this.checkoutFacade.createBasketAddress(shippingAddress, 'shipping');
     } else {
-      this.createBasketAddress.emit({ address: invoiceAddress, scope: 'any' });
+      this.checkoutFacade.createBasketAddress(invoiceAddress, 'any');
     }
   }
 

--- a/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.html
+++ b/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.html
@@ -15,160 +15,20 @@
 
   <!-- ------------------------------- invoice address ---------------------------------- -->
   <div class="col-md-6 col-lg-4" data-testing-id="invoiceToAddress">
-    <h2>{{ 'checkout.address.billing.label' | translate }}</h2>
-    <div *ngIf="basket.invoiceToAddress" class="address-box">
-      <!-- edit invoice address -->
-      <a
-        *ngIf="invoice.isFormCollapsed"
-        class="btn-tool float-right"
-        title="{{ 'checkout.address.update.button.label' | translate }}"
-        (click)="showInvoiceAddressForm(basket.invoiceToAddress)"
-        data-testing-id="edit-invoice-address-link"
-      >
-        <fa-icon [icon]="['fas', 'pencil-alt']"></fa-icon>
-      </a>
-
-      <!-- display invoice address -->
-      <ish-address [address]="basket.invoiceToAddress"></ish-address>
-    </div>
-    <p *ngIf="!basket.invoiceToAddress && nextDisabled" class="text-danger">
-      {{ 'checkout.addresses.no_Selection.invoice.error' | translate }}
-    </p>
-
-    <!-- invoice address selection -->
-    <ng-container *ngIf="invoice.addresses && invoice.addresses.length">
-      <form [formGroup]="invoice.form">
-        <ish-select-address
-          [form]="invoice.form"
-          controlName="id"
-          [addresses]="invoice.addresses"
-          [emptyOptionLabel]="invoice.emptyOptionLabel"
-          inputClass="col-12"
-        ></ish-select-address>
-      </form>
-    </ng-container>
-
-    <!-- Add a new Invoice to address -->
-    <div class="row" *ngIf="invoice.isFormCollapsed && currentUser" data-testing-id="create-invoice-address-link">
-      <button
-        class="btn btn-link"
-        (click)="showInvoiceAddressForm()"
-        [attr.aria-expanded]="!invoice.isFormCollapsed"
-        aria-controls="collapseBasic"
-      >
-        {{ 'checkout.create_address.link' | translate }}
-      </button>
-    </div>
-
-    <!-- invoice address form -->
-    <div id="collapseBasic" [ngbCollapse]="invoice.isFormCollapsed" data-testing-id="invoice-address-form">
-      <ish-customer-address-form
-        [address]="invoice.address"
-        [resetForm]="!invoice.isFormCollapsed"
-        (save)="saveCustomerInvoiceAddress($event)"
-        (cancel)="cancelEditAddress(invoice)"
-      >
-      </ish-customer-address-form>
-    </div>
+    <ish-basket-invoice-address-widget-container
+      [showErrors]="nextDisabled"
+      [collapse]="active === 'shipping'"
+      (collapseChange)="invoiceCollapsed($event)"
+    ></ish-basket-invoice-address-widget-container>
   </div>
 
   <!-- ------------------------------ shipping address ----------------------------------------- -->
   <div class="col-md-6 col-lg-4" data-testing-id="shipToAddress">
-    <h2>{{ 'checkout.address.shipping.label' | translate }}</h2>
-
-    <!-- Display shipping address container -->
-    <div *ngIf="basket.commonShipToAddress" class="address-box">
-      <ng-container *ngIf="!basket.invoiceToAddress || basket.commonShipToAddress.urn !== basket.invoiceToAddress.urn">
-        <div class="float-right">
-          <!-- edit shipping address -->
-          <a
-            *ngIf="shipping.isFormCollapsed"
-            class="btn-tool"
-            title="{{ 'checkout.address.update.button.label' | translate }}"
-            (click)="showShippingAddressForm(basket.commonShipToAddress)"
-            data-testing-id="edit-shipping-address-link"
-          >
-            <fa-icon [icon]="['fas', 'pencil-alt']"></fa-icon>
-          </a>
-
-          <!-- delete shipping address -->
-          <a
-            *ngIf="shipping.isAddressDeleteable"
-            class="btn-tool"
-            title="{{ 'checkout.address.delete.button.label' | translate }}"
-            (click)="modalDialog.show(basket.commonShipToAddress)"
-          >
-            <fa-icon [icon]="['fas', 'trash-alt']"></fa-icon>
-          </a>
-
-          <ish-modal-dialog
-            #modalDialog
-            [options]="{
-              titleText: 'checkout.address.delete.confirmation.heading' | translate,
-              confirmText: 'checkout.address.button.delete' | translate,
-              rejectText: 'checkout.address.button.cancel' | translate
-            }"
-            (confirmed)="deleteAddress($event)"
-          >
-            <p>{{ 'checkout.address.delete.confirmation.text' | translate }}</p>
-            <small class="help-block">{{ 'checkout.address.delete.confirmation.deletionhint' | translate }}</small>
-          </ish-modal-dialog>
-        </div>
-
-        <!-- display shipping address -->
-        <ish-address [address]="basket.commonShipToAddress"></ish-address>
-      </ng-container>
-
-      <p *ngIf="sameShippingAndInvoiceAddress" data-testing-id="sameAsInvoice" class="section">
-        {{ 'checkout.same_as_billing_address.text' | translate }}
-      </p>
-
-      <p></p>
-    </div>
-
-    <p *ngIf="!basket.commonShipToAddress && nextDisabled" class="text-danger">
-      {{ 'checkout.addresses.no_Selection.shipping.error' | translate }}
-    </p>
-
-    <!-- shipping address selection -->
-    <ng-container *ngIf="shipping.addresses && shipping.addresses.length">
-      <form [formGroup]="shipping.form">
-        <ish-select-address
-          [form]="shipping.form"
-          controlName="id"
-          [addresses]="shipping.addresses"
-          [emptyOptionLabel]="shipping.emptyOptionLabel"
-          inputClass="col-12"
-        ></ish-select-address>
-      </form>
-    </ng-container>
-
-    <!-- Add a new Shipping to address -->
-    <div
-      *ngIf="shipping.isFormCollapsed && (currentUser || sameShippingAndInvoiceAddress)"
-      class="row"
-      data-testing-id="create-shipping-address-link"
-    >
-      <button
-        class="btn btn-link"
-        (click)="showShippingAddressForm()"
-        [attr.aria-expanded]="!shipping.isFormCollapsed"
-        aria-controls="collapseBasic"
-      >
-        {{ 'checkout.create_address.link' | translate }}
-      </button>
-    </div>
-
-    <!-- shipping address form -->
-    <div id="collapseBasic" [ngbCollapse]="shipping.isFormCollapsed" data-testing-id="shipping-address-form">
-      <ish-customer-address-form
-        [address]="shipping.address"
-        [resetForm]="!shipping.isFormCollapsed"
-        (save)="saveCustomerShippingAddress($event)"
-        (cancel)="cancelEditAddress(shipping)"
-      >
-      </ish-customer-address-form>
-    </div>
+    <ish-basket-shipping-address-widget-container
+      [showErrors]="nextDisabled"
+      [collapse]="active === 'invoice'"
+      (collapseChange)="shippingCollapsed($event)"
+    ></ish-basket-shipping-address-widget-container>
   </div>
 
   <!-- Cart Summary -->

--- a/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.spec.ts
+++ b/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.spec.ts
@@ -1,27 +1,21 @@
-import { Component, SimpleChange, SimpleChanges } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
-import { anything, spy, verify } from 'ts-mockito';
 
-import { Address } from 'ish-core/models/address/address.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { User } from 'ish-core/models/user/user.model';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
-import { CustomerAddressFormComponent } from 'ish-shared/address-forms/components/customer-address-form/customer-address-form.component';
-import { AddressComponent } from 'ish-shared/address/components/address/address.component';
 import { BasketCostSummaryComponent } from 'ish-shared/basket/components/basket-cost-summary/basket-cost-summary.component';
 import { BasketItemsSummaryComponent } from 'ish-shared/basket/components/basket-items-summary/basket-items-summary.component';
 import { BasketValidationResultsComponent } from 'ish-shared/basket/components/basket-validation-results/basket-validation-results.component';
+import { BasketInvoiceAddressWidgetContainerComponent } from 'ish-shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container';
+import { BasketShippingAddressWidgetContainerComponent } from 'ish-shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container';
 import { ContentIncludeContainerComponent } from 'ish-shared/cms/containers/content-include/content-include.container';
 import { ErrorMessageComponent } from 'ish-shared/common/components/error-message/error-message.component';
 import { ModalDialogLinkComponent } from 'ish-shared/common/components/modal-dialog-link/modal-dialog-link.component';
-import { ModalDialogComponent } from 'ish-shared/common/components/modal-dialog/modal-dialog.component';
-import { SelectAddressComponent } from 'ish-shared/forms/components/select-address/select-address.component';
 
 import { CheckoutAddressComponent } from './checkout-address.component';
 
@@ -38,17 +32,14 @@ describe('Checkout Address Component', () => {
       declarations: [
         CheckoutAddressComponent,
         DummyComponent,
-        MockComponent(AddressComponent),
         MockComponent(BasketCostSummaryComponent),
+        MockComponent(BasketInvoiceAddressWidgetContainerComponent),
         MockComponent(BasketItemsSummaryComponent),
+        MockComponent(BasketShippingAddressWidgetContainerComponent),
         MockComponent(BasketValidationResultsComponent),
         MockComponent(ContentIncludeContainerComponent),
-        MockComponent(CustomerAddressFormComponent),
         MockComponent(ErrorMessageComponent),
-        MockComponent(FaIconComponent),
-        MockComponent(ModalDialogComponent),
         MockComponent(ModalDialogLinkComponent),
-        MockComponent(SelectAddressComponent),
       ],
       imports: [
         NgbCollapseModule,
@@ -64,13 +55,6 @@ describe('Checkout Address Component', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement;
     component.basket = BasketMockData.getBasket();
-    component.addresses = [
-      BasketMockData.getAddress(),
-      { id: '4712', firstName: 'John', invoiceToAddress: true, shipToAddress: true } as Address,
-      { id: '4713', firstName: 'Susan', invoiceToAddress: false, shipToAddress: true } as Address,
-      { id: '4714', firstName: 'Dave', invoiceToAddress: true, shipToAddress: false } as Address,
-    ];
-    component.currentUser = { firstName: 'Patricia', lastName: 'Miller' } as User;
   });
 
   it('should be created', () => {
@@ -79,29 +63,10 @@ describe('Checkout Address Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
-  it('should render invoiceToAddress and ShipToAddress sections if set', () => {
+  it('should render invoiceToAddress and ShipToAddress widgets if set', () => {
     fixture.detectChanges();
     expect(element.querySelector('div[data-testing-id=invoiceToAddress]')).toBeTruthy();
     expect(element.querySelector('div[data-testing-id=shipToAddress]')).toBeTruthy();
-  });
-
-  it('should render create address links after creation', () => {
-    fixture.detectChanges();
-    expect(element.querySelector('div[data-testing-id=create-invoice-address-link]')).toBeTruthy();
-    expect(element.querySelector('div[data-testing-id=create-shipping-address-link]')).toBeTruthy();
-  });
-
-  it('should render one edit link if basket has the same invoice and shipTo address', () => {
-    fixture.detectChanges();
-    expect(element.querySelector('a[data-testing-id=edit-invoice-address-link]')).toBeTruthy();
-    expect(element.querySelector('a[data-testing-id=edit-shipping-address-link]')).toBeFalsy();
-  });
-
-  it('should render one edit link the shipping address if basket has no invoice address', () => {
-    component.basket.invoiceToAddress = undefined;
-    fixture.detectChanges();
-    expect(element.querySelector('a[data-testing-id=edit-invoice-address-link]')).toBeFalsy();
-    expect(element.querySelector('a[data-testing-id=edit-shipping-address-link]')).toBeTruthy();
   });
 
   it('should not render address forms after creation', () => {
@@ -120,67 +85,6 @@ describe('Checkout Address Component', () => {
     expect(element.querySelector('ish-basket-cost-summary')).toBeTruthy();
   });
 
-  it('should render invoiceToAddressBox if invoiceToAddress is set', () => {
-    fixture.detectChanges();
-    expect(element.querySelector('div[data-testing-id=invoiceToAddress] .address-box')).toBeTruthy();
-  });
-
-  it('should render shipToAddressBox if invoiceToAddress is set', () => {
-    fixture.detectChanges();
-    expect(element.querySelector('div[data-testing-id=shipToAddress] .address-box')).toBeTruthy();
-  });
-
-  it('should render sameAsInvoiceAddress text if shipTo and invoiceTo address are identical', () => {
-    fixture.detectChanges();
-    expect(element.querySelector('p[data-testing-id=sameAsInvoice]')).toBeTruthy();
-  });
-
-  /* addresses can be selected as invoice address if they are not set as invoiceAddress at the basket and if the address is a invoice address */
-  it('should determine invoice addresses for the select box', () => {
-    const changes: SimpleChanges = {
-      addresses: new SimpleChange(undefined, component.addresses, false),
-    };
-    fixture.detectChanges();
-    component.ngOnChanges(changes);
-    expect(component.invoice.addresses).toHaveLength(2);
-    expect(component.invoice.addresses[0].id).toEqual('4712');
-    expect(component.invoice.addresses[1].id).toEqual('4714');
-  });
-
-  /* addresses can be selected as shipping address if they are not set as shippingAddress at the basket and if the address is a shipping address */
-  it('should determine shipping addresses for the select box', () => {
-    const changes: SimpleChanges = {
-      addresses: new SimpleChange(undefined, component.addresses, false),
-    };
-    component.ngOnChanges(changes);
-    fixture.detectChanges();
-    expect(component.shipping.addresses).toHaveLength(2);
-    expect(component.shipping.addresses[0].id).toEqual('4712');
-    expect(component.shipping.addresses[1].id).toEqual('4713');
-  });
-
-  it('should throw updateInvoiceAddress event when invoice address form value id changes', done => {
-    fixture.detectChanges();
-
-    component.assignAddressToBasket.subscribe(formValue => {
-      expect(formValue.addressId).toBe('testId');
-      done();
-    });
-
-    component.invoice.form.get('id').setValue('testId');
-  });
-
-  it('should throw updateshippingAddress event when shipping address form value id changes', done => {
-    fixture.detectChanges();
-
-    component.assignAddressToBasket.subscribe(formValue => {
-      expect(formValue.addressId).toBe('testId');
-      done();
-    });
-
-    component.shipping.form.get('id').setValue('testId');
-  });
-
   it('should not render an error if no error occurs', () => {
     component.error = undefined;
     fixture.detectChanges();
@@ -191,132 +95,6 @@ describe('Checkout Address Component', () => {
     component.error = { status: 404 } as HttpError;
     fixture.detectChanges();
     expect(element.querySelector('ish-error-message')).toBeTruthy();
-  });
-
-  it('should render invoice address form if showInvoiceAddressForm is called', () => {
-    component.showInvoiceAddressForm();
-    fixture.detectChanges();
-
-    expect(component.invoice.isFormCollapsed).toBeFalse();
-    expect(component.shipping.isFormCollapsed).toBeTrue();
-    expect(
-      element.querySelector('div.show[data-testing-id=invoice-address-form] ish-customer-address-form')
-    ).toBeTruthy();
-    expect(
-      element.querySelector('div.show[data-testing-id=shipping-address-form] ish-checkout-address-form')
-    ).toBeFalsy();
-    expect(element.querySelector('div[data-testing-id=create-invoice-address-link]')).toBeFalsy();
-    expect(element.querySelector('div[data-testing-id=create-shipping-address-link]')).toBeTruthy();
-  });
-
-  it('should render shipping address form if showShippingAddressForm is called', () => {
-    component.showShippingAddressForm();
-    fixture.detectChanges();
-
-    expect(component.invoice.isFormCollapsed).toBeTrue();
-    expect(component.shipping.isFormCollapsed).toBeFalse();
-    expect(
-      element.querySelector('div.show[data-testing-id=shipping-address-form] ish-customer-address-form')
-    ).toBeTruthy();
-    expect(
-      element.querySelector('div.show[data-testing-id=invoice-address-form] ish-checkout-address-form')
-    ).toBeFalsy();
-    expect(element.querySelector('div[data-testing-id=create-invoice-address-link]')).toBeTruthy();
-    expect(element.querySelector('div[data-testing-id=create-shipping-address-link]')).toBeFalsy();
-  });
-
-  it('should set isShippingAddressDeleteable to true if the user has no preferred addresses', () => {
-    const changes: SimpleChanges = {
-      addresses: new SimpleChange(undefined, component.addresses, false),
-    };
-    component.ngOnChanges(changes);
-    expect(component.shipping.isAddressDeleteable).toBeTrue();
-  });
-
-  it('should set isShippingAddressDeleteable to false if the user has a preferred invoice address', () => {
-    const changes: SimpleChanges = {
-      addresses: new SimpleChange(undefined, component.addresses, false),
-    };
-    component.currentUser.preferredInvoiceToAddressUrn = BasketMockData.getAddress().urn;
-    component.ngOnChanges(changes);
-    expect(component.shipping.isAddressDeleteable).toBeFalse();
-  });
-
-  it('should set isShippingAddressDeleteable to false if the user has a preferred shipping address', () => {
-    const changes: SimpleChanges = {
-      addresses: new SimpleChange(undefined, component.addresses, false),
-    };
-    component.currentUser.preferredShipToAddressUrn = BasketMockData.getAddress().urn;
-    component.ngOnChanges(changes);
-    expect(component.shipping.isAddressDeleteable).toBeFalse();
-  });
-
-  it('should throw createInvoiceAddress event when saveCustomerInvoiceAddress is triggered and invoice.address is undefined', done => {
-    fixture.detectChanges();
-
-    component.createAddress.subscribe(address => {
-      expect(address.address.id).toBe(BasketMockData.getAddress().id);
-      done();
-    });
-
-    component.saveCustomerInvoiceAddress(BasketMockData.getAddress());
-  });
-
-  it('should throw updateInvoiceAddress event when saveCustomerInvoiceAddress is triggered and invoice.address is defined', done => {
-    fixture.detectChanges();
-    component.invoice.address = component.basket.invoiceToAddress;
-
-    component.updateAddress.subscribe(address => {
-      expect(address.id).toBe(BasketMockData.getAddress().id);
-      done();
-    });
-
-    component.saveCustomerInvoiceAddress(BasketMockData.getAddress());
-  });
-
-  it('should throw createShippingAddress event when saveCustomerShippingAddress is triggered and shipping.address is undefined', done => {
-    fixture.detectChanges();
-
-    component.createAddress.subscribe(address => {
-      expect(address.address.id).toBe(BasketMockData.getAddress().id);
-      done();
-    });
-
-    component.saveCustomerShippingAddress(BasketMockData.getAddress());
-  });
-
-  it('should throw updateShippingAddress event when saveCustomerShippingAddress is triggered and shipping.address is defined', done => {
-    fixture.detectChanges();
-    component.shipping.address = component.basket.commonShipToAddress;
-
-    component.updateAddress.subscribe(address => {
-      expect(address.id).toBe(BasketMockData.getAddress().id);
-      done();
-    });
-
-    component.saveCustomerShippingAddress(BasketMockData.getAddress());
-  });
-
-  it('should throw deleteShippingAddress event when deleteAddress is triggered', () => {
-    const emitter = spy(component.deleteShippingAddress);
-
-    component.deleteAddress(BasketMockData.getAddress());
-
-    verify(emitter.emit(anything())).once();
-  });
-
-  it('should collape invoice address form when cancelEditAddress for an invoice address is triggered', () => {
-    component.invoice.isFormCollapsed = false;
-
-    component.cancelEditAddress(component.invoice);
-    expect(component.invoice.isFormCollapsed).toBeTrue();
-  });
-
-  it('should collapse shipping address form when cancelEditAddress for a shipping address is triggered', () => {
-    component.shipping.isFormCollapsed = false;
-
-    component.cancelEditAddress(component.shipping);
-    expect(component.shipping.isFormCollapsed).toBeTrue();
   });
 
   it('should not render an error if the user has currently no addresses selected', () => {

--- a/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.ts
+++ b/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.ts
@@ -1,220 +1,24 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
-import { AddressHelper } from 'ish-core/models/address/address.helper';
-import { Address } from 'ish-core/models/address/address.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { User } from 'ish-core/models/user/user.model';
-
-class FormType {
-  addresses: Address[]; // address select options
-  form: FormGroup;
-  emptyOptionLabel: string; // select box label
-  isFormCollapsed = true;
-  address: Address;
-  isAddressDeleteable: boolean;
-}
 
 /**
- * The Checkout Address Component renders the checkout address page. On this page the user can change invoice and shipping address and create a new invoice or shipping address, respectively. See also {@link CheckoutAddressPageContainerComponent}
- *
- * @example
- *<ish-checkout-address
-     [currentUser]="currentUser$ | async"
-     [basket]="basket"
-     [addresses]="addresses$ | async"
-     [error]="(basketError$ | async) || (addressesError$ | async)"
-     (assignAddressToBasket)="assignAddressToBasket($event)"
-     (updateAddress)="updateAddress($event)"
-     (createAddress)="createAddress($event)"
-     (deleteShippingAddress)="deleteCustomerAddress($event)"
-     (nextStep)="nextStep()"
-  ></ish-checkout-address>
+ * The Checkout Address Component renders the checkout address page. On this page the user can change invoice and shipping address and create a new invoice or shipping address, respectively.
  */
 @Component({
   selector: 'ish-checkout-address',
   templateUrl: './checkout-address.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CheckoutAddressComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() currentUser: User;
+export class CheckoutAddressComponent {
   @Input() basket: Basket;
-  @Input() addresses: Address[];
   @Input() error: HttpError;
 
-  @Output() assignAddressToBasket = new EventEmitter<{ addressId: string; scope: 'invoice' | 'shipping' | 'any' }>();
-  @Output() createAddress = new EventEmitter<{ address: Address; scope: 'invoice' | 'shipping' | 'any' }>();
-  @Output() updateAddress = new EventEmitter<Address>();
-  @Output() deleteShippingAddress = new EventEmitter<string>();
   @Output() nextStep = new EventEmitter<void>();
 
-  invoice = new FormType();
-  shipping = new FormType();
-
   submitted = false;
-
-  private destroy$ = new Subject();
-
-  constructor(private router: Router, private fb: FormBuilder) {}
-
-  ngOnInit() {
-    // create invoice address form (selectbox)
-    this.invoice.form = new FormGroup({
-      id: new FormControl(''),
-    });
-
-    // trigger set basket invoice address if it changes
-    this.invoice.form
-      .get('id')
-      .valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(invoiceAddressId =>
-        this.assignAddressToBasket.emit({ addressId: invoiceAddressId, scope: 'invoice' })
-      );
-
-    // create shipping address form (selectbox)
-    this.shipping.form = new FormGroup({
-      id: new FormControl(''),
-    });
-
-    // trigger set basket shipping address if it changes
-    this.shipping.form
-      .get('id')
-      .valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(shippingAddressId =>
-        this.assignAddressToBasket.emit({ addressId: shippingAddressId, scope: 'shipping' })
-      );
-  }
-
-  ngOnChanges(c: SimpleChanges) {
-    if (this.haveBasketOrAddressesChanged(c)) {
-      // prepare select box label and content
-      this.prepareInvoiceAddressSelectBox();
-      this.prepareShippingAddressSelectBox();
-
-      // close possible address forms after address changes
-      this.invoice.isFormCollapsed = true;
-      this.shipping.isFormCollapsed = true;
-
-      this.calculateShippingAddressDeletable();
-    }
-  }
-
-  /**
-   * determine whether the basket or the customer addresses have changed
-   */
-  private haveBasketOrAddressesChanged(c: SimpleChanges) {
-    return this.basket && this.addresses && (c.addresses || c.basket);
-  }
-
-  /**
-   * determine whether the shipping address is deleteable
-   */
-  private calculateShippingAddressDeletable() {
-    this.shipping.isAddressDeleteable =
-      this.basket.commonShipToAddress &&
-      this.currentUser &&
-      this.addresses.length > 1 &&
-      (!this.currentUser.preferredInvoiceToAddressUrn ||
-        this.basket.commonShipToAddress.urn !== this.currentUser.preferredInvoiceToAddressUrn) &&
-      (!this.currentUser.preferredShipToAddressUrn ||
-        this.basket.commonShipToAddress.urn !== this.currentUser.preferredShipToAddressUrn);
-  }
-
-  /**
-   * Sets the label of the invoice select box, which depends on whether or not there is already a basket invoice address.
-   * Determines addresses of the select box: all invoice addresses are shown except the address which is currently assigned as invoive address to the basket
-   */
-  prepareInvoiceAddressSelectBox() {
-    this.invoice.emptyOptionLabel = this.basket.invoiceToAddress
-      ? 'checkout.addresses.select_a_different_address.default'
-      : 'checkout.addresses.select_invoice_address.button';
-
-    this.invoice.addresses = this.addresses.filter(
-      (address: Address) =>
-        ((this.basket.invoiceToAddress && address.id !== this.basket.invoiceToAddress.id) ||
-          !this.basket.invoiceToAddress) &&
-        address.invoiceToAddress
-    );
-
-    // preset (empty) basket invoice address if there is only one invoice address available
-    if (this.invoice.addresses.length === 1 && this.basket && !this.basket.invoiceToAddress) {
-      this.assignAddressToBasket.emit({ addressId: this.invoice.addresses[0].id, scope: 'invoice' });
-    }
-  }
-
-  /**
-   * Sets the label of the shipping select box, which depends on whether or not there is already a basket shipping address.
-   * Determines addresses of the select box: all shipping addresses are shown except the address which is currently assigned as shipping address to the basket
-   */
-  prepareShippingAddressSelectBox() {
-    this.shipping.emptyOptionLabel = this.basket.commonShipToAddress
-      ? 'checkout.addresses.select_a_different_address.default'
-      : 'checkout.addresses.select_shipping_address.button';
-
-    this.shipping.addresses = this.addresses.filter(
-      (address: Address) =>
-        ((this.basket.commonShipToAddress && address.id !== this.basket.commonShipToAddress.id) ||
-          !this.basket.commonShipToAddress) &&
-        address.shipToAddress
-    );
-
-    // preset (empty) basket shipping address if there is only one shipping address available
-    if (this.shipping.addresses.length === 1 && this.basket && !this.basket.commonShipToAddress) {
-      this.assignAddressToBasket.emit({ addressId: this.shipping.addresses[0].id, scope: 'shipping' });
-    }
-  }
-
-  showInvoiceAddressForm(address?: Address) {
-    this.invoice.isFormCollapsed = false;
-    this.cancelEditAddress(this.shipping);
-    this.invoice.address = address ? address : undefined;
-  }
-
-  showShippingAddressForm(address?: Address) {
-    this.shipping.isFormCollapsed = false;
-    this.cancelEditAddress(this.invoice);
-    this.shipping.address = address ? address : undefined;
-  }
-
-  /* functions for reactioning on events of the checkout-address-component */
-  saveCustomerInvoiceAddress(address: Address) {
-    if (this.invoice.address) {
-      this.updateAddress.emit(address);
-    } else {
-      this.createAddress.emit({ address, scope: 'invoice' });
-    }
-  }
-
-  saveCustomerShippingAddress(address: Address) {
-    if (this.shipping.address) {
-      this.updateAddress.emit(address);
-    } else {
-      this.createAddress.emit({ address, scope: 'shipping' });
-    }
-  }
-
-  cancelEditAddress(formType: FormType) {
-    formType.isFormCollapsed = true;
-    formType.address = undefined;
-  }
-
-  deleteAddress(address: Address) {
-    this.deleteShippingAddress.emit(address.id);
-  }
+  active: 'invoice' | 'shipping';
 
   /**
    * leads to next checkout page (checkout shipping)
@@ -230,11 +34,15 @@ export class CheckoutAddressComponent implements OnInit, OnChanges, OnDestroy {
     return this.basket && (!this.basket.invoiceToAddress || !this.basket.commonShipToAddress) && this.submitted;
   }
 
-  get sameShippingAndInvoiceAddress() {
-    return this.basket && AddressHelper.equal(this.basket.invoiceToAddress, this.basket.commonShipToAddress);
+  invoiceCollapsed(value: boolean) {
+    if (!value) {
+      this.active = 'invoice';
+    }
   }
 
-  ngOnDestroy() {
-    this.destroy$.next();
+  shippingCollapsed(value: boolean) {
+    if (!value) {
+      this.active = 'shipping';
+    }
   }
 }

--- a/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.ts
+++ b/src/app/pages/checkout-address/components/checkout-address/checkout-address.component.ts
@@ -14,6 +14,7 @@ import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { AddressHelper } from 'ish-core/models/address/address.helper';
 import { Address } from 'ish-core/models/address/address.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
@@ -230,11 +231,7 @@ export class CheckoutAddressComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   get sameShippingAndInvoiceAddress() {
-    return (
-      this.basket &&
-      this.basket.invoiceToAddress &&
-      this.basket.commonShipToAddress.urn === this.basket.invoiceToAddress.urn
-    );
+    return this.basket && AddressHelper.equal(this.basket.invoiceToAddress, this.basket.commonShipToAddress);
   }
 
   ngOnDestroy() {

--- a/src/app/pages/registration/registration-page.module.ts
+++ b/src/app/pages/registration/registration-page.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { AddressFormsSharedModule } from 'ish-shared/address-forms/address-forms.module';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { RegistrationCompanyFormComponent } from './components/registration-company-form/registration-company-form.component';
@@ -13,7 +12,7 @@ import { RegistrationPageContainerComponent } from './registration-page.containe
 const registrationPageRoutes: Routes = [{ path: '', component: RegistrationPageContainerComponent }];
 
 @NgModule({
-  imports: [AddressFormsSharedModule, RouterModule.forChild(registrationPageRoutes), SharedModule],
+  imports: [RouterModule.forChild(registrationPageRoutes), SharedModule],
   declarations: [
     RegistrationCompanyFormComponent,
     RegistrationCredentialsFormComponent,

--- a/src/app/shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container.html
+++ b/src/app/shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container.html
@@ -1,0 +1,58 @@
+<h2>{{ 'checkout.address.billing.label' | translate }}</h2>
+<ng-container *ngIf="invoiceAddress$ | async as address">
+  <div class="address-box">
+    <!-- edit invoice address -->
+    <a
+      *ngIf="collapseChange | async"
+      class="btn-tool float-right"
+      title="{{ 'checkout.address.update.button.label' | translate }}"
+      (click)="showAddressForm(address)"
+      data-testing-id="edit-invoice-address-link"
+    >
+      <fa-icon [icon]="['fas', 'pencil-alt']"></fa-icon>
+    </a>
+
+    <!-- display invoice address -->
+    <ish-address [address]="address"></ish-address>
+  </div>
+  <p *ngIf="!address && showErrors" class="text-danger">
+    {{ 'checkout.addresses.no_Selection.invoice.error' | translate }}
+  </p>
+</ng-container>
+
+<!-- invoice address selection -->
+<ng-container *ngIf="addresses$ | async as addresses">
+  <form *ngIf="addresses.length" [formGroup]="form">
+    <ish-select-address
+      [form]="form"
+      controlName="id"
+      [addresses]="addresses"
+      [emptyOptionLabel]="emptyOptionLabel$ | async"
+      inputClass="col-12"
+    ></ish-select-address>
+  </form>
+</ng-container>
+
+<!-- Add a new Invoice to address -->
+<div class="row" *ngIf="collapseChange | async">
+  <button
+    data-testing-id="create-invoice-address-link"
+    class="btn btn-link"
+    (click)="showAddressForm()"
+    [attr.aria-expanded]="!(collapseChange | async)"
+    aria-controls="collapseBasic"
+  >
+    {{ 'checkout.create_address.link' | translate }}
+  </button>
+</div>
+
+<!-- invoice address form -->
+<div id="collapseBasic" [ngbCollapse]="collapseChange | async" data-testing-id="invoice-address-form">
+  <ish-customer-address-form
+    [address]="editAddress"
+    [resetForm]="!(collapseChange | async)"
+    (save)="saveAddress($event)"
+    (cancel)="cancelEditAddress()"
+  >
+  </ish-customer-address-form>
+</div>

--- a/src/app/shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container.spec.ts
+++ b/src/app/shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container.spec.ts
@@ -1,0 +1,178 @@
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent, MockDirective } from 'ng-mocks';
+import { EMPTY, of } from 'rxjs';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
+import { findAllDataTestingIDs, findAllIshElements } from 'ish-core/utils/dev/html-query-utils';
+import { CustomerAddressFormComponent } from 'ish-shared/address-forms/components/customer-address-form/customer-address-form.component';
+import { AddressComponent } from 'ish-shared/address/components/address/address.component';
+import { SelectAddressComponent } from 'ish-shared/forms/components/select-address/select-address.component';
+
+import { BasketInvoiceAddressWidgetContainerComponent } from './basket-invoice-address-widget.container';
+
+describe('Basket Invoice Address Widget Container', () => {
+  let component: BasketInvoiceAddressWidgetContainerComponent;
+  let fixture: ComponentFixture<BasketInvoiceAddressWidgetContainerComponent>;
+  let element: HTMLElement;
+  let checkoutFacade: CheckoutFacade;
+  let accountFacade: AccountFacade;
+
+  beforeEach(async(() => {
+    checkoutFacade = mock(CheckoutFacade);
+    when(checkoutFacade.basketInvoiceAddress$).thenReturn(EMPTY);
+
+    accountFacade = mock(AccountFacade);
+    when(accountFacade.addresses$()).thenReturn(EMPTY);
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [
+        BasketInvoiceAddressWidgetContainerComponent,
+        MockComponent(AddressComponent),
+        MockComponent(CustomerAddressFormComponent),
+        MockComponent(FaIconComponent),
+        MockComponent(SelectAddressComponent),
+        MockDirective(NgbCollapse),
+      ],
+      providers: [
+        { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
+        { provide: AccountFacade, useFactory: () => instance(accountFacade) },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BasketInvoiceAddressWidgetContainerComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should render create link if invoice is not set', () => {
+    fixture.detectChanges();
+
+    expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+      Array [
+        "create-invoice-address-link",
+        "invoice-address-form",
+      ]
+    `);
+  });
+
+  describe('with address on basket', () => {
+    beforeEach(() => {
+      when(checkoutFacade.basketInvoiceAddress$).thenReturn(of(BasketMockData.getAddress()));
+      when(accountFacade.addresses$()).thenReturn(of([BasketMockData.getAddress()]));
+    });
+
+    it('should render if invoice is set', () => {
+      fixture.detectChanges();
+
+      expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+        Array [
+          "ish-address",
+          "ish-customer-address-form",
+        ]
+      `);
+      expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+        Array [
+          "create-invoice-address-link",
+          "edit-invoice-address-link",
+          "invoice-address-form",
+        ]
+      `);
+    });
+
+    it('should expand form if invoice is edited', () => {
+      fixture.detectChanges();
+      (element.querySelector('a[data-testing-id="edit-invoice-address-link"') as HTMLLinkElement).click();
+      fixture.detectChanges();
+
+      expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+        Array [
+          "ish-address",
+          "ish-customer-address-form",
+        ]
+      `);
+      expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+        Array [
+          "invoice-address-form",
+        ]
+      `);
+
+      const form = fixture.debugElement.query(By.css('ish-customer-address-form'))
+        .componentInstance as CustomerAddressFormComponent;
+      expect(form.address).toBeTruthy();
+    });
+
+    it('should expand form if invoice is created', () => {
+      fixture.detectChanges();
+      (element.querySelector('[data-testing-id="create-invoice-address-link"') as HTMLLinkElement).click();
+      fixture.detectChanges();
+
+      expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+        Array [
+          "ish-address",
+          "ish-customer-address-form",
+        ]
+      `);
+      expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+        Array [
+          "invoice-address-form",
+        ]
+      `);
+
+      const form = fixture.debugElement.query(By.css('ish-customer-address-form'))
+        .componentInstance as CustomerAddressFormComponent;
+      expect(form.address).toBeFalsy();
+    });
+  });
+
+  describe('address selection', () => {
+    const address = BasketMockData.getAddress();
+    const addresses = [
+      { ...address, id: '1', invoiceToAddress: false },
+      { ...address, id: '2', invoiceToAddress: true },
+      { ...address, id: '3', invoiceToAddress: true },
+      { ...address, id: '4', invoiceToAddress: true },
+    ];
+
+    beforeEach(() => {
+      when(checkoutFacade.basketInvoiceAddress$).thenReturn(of(addresses[1]));
+      when(accountFacade.addresses$()).thenReturn(of(addresses));
+    });
+
+    it('should only use valid addresses for selection display', () => {
+      fixture.detectChanges();
+
+      const selectAddress = fixture.debugElement.query(By.css('ish-select-address'))
+        .componentInstance as SelectAddressComponent;
+      expect(selectAddress.addresses.map(add => add.id)).toMatchInlineSnapshot(`
+        Array [
+          "3",
+          "4",
+        ]
+      `);
+    });
+
+    it('should update address after selecting', () => {
+      fixture.detectChanges();
+      component.form.setValue({ id: addresses[0].id });
+
+      verify(checkoutFacade.assignBasketAddress(anything(), 'invoice')).once();
+    });
+  });
+});

--- a/src/app/shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container.ts
+++ b/src/app/shared/checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container.ts
@@ -1,0 +1,104 @@
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { BehaviorSubject, Observable, Subject, combineLatest } from 'rxjs';
+import { filter, map, take, takeUntil } from 'rxjs/operators';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { Address } from 'ish-core/models/address/address.model';
+
+/**
+ * Standalone widget component for selecting and setting the basket invoice address in the checkout.
+ */
+@Component({
+  selector: 'ish-basket-invoice-address-widget-container',
+  templateUrl: './basket-invoice-address-widget.container.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BasketInvoiceAddressWidgetContainerComponent implements OnInit, OnDestroy {
+  @Input() showErrors = true;
+
+  @Output() collapseChange = new BehaviorSubject(true);
+
+  @Input()
+  set collapse(value: boolean) {
+    this.collapseChange.next(value);
+  }
+
+  invoiceAddress$: Observable<Address>;
+  emptyOptionLabel$: Observable<string>;
+  addresses$: Observable<Address[]>;
+
+  form: FormGroup;
+  editAddress: Address;
+
+  private destroy$ = new Subject();
+
+  constructor(private checkoutFacade: CheckoutFacade, private accountFacade: AccountFacade) {
+    this.form = new FormGroup({
+      id: new FormControl(''),
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+  }
+
+  ngOnInit() {
+    this.invoiceAddress$ = this.checkoutFacade.basketInvoiceAddress$;
+
+    this.emptyOptionLabel$ = this.invoiceAddress$.pipe(
+      map(address =>
+        address
+          ? 'checkout.addresses.select_a_different_address.default'
+          : 'checkout.addresses.select_invoice_address.button'
+      )
+    );
+    this.addresses$ = combineLatest([this.accountFacade.addresses$(), this.invoiceAddress$]).pipe(
+      map(
+        ([addresses, invoiceAddress]) =>
+          addresses &&
+          addresses
+            .filter(address => address.invoiceToAddress)
+            .filter(address => address.id !== (invoiceAddress && invoiceAddress.id))
+      )
+    );
+
+    combineLatest([this.addresses$, this.invoiceAddress$])
+      .pipe(
+        filter(([addresses]) => addresses && !!addresses.length),
+        take(1)
+      )
+      .subscribe(([addresses, invoiceAddress]) => {
+        if (!invoiceAddress && addresses.length === 1) {
+          this.checkoutFacade.assignBasketAddress(addresses[0].id, 'invoice');
+        }
+      });
+
+    this.form
+      .get('id')
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(invoiceAddressId => this.checkoutFacade.assignBasketAddress(invoiceAddressId, 'invoice'));
+
+    this.invoiceAddress$.pipe(takeUntil(this.destroy$)).subscribe(() => (this.collapse = true));
+  }
+
+  showAddressForm(address?: Address) {
+    this.editAddress = address;
+    this.collapse = false;
+  }
+
+  saveAddress(address: Address) {
+    if (this.editAddress) {
+      this.checkoutFacade.updateBasketAddress(address);
+    } else {
+      this.checkoutFacade.createBasketAddress(address, 'invoice');
+      (this.form.get('id') as FormControl).setValue('', { emitEvent: false });
+    }
+  }
+
+  cancelEditAddress() {
+    this.collapse = true;
+    this.editAddress = undefined;
+  }
+}

--- a/src/app/shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container.html
+++ b/src/app/shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container.html
@@ -1,0 +1,92 @@
+<h2>{{ 'checkout.address.shipping.label' | translate }}</h2>
+<ng-container *ngIf="shippingAddress$ | async as address">
+  <div class="address-box">
+    <ng-container *ngIf="!(basketInvoiceAndShippingAddressEqual$ | async)">
+      <div class="float-right">
+        <!-- edit shipping address -->
+        <a
+          *ngIf="collapseChange | async"
+          class="btn-tool"
+          title="{{ 'checkout.address.update.button.label' | translate }}"
+          (click)="showAddressForm(address)"
+          data-testing-id="edit-shipping-address-link"
+        >
+          <fa-icon [icon]="['fas', 'pencil-alt']"></fa-icon>
+        </a>
+
+        <!-- delete shipping address -->
+        <a
+          *ngIf="(basketShippingAddressDeletable$ | async) && (collapseChange | async)"
+          class="btn-tool"
+          title="{{ 'checkout.address.delete.button.label' | translate }}"
+          (click)="modalDialog.show(address)"
+        >
+          <fa-icon [icon]="['fas', 'trash-alt']"></fa-icon>
+        </a>
+
+        <ish-modal-dialog
+          #modalDialog
+          [options]="{
+            titleText: 'checkout.address.delete.confirmation.heading' | translate,
+            confirmText: 'checkout.address.button.delete' | translate,
+            rejectText: 'checkout.address.button.cancel' | translate
+          }"
+          (confirmed)="deleteAddress($event)"
+        >
+          <p>{{ 'checkout.address.delete.confirmation.text' | translate }}</p>
+          <small class="help-block">{{ 'checkout.address.delete.confirmation.deletionhint' | translate }}</small>
+        </ish-modal-dialog>
+      </div>
+
+      <!-- display shipping address -->
+      <ish-address [address]="address"></ish-address>
+    </ng-container>
+
+    <p *ngIf="basketInvoiceAndShippingAddressEqual$ | async" data-testing-id="sameAsInvoice" class="section">
+      {{ 'checkout.same_as_billing_address.text' | translate }}
+    </p>
+
+    <p></p>
+  </div>
+
+  <p *ngIf="!address && showErrors" class="text-danger">
+    {{ 'checkout.addresses.no_Selection.shipping.error' | translate }}
+  </p>
+</ng-container>
+
+<!-- shipping address selection -->
+<ng-container *ngIf="addresses$ | async as addresses">
+  <form *ngIf="addresses.length" [formGroup]="form">
+    <ish-select-address
+      [form]="form"
+      controlName="id"
+      [addresses]="addresses"
+      [emptyOptionLabel]="emptyOptionLabel$ | async"
+      inputClass="col-12"
+    ></ish-select-address>
+  </form>
+</ng-container>
+
+<!-- Add a new Shipping to address -->
+<div *ngIf="collapseChange | async" class="row">
+  <button
+    data-testing-id="create-shipping-address-link"
+    class="btn btn-link"
+    (click)="showAddressForm()"
+    [attr.aria-expanded]="!(collapseChange | async)"
+    aria-controls="collapseBasic"
+  >
+    {{ 'checkout.create_address.link' | translate }}
+  </button>
+</div>
+
+<!-- shipping address form -->
+<div id="collapseBasic" [ngbCollapse]="collapseChange | async" data-testing-id="shipping-address-form">
+  <ish-customer-address-form
+    [address]="editAddress"
+    [resetForm]="!(collapseChange | async)"
+    (save)="saveAddress($event)"
+    (cancel)="cancelEditAddress()"
+  >
+  </ish-customer-address-form>
+</div>

--- a/src/app/shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container.spec.ts
+++ b/src/app/shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container.spec.ts
@@ -1,0 +1,210 @@
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent, MockDirective } from 'ng-mocks';
+import { EMPTY, of } from 'rxjs';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
+import { findAllDataTestingIDs, findAllIshElements } from 'ish-core/utils/dev/html-query-utils';
+import { CustomerAddressFormComponent } from 'ish-shared/address-forms/components/customer-address-form/customer-address-form.component';
+import { AddressComponent } from 'ish-shared/address/components/address/address.component';
+import { ModalDialogComponent } from 'ish-shared/common/components/modal-dialog/modal-dialog.component';
+import { SelectAddressComponent } from 'ish-shared/forms/components/select-address/select-address.component';
+
+import { BasketShippingAddressWidgetContainerComponent } from './basket-shipping-address-widget.container';
+
+describe('Basket Shipping Address Widget Container', () => {
+  let component: BasketShippingAddressWidgetContainerComponent;
+  let fixture: ComponentFixture<BasketShippingAddressWidgetContainerComponent>;
+  let element: HTMLElement;
+  let checkoutFacade: CheckoutFacade;
+  let accountFacade: AccountFacade;
+
+  beforeEach(async(() => {
+    checkoutFacade = mock(CheckoutFacade);
+    when(checkoutFacade.basketShippingAddress$).thenReturn(EMPTY);
+
+    accountFacade = mock(AccountFacade);
+    when(accountFacade.addresses$()).thenReturn(EMPTY);
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [
+        BasketShippingAddressWidgetContainerComponent,
+        MockComponent(AddressComponent),
+        MockComponent(CustomerAddressFormComponent),
+        MockComponent(FaIconComponent),
+        MockComponent(ModalDialogComponent),
+        MockComponent(SelectAddressComponent),
+        MockDirective(NgbCollapse),
+      ],
+      providers: [
+        { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
+        { provide: AccountFacade, useFactory: () => instance(accountFacade) },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BasketShippingAddressWidgetContainerComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should render create link if shipping is not set', () => {
+    fixture.detectChanges();
+
+    expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+      Array [
+        "create-shipping-address-link",
+        "shipping-address-form",
+      ]
+    `);
+  });
+
+  describe('with shipping address on basket', () => {
+    beforeEach(() => {
+      const address = BasketMockData.getAddress();
+      when(checkoutFacade.basketShippingAddress$).thenReturn(of(address));
+      when(accountFacade.addresses$()).thenReturn(of([address, { ...address, id: 'test' }]));
+    });
+
+    it('should render if shipping is set', () => {
+      fixture.detectChanges();
+
+      expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+        Array [
+          "ish-address",
+          "ish-customer-address-form",
+          "ish-modal-dialog",
+          "ish-select-address",
+        ]
+      `);
+      expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+        Array [
+          "create-shipping-address-link",
+          "edit-shipping-address-link",
+          "shipping-address-form",
+        ]
+      `);
+    });
+
+    it('should expand form if shipping is edited', () => {
+      fixture.detectChanges();
+      (element.querySelector('a[data-testing-id="edit-shipping-address-link"') as HTMLLinkElement).click();
+      fixture.detectChanges();
+
+      expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+        Array [
+          "ish-address",
+          "ish-customer-address-form",
+          "ish-modal-dialog",
+          "ish-select-address",
+        ]
+      `);
+      expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+        Array [
+          "shipping-address-form",
+        ]
+      `);
+
+      const form = fixture.debugElement.query(By.css('ish-customer-address-form'))
+        .componentInstance as CustomerAddressFormComponent;
+      expect(form.address).toBeTruthy();
+    });
+
+    describe('with same invoice address', () => {
+      beforeEach(() => {
+        when(checkoutFacade.basketInvoiceAndShippingAddressEqual$).thenReturn(of(true));
+      });
+
+      it('should render if shipping is set', () => {
+        fixture.detectChanges();
+
+        expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+          Array [
+            "ish-customer-address-form",
+            "ish-select-address",
+          ]
+        `);
+        expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+          Array [
+            "create-shipping-address-link",
+            "sameAsInvoice",
+            "shipping-address-form",
+          ]
+        `);
+      });
+
+      it('should expand form if shipping is created', () => {
+        fixture.detectChanges();
+        (element.querySelector('[data-testing-id="create-shipping-address-link"') as HTMLLinkElement).click();
+        fixture.detectChanges();
+
+        expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+          Array [
+            "ish-customer-address-form",
+            "ish-select-address",
+          ]
+        `);
+        expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+          Array [
+            "sameAsInvoice",
+            "shipping-address-form",
+          ]
+        `);
+
+        const form = fixture.debugElement.query(By.css('ish-customer-address-form'))
+          .componentInstance as CustomerAddressFormComponent;
+        expect(form.address).toBeFalsy();
+      });
+    });
+  });
+
+  describe('address selection', () => {
+    const address = BasketMockData.getAddress();
+    const addresses = [
+      { ...address, id: '1', shipToAddress: false },
+      { ...address, id: '2', shipToAddress: true },
+      { ...address, id: '3', shipToAddress: true },
+      { ...address, id: '4', shipToAddress: true },
+    ];
+
+    beforeEach(() => {
+      when(checkoutFacade.basketShippingAddress$).thenReturn(of(addresses[1]));
+      when(accountFacade.addresses$()).thenReturn(of(addresses));
+    });
+
+    it('should only use valid addresses for selection display', () => {
+      fixture.detectChanges();
+
+      const selectAddress = fixture.debugElement.query(By.css('ish-select-address'))
+        .componentInstance as SelectAddressComponent;
+      expect(selectAddress.addresses.map(add => add.id)).toMatchInlineSnapshot(`
+        Array [
+          "3",
+          "4",
+        ]
+      `);
+    });
+
+    it('should update address after selecting', () => {
+      fixture.detectChanges();
+      component.form.setValue({ id: addresses[0].id });
+
+      verify(checkoutFacade.assignBasketAddress(anything(), 'shipping')).once();
+    });
+  });
+});

--- a/src/app/shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container.ts
+++ b/src/app/shared/checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container.ts
@@ -1,0 +1,112 @@
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { BehaviorSubject, Observable, Subject, combineLatest } from 'rxjs';
+import { filter, map, take, takeUntil } from 'rxjs/operators';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { Address } from 'ish-core/models/address/address.model';
+
+/**
+ * Standalone widget component for selecting and setting the basket shipping address in the checkout.
+ */
+@Component({
+  selector: 'ish-basket-shipping-address-widget-container',
+  templateUrl: './basket-shipping-address-widget.container.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BasketShippingAddressWidgetContainerComponent implements OnInit, OnDestroy {
+  @Input() showErrors = true;
+
+  @Output() collapseChange = new BehaviorSubject(true);
+
+  @Input()
+  set collapse(value: boolean) {
+    this.collapseChange.next(value);
+  }
+
+  shippingAddress$: Observable<Address>;
+  emptyOptionLabel$: Observable<string>;
+  addresses$: Observable<Address[]>;
+  basketInvoiceAndShippingAddressEqual$: Observable<boolean>;
+  basketShippingAddressDeletable$: Observable<boolean>;
+
+  form: FormGroup;
+  editAddress: Address;
+
+  private destroy$ = new Subject();
+
+  constructor(private checkoutFacade: CheckoutFacade, private accountFacade: AccountFacade) {
+    this.form = new FormGroup({
+      id: new FormControl(''),
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+  }
+
+  ngOnInit() {
+    this.shippingAddress$ = this.checkoutFacade.basketShippingAddress$;
+    this.basketInvoiceAndShippingAddressEqual$ = this.checkoutFacade.basketInvoiceAndShippingAddressEqual$;
+    this.basketShippingAddressDeletable$ = this.checkoutFacade.basketShippingAddressDeletable$;
+
+    this.emptyOptionLabel$ = this.shippingAddress$.pipe(
+      map(address =>
+        address
+          ? 'checkout.addresses.select_a_different_address.default'
+          : 'checkout.addresses.select_shipping_address.button'
+      )
+    );
+    this.addresses$ = combineLatest([this.accountFacade.addresses$(), this.shippingAddress$]).pipe(
+      map(
+        ([addresses, shippingAddress]) =>
+          addresses &&
+          addresses
+            .filter(address => address.shipToAddress)
+            .filter(address => address.id !== (shippingAddress && shippingAddress.id))
+      )
+    );
+
+    combineLatest([this.addresses$, this.shippingAddress$])
+      .pipe(
+        filter(([addresses]) => addresses && !!addresses.length),
+        take(1)
+      )
+      .subscribe(([addresses, shippingAddress]) => {
+        if (!shippingAddress && addresses.length === 1) {
+          this.checkoutFacade.assignBasketAddress(addresses[0].id, 'shipping');
+        }
+      });
+
+    this.form
+      .get('id')
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(shippingAddressId => this.checkoutFacade.assignBasketAddress(shippingAddressId, 'shipping'));
+
+    this.shippingAddress$.pipe(takeUntil(this.destroy$)).subscribe(() => (this.collapse = true));
+  }
+
+  showAddressForm(address?: Address) {
+    this.editAddress = address;
+    this.collapse = false;
+  }
+
+  saveAddress(address: Address) {
+    if (this.editAddress) {
+      this.checkoutFacade.updateBasketAddress(address);
+    } else {
+      this.checkoutFacade.createBasketAddress(address, 'shipping');
+      (this.form.get('id') as FormControl).setValue('', { emitEvent: false });
+    }
+  }
+
+  cancelEditAddress() {
+    this.collapse = true;
+    this.editAddress = undefined;
+  }
+
+  deleteAddress(address: Address) {
+    this.checkoutFacade.deleteBasketAddress(address.id);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -35,6 +35,8 @@ import { BasketValidationResultsComponent } from './basket/components/basket-val
 import { LineItemDescriptionComponent } from './basket/components/line-item-description/line-item-description.component';
 import { LineItemListComponent } from './basket/components/line-item-list/line-item-list.component';
 import { BasketPromotionContainerComponent } from './basket/containers/basket-promotion/basket-promotion.container';
+import { BasketInvoiceAddressWidgetContainerComponent } from './checkout/containers/basket-invoice-address-widget/basket-invoice-address-widget.container';
+import { BasketShippingAddressWidgetContainerComponent } from './checkout/containers/basket-shipping-address-widget/basket-shipping-address-widget.container';
 import { CMSModule } from './cms/cms.module';
 import { CMSCarouselComponent } from './cms/components/cms-carousel/cms-carousel.component';
 import { CMSContainerComponent } from './cms/components/cms-container/cms-container.component';
@@ -168,9 +170,11 @@ const exportedComponents = [
   BasketAddressSummaryComponent,
   BasketCostSummaryComponent,
   BasketInfoComponent,
+  BasketInvoiceAddressWidgetContainerComponent,
   BasketItemsSummaryComponent,
   BasketPromotionCodeComponent,
   BasketPromotionContainerComponent,
+  BasketShippingAddressWidgetContainerComponent,
   BasketValidationResultsComponent,
   BreadcrumbComponent,
   ContentIncludeContainerComponent,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -22,6 +22,7 @@ import { ShellModule } from 'ish-shell/shell.module';
 
 import { QuotingExportsModule } from '../extensions/quoting/exports/quoting-exports.module';
 
+import { AddressFormsSharedModule } from './address-forms/address-forms.module';
 import { AddressComponent } from './address/components/address/address.component';
 import { BasketAddressSummaryComponent } from './basket/components/basket-address-summary/basket-address-summary.component';
 import { BasketCostSummaryComponent } from './basket/components/basket-cost-summary/basket-cost-summary.component';
@@ -99,6 +100,7 @@ import { PromotionDetailsComponent } from './promotion/components/promotion-deta
 import { RecentlyViewedContainerComponent } from './recently/containers/recently-viewed/recently-viewed.container';
 
 const importExportModules = [
+  AddressFormsSharedModule,
   CMSModule,
   CommonModule,
   DeferLoadModule,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


- [ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

- Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For a customer project it is necessary to transform the 5-step checkout into a 4-step checkout. In this particular case the addresses-step is not used, instead invoice addresses should be selected in the payment step and shipping-addresses are selected in the shipment step.
To make this possible, the components for selecting addresses are transformed into widgets.

Issue Number: 


## What Is the New Behavior?
Address selection components are refactored into two widgets responsible for selecting invoice and shipping addresses on their own.

## Does this PR Introduce a Breaking Change?

No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other Information
