### PR TITLE
fix: repair memoization of promotion selectors

### DIFF
--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -192,13 +192,13 @@ export class ShoppingFacade {
   // PROMOTIONS
   promotion$(promotionId: string) {
     this.store.dispatch(new LoadPromotion({ promoId: promotionId }));
-    return this.store.pipe(select(getPromotion, { promoId: promotionId }));
+    return this.store.pipe(select(getPromotion(), { promoId: promotionId }));
   }
 
   promotions$(promotionIds: string[]) {
     promotionIds.forEach(promotionId => {
       this.store.dispatch(new LoadPromotion({ promoId: promotionId }));
     });
-    return this.store.pipe(select(getPromotions, { promotionIds }));
+    return this.store.pipe(select(getPromotions(), { promotionIds }));
   }
 }

--- a/src/app/core/store/shopping/promotions/promotions.selectors.spec.ts
+++ b/src/app/core/store/shopping/promotions/promotions.selectors.spec.ts
@@ -63,16 +63,39 @@ describe('Promotions Selectors', () => {
   describe('state with a promotion', () => {
     beforeEach(() => {
       store$.dispatch(new LoadPromotionSuccess({ promotion: promo }));
+      store$.dispatch(new LoadPromotionSuccess({ promotion: promo1 }));
     });
 
     describe('but no current router state', () => {
       it('should return the promotion information when used', () => {
-        expect(getPromotionEntities(store$.state)).toEqual({ [promo.id]: promo });
+        expect(getPromotionEntities(store$.state)).toMatchInlineSnapshot(`
+          Object {
+            "id": Object {
+              "id": "id",
+            },
+            "id1": Object {
+              "id": "id1",
+            },
+          }
+        `);
       });
 
       it('should return a promotion stub if promotion is selected', () => {
-        expect(getPromotion(store$.state, { promoId: promo.id })).toBeTruthy();
-        expect(getPromotions(store$.state, { promotionIds: [promo.id, promo1.id] })).toBeTruthy();
+        expect(getPromotion()(store$.state, { promoId: promo.id })).toMatchInlineSnapshot(`
+          Object {
+            "id": "id",
+          }
+        `);
+        expect(getPromotions()(store$.state, { promotionIds: [promo.id, promo1.id] })).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "id": "id",
+            },
+            Object {
+              "id": "id1",
+            },
+          ]
+        `);
       });
     });
   });

--- a/src/app/shared/components/basket/basket-promotion/basket-promotion.component.spec.ts
+++ b/src/app/shared/components/basket/basket-promotion/basket-promotion.component.spec.ts
@@ -8,6 +8,7 @@ import { instance, mock, when } from 'ts-mockito';
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { BasketRebate } from 'ish-core/models/basket-rebate/basket-rebate.model';
+import { Promotion } from 'ish-core/models/promotion/promotion.model';
 import { getICMBaseURL } from 'ish-core/store/configuration';
 import { PromotionDetailsComponent } from 'ish-shared/components/promotion/promotion-details/promotion-details.component';
 
@@ -51,7 +52,7 @@ describe('Basket Promotion Component', () => {
         id: 'PROMO_UUID',
         title: 'MyPromotionTitle',
         disableMessages: false,
-      })
+      } as Promotion)
     );
 
     component.rebate = {
@@ -74,7 +75,7 @@ describe('Basket Promotion Component', () => {
         id: 'PROMO_UUID',
         title: 'MyPromotionTitle',
         disableMessages: true,
-      })
+      } as Promotion)
     );
 
     component.rebate = {

--- a/src/app/shared/components/product/product-promotion/product-promotion.component.spec.ts
+++ b/src/app/shared/components/product/product-promotion/product-promotion.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { MockComponent } from 'ng-mocks';
-import { of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
@@ -19,6 +19,7 @@ describe('Product Promotion Component', () => {
 
   beforeEach(async(() => {
     shoppingFacade = mock(ShoppingFacade);
+    when(shoppingFacade.promotions$(anything())).thenReturn(EMPTY);
 
     TestBed.configureTestingModule({
       declarations: [


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


- [ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

- Bugfix

## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Promotions are not correctly memoized. When a promotion is edited during the runtime of the PWA, the memoization does not correctly re-fetch data from the store.

## What Is the New Behavior?

Promotions are correctly memoized.
