### PR TITLE
add anchor scrolling / fragment navigation for serverHtml content

### DIFF
--- a/src/app/core/directives/server-html.directive.ts
+++ b/src/app/core/directives/server-html.directive.ts
@@ -99,7 +99,11 @@ export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnD
         }
 
         if (cb && this.callbacks && typeof this.callbacks[cb] === 'function') {
+          // handle links with callback functions, e.g. <a callback="availableCallbackFunction">
           this.callbacks[cb]();
+        } else if (href.startsWith('#')) {
+          // handle fragment links / anchor navigation
+          document.getElementById(href.replace('#', '')).scrollIntoView({ block: 'start', behavior: 'smooth' });
         } else {
           // otherwise handle as routerLink
           this.router.navigateByUrl(href);


### PR DESCRIPTION
## What Is the Current Behavior?
Anchor scrolling / fragment navigation on a pages with content fetched via ICM CMS REST API doesn't work as expected. The ishServerHtml directive does not handle such links with only the a given anchor correctly, but will reload the application to a wrong route instead of scrolling on the current page. Complete routes with fragment navigation work as expected.

Such links do not work:
```<a href="#Software" title="Software">Software</a>```

These links would work:
```<a href="page://systempage.termsAndConditions.pagelet2-Page#OtherDocuments" title="OtherDocuments">Other Documents</a>```

This can be tested with the "Terms & Conditions" ICM demo content.

## What Is the New Behavior?

The ishServerHtml directive handles links like `<a href="#Software"` as anchor links and scrolls on the current page to the according anchor.


## Does this PR Introduce a Breaking Change?
 [x] No
