### PR TITLE
refactor: use class MockDirective instead of MockComponent to mock directives i…

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { CookieLawModule } from 'angular2-cookie-law';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { coreReducers } from 'ish-core/store/core-store.module';
@@ -27,7 +27,7 @@ describe('App Component', () => {
         AppComponent,
         MockComponent(FooterComponent),
         MockComponent(HeaderComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
       ],
       imports: [
         CookieLawModule,

--- a/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.spec.ts
+++ b/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { anything, capture, spy, verify } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
@@ -33,7 +33,7 @@ describe('Quote Edit Component', () => {
         MockComponent(LoadingComponent),
         MockComponent(QuoteStateComponent),
         MockComponent(RecentlyViewedComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
         QuoteEditComponent,
       ],
       imports: [ReactiveFormsModule, RouterTestingModule, TranslateModule.forRoot()],

--- a/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { LoadingComponent } from 'ish-shared/components/common/loading/loading.component';
@@ -19,7 +19,7 @@ describe('Account Order History Page Component', () => {
         AccountOrderHistoryPageComponent,
         MockComponent(LoadingComponent),
         MockComponent(OrderListComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
       ],
       imports: [TranslateModule.forRoot()],
     }).compileComponents();

--- a/src/app/pages/account-overview/account-overview/account-overview.component.spec.ts
+++ b/src/app/pages/account-overview/account-overview/account-overview.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { Customer } from 'ish-core/models/customer/customer.model';
@@ -27,7 +27,7 @@ describe('Account Overview Component', () => {
         MockComponent(FaIconComponent),
         MockComponent(LazyQuoteWidgetComponent),
         MockComponent(OrderWidgetComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
       ],
       imports: [TranslateModule.forRoot()],
     }).compileComponents();

--- a/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent, MockPipe } from 'ng-mocks';
+import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
 
 import { AVAILABLE_LOCALES } from 'ish-core/configurations/injection-keys';
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
@@ -31,7 +31,7 @@ describe('Account Profile Component', () => {
       declarations: [
         AccountProfileComponent,
         MockComponent(FaIconComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
         MockPipe(DatePipe),
       ],
       imports: [TranslateModule.forRoot()],

--- a/src/app/pages/forgot-password/request-reminder/request-reminder.component.spec.ts
+++ b/src/app/pages/forgot-password/request-reminder/request-reminder.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { coreReducers } from 'ish-core/store/core-store.module';
@@ -23,8 +23,8 @@ describe('Request Reminder Component', () => {
       declarations: [
         MockComponent(LoadingComponent),
         MockComponent(RequestReminderFormComponent),
-        MockComponent(ServerHtmlDirective),
         MockComponent(UpdatePasswordFormComponent),
+        MockDirective(ServerHtmlDirective),
         RequestReminderComponent,
       ],
       imports: [RouterTestingModule, TranslateModule.forRoot(), ngrxTesting({ reducers: coreReducers })],

--- a/src/app/pages/forgot-password/update-password/update-password.component.spec.ts
+++ b/src/app/pages/forgot-password/update-password/update-password.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { coreReducers } from 'ish-core/store/core-store.module';
@@ -23,8 +23,8 @@ describe('Update Password Component', () => {
       declarations: [
         MockComponent(LoadingComponent),
         MockComponent(RequestReminderFormComponent),
-        MockComponent(ServerHtmlDirective),
         MockComponent(UpdatePasswordFormComponent),
+        MockDirective(ServerHtmlDirective),
         UpdatePasswordComponent,
       ],
       imports: [RouterTestingModule, TranslateModule.forRoot(), ngrxTesting({ reducers: coreReducers })],

--- a/src/app/shared/address-forms/components/address-form-business/address-form-business.component.spec.ts
+++ b/src/app/shared/address-forms/components/address-form-business/address-form-business.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { AddressMockData } from 'ish-core/utils/dev/address-mock-data';
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
@@ -23,7 +23,7 @@ describe('Address Form Business Component', () => {
         FormControlFeedbackComponent,
         InputComponent,
         MockComponent(FaIconComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],
     }).compileComponents();

--- a/src/app/shared/cms/components/cms-image-enhanced/cms-image-enhanced.component.spec.ts
+++ b/src/app/shared/cms/components/cms-image-enhanced/cms-image-enhanced.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MockComponent } from 'ng-mocks';
+import { MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { createContentPageletView } from 'ish-core/models/content-view/content-view.model';
@@ -15,7 +15,7 @@ describe('Cms Image Enhanced Component', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      declarations: [CMSImageEnhancedComponent, MockComponent(ServerHtmlDirective)],
+      declarations: [CMSImageEnhancedComponent, MockDirective(ServerHtmlDirective)],
     }).compileComponents();
   }));
 

--- a/src/app/shared/components/product/product-promotion/product-promotion.component.spec.ts
+++ b/src/app/shared/components/product/product-promotion/product-promotion.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
@@ -24,7 +24,7 @@ describe('Product Promotion Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(PromotionDetailsComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
         ProductPromotionComponent,
       ],
       providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],

--- a/src/app/shared/components/promotion/promotion-details/promotion-details.component.spec.ts
+++ b/src/app/shared/components/promotion/promotion-details/promotion-details.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { configurationReducer } from 'ish-core/store/configuration/configuration.reducer';
@@ -19,7 +19,7 @@ describe('Promotion Details Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(ModalDialogLinkComponent),
-        MockComponent(ServerHtmlDirective),
+        MockDirective(ServerHtmlDirective),
         PromotionDetailsComponent,
       ],
       imports: [

--- a/src/app/shared/forms/components/checkbox/checkbox.component.spec.ts
+++ b/src/app/shared/forms/components/checkbox/checkbox.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -18,7 +18,7 @@ describe('Checkbox Component', () => {
       declarations: [
         CheckboxComponent,
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],
     }).compileComponents();

--- a/src/app/shared/forms/components/input-birthday/input-birthday.component.spec.ts
+++ b/src/app/shared/forms/components/input-birthday/input-birthday.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -18,7 +18,7 @@ describe('Input Birthday Component', () => {
       declarations: [
         InputBirthdayComponent,
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],
     })

--- a/src/app/shared/forms/components/input/input.component.spec.ts
+++ b/src/app/shared/forms/components/input/input.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -18,7 +18,7 @@ describe('Input Component', () => {
       declarations: [
         InputComponent,
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],
     })

--- a/src/app/shared/forms/components/select-address/select-address.component.spec.ts
+++ b/src/app/shared/forms/components/select-address/select-address.component.spec.ts
@@ -2,7 +2,7 @@ import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { Address } from 'ish-core/models/address/address.model';
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
@@ -19,7 +19,7 @@ describe('Select Address Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectAddressComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select-country/select-country.component.spec.ts
+++ b/src/app/shared/forms/components/select-country/select-country.component.spec.ts
@@ -2,7 +2,7 @@ import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -18,7 +18,7 @@ describe('Select Country Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectCountryComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select-language/select-language.component.spec.ts
+++ b/src/app/shared/forms/components/select-language/select-language.component.spec.ts
@@ -2,7 +2,7 @@ import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { Locale } from 'ish-core/models/locale/locale.model';
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
@@ -19,7 +19,7 @@ describe('Select Language Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectLanguageComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select-region/select-region.component.spec.ts
+++ b/src/app/shared/forms/components/select-region/select-region.component.spec.ts
@@ -2,7 +2,7 @@ import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -18,7 +18,7 @@ describe('Select Region Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectRegionComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select-security-question/select-security-question.component.spec.ts
+++ b/src/app/shared/forms/components/select-security-question/select-security-question.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -17,7 +17,7 @@ describe('Select Security Question Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectSecurityQuestionComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select-title/select-title.component.spec.ts
+++ b/src/app/shared/forms/components/select-title/select-title.component.spec.ts
@@ -2,7 +2,7 @@ import { SimpleChange, SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -18,7 +18,7 @@ describe('Select Title Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectTitleComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select-year-month/select-year-month.component.spec.ts
+++ b/src/app/shared/forms/components/select-year-month/select-year-month.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -17,7 +17,7 @@ describe('Select Year Month Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectYearMonthComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/select/select.component.spec.ts
+++ b/src/app/shared/forms/components/select/select.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { FormControlFeedbackComponent } from 'ish-shared/forms/components/form-control-feedback/form-control-feedback.component';
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
@@ -17,7 +17,7 @@ describe('Select Component', () => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent(FormControlFeedbackComponent),
-        MockComponent(ShowFormFeedbackDirective),
+        MockDirective(ShowFormFeedbackDirective),
         SelectComponent,
       ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/shared/forms/components/textarea/textarea.component.spec.ts
+++ b/src/app/shared/forms/components/textarea/textarea.component.spec.ts
@@ -2,7 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockDirective } from 'ng-mocks';
 
 import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form-feedback.directive';
 
@@ -15,7 +15,7 @@ describe('Textarea Component', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [MockComponent(ShowFormFeedbackDirective), TextareaComponent],
+      declarations: [MockDirective(ShowFormFeedbackDirective), TextareaComponent],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })

--- a/src/app/shell/footer/footer/footer.component.spec.ts
+++ b/src/app/shell/footer/footer/footer.component.spec.ts
@@ -3,7 +3,7 @@ import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { coreReducers } from 'ish-core/store/core-store.module';
@@ -24,7 +24,7 @@ describe('Footer Component', () => {
         TranslateModule.forRoot(),
         ngrxTesting({ reducers: coreReducers }),
       ],
-      declarations: [FooterComponent, MockComponent(FaIconComponent), MockComponent(ServerHtmlDirective)],
+      declarations: [FooterComponent, MockComponent(FaIconComponent), MockDirective(ServerHtmlDirective)],
     })
       .compileComponents()
       .then(() => {


### PR DESCRIPTION
## PR Type
 [ ] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [x] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
Some tests use class MockComponent to mock directives instead of class MockDirective.


## What Is the New Behavior?
Class MockDirective is used to mock directives in tests.


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No
