### PR TITLE
feat: localized product attributes

### DIFF
--- a/src/app/core/models/product/product.mapper.spec.ts
+++ b/src/app/core/models/product/product.mapper.spec.ts
@@ -114,6 +114,26 @@ describe('Product Mapper', () => {
       expect(product.type).toEqual('RetailSet');
       expect(ProductHelper.isRetailSet(product)).toBeTrue();
     });
+
+    it('should return attributes or detailed product attributes when PRODUCT_DETAIL_ATTRIBUTES enabled', () => {
+      const p1: Product = productMapper.fromData({
+        sku: '1',
+        attributes: [{ name: 'Graphics', type: 'String', value: 'NVIDIA Quadro K2200' }],
+      } as ProductData);
+      const p2: Product = productMapper.fromData(({
+        sku: '1',
+        attributes: [{ name: 'Graphics', type: 'String', value: 'NVIDIA Quadro K2200' }],
+        attributeGroups: {
+          PRODUCT_DETAIL_ATTRIBUTES: {
+            attributes: [{ name: 'Grafikkarte', type: 'String', value: 'NVIDIA Quadro K2200' }],
+          },
+        },
+      } as unknown) as ProductData);
+      expect(p1).toBeTruthy();
+      expect(p1.attributes).toEqual([{ name: 'Graphics', type: 'String', value: 'NVIDIA Quadro K2200' }]);
+      expect(p2).toBeTruthy();
+      expect(p2.attributes).toEqual([{ name: 'Grafikkarte', type: 'String', value: 'NVIDIA Quadro K2200' }]);
+    });
   });
 
   describe('fromStubData', () => {

--- a/src/app/core/models/product/product.mapper.ts
+++ b/src/app/core/models/product/product.mapper.ts
@@ -188,7 +188,11 @@ export class ProductMapper {
       minOrderQuantity: data.minOrderQuantity || 1,
       packingUnit: data.packingUnit,
       maxOrderQuantity: data.maxOrderQuantity || 100,
-      attributes: data.attributes,
+      attributes:
+        (data.attributeGroups &&
+          data.attributeGroups.PRODUCT_DETAIL_ATTRIBUTES &&
+          data.attributeGroups.PRODUCT_DETAIL_ATTRIBUTES.attributes) ||
+        data.attributes,
       attributeGroups: data.attributeGroups,
       images: this.imageMapper.fromImages(data.images),
       listPrice: filterPrice(data.listPrice),


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Feature  


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
Closes #91 

While localized calls to the `/products/<sku>` REST resource return the product attribute values as localized values the attribute names are still returned in English. This will then result in a language mix in localized storefronts.


## What Is the New Behavior?

The attribute values as well as the attribute names should be returned in the requested locale with the `/products/<sku>` call.


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No
