### PR TITLE
feat: add support for CMS Landing Page components

### DIFF
--- a/src/app/shared/cms/cms.module.ts
+++ b/src/app/shared/cms/cms.module.ts
@@ -6,6 +6,7 @@ import { CMSDialogComponent } from './components/cms-dialog/cms-dialog.component
 import { CMSFreestyleComponent } from './components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './components/cms-image/cms-image.component';
+import { CMSLandingPageComponent } from './components/cms-landing-page/cms-landing-page.component';
 import { CMSProductListComponent } from './components/cms-product-list/cms-product-list.component';
 import { CMSStandardPageComponent } from './components/cms-standard-page/cms-standard-page.component';
 import { CMSStaticPageComponent } from './components/cms-static-page/cms-static-page.component';
@@ -77,6 +78,14 @@ import { SfeAdapterService } from './sfe-adapter/sfe-adapter.service';
       useValue: {
         definitionQualifiedName: 'app_sf_responsive_cm:component.common.video.pagelet2-Component',
         class: CMSVideoComponent,
+      },
+      multi: true,
+    },
+    {
+      provide: CMS_COMPONENT,
+      useValue: {
+        definitionQualifiedName: 'app_sf_responsive_cm:component.shopping.landingPage.pagelet2-Component',
+        class: CMSLandingPageComponent,
       },
       multi: true,
     },

--- a/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.html
+++ b/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.html
@@ -1,0 +1,4 @@
+<ish-content-slot
+  [slot]="'app_sf_responsive_cm:slot.landingPage.content.pagelet2-Slot'"
+  [pagelet]="pagelet"
+></ish-content-slot>

--- a/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.spec.ts
+++ b/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
+
+import { ContentPagelet } from 'ish-core/models/content-pagelet/content-pagelet.model';
+import { ContentPageletView, createContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { ContentSlotComponent } from 'ish-shared/cms/components/content-slot/content-slot.component';
+
+import { CMSLandingPageComponent } from './cms-landing-page.component';
+
+describe('Cms Landing Page Component', () => {
+  let component: CMSLandingPageComponent;
+  let fixture: ComponentFixture<CMSLandingPageComponent>;
+  let element: HTMLElement;
+  let pageletView: ContentPageletView;
+  let pagelet: ContentPagelet;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CMSLandingPageComponent, MockComponent(ContentSlotComponent)],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CMSLandingPageComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    pagelet = {
+      domain: 'domain',
+      displayName: 'pagelet1',
+      definitionQualifiedName: 'fq',
+      id: 'id',
+      configurationParameters: {},
+    };
+    pageletView = createContentPageletView(pagelet);
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    component.pagelet = pageletView;
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+});

--- a/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.ts
+++ b/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+import { ContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { CMSComponent } from 'ish-shared/cms/models/cms-component/cms-component.model';
+
+/**
+ * The CMS Landing Page Component to render CMS managed content
+ * that is wrapped within a landing page component.
+ */
+@Component({
+  selector: 'ish-cms-landing-page',
+  templateUrl: './cms-landing-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CMSLandingPageComponent implements CMSComponent {
+  @Input() pagelet: ContentPageletView;
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -30,6 +30,7 @@ import { CMSDialogComponent } from './cms/components/cms-dialog/cms-dialog.compo
 import { CMSFreestyleComponent } from './cms/components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './cms/components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './cms/components/cms-image/cms-image.component';
+import { CMSLandingPageComponent } from './cms/components/cms-landing-page/cms-landing-page.component';
 import { CMSProductListComponent } from './cms/components/cms-product-list/cms-product-list.component';
 import { CMSStandardPageComponent } from './cms/components/cms-standard-page/cms-standard-page.component';
 import { CMSStaticPageComponent } from './cms/components/cms-static-page/cms-static-page.component';
@@ -136,6 +137,7 @@ const declaredComponents = [
   CMSFreestyleComponent,
   CMSImageComponent,
   CMSImageEnhancedComponent,
+  CMSLandingPageComponent,
   CMSProductListComponent,
   CMSStandardPageComponent,
   CMSStaticPageComponent,
@@ -221,6 +223,7 @@ const exportedComponents = [
     CMSFreestyleComponent,
     CMSImageComponent,
     CMSImageEnhancedComponent,
+    CMSLandingPageComponent,
     CMSProductListComponent,
     CMSStandardPageComponent,
     CMSStaticPageComponent,


### PR DESCRIPTION
Added PWA rendering support for CMS Landing Page components (e.g. Responsive Starter Store Homepage content). These components are basically caching wrappers in the classic ICM storefront. But with the support in the PWA content within such Landing Page components can be rendered too.