### PR TITLE
fix: quote dialog submit behaviour

### DIFF
--- a/e2e/cypress/integration/specs/quoting/quote-handling-anonymous.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/quoting/quote-handling-anonymous.b2b.e2e-spec.ts
@@ -44,15 +44,16 @@ describe('Quote Handling as Anonymous User', () => {
 
     it('user should be able to submit quote request', () => {
       at(ProductDetailPage, page => page.addProductToQuoteRequest());
-      at(QuoteRequestDialog, dialog => dialog.submitQuoteRequest());
-      at(QuoteDetailPage, page => {
-        page.productId.eq(0).should('contain', _.product.sku);
-        page.quoteState.should('have.text', 'Submitted');
+      at(QuoteRequestDialog, dialog => {
+        dialog.submitQuoteRequest();
+        dialog.productId.eq(0).should('contain', _.product.sku);
+        dialog.quoteState.should('have.text', 'Submitted');
+        dialog.hide();
       });
     });
 
     it('user should log out', () => {
-      at(QuoteDetailPage, page => page.header.logout());
+      at(ProductDetailPage, page => page.header.logout());
       at(HomePage);
     });
   });

--- a/e2e/cypress/integration/specs/quoting/quote-handling.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/quoting/quote-handling.b2b.e2e-spec.ts
@@ -97,6 +97,7 @@ describe('Quote Handling', () => {
     at(FamilyPage, page => page.productList.addProductToQuoteRequest(_.product.sku));
     at(QuoteRequestDialog, dialog => {
       dialog.submitQuoteRequest();
+      dialog.gotoQuoteDetail();
     });
     at(QuoteDetailPage, page => {
       page.quoteState.should('have.text', 'Submitted');
@@ -109,6 +110,7 @@ describe('Quote Handling', () => {
     at(FamilyPage, page => page.productList.addProductToQuoteRequest(_.product.sku));
     at(QuoteRequestDialog, dialog => {
       dialog.submitQuoteRequest();
+      dialog.gotoQuoteDetail();
     });
     at(QuoteDetailPage, page => {
       page.copyQuoteRequest();

--- a/src/app/extensions/quoting/facades/quoting.facade.ts
+++ b/src/app/extensions/quoting/facades/quoting.facade.ts
@@ -114,8 +114,8 @@ export class QuotingFacade {
     this.store.dispatch(new UpdateSubmitQuoteRequest(payload));
   }
 
-  copyQuoteRequest() {
-    this.store.dispatch(new CreateQuoteRequestFromQuoteRequest());
+  copyQuoteRequest(preventRedirect?: boolean) {
+    this.store.dispatch(new CreateQuoteRequestFromQuoteRequest({ redirect: !preventRedirect }));
   }
 
   updateQuoteRequestItem(update: LineItemUpdate) {

--- a/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.html
+++ b/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.html
@@ -1,12 +1,12 @@
-<ng-container *ngIf="activeQuoteRequest$ | async as quote">
+<ng-container *ngIf="selectedQuoteRequest$ | async as quote">
   <div class="modal-header">
     <h2 class="modal-title" *ngIf="quote">
       <!-- Titel and Description -->
-      <ng-container *ngIf="quote.displayName; else noDisplayName">
-        {{ 'quote.edit.unsubmitted.quote_request_details.text' | translate }} - {{ quote.displayName }}
+      <ng-container *ngIf="quote.state === 'Submitted'; else quoteTitle">
+        {{ 'quote.edit.submitted.heading' | translate }}
       </ng-container>
-      <ng-template #noDisplayName>
-        {{ 'quote.edit.unsubmitted.quote_request_details.text' | translate }} - {{ quote.number }}
+      <ng-template #quoteTitle>
+        {{ 'quote.edit.unsubmitted.quote_request_details.text' | translate }} - {{ quote.displayName || quote.number }}
       </ng-template>
     </h2>
     <button type="button" class="close" [attr.aria-label]="'dialog.close.text' | translate" (click)="hide()">
@@ -16,6 +16,24 @@
 
   <form [formGroup]="form" class="form-horizontal form-horizontal-inline">
     <div class="modal-body">
+      <!-- Submitted -->
+      <ng-container *ngIf="quote.state === 'Submitted' && user$ | async as user">
+        <p>
+          {{ 'quote.edit.submitted.your_quote_number.text' | translate }}
+          <a [routerLink]="['/account/quote-request', quote.id]" (click)="hide()">{{ quote.number }}</a>
+        </p>
+        <p
+          [ishServerHtml]="
+            'quote.edit.submitted.your_quote_request.text'
+              | translate: { '0': 'route://account/quote-list', '1': 'route://account' }
+          "
+          [callbacks]="{
+            callbackHideDialogModal: callbackHideDialogModal
+          }"
+        ></p>
+        <p>{{ 'quote.edit.submitted.we_will_email.text' | translate: { '0': user.email } }}</p>
+      </ng-container>
+
       <ng-container *ngIf="quote">
         <div class="row">
           <label class="col-4 col-md-3 col-xl-2 col-form-label">{{
@@ -39,28 +57,45 @@
 
         <div class="section">
           <!-- displayName -->
-          <ish-input
-            [form]="form"
-            controlName="displayName"
-            label="quote.edit.unsubmitted.name.label"
-            labelClass="col-4 col-md-3 col-xl-2"
-            inputClass="col-8 col-md-9 col-xl-10"
-            maxLength="256"
-            [placeholder]="'quote.edit.unsubmitted.enter_an_optional_name.text'"
-          ></ish-input>
+          <ng-container *ngIf="quote.state != 'Submitted'; else staticDisplayName">
+            <ish-input
+              [form]="form"
+              controlName="displayName"
+              label="quote.edit.unsubmitted.name.label"
+              labelClass="col-4 col-md-3 col-xl-2"
+              inputClass="col-8 col-md-9 col-xl-10"
+              maxLength="256"
+              [placeholder]="'quote.edit.unsubmitted.enter_an_optional_name.text'"
+            ></ish-input>
+          </ng-container>
+          <ng-template #staticDisplayName>
+            <div class="row has-feedback">
+              <label class="col-4 col-md-3 col-xl-2 col-form-label">{{
+                'quote.edit.unsubmitted.name.label' | translate
+              }}</label>
+              <div class="col-8 col-md-9 col-xl-10">
+                <p class="form-control-plaintext">{{ quote.displayName }}</p>
+              </div>
+            </div>
+          </ng-template>
 
+          <!-- description -->
           <div class="row form-group">
-            <label for="#SHOUD_EQUAL_TEXTAREA_ID#" class="col-form-label col-4 col-md-3 col-xl-2">{{
+            <label for="quote-description" class="col-form-label col-4 col-md-3 col-xl-2">{{
               'quote.edit.unsubmitted.comment.label' | translate
             }}</label>
             <div class="col-8 col-md-9 col-xl-10">
-              <textarea
-                formControlName="description"
-                class="form-control"
-                [placeholder]="'quote.edit.unsubmitted.provide_comment.text' | translate"
-              >
-              </textarea>
-              <!-- ><isif condition="#QuoteEditForm:Invalid#"><isprint value="#QuoteEditForm:Description:Value#"><iselse><isprint value="#Quote:Description#"></isif></textarea> -->
+              <ng-container *ngIf="quote.state != 'Submitted'; else staticDescription">
+                <textarea
+                  formControlName="description"
+                  class="form-control"
+                  [placeholder]="'quote.edit.unsubmitted.provide_comment.text' | translate"
+                  id="quote-description"
+                ></textarea>
+              </ng-container>
+              <ng-template #staticDescription>
+                <p class="form-control-plaintext">{{ quote.description }}</p>
+              </ng-template>
             </div>
           </div>
         </div>
@@ -85,27 +120,31 @@
 
     <div class="modal-footer flex-wrap flex-row-reverse justify-content-between">
       <div>
-        <button
-          *ngIf="quote"
-          type="submit"
-          class="btn btn-secondary"
-          [disabled]="!quote"
-          (click)="update()"
-          data-testing-id="saveQuoteRequest"
-        >
-          {{ 'quote.edit.button.save.label' | translate }}
-        </button>
-        <button
-          *ngIf="quote"
-          [routerLink]="'/account/quote-request/' + quote.id"
-          type="submit"
-          class="btn btn-primary"
-          [disabled]="quote.items.length === 0"
-          (click)="submit()"
-          data-testing-id="submitQuoteRequest"
-        >
-          {{ 'quote.edit.button.submit.label' | translate }}
-        </button>
+        <ng-container *ngIf="quote.state != 'Submitted'; else copyQuoteRequest">
+          <button
+            type="submit"
+            class="btn btn-secondary"
+            [disabled]="!quote"
+            (click)="update()"
+            data-testing-id="saveQuoteRequest"
+          >
+            {{ 'quote.edit.button.save.label' | translate }}
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary"
+            [disabled]="quote.items.length === 0"
+            (click)="submit()"
+            data-testing-id="submitQuoteRequest"
+          >
+            {{ 'quote.edit.button.submit.label' | translate }}
+          </button>
+        </ng-container>
+        <ng-template #copyQuoteRequest>
+          <button class="btn btn-secondary" name="copy" type="submit" (click)="copy()">
+            {{ 'quote.edit.button.create_new_from_quote.label' | translate }}
+          </button>
+        </ng-template>
       </div>
       <div class="d-md-none row form-group md-left">
         <a routerLink="/account/quote-list" (click)="hide()">{{ 'quote.edit.back_to_quotes.link' | translate }}</a>

--- a/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.spec.ts
+++ b/src/app/extensions/quoting/shared/product/product-add-to-quote-dialog/product-add-to-quote-dialog.component.spec.ts
@@ -3,11 +3,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { AccountFacade } from 'ish-core/facades/account.facade';
 import { MessageFacade } from 'ish-core/facades/message.facade';
+import { DatePipe } from 'ish-core/pipes/date.pipe';
 import { LineItemListComponent } from 'ish-shared/components/basket/line-item-list/line-item-list.component';
 import { LoadingComponent } from 'ish-shared/components/common/loading/loading.component';
 import { InputComponent } from 'ish-shared/forms/components/input/input.component';
@@ -23,10 +26,12 @@ describe('Product Add To Quote Dialog Component', () => {
   let element: HTMLElement;
   let quotingFacade: QuotingFacade;
   let messageFacade: MessageFacade;
+  let accountFacade: AccountFacade;
 
   beforeEach(async(() => {
     quotingFacade = mock(QuotingFacade);
     messageFacade = mock(MessageFacade);
+    accountFacade = mock(AccountFacade);
 
     TestBed.configureTestingModule({
       imports: [ReactiveFormsModule, RouterTestingModule, TranslateModule.forRoot()],
@@ -35,12 +40,15 @@ describe('Product Add To Quote Dialog Component', () => {
         MockComponent(LineItemListComponent),
         MockComponent(LoadingComponent),
         MockComponent(QuoteStateComponent),
+        MockDirective(ServerHtmlDirective),
+        MockPipe(DatePipe),
         ProductAddToQuoteDialogComponent,
       ],
       providers: [
         NgbActiveModal,
         { provide: QuotingFacade, useFactory: () => instance(quotingFacade) },
         { provide: MessageFacade, useFactory: () => instance(messageFacade) },
+        { provide: AccountFacade, useFactory: () => instance(accountFacade) },
       ],
     }).compileComponents();
   }));
@@ -49,10 +57,11 @@ describe('Product Add To Quote Dialog Component', () => {
     fixture = TestBed.createComponent(ProductAddToQuoteDialogComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
+    when(quotingFacade.activeQuoteRequest$).thenReturn(EMPTY);
   });
 
   it('should be created', () => {
-    when(quotingFacade.activeQuoteRequest$).thenReturn(EMPTY);
+    when(quotingFacade.quoteRequest$).thenReturn(EMPTY);
 
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
@@ -61,7 +70,7 @@ describe('Product Add To Quote Dialog Component', () => {
 
   describe('Quote Request', () => {
     beforeEach(() => {
-      when(quotingFacade.activeQuoteRequest$).thenReturn(
+      when(quotingFacade.quoteRequest$).thenReturn(
         of({
           id: 'ID',
           type: 'QuoteRequest',

--- a/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.html
+++ b/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.html
@@ -106,7 +106,7 @@
     ></ish-input>
     <ng-template #staticDisplayName>
       <div class="row has-feedback">
-        <label for="#SHOUD_EQUAL_INPUT_ID#" class="col-4 col-md-3 col-xl-2 col-form-label">{{
+        <label class="col-4 col-md-3 col-xl-2 col-form-label">{{
           'quote.edit.unsubmitted.name.label' | translate
         }}</label>
         <div class="col-8 col-md-9 col-xl-10">
@@ -120,7 +120,7 @@
       class="row"
       [ngClass]="{ 'form-group': quote.state === 'New' }"
     >
-      <label for="#SHOUD_EQUAL_TEXTAREA_ID#" class="col-4 col-md-3 col-xl-2 col-form-label">{{
+      <label for="quote-description" class="col-4 col-md-3 col-xl-2 col-form-label">{{
         'quote.edit.unsubmitted.comment.label' | translate
       }}</label>
       <div class="col-8 col-md-9 col-xl-10">
@@ -129,6 +129,7 @@
             formControlName="description"
             class="form-control"
             [placeholder]="'quote.edit.unsubmitted.provide_comment.text' | translate"
+            id="quote-description"
           >
           </textarea>
         </ng-container>

--- a/src/app/extensions/quoting/store/quote-request/quote-request.actions.ts
+++ b/src/app/extensions/quoting/store/quote-request/quote-request.actions.ts
@@ -129,6 +129,7 @@ export class UpdateSubmitQuoteRequest implements Action {
 
 export class CreateQuoteRequestFromQuoteRequest implements Action {
   readonly type = QuoteRequestActionTypes.CreateQuoteRequestFromQuoteRequest;
+  constructor(public payload?: { redirect?: boolean }) {}
 }
 
 export class CreateQuoteRequestFromQuoteRequestFail implements Action {

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -2486,7 +2486,7 @@
   "quote.edit.products_not_available.text": "Die folgenden Produkte können in das aktuelle Preisangebot nicht aufgenommen werden, weil sie veraltet oder nicht verfügbar sind:",
   "quote.edit.submitted.heading": "Vielen Dank für Ihre Preisanfrage",
   "quote.edit.submitted.your_quote_number.text": "Ihre Preisangebotsnummer lautet:",
-  "quote.edit.submitted.your_quote_request.text": "Ihre Preisanfrage wurde gesendet.<br/>Den Status ihrer <a href=\"{{0}}\">Preisangebote</a> können Sie im Bereich <a href=\"{{1}}\">Mein Konto</a> einsehen.",
+  "quote.edit.submitted.your_quote_request.text": "Ihre Preisanfrage wurde gesendet.<br/>Den Status ihrer <a callback=\"callbackHideDialogModal\" href=\"{{0}}\">Preisangebote</a> können Sie im Bereich <a callback=\"callbackHideDialogModal\" href=\"{{1}}\">Mein Konto</a> einsehen.",
   "quote.edit.submitted.we_will_email.text": "Wir werden per E-Mail {{0}} über den Status ihres Preisangebots informieren.",
   "quote.edit.unsubmitted.quote_request_details.text": "Details der Preisanfrage",
   "quote.edit.responded.quote_details.text": "Preisangebot-Details",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -2486,7 +2486,7 @@
   "quote.edit.products_not_available.text": "The following products cannot be added to the current quote because the products are outdated or not available:",
   "quote.edit.submitted.heading": "Thank you for your quote request",
   "quote.edit.submitted.your_quote_number.text": "Your quote number is:",
-  "quote.edit.submitted.your_quote_request.text": "Your quote request has been submitted.<br/>You can check the status of your <a href=\"{{0}}\">quotes</a> in your <a href=\"{{1}}\">My Account</a> section.",
+  "quote.edit.submitted.your_quote_request.text": "Your quote request has been submitted.<br/>You can check the status of your <a callback=\"callbackHideDialogModal\" href=\"{{0}}\">quotes</a> in your <a callback=\"callbackHideDialogModal\" href=\"{{1}}\">My Account</a> section.",
   "quote.edit.submitted.we_will_email.text": "We will e-mail {{0}} to keep you updated on the status of your quote.",
   "quote.edit.unsubmitted.quote_request_details.text": "Quote Request Details",
   "quote.edit.responded.quote_details.text": "Quote Details",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -2485,7 +2485,7 @@
   "quote.edit.products_not_available.text": "Impossible d’ajouter les produits suivants au devis actuel car ils sont devenus obsolètes ou ne sont plus disponibles :",
   "quote.edit.submitted.heading": "Nous vous remercions pour votre demande de devis",
   "quote.edit.submitted.your_quote_number.text": "Votre numéro de devis est :",
-  "quote.edit.submitted.your_quote_request.text": "Votre demande de devis a été soumise.<br/>Vous pouvez consulter l’état de vos <a href=\"{{0}}\">devis</a> dans la section <a href=\"{{1}}\">Mon compte</a>.",
+  "quote.edit.submitted.your_quote_request.text": "Votre demande de devis a été soumise.<br/>Vous pouvez consulter l’état de vos <a callback=\"callbackHideDialogModal\" href=\"{{0}}\">devis</a> dans la section <a callback=\"callbackHideDialogModal\" href=\"{{1}}\">Mon compte</a>.",
   "quote.edit.submitted.we_will_email.text": "Nous vous enverrons un courriel à {{0}} pour vous tenir au courant de l’état de votre devis.",
   "quote.edit.unsubmitted.quote_request_details.text": "Détails de la demande de devis",
   "quote.edit.responded.quote_details.text": "Détails du devis",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->



"Submit Quote Request" links to quote request details in my account area. The user loses his context.
(Issue Number: ISREST-941)

## What Is the New Behavior?

Click on "Submit Quote Request" - closes modal and shows "Thank you for your quote request" in a new modal. 
(Additional: Behaviour of "Create new QuoteRequest from QuoteRequest" in Dialog)


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No
