### PR TITLE
fix: Angular decorator imports are removed on save

### DIFF
--- a/schematics/src/service/factory_spec.ts
+++ b/schematics/src/service/factory_spec.ts
@@ -24,7 +24,9 @@ describe('Service Schematic', () => {
     expect(files).toContain('/projects/bar/src/app/core/services/foo/foo.service.spec.ts');
     expect(files).toContain('/projects/bar/src/app/core/services/foo/foo.service.ts');
 
-    expect(tree.readContent('/projects/bar/src/app/core/services/foo/foo.service.ts')).toContain('../api/api.service');
+    expect(tree.readContent('/projects/bar/src/app/core/services/foo/foo.service.ts')).toContain(
+      'ish-core/services/api/api.service'
+    );
   });
 
   it('should ignore folders in name', async () => {

--- a/schematics/src/service/files/__name@dasherize__/__name@dasherize__.service.__tsext__
+++ b/schematics/src/service/files/__name@dasherize__/__name@dasherize__.service.__tsext__
@@ -1,8 +1,12 @@
 import { Injectable } from '@angular/core';
 
-import { ApiService } from '<% if(!extension) { %>..<% } else { %>ish-core/services<% } %>/api/api.service';
+import { ApiService } from 'ish-core/services/api/api.service';
 
 @Injectable({ providedIn: 'root' })
 export class <%= classify(name) %>Service {
   constructor(private apiService: ApiService) {}
+
+  get<%= classify(name) %>() {
+    return this.apiService.get('<%= dasherize(name) %>');
+  }
 }

--- a/src/app/core/store/checkout/viewconf/viewconf.effects.ts
+++ b/src/app/core/store/checkout/viewconf/viewconf.effects.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect } from '@ngrx/effects';
-import { Store } from '@ngrx/store';
 import { mapToData, ofRoute } from 'ngrx-router';
 import { map } from 'rxjs/operators';
 
@@ -8,7 +7,7 @@ import { SetCheckoutStep } from './viewconf.actions';
 
 @Injectable()
 export class ViewconfEffects {
-  constructor(private actions$: Actions, private store: Store<{}>) {}
+  constructor(private actions$: Actions) {}
 
   @Effect()
   retrieveCheckoutStepFromRouting$ = this.actions$.pipe(

--- a/src/app/core/store/contact/contact/contact.effects.ts
+++ b/src/app/core/store/contact/contact/contact.effects.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Store } from '@ngrx/store';
 import { concatMap, map, mapTo } from 'rxjs/operators';
 
 import { ContactService } from 'ish-core/services/contact/contact.service';
@@ -10,7 +9,7 @@ import * as ContactActions from './contact.actions';
 
 @Injectable()
 export class ContactEffects {
-  constructor(private actions$: Actions, private store: Store<{}>, private contactService: ContactService) {}
+  constructor(private actions$: Actions, private contactService: ContactService) {}
 
   /**
    * Load the contact subjects, which the customer can select for his request

--- a/src/app/pages/basket/shopping-basket/shopping-basket.component.ts
+++ b/src/app/pages/basket/shopping-basket/shopping-basket.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
 
 import { BasketView } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
@@ -40,7 +39,7 @@ export class ShoppingBasketComponent {
   form: FormGroup;
   submitted = false;
 
-  constructor(private router: Router) {
+  constructor() {
     this.form = new FormGroup({});
   }
 

--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.ts
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.ts
@@ -10,7 +10,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { FormlyFormOptions } from '@ngx-formly/core';
 import { Subject } from 'rxjs';
 import { filter, take, takeUntil } from 'rxjs/operators';
@@ -58,7 +58,7 @@ export class CheckoutPaymentComponent implements OnInit, OnChanges, OnDestroy {
 
   private destroy$ = new Subject();
 
-  constructor(private route: ActivatedRoute, private router: Router) {}
+  constructor(private route: ActivatedRoute) {}
 
   /**
    * create payment form

--- a/src/app/pages/checkout-shipping/checkout-shipping/checkout-shipping.component.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping/checkout-shipping.component.ts
@@ -10,7 +10,6 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -35,8 +34,6 @@ export class CheckoutShippingComponent implements OnInit, OnChanges, OnDestroy {
   submitted = false;
 
   private destroy$ = new Subject();
-
-  constructor(private router: Router) {}
 
   ngOnInit() {
     this.shippingForm = new FormGroup({

--- a/src/app/shared/components/basket/basket-info/basket-info.component.ts
+++ b/src/app/shared/components/basket/basket-info/basket-info.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -19,7 +19,7 @@ import { BasketInfo } from 'ish-core/models/basket-info/basket-info.model';
 })
 export class BasketInfoComponent implements OnInit {
   infoMessages$: Observable<BasketInfo[]>;
-  constructor(private checkoutFacade: CheckoutFacade, private cd: ChangeDetectorRef) {}
+  constructor(private checkoutFacade: CheckoutFacade) {}
 
   ngOnInit() {
     this.infoMessages$ = this.checkoutFacade.basketInfo$.pipe(

--- a/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.ts
+++ b/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.ts
@@ -1,12 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { uniq } from 'lodash-es';
 import { Observable, Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
@@ -42,7 +34,7 @@ export class BasketValidationResultsComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject();
 
-  constructor(private checkoutFacade: CheckoutFacade, private cd: ChangeDetectorRef) {}
+  constructor(private checkoutFacade: CheckoutFacade) {}
 
   @Output() continueCheckout = new EventEmitter<void>();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
       "ngrx-router": ["src/ngrx-router"]
     },
     "typeRoots": ["node_modules/@types", "node_modules/jest-extended"],
-    "lib": ["es2018", "dom"]
+    "lib": ["es2018", "dom"],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/tslint.json
+++ b/tslint.json
@@ -99,7 +99,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-unused-declaration": true,
     "no-parameter-reassignment": true,
     "throw-error": true,
     "no-var-keyword": true,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [x] Refactoring (no functional changes, no API changes)  
 [x] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sometimes VSCode+tslint removes imports of decorators although they are not unused.




## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No

