### PR TITLE
fix: minor quoting issues

### DIFF
--- a/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.html
+++ b/src/app/extensions/quoting/shared/quote/quote-edit/quote-edit.component.html
@@ -45,15 +45,12 @@
       {{ 'quote.edit.submitted.your_quote_number.text' | translate }}
       <a [routerLink]="['/account/quote-request', quote.id]">{{ quote.number }}</a>
     </p>
-    <p>
-      {{ 'quote.edit.submitted.your_quote_request.text' | translate }} <br />
-      <span
-        [ishServerHtml]="
-          'quote.edit.submitted.you_can_check.text'
-            | translate: { '0': 'route://account/quote-list', '1': 'route://account' }
-        "
-      ></span>
-    </p>
+    <p
+      [ishServerHtml]="
+        'quote.edit.submitted.you_can_check.text'
+          | translate: { '0': 'route://account/quote-list', '1': 'route://account' }
+      "
+    ></p>
     <p>{{ 'quote.edit.submitted.we_will_email.text' | translate: { '0': user.email } }}</p>
   </ng-container>
 

--- a/src/app/pages/account/account-page.module.ts
+++ b/src/app/pages/account/account-page.module.ts
@@ -57,7 +57,12 @@ const accountPageRoutes: Routes = [
       },
       {
         path: 'quote',
-        data: { breadcrumbData: [{ key: 'quote.quotes.link' }] },
+        data: {
+          breadcrumbData: [
+            { key: 'quote.quotes.link', link: '/account/quote-list' },
+            { key: 'quote.quote_details.link' },
+          ],
+        },
         loadChildren: () =>
           import('../../extensions/quoting/pages/quote-edit/quote-edit-page.module').then(m => m.QuoteEditPageModule),
       },

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -2484,7 +2484,7 @@
   "quote.edit.product_not_available.text": "Das Produkt {{0}} ist nicht verfügbar und kann in die aktuelle Bestellanfrage nicht eingefügt werden.",
   "quote.edit.cannot_copy_quote.text": "Das Preisangebot kann nicht kopiert werden, weil alle Produkte veraltet oder nicht verfügbar sind.",
   "quote.edit.products_not_available.text": "Die folgenden Produkte können in das aktuelle Preisangebot nicht aufgenommen werden, weil sie veraltet oder nicht verfügbar sind:",
-  "quote.edit.submitted.heading": "Vielen Dank für Ihr Preisangebot!",
+  "quote.edit.submitted.heading": "Vielen Dank für Ihre Preisanfrage",
   "quote.edit.submitted.your_quote_number.text": "Ihre Preisangebotsnummer lautet:",
   "quote.edit.submitted.your_quote_request.text": "Ihre Preisanfrage wurde gesendet.",
   "quote.edit.submitted.you_can_check.text": "Den Status ihrer <a href=\"{{0}}\">Preisangebote</a> können Sie im Bereich <a href=\"{{1}}\">Mein Konto</a> einsehen.",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -2484,7 +2484,7 @@
   "quote.edit.product_not_available.text": "The product {{0}} is not available and cannot be added to the current requisition.",
   "quote.edit.cannot_copy_quote.text": "The quote cannot be copied because all products are outdated or not available.",
   "quote.edit.products_not_available.text": "The following products cannot be added to the current quote because the products are outdated or not available:",
-  "quote.edit.submitted.heading": "THANK YOU FOR YOUR QUOTE",
+  "quote.edit.submitted.heading": "Thank you for your quote request",
   "quote.edit.submitted.your_quote_number.text": "Your quote number is:",
   "quote.edit.submitted.your_quote_request.text": "Your quote request has been submitted.",
   "quote.edit.submitted.you_can_check.text": "You can check the status of your <a href=\"{{0}}\">quotes</a> in your <a href=\"{{1}}\">My Account</a> section.",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -2483,7 +2483,7 @@
   "quote.edit.product_not_available.text": "Le produit {{0}} n’est pas disponible et ne peut pas être ajouté à la demande d’achat actuelle.",
   "quote.edit.cannot_copy_quote.text": "Impossible de copier le devis car tous les produits sont devenus obsolètes ou ne sont plus disponibles.",
   "quote.edit.products_not_available.text": "Impossible d’ajouter les produits suivants au devis actuel car ils sont devenus obsolètes ou ne sont plus disponibles :",
-  "quote.edit.submitted.heading": "NOUS VOUS REMERCIONS POUR VOTRE DEVIS",
+  "quote.edit.submitted.heading": "Nous vous remercions pour votre demande de devis",
   "quote.edit.submitted.your_quote_number.text": "Votre numéro de devis est :",
   "quote.edit.submitted.your_quote_request.text": "Votre demande de devis a été soumise.",
   "quote.edit.submitted.you_can_check.text": "Vous pouvez consulter l’état de vos <a href=\"{{0}}\">devis</a> dans la section <a href=\"{{1}}\">Mon compte</a>.",


### PR DESCRIPTION
## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  

_Issue Number: ISREST-945 - Rename "Thank you for your quote" page_
**Current Behavior**
Heading: Thank you for your quote => user submitted no quote, it is a quote request
**Expected Behavior**
Heading: Thank you for your quote request



_Issue Number: ISREST-944 - Quoting - Thank you for your quote request displays additional info message with duplicated content_
**Current Behavior**
"Thank you for your quote request" page displays an additional info message, which displays the same content like the page.
**Expected Behavior**
Remove duplicated content regarding the quote request state on this page.

_Quote Detail page (in comparison to the Quote Request Detail page) does not display a complete breadcrumb_
**Current Behavior**
Home/ My Account/ Quotes
**Expected Behavior**
Home/ My Account/ Quotes/ Quote Details

