### PR TITLE
fix: display of product labels for product lists (#73)

### DIFF
--- a/src/app/core/models/product/__snapshots__/product.mapper.spec.ts.snap
+++ b/src/app/core/models/product/__snapshots__/product.mapper.spec.ts.snap
@@ -2,7 +2,17 @@
 
 exports[`Product Mapper fromStubData should construct a stub when supplied with a complex API response 1`] = `
 Object {
-  "attributeGroups": undefined,
+  "attributeGroups": Object {
+    "attrGroup": Object {
+      "attributes": Array [
+        Object {
+          "name": "attrName",
+          "type": "Boolean",
+          "value": true,
+        },
+      ],
+    },
+  },
   "availability": true,
   "completenessLevel": 2,
   "defaultCategoryId": undefined,

--- a/src/app/core/models/product/product.interface.ts
+++ b/src/app/core/models/product/product.interface.ts
@@ -74,7 +74,7 @@ export interface ProductData {
 }
 
 export interface ProductDataStub {
-  attributeGroups?: { [id: string]: AttributeGroup };
+  attributeGroup?: { name: string; attributes: Attribute[] };
   attributes: Attribute[];
   description: string;
   title: string;

--- a/src/app/core/models/product/product.mapper.spec.ts
+++ b/src/app/core/models/product/product.mapper.spec.ts
@@ -148,6 +148,16 @@ describe('Product Mapper', () => {
         attributes: [{ name: 'sku', value: 'productSKU', type: 'String' }],
         title: 'productName',
         description: 'productDescription',
+        attributeGroup: {
+          name: 'attrGroup',
+          attributes: [
+            {
+              name: 'attrName',
+              type: 'Boolean',
+              value: true,
+            },
+          ],
+        },
       });
       expect(stub).toBeTruthy();
       expect(stub.name).toEqual('productName');
@@ -177,6 +187,16 @@ describe('Product Mapper', () => {
         ] as Attribute[],
         description: 'EasyShare M552, 14MP, 6.858 cm (2.7 ") LCD, 4x, 28mm, HD 720p, Black',
         title: 'Kodak M series EasyShare M552',
+        attributeGroup: {
+          name: 'attrGroup',
+          attributes: [
+            {
+              name: 'attrName',
+              type: 'Boolean',
+              value: true,
+            },
+          ],
+        },
       });
 
       expect(stub).toMatchSnapshot();

--- a/src/app/core/models/product/product.mapper.ts
+++ b/src/app/core/models/product/product.mapper.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 
+import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.model';
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { CategoryData } from 'ish-core/models/category/category.interface';
 import { CategoryMapper } from 'ish-core/models/category/category.mapper';
@@ -31,6 +32,13 @@ function retrieveStubAttributeValue<T>(data: ProductDataStub, attributeName: str
  */
 function mapPromotionIds(data: Link[]): string[] {
   return data ? data.map(promotionLink => promotionLink.itemId) : [];
+}
+
+/**
+ * maps an attribute group and its attribute data to the same format as it is used in a single product call
+ */
+function mapAttributeGroups(data: ProductDataStub): { [id: string]: AttributeGroup } {
+  return { [data.attributeGroup.name]: { attributes: data.attributeGroup.attributes } };
 }
 
 /**
@@ -142,7 +150,7 @@ export class ProductMapper {
       longDescription: undefined,
       minOrderQuantity,
       packingUnit: retrieveStubAttributeValue(data, 'packingUnit'),
-      attributeGroups: data.attributeGroups,
+      attributeGroups: data.attributeGroup && mapAttributeGroups(data),
       readyForShipmentMin: undefined,
       readyForShipmentMax: undefined,
       roundedAverageRating: +retrieveStubAttributeValue<string>(data, 'roundedAverageRating') || 0,

--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -30,12 +30,32 @@ describe('Products Service', () => {
         uri: '/categories/CategoryID/products/ProductA',
         title: 'Product A',
         attributes: [{ name: 'sku', type: 'String', value: 'ProductA' }],
+        attributeGroup: {
+          name: 'attrGroupA',
+          attributes: [
+            {
+              name: 'attrNameA',
+              type: 'Boolean',
+              value: true,
+            },
+          ],
+        },
       },
       {
         type: 'Link',
         uri: '/categories/CategoryID/products/ProductB',
         title: 'Product B',
         attributes: [{ name: 'sku', type: 'String', value: 'ProductB' }],
+        attributeGroup: {
+          name: 'attrGroupB',
+          attributes: [
+            {
+              name: 'attrNameB',
+              type: 'Boolean',
+              value: true,
+            },
+          ],
+        },
       },
     ],
     type: 'ResourceCollection',

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -70,7 +70,7 @@ export class ProductsService {
 
     let params = new HttpParams()
       .set('attrs', ProductsService.STUB_ATTRS)
-      .set('attrsGroups', AttributeGroupTypes.ProductLabelAttributes) // TODO: validate if this is working once ISREST-523 is implemented
+      .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('amount', this.itemsPerPage.toString())
       .set('offset', ((page - 1) * this.itemsPerPage).toString())
       .set('returnSortKeys', 'true')


### PR DESCRIPTION
## PR Type

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
Product labels for products (like 'Sale' and 'Topseller') are not displayed on product list page until product detail page of the product has been opened.

Issue Number: #73 


## What Is the New Behavior?
Product labels are always displayed on product list page.

## Does this PR Introduce a Breaking Change?
 [ ] Yes  
 [x] No