### PR TITLE
fix: display product labels on search result page

### DIFF
--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -114,6 +114,7 @@ export class ProductsService {
       .set('amount', this.itemsPerPage.toString())
       .set('offset', ((page - 1) * this.itemsPerPage).toString())
       .set('attrs', ProductsService.STUB_ATTRS)
+      .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
     if (sortKey) {
       params = params.set('sortKey', sortKey);


### PR DESCRIPTION
PR Type
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other:

What Is the Current Behavior?
Product labels for products (like 'Sale' and 'Topseller') are not displayed on search result page.

What Is the New Behavior?
Product labels are displayed on search result page.

Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No