### PR TITLE
chore: update recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,17 +15,14 @@
     "angular.ng-template",
     "mikael.angular-beastcode",
     "formulahendry.auto-rename-tag",
-    "stringham.move-ts",
     // code style + formatting
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "hex-ci.stylelint-plus",
     "ms-vscode.vscode-typescript-tslint-plugin",
     // testing
-    "orta.vscode-jest",
-    "andys8.jest-snippets",
-    "asvetliakov.snapshot-tools"
+    "andys8.jest-snippets"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-  "unwantedRecommendations": []
+  "unwantedRecommendations": ["eg2.tslint"]
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [ ] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [x] Other: VSCode config

## What Is the New Behavior?

removed extensions:
`stringham.move-ts` - native support
`asvetliakov.snapshot-tools` - prefer jest inline snapshots
`orta.vscode-jest` - slows down most of the time instead of helping

