### PR TITLE
feat: filter api v1

### DIFF
--- a/e2e/cypress/integration/pages/header.module.ts
+++ b/e2e/cypress/integration/pages/header.module.ts
@@ -65,6 +65,16 @@ export class HeaderModule {
     return cy.get('ish-header');
   }
 
+  getSearchSuggestions(searchTerm: string) {
+    cy.get('[data-testing-id="search-box-desktop"] input.searchTerm').type(searchTerm);
+    cy.get('ul.search-suggest-results').should('be.visible');
+    return cy.get('ul.search-suggest-results').get('li button');
+  }
+
+  doProductSearch(searchTerm: string) {
+    cy.get('[data-testing-id="search-box-desktop"] input.searchTerm').clear().type(searchTerm).type('{enter}');
+  }
+
   topLevelCategoryLink(id: string) {
     return cy.get(`[data-testing-id="${id}-link"]`).first();
   }

--- a/e2e/cypress/integration/pages/shopping/family.page.ts
+++ b/e2e/cypress/integration/pages/shopping/family.page.ts
@@ -1,5 +1,6 @@
 import { HeaderModule } from '../header.module';
 
+import { FilterNavigationModule } from './filter-navigation.module';
 import { ProductListModule } from './product-list.module';
 
 export class FamilyPage {
@@ -8,6 +9,8 @@ export class FamilyPage {
   readonly header = new HeaderModule();
 
   readonly productList = new ProductListModule('ish-product-listing');
+
+  readonly filterNavigation = new FilterNavigationModule();
 
   static navigateTo(categoryUniqueId: string, page?: number) {
     cy.visit(`/cat${categoryUniqueId}${page ? `?page=${page}` : ''}`);

--- a/e2e/cypress/integration/pages/shopping/filter-navigation.module.ts
+++ b/e2e/cypress/integration/pages/shopping/filter-navigation.module.ts
@@ -3,6 +3,7 @@ export class FilterNavigationModule {
     const filterGroup = cy.get('div.filter-group').contains(name).parent();
     return {
       filterClick: (value: string) => filterGroup.find(`[data-testing-id=filter-link-${value}]`).click(),
+      getFilter: (value: string) => filterGroup.find(`[data-testing-id=filter-link-${value}]`),
     };
   }
 }

--- a/e2e/cypress/integration/specs/filter/filter-category.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/filter/filter-category.b2b.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { at } from '../../framework';
+import { FamilyPage } from '../../pages/shopping/family.page';
+
+const _ = {
+  product: {
+    sku: '1691832',
+    name: "Belkin 17'' LCD Rack Console with Dual-Rail Technology",
+    defaultCategory: {
+      categoryId: 'servers.servers-rack-consoles',
+      name: 'Rank Consoles',
+      results: 6,
+    },
+  },
+  filter: {
+    name: 'Price',
+    entryName: 'ProductSalePriceNet_1000_0_TO',
+    results: 5,
+  },
+};
+
+describe('Product Category Context', () => {
+  describe('located under default category', () => {
+    before(() => FamilyPage.navigateTo(_.product.defaultCategory.categoryId));
+
+    it('should see the product on the family page', () => {
+      at(FamilyPage, page => {
+        page.productList.makeAllProductsVisible();
+        page.productList.productTile(_.product.sku).should('contain', _.product.name);
+      });
+    });
+
+    it('should see the correct filter with expecting results', () => {
+      at(FamilyPage, page => {
+        page.filterNavigation
+          .filter(_.filter.name)
+          .getFilter(_.filter.entryName)
+          .should('contain', `(${_.filter.results})`);
+      });
+    });
+
+    it('should filter products by price', () => {
+      at(FamilyPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+    });
+
+    it(`should see other results in search result page`, () => {
+      at(FamilyPage, page => page.productList.numberOfItems.should('equal', _.filter.results));
+    });
+
+    it('should deselect filter', () => {
+      at(FamilyPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+    });
+
+    it(`should see other results in search result page`, () => {
+      at(FamilyPage, page => page.productList.numberOfItems.should('equal', _.product.defaultCategory.results));
+    });
+  });
+});

--- a/e2e/cypress/integration/specs/filter/filter-category.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/filter/filter-category.b2c.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { at } from '../../framework';
+import { FamilyPage } from '../../pages/shopping/family.page';
+
+const _ = {
+  product: {
+    sku: '872843',
+    name: 'Epson Multipack',
+    defaultCategory: {
+      categoryId: 'Computers.225.373.377',
+      name: 'Ink Cartridges',
+      results: 30,
+    },
+  },
+  filter: {
+    name: 'Price',
+    entryName: 'ProductSalePriceGross_50_0_TO_99_99',
+    results: 9,
+  },
+};
+
+describe('Product Category Context', () => {
+  describe('located under default category', () => {
+    before(() => FamilyPage.navigateTo(_.product.defaultCategory.categoryId));
+
+    it('should see the product on the family page', () => {
+      at(FamilyPage, page => {
+        page.productList.makeAllProductsVisible();
+        page.productList.productTile(_.product.sku).should('contain', _.product.name);
+      });
+    });
+
+    it('should see the correct filter with expecting results', () => {
+      at(FamilyPage, page => {
+        page.filterNavigation
+          .filter(_.filter.name)
+          .getFilter(_.filter.entryName)
+          .should('contain', `(${_.filter.results})`);
+      });
+    });
+
+    it('should filter products by price', () => {
+      at(FamilyPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+    });
+
+    it(`should see other results in search result page`, () => {
+      at(FamilyPage, page => page.productList.numberOfItems.should('equal', _.filter.results));
+    });
+
+    it('should deselect filter', () => {
+      at(FamilyPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+    });
+
+    it(`should see other results in search result page`, () => {
+      at(FamilyPage, page => page.productList.numberOfItems.should('equal', _.product.defaultCategory.results));
+    });
+  });
+});

--- a/e2e/cypress/integration/specs/filter/filter-search-results.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/filter/filter-search-results.b2b.e2e-spec.ts
@@ -1,0 +1,60 @@
+import { at } from '../../framework';
+import { HomePage } from '../../pages/home.page';
+import { SearchResultPage } from '../../pages/shopping/search-result.page';
+
+const _ = {
+  suggestTerm: 'b',
+  searchTerm: 'belkin',
+  suggestItemText: 'Belkin',
+  product: '643941',
+  results: 161,
+  filter: {
+    name: 'Price',
+    entryName: 'ProductSalePriceNet_100_0_TO_249_99',
+    results: 5,
+  },
+};
+
+describe('Searching B2B User', () => {
+  before(() => HomePage.navigateTo());
+
+  it('should enter search term and wait for displayed suggestions', () => {
+    at(HomePage, page => page.header.getSearchSuggestions(_.suggestTerm).should('contain', _.suggestItemText));
+  });
+
+  it('should perform search and land on search result page', () => {
+    at(HomePage, page => page.header.doProductSearch(_.searchTerm));
+    at(SearchResultPage);
+  });
+
+  it('should see results on search result page', () => {
+    at(SearchResultPage, page => page.productList.visibleProducts.should('have.length.gte', 1));
+  });
+
+  it('should see the correct filter', () => {
+    at(SearchResultPage, page => {
+      page.filterNavigation.filter('Color').getFilter('Red').should('be.visible');
+
+      page.filterNavigation
+        .filter(_.filter.name)
+        .getFilter(_.filter.entryName)
+        .should('contain', `(${_.filter.results})`);
+    });
+  });
+
+  it('should filter products by price', () => {
+    at(SearchResultPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+  });
+
+  it(`should see other results in search result page`, () => {
+    at(SearchResultPage, page => page.productList.numberOfItems.should('equal', _.filter.results));
+  });
+
+  it('should deselect filter', () => {
+    at(SearchResultPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+  });
+
+  it(`should see other results in search result page`, () => {
+    at(SearchResultPage, page => page.productList.numberOfItems.should('equal', _.results));
+  });
+});

--- a/e2e/cypress/integration/specs/filter/filter-search-results.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/filter/filter-search-results.b2c.e2e-spec.ts
@@ -1,0 +1,60 @@
+import { at } from '../../framework';
+import { HomePage } from '../../pages/home.page';
+import { SearchResultPage } from '../../pages/shopping/search-result.page';
+
+const _ = {
+  suggestTerm: 'k',
+  searchTerm: 'kodak',
+  suggestItemText: 'Kodak',
+  product: '7912057',
+  results: 23,
+  filter: {
+    name: 'Price',
+    entryName: 'ProductSalePriceGross_100_0_TO_249_99',
+    results: 16,
+  },
+};
+
+describe('Searching User', () => {
+  before(() => HomePage.navigateTo());
+
+  it('should enter search term and wait for displayed suggestions', () => {
+    at(HomePage, page => page.header.getSearchSuggestions(_.suggestTerm).should('contain', _.suggestItemText));
+  });
+
+  it('should perform search and land on search result page', () => {
+    at(HomePage, page => page.header.doProductSearch(_.searchTerm));
+    at(SearchResultPage);
+  });
+
+  it('should see results on search result page', () => {
+    at(SearchResultPage, page => page.productList.visibleProducts.should('have.length.gte', 1));
+  });
+
+  it('should see the correct filter', () => {
+    at(SearchResultPage, page => {
+      page.filterNavigation.filter('Color').getFilter('Red').should('be.visible');
+
+      page.filterNavigation
+        .filter(_.filter.name)
+        .getFilter(_.filter.entryName)
+        .should('contain', `(${_.filter.results})`);
+    });
+  });
+
+  it('should filter products by price', () => {
+    at(SearchResultPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+  });
+
+  it(`should see other results in search result page`, () => {
+    at(SearchResultPage, page => page.productList.numberOfItems.should('equal', _.filter.results));
+  });
+
+  it('should deselect filter', () => {
+    at(SearchResultPage, page => page.filterNavigation.filter(_.filter.name).filterClick(_.filter.entryName));
+  });
+
+  it(`should see other results in search result page`, () => {
+    at(SearchResultPage, page => page.productList.numberOfItems.should('equal', _.results));
+  });
+});

--- a/e2e/cypress/integration/specs/shopping/paging-product-list-family-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/shopping/paging-product-list-family-page.b2c.e2e-spec.ts
@@ -64,3 +64,21 @@ describe('Google Page Crawler', () => {
     });
   });
 });
+
+describe('Pagination & endless scroll', () => {
+  it('should be able to follow different pages started at page 2', () => {
+    FamilyPage.navigateTo(_.category, 2);
+
+    at(FamilyPage, page => {
+      page.productList.currentPage.should('equal', 2);
+
+      cy.scrollTo('bottom');
+      waitLoadingEnd();
+      page.productList.currentPage.should('equal', 3);
+
+      cy.scrollTo('bottom');
+      waitLoadingEnd();
+      page.productList.currentPage.should('equal', 4);
+    });
+  });
+});

--- a/e2e/cypress/integration/specs/shopping/search-category-routing.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/shopping/search-category-routing.b2c.e2e-spec.ts
@@ -1,0 +1,33 @@
+import { at, waitLoadingEnd } from '../../framework';
+import { FamilyPage } from '../../pages/shopping/family.page';
+import { SearchResultPage } from '../../pages/shopping/search-result.page';
+
+const _ = {
+  suggestTerm: '*',
+  category: 'Computers.897.897_Microsoft', // /Microsoft-catComputers.897.897_Microsoft?view=grid
+  filter: {
+    name: 'Brand',
+    entryName: 'ManufacturerName_Microsoft',
+    results: 8,
+  },
+};
+
+describe('Searching User', () => {
+  before(() => FamilyPage.navigateTo(_.category));
+
+  it('should perform search and land on search result page', () => {
+    at(FamilyPage, page => page.header.searchBox.search(_.suggestTerm));
+    at(SearchResultPage, () => {
+      waitLoadingEnd(1000);
+      cy.go('back');
+      waitLoadingEnd(1000);
+    });
+    at(FamilyPage, page => {
+      waitLoadingEnd(1000);
+      page.filterNavigation
+        .filter(_.filter.name)
+        .getFilter(_.filter.entryName)
+        .should('contain', `(${_.filter.results})`);
+    });
+  });
+});

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -1,14 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { debounce, debounceTime, filter, map, switchMap, tap } from 'rxjs/operators';
+import { debounce, filter, map, switchMap, tap } from 'rxjs/operators';
 
 import { ProductListingID } from 'ish-core/models/product-listing/product-listing.model';
 import { ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
 import { addProductToBasket } from 'ish-core/store/customer/basket';
 import {
   getCategory,
-  getCategoryLoading,
   getNavigationCategories,
   getSelectedCategory,
   loadTopLevelCategories,
@@ -47,7 +46,7 @@ import {
 } from 'ish-core/store/shopping/recently';
 import { getSearchTerm, getSuggestSearchResults, suggestSearch } from 'ish-core/store/shopping/search';
 import { toObservable } from 'ish-core/utils/functions';
-import { whenFalsy } from 'ish-core/utils/operators';
+import { whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 
 // tslint:disable:member-ordering
 @Injectable({ providedIn: 'root' })
@@ -57,7 +56,6 @@ export class ShoppingFacade {
   // CATEGORY
 
   selectedCategory$ = this.store.pipe(select(getSelectedCategory));
-  selectedCategoryLoading$ = this.store.pipe(select(getCategoryLoading), debounceTime(500));
 
   category$(uniqueId: string) {
     return this.store.pipe(select(getCategory(uniqueId)));
@@ -164,7 +162,13 @@ export class ShoppingFacade {
 
   // FILTER
 
-  currentFilter$ = this.store.pipe(select(getAvailableFilter));
+  currentFilter$(withCategoryFilter: boolean) {
+    return this.store.pipe(
+      select(getAvailableFilter),
+      whenTruthy(),
+      map(x => (withCategoryFilter ? x : { ...x, filter: x.filter.filter(f => f.id !== 'CategoryUUIDLevelMulti') }))
+    );
+  }
 
   // COMPARE
 

--- a/src/app/core/models/facet/facet.interface.ts
+++ b/src/app/core/models/facet/facet.interface.ts
@@ -7,4 +7,7 @@ export class FacetData {
   selected: boolean;
   link: Link;
   level: number;
+  mappedValue?: string;
+  mappedType?: 'colorcode' | 'image' | 'text';
+  displayValue: string;
 }

--- a/src/app/core/models/facet/facet.model.ts
+++ b/src/app/core/models/facet/facet.model.ts
@@ -1,8 +1,12 @@
+import { URLFormParams } from 'ish-core/utils/url-form-params';
+
 export class Facet {
   name: string;
   count: number;
   selected: boolean;
   displayName: string;
-  searchParameter: string;
+  searchParameter: URLFormParams;
   level: number;
+  mappedValue?: string;
+  mappedType?: 'colorcode' | 'image' | 'text';
 }

--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.spec.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.spec.ts
@@ -32,14 +32,21 @@ describe('Filter Navigation Mapper', () => {
 
     it('should parse objects when elements exists with facets', () => {
       const data = {
-        elements: [{ facets: [{ name: 'testName', link: { uri: '/filters/uri;SearchParameter=param' } }] }],
+        elements: [{ filterEntries: [{ name: 'testName', link: { uri: '/filters/uri?SearchParameter=param' } }] }],
       } as FilterNavigationData;
 
       const model = mapper.fromData(data);
       expect(model.filter).toBeTruthy();
       expect(model.filter).toHaveLength(1);
       expect(model.filter[0].facets).toHaveLength(1);
-      expect(model.filter[0].facets[0].searchParameter).toBe('param');
+      expect(model.filter[0].facets[0].searchParameter).toMatchInlineSnapshot(`
+        Object {
+          "SearchParameter": Array [
+            "param",
+          ],
+          "category": undefined,
+        }
+      `);
     });
 
     it('should parse objects when elements exists', () => {

--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import b64u from 'b64u';
 
-import { Facet } from 'ish-core/models/facet/facet.model';
-import { FilterData, FilterValueMap } from 'ish-core/models/filter/filter.interface';
-import { Filter } from 'ish-core/models/filter/filter.model';
+import { FacetData } from 'ish-core/models/facet/facet.interface';
+import { FilterData } from 'ish-core/models/filter/filter.interface';
 import { getICMStaticURL } from 'ish-core/store/core/configuration';
-import { formParamsToString, stringToFormParams } from 'ish-core/utils/url-form-params';
+import { stringToFormParams } from 'ish-core/utils/url-form-params';
 
 import { FilterNavigationData } from './filter-navigation.interface';
 import { FilterNavigation } from './filter-navigation.model';
@@ -27,8 +25,8 @@ export class FilterNavigationMapper {
               id: filterData.id,
               name: filterData.name,
               displayType: filterData.displayType,
+              limitCount: filterData.limitCount || -1,
               facets: this.mapFacetData(filterData),
-              filterValueMap: this.parseFilterValueMap(filterData.filterValueMap),
               selectionType: filterData.selectionType || 'single',
             }))
           : [],
@@ -38,40 +36,33 @@ export class FilterNavigationMapper {
   /**
    * parse ish-link to
    */
-  private parseFilterValueMapUrl(url: string) {
-    const urlParts = url.split(':');
-    return `${this.icmStaticURL}/${urlParts[0]}/-${urlParts[1]}`;
-  }
-
-  /**
-   * parse FilterValueMap for image-links
-   */
-  private parseFilterValueMap(filterValueMap: FilterValueMap): FilterValueMap {
-    return filterValueMap
-      ? Object.keys(filterValueMap).reduce((acc, k) => {
-          acc[k] = {
-            mapping:
-              filterValueMap[k].type === 'image'
-                ? `url(${this.parseFilterValueMapUrl(filterValueMap[k].mapping)})`
-                : filterValueMap[k].mapping,
-            type: filterValueMap[k].type,
-          };
-          return acc;
-        }, {})
-      : {};
+  private parseFilterValue(filterEntry: FacetData): string {
+    if (filterEntry.mappedType === 'image' && filterEntry.mappedValue) {
+      const urlParts = filterEntry.mappedValue.split(':');
+      return `url(${this.icmStaticURL}/${urlParts[0]}/-${urlParts[1]})`;
+    }
+    return filterEntry.mappedValue;
   }
 
   private mapFacetData(filterData: FilterData) {
-    return filterData.facets
-      ? filterData.facets.reduce((acc, facet) => {
+    return filterData.filterEntries
+      ? filterData.filterEntries.reduce((acc, facet) => {
+          const category = facet.link.uri.includes('/categories/')
+            ? [facet.link.uri.split('/productfilters')[0].split('/categories/')[1]]
+            : undefined;
           if (facet.name !== 'Show all') {
             acc.push({
               name: facet.name,
               count: facet.count,
               selected: facet.selected,
-              displayName: facet.link.title,
-              searchParameter: facet.link.uri.split(';SearchParameter=')[1],
+              displayName: facet.displayValue || undefined,
+              searchParameter: {
+                ...stringToFormParams(facet.link.uri.split('?')[1] || ''),
+                category,
+              },
               level: facet.level || 0,
+              mappedValue: this.parseFilterValue(facet),
+              mappedType: facet.mappedType || undefined,
             });
           } else {
             console.warn(`Limiting filters is not supported. Set limit to -1 in the BackOffice (${filterData.name})`);
@@ -79,52 +70,5 @@ export class FilterNavigationMapper {
           return acc;
         }, [])
       : [];
-  }
-
-  fixSearchParameters(filterNavigation: FilterNavigation) {
-    filterNavigation.filter.forEach(filter => {
-      filter.id = filter.id.replace(/\ /g, '+');
-      const selected = filter.facets
-        .filter(facet => facet.selected)
-        .map(facet => (filter.id.includes('Price') ? this.fixPrice(filter.id, facet.searchParameter) : facet.name));
-      filter.facets.forEach(facet => {
-        facet.name = facet.name.replace(/\ /g, '+');
-        if (filter.id.includes('Price')) {
-          facet.name = this.fixPrice(filter.id, facet.searchParameter);
-        }
-        this.postProcess(filter, facet, selected);
-      });
-    });
-
-    return filterNavigation;
-  }
-
-  private fixPrice(filterId: string, searchParameter: string): string {
-    const decodedSearchParams = b64u.decode(b64u.fromBase64(searchParameter));
-    const params = stringToFormParams(decodedSearchParams);
-    return params[filterId][0];
-  }
-
-  private postProcess(filter: Filter, facet: Facet, selected: string[]): Facet {
-    const decodedSearchParams = b64u.decode(b64u.fromBase64(facet.searchParameter));
-    const paramsMap = stringToFormParams(decodedSearchParams);
-    const isOr = filter.selectionType.endsWith('or');
-    if (filter.selectionType === 'single') {
-      if (facet.selected) {
-        paramsMap[filter.id] = [];
-      } else {
-        paramsMap[filter.id] = [facet.name];
-      }
-    } else if (filter.selectionType.startsWith('multiple')) {
-      if (facet.selected) {
-        const newSelected = [...selected];
-        newSelected.splice(newSelected.indexOf(facet.name), 1);
-        paramsMap[filter.id] = newSelected;
-      } else {
-        paramsMap[filter.id] = [...selected, facet.name];
-      }
-    }
-    facet.searchParameter = b64u.toBase64(b64u.encode('&' + formParamsToString(paramsMap, isOr ? '_or_' : '_and_')));
-    return facet;
   }
 }

--- a/src/app/core/models/filter/filter.interface.ts
+++ b/src/app/core/models/filter/filter.interface.ts
@@ -1,21 +1,13 @@
 import { FacetData } from 'ish-core/models/facet/facet.interface';
 
-export interface FilterValueMap {
-  [key: string]: {
-    mapping: string;
-    type: 'colorcode' | 'image' | 'text';
-  };
-}
-
 export interface FilterData {
   name: string;
   type: string;
   id: string;
-  facets: FacetData[];
+  filterEntries: FacetData[];
   displayType: string;
   selectionType: string;
   limitCount: number;
   minCount: number;
   scope: string;
-  filterValueMap?: FilterValueMap;
 }

--- a/src/app/core/models/filter/filter.model.ts
+++ b/src/app/core/models/filter/filter.model.ts
@@ -1,12 +1,10 @@
 import { Facet } from 'ish-core/models/facet/facet.model';
 
-import { FilterValueMap } from './filter.interface';
-
 export interface Filter {
   name: string;
   displayType: string;
   id: string;
   facets: Facet[];
   selectionType: string;
-  filterValueMap?: FilterValueMap;
+  limitCount?: number;
 }

--- a/src/app/core/models/product-listing/product-listing.mapper.spec.ts
+++ b/src/app/core/models/product-listing/product-listing.mapper.spec.ts
@@ -61,7 +61,7 @@ describe('Product Listing Mapper', () => {
         sortKeys: ['name-desc'],
         itemCount: 200,
         sorting: 'name-asc',
-        filters: 'bla=blubb',
+        filters: { bla: ['blubb'] },
         startPage: 4,
       })
     ).toMatchInlineSnapshot(`
@@ -75,7 +75,11 @@ describe('Product Listing Mapper', () => {
           "D",
         ],
         "id": Object {
-          "filters": "bla=blubb",
+          "filters": Object {
+            "bla": Array [
+              "blubb",
+            ],
+          },
           "sorting": "name-asc",
           "type": "test",
           "value": "dummy",

--- a/src/app/core/models/product-listing/product-listing.mapper.ts
+++ b/src/app/core/models/product-listing/product-listing.mapper.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { range } from 'lodash-es';
 
 import { PRODUCT_LISTING_ITEMS_PER_PAGE } from 'ish-core/configurations/injection-keys';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 import { ProductListingType } from './product-listing.model';
 
@@ -18,7 +19,7 @@ export class ProductListingMapper {
       sortKeys?: string[];
       itemCount?: number;
       sorting?: string;
-      filters?: string;
+      filters?: URLFormParams;
     }
   ): ProductListingType {
     const pages = range(0, Math.ceil(skus.length / this.itemsPerPage)).map(n =>

--- a/src/app/core/models/product-listing/product-listing.model.ts
+++ b/src/app/core/models/product-listing/product-listing.model.ts
@@ -1,8 +1,11 @@
+import { URLFormParams } from 'ish-core/utils/url-form-params';
+
 export interface ProductListingID {
   type: string;
   value: string;
   sorting?: string;
-  filters?: string;
+  filters?: URLFormParams;
+  page?: number;
 }
 
 export interface ProductListingType {

--- a/src/app/core/models/search-parameter/search-parameter.mapper.spec.ts
+++ b/src/app/core/models/search-parameter/search-parameter.mapper.spec.ts
@@ -8,9 +8,7 @@ describe('Search Parameter Mapper', () => {
       searchParameter.queryTerm = 'camera';
       searchParameter.sortings = ['name-asc', 'sku-desc'];
 
-      expect(SearchParameterMapper.toData(searchParameter)).toEqual(
-        'JkBRdWVyeVRlcm09Y2FtZXJhJkBTb3J0Lm5hbWU9MCZAU29ydC5za3U9MQ=='
-      );
+      expect(SearchParameterMapper.toData(searchParameter)).toEqual('&searchTerm=camera&@Sort.name=0&@Sort.sku=1');
     });
   });
 });

--- a/src/app/core/models/search-parameter/search-parameter.mapper.ts
+++ b/src/app/core/models/search-parameter/search-parameter.mapper.ts
@@ -1,5 +1,3 @@
-import b64u from 'b64u';
-
 import { SearchParameter } from './search-parameter.model';
 
 export class SearchParameterMapper {
@@ -10,7 +8,7 @@ export class SearchParameterMapper {
     let data = '';
 
     if (searchParameter.queryTerm) {
-      data += '&@QueryTerm=' + searchParameter.queryTerm;
+      data += '&searchTerm=' + searchParameter.queryTerm;
     }
     if (searchParameter.data) {
       data += searchParameter.data;
@@ -25,6 +23,6 @@ export class SearchParameterMapper {
         }
       });
     }
-    return b64u.toBase64(b64u.encode(data));
+    return data;
   }
 }

--- a/src/app/core/services/filter/filter.service.spec.ts
+++ b/src/app/core/services/filter/filter.service.spec.ts
@@ -1,16 +1,21 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { FilterNavigationData } from 'ish-core/models/filter-navigation/filter-navigation.interface';
 import { ApiService } from 'ish-core/services/api/api.service';
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { getProductListingItemsPerPage } from 'ish-core/store/shopping/product-listing';
+import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 import { FilterService } from './filter.service';
 
 describe('Filter Service', () => {
   let apiService: ApiService;
-  let filterService;
+  let filterService: FilterService;
   const productsMock = {
     elements: [{ uri: 'products/123' }, { uri: 'products/234' }],
     total: 2,
@@ -22,9 +27,9 @@ describe('Filter Service', () => {
         id: 'test',
         displayType: 'text_clear',
         selectionType: 'single',
-        facets: [
-          { name: 'a', link: { uri: 'domain/filters/dahinter;SearchParameter=' } },
-          { name: 'b', link: { uri: 'domain/filters/dahinter;SearchParameter=' } },
+        filterEntries: [
+          { name: 'a', link: { uri: 'domain/productfilters/dahinter?SearchParameter=' } },
+          { name: 'b', link: { uri: 'domain/productfilters/dahinter?SearchParameter=' } },
         ],
       },
     ],
@@ -34,7 +39,19 @@ describe('Filter Service', () => {
     apiService = mock(ApiService);
 
     TestBed.configureTestingModule({
-      providers: [FilterService, { provide: ApiService, useFactory: () => instance(apiService) }, provideMockStore()],
+      imports: [CoreStoreModule.forTesting(), RouterTestingModule, ShoppingStoreModule.forTesting('productListing')],
+      providers: [
+        FilterService,
+        { provide: ApiService, useFactory: () => instance(apiService) },
+        provideMockStore({
+          selectors: [
+            {
+              selector: getProductListingItemsPerPage,
+              value: { itemsPerPage: 2 },
+            },
+          ],
+        }),
+      ],
     });
     filterService = TestBed.inject(FilterService);
   });
@@ -44,37 +61,40 @@ describe('Filter Service', () => {
   });
 
   it("should get Filter data when 'getFilterForCategory' is called", done => {
-    when(apiService.get('filters', anything())).thenReturn(of(filterMock));
+    when(apiService.get('categories/A/B/productfilters', anything())).thenReturn(of(filterMock));
     filterService.getFilterForCategory('A.B').subscribe(data => {
       expect(data.filter).toHaveLength(1);
       expect(data.filter[0].facets).toHaveLength(2);
       expect(data.filter[0].facets[0].name).toEqual('a');
       expect(data.filter[0].facets[1].name).toEqual('b');
-      verify(apiService.get(`filters`, anything())).once();
+      verify(apiService.get('categories/A/B/productfilters', anything())).once();
       done();
     });
   });
 
   it("should get Filter data when 'applyFilter' is called", done => {
-    when(apiService.get('filters/default;SearchParameter=b')).thenReturn(of(filterMock));
-    filterService.applyFilter('b').subscribe(data => {
+    when(apiService.get<FilterNavigationData>('productfilters?SearchParameter=b', anything())).thenReturn(
+      of(filterMock)
+    );
+    filterService.applyFilter({ SearchParameter: ['b'] } as URLFormParams).subscribe(data => {
       expect(data.filter).toHaveLength(1);
       expect(data.filter[0].facets).toHaveLength(2);
       expect(data.filter[0].facets[0].name).toEqual('a');
       expect(data.filter[0].facets[1].name).toEqual('b');
-      verify(apiService.get('filters/default;SearchParameter=b')).once();
+      verify(apiService.get('productfilters?SearchParameter=b', anything())).once();
       done();
     });
   });
 
   it("should get Product SKUs when 'getFilteredProducts' is called", done => {
-    when(apiService.get('filters/default;SearchParameter=b/hits')).thenReturn(of(productsMock));
-    filterService.getFilteredProducts('b').subscribe(data => {
+    when(apiService.get('products?SearchParameter=b&returnSortKeys=true', anything())).thenReturn(of(productsMock));
+
+    filterService.getFilteredProducts({ SearchParameter: ['b'] } as URLFormParams, 1).subscribe(data => {
       expect(data).toEqual({
         productSKUs: ['123', '234'],
         total: 2,
       });
-      verify(apiService.get('filters/default;SearchParameter=b/hits')).once();
+      verify(apiService.get('products?SearchParameter=b&returnSortKeys=true', anything())).once();
       done();
     });
   });

--- a/src/app/core/services/filter/filter.service.ts
+++ b/src/app/core/services/filter/filter.service.ts
@@ -1,8 +1,10 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { FilterNavigationData } from 'ish-core/models/filter-navigation/filter-navigation.interface';
 import { FilterNavigationMapper } from 'ish-core/models/filter-navigation/filter-navigation.mapper';
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
@@ -11,57 +13,102 @@ import { ProductMapper } from 'ish-core/models/product/product.mapper';
 import { SearchParameterMapper } from 'ish-core/models/search-parameter/search-parameter.mapper';
 import { SearchParameter } from 'ish-core/models/search-parameter/search-parameter.model';
 import { ApiService } from 'ish-core/services/api/api.service';
+import { ProductsService } from 'ish-core/services/products/products.service';
+import { getProductListingItemsPerPage } from 'ish-core/store/shopping/product-listing';
+import { URLFormParams, formParamsToString } from 'ish-core/utils/url-form-params';
 
 @Injectable({ providedIn: 'root' })
 export class FilterService {
-  constructor(private apiService: ApiService, private filterNavigationMapper: FilterNavigationMapper) {}
+  private itemsPerPage: number;
+
+  constructor(
+    private apiService: ApiService,
+    private filterNavigationMapper: FilterNavigationMapper,
+    private store: Store
+  ) {
+    this.store
+      .pipe(select(getProductListingItemsPerPage))
+      .subscribe(itemsPerPage => (this.itemsPerPage = itemsPerPage));
+  }
 
   getFilterForCategory(categoryUniqueId: string): Observable<FilterNavigation> {
-    const idList = categoryUniqueId.split('.');
-    // TODO from REST
-    const categoryDomainName = this.getDomainId(idList[0]);
-    const params = new HttpParams()
-      .set('CategoryDomainName', categoryDomainName)
-      .set('CategoryName', idList[idList.length - 1]);
-    return this.apiService
-      .get<FilterNavigationData>('filters', { params, skipApiErrorHandling: true })
-      .pipe(
-        map(filter => this.filterNavigationMapper.fromData(filter)),
-        map(filter => this.filterNavigationMapper.fixSearchParameters(filter))
-      );
+    const categoryPath = categoryUniqueId.split('.').join('/');
+    return this.applyFilterWithCategory('', categoryPath).pipe(
+      map(filter => this.filterNavigationMapper.fromData(filter))
+    );
   }
 
   getFilterForSearch(searchTerm: string): Observable<FilterNavigation> {
     // tslint:disable-next-line:ish-no-object-literal-type-assertion
     const searchParameter = SearchParameterMapper.toData({ queryTerm: searchTerm } as SearchParameter);
     return this.apiService
-      .get<FilterNavigationData>(`filters/default;SearchParameter=${searchParameter}`, { skipApiErrorHandling: true })
-      .pipe(
-        map(filter => this.filterNavigationMapper.fromData(filter)),
-        map(filter => this.filterNavigationMapper.fixSearchParameters(filter))
-      );
+      .get<FilterNavigationData>(`productfilters?${searchParameter}`, { skipApiErrorHandling: true })
+      .pipe(map(filter => this.filterNavigationMapper.fromData(filter)));
   }
 
-  applyFilter(searchParameter: string): Observable<FilterNavigation> {
-    return this.apiService.get<FilterNavigationData>(`filters/default;SearchParameter=${searchParameter}`).pipe(
-      map(filter => this.filterNavigationMapper.fromData(filter)),
-      map(filter => this.filterNavigationMapper.fixSearchParameters(filter))
-    );
+  applyFilter(searchParameter: URLFormParams): Observable<FilterNavigation> {
+    const params = formParamsToString({ ...searchParameter, category: undefined });
+    const categoryPath = searchParameter.category ? searchParameter.category[0] : undefined;
+    return (categoryPath
+      ? this.applyFilterWithCategory(params, categoryPath)
+      : this.applyFilterWithoutCategory(params)
+    ).pipe(map(filter => this.filterNavigationMapper.fromData(filter)));
   }
 
-  getFilteredProducts(searchParameter: string): Observable<{ total: number; productSKUs: string[] }> {
-    return this.apiService.get(`filters/default;SearchParameter=${searchParameter}/hits`).pipe(
-      map((x: { total: number; elements: Link[] }) => ({
+  getFilteredProducts(
+    searchParameter: URLFormParams,
+    page: number = 1,
+    sortKey?: string
+  ): Observable<{ total: number; productSKUs: string[]; sortKeys: string[] }> {
+    let params = new HttpParams()
+      .set('amount', this.itemsPerPage.toString())
+      .set('offset', ((page - 1) * this.itemsPerPage).toString())
+      .set('attrs', ProductsService.STUB_ATTRS)
+      .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
+      .set('returnSortKeys', 'true');
+    if (sortKey) {
+      params = params.set('sortKey', sortKey);
+    }
+
+    const searchParameterString = formParamsToString({ ...searchParameter, category: undefined });
+    const categoryPath = searchParameter.category ? searchParameter.category[0] : undefined;
+
+    return (categoryPath
+      ? this.getFilteredProductsWithCategory(searchParameterString, categoryPath, params)
+      : this.getFilteredProductsWithoutCategory(searchParameterString, params)
+    ).pipe(
+      map((x: { total: number; elements: Link[]; sortKeys: string[] }) => ({
         productSKUs: x.elements.map(l => l.uri).map(ProductMapper.parseSKUfromURI),
         total: x.total,
+        sortKeys: x.sortKeys,
       }))
     );
   }
 
-  private getDomainId(rootName: string) {
-    if (rootName === 'Specials' || rootName === 'Cameras-Camcorders') {
-      return 'inSPIRED-inTRONICS-' + rootName;
-    }
-    return 'inSPIRED-' + rootName;
+  private getFilteredProductsWithoutCategory(searchParameter: string, params: HttpParams) {
+    return this.apiService.get(`products${(searchParameter ? `?${searchParameter}&` : '?') + 'returnSortKeys=true'}`, {
+      params,
+    });
+  }
+
+  private getFilteredProductsWithCategory(searchParameter: string, category: string, params: HttpParams) {
+    return this.apiService.get(
+      `categories/${category}/products${(searchParameter ? `?${searchParameter}&` : '?') + 'returnSortKeys=true'}`,
+      { params }
+    );
+  }
+
+  private applyFilterWithoutCategory(searchParameter: string): Observable<FilterNavigationData> {
+    const params = searchParameter ? `?${searchParameter}` : '';
+    return this.apiService.get<FilterNavigationData>(`productfilters${params}`, {
+      skipApiErrorHandling: true,
+    });
+  }
+
+  private applyFilterWithCategory(searchParameter: string, category: string): Observable<FilterNavigationData> {
+    const params = searchParameter ? `?${searchParameter}` : '';
+    return this.apiService.get<FilterNavigationData>(`categories/${category}/productfilters${params}`, {
+      skipApiErrorHandling: true,
+    });
   }
 }

--- a/src/app/core/services/product-master-variations/product-master-variations.service.spec.ts
+++ b/src/app/core/services/product-master-variations/product-master-variations.service.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import b64u from 'b64u';
 
 import { Filter } from 'ish-core/models/filter/filter.model';
 import { VariationProductMasterView, VariationProductView } from 'ish-core/models/product-view/product-view.model';
+import { URLFormParams, formParamsToString } from 'ish-core/utils/url-form-params';
 
 import { ProductMasterVariationsService } from './product-master-variations.service';
 
@@ -33,8 +33,7 @@ describe('Product Master Variations Service', () => {
         `${val.id}: ` +
         serialize(
           val.facets.map(
-            facet =>
-              `${facet.name}:${facet.selected}:${facet.count} -> ${b64u.decode(b64u.fromBase64(facet.searchParameter))}`
+            facet => `${facet.name}:${facet.selected}:${facet.count} -> ${formParamsToString(facet.searchParameter)}`
           )
         ),
     });
@@ -58,7 +57,7 @@ describe('Product Master Variations Service', () => {
 
   describe('without extra filters activated', () => {
     it('should respond with unselected filters and all variations when queried', () => {
-      expect(productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, ''))
+      expect(productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, {}))
         .toMatchInlineSnapshot(`
         Object {
           "filterNavigation": Object {
@@ -89,7 +88,10 @@ describe('Product Master Variations Service', () => {
   describe('with extra single filters activated', () => {
     it('should respond with selected filters and all variations when queried', () => {
       expect(
-        productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, 'HDD=512GB&COL=Red')
+        productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, {
+          HDD: ['512GB'],
+          COL: ['Red'],
+        } as URLFormParams)
       ).toMatchInlineSnapshot(`
         Object {
           "filterNavigation": Object {
@@ -115,8 +117,11 @@ describe('Product Master Variations Service', () => {
 
   describe('with extra single filters restricting other filters activated', () => {
     it('should respond with selected filters and all variations when queried', () => {
-      expect(productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, 'COL=Black'))
-        .toMatchInlineSnapshot(`
+      expect(
+        productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, {
+          COL: ['Black'],
+        } as URLFormParams)
+      ).toMatchInlineSnapshot(`
         Object {
           "filterNavigation": Object {
             "filter": Array [
@@ -141,10 +146,10 @@ describe('Product Master Variations Service', () => {
   describe('with extra multi filters activated', () => {
     it('should respond with selected filters and all variations when queried', () => {
       expect(
-        productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(
-          master,
-          'HDD=512GB,256GB&COL=Red'
-        )
+        productMasterVariationsService.getFiltersAndFilteredVariationsForMasterProduct(master, {
+          HDD: ['512GB', '256GB'],
+          COL: ['Red'],
+        } as URLFormParams)
       ).toMatchInlineSnapshot(`
         Object {
           "filterNavigation": Object {

--- a/src/app/core/services/product-master-variations/product-master-variations.service.ts
+++ b/src/app/core/services/product-master-variations/product-master-variations.service.ts
@@ -1,20 +1,18 @@
 import { Injectable } from '@angular/core';
-import b64u from 'b64u';
 import { groupBy } from 'lodash-es';
 
 import { Facet } from 'ish-core/models/facet/facet.model';
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { VariationAttribute } from 'ish-core/models/product-variation/variation-attribute.model';
 import { VariationProductMasterView, VariationProductView } from 'ish-core/models/product-view/product-view.model';
-import { URLFormParams, formParamsToString, stringToFormParams } from 'ish-core/utils/url-form-params';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 @Injectable({ providedIn: 'root' })
 export class ProductMasterVariationsService {
   getFiltersAndFilteredVariationsForMasterProduct(
     product: VariationProductMasterView,
-    filterString: string
+    filters: URLFormParams
   ): { filterNavigation: FilterNavigation; products: string[] } {
-    const filters = stringToFormParams(filterString);
     return {
       filterNavigation: this.createFilterNavigation(product, filters),
       products: this.filterVariations(product, filters),
@@ -64,9 +62,10 @@ export class ProductMasterVariationsService {
   private createFacet(
     filterName: string,
     attribute: VariationAttribute,
-    filters: URLFormParams,
+    filtersURLFormParams: URLFormParams,
     variations: VariationProductView[]
   ): Facet {
+    const filters = filtersURLFormParams || {};
     const selected = !!filters[filterName] && filters[filterName].includes(attribute.value);
     const newFilters = {
       ...filters,
@@ -76,7 +75,7 @@ export class ProductMasterVariationsService {
     };
     return {
       name: attribute.value,
-      searchParameter: b64u.toBase64(b64u.encode(formParamsToString(newFilters))),
+      searchParameter: newFilters,
       count:
         this.potentialMatches(newFilters, variations).length &&
         variations.filter(variation =>

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -21,7 +21,7 @@ import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-togg
  */
 @Injectable({ providedIn: 'root' })
 export class ProductsService {
-  private static STUB_ATTRS =
+  static STUB_ATTRS =
     'sku,salePrice,listPrice,availability,manufacturer,image,minOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet';
 
   private itemsPerPage: number;
@@ -103,7 +103,7 @@ export class ProductsService {
    */
   searchProducts(
     searchTerm: string,
-    page: number,
+    page: number = 1,
     sortKey?: string
   ): Observable<{ products: Product[]; sortKeys: string[]; total: number }> {
     if (!searchTerm) {

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -2,17 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { isEqual } from 'lodash-es';
-import {
-  distinctUntilChanged,
-  filter,
-  map,
-  mergeMap,
-  switchMap,
-  switchMapTo,
-  tap,
-  withLatestFrom,
-} from 'rxjs/operators';
+import { filter, map, mergeMap, switchMap, switchMapTo, tap, withLatestFrom } from 'rxjs/operators';
 
 import { MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH } from 'ish-core/configurations/injection-keys';
 import { CategoryHelper } from 'ish-core/models/category/category.model';
@@ -111,8 +101,7 @@ export class CategoriesEffects {
           filter(cat => cat.hasOnlineProducts),
           map(({ uniqueId }) => loadMoreProducts({ id: { type: 'category', value: uniqueId } }))
         )
-      ),
-      distinctUntilChanged(isEqual)
+      )
     )
   );
 

--- a/src/app/core/store/shopping/categories/categories.reducer.spec.ts
+++ b/src/app/core/store/shopping/categories/categories.reducer.spec.ts
@@ -36,7 +36,6 @@ describe('Categories Reducer', () => {
         const action = loadCategory({ categoryId: '123' });
         const state = categoriesReducer(initialState, action);
 
-        expect(state.loading).toBeTrue();
         expect(state.categories).toEqual(categoryTree());
       });
     });
@@ -46,7 +45,6 @@ describe('Categories Reducer', () => {
         const action = loadCategoryFail({ error: {} as HttpError });
         const state = categoriesReducer(initialState, action);
 
-        expect(state.loading).toBeFalse();
         expect(state.categories).toEqual(categoryTree());
       });
     });
@@ -87,13 +85,6 @@ describe('Categories Reducer', () => {
 
         expect(Object.keys(state2.categories.nodes)).toHaveLength(1);
         expect(state2.categories.nodes[category.uniqueId]).toEqual(updatedCategory);
-      });
-
-      it('should set loading to false', () => {
-        const action = loadCategorySuccess({ categories: categoryTree([category]) });
-        const state = categoriesReducer(initialState, action);
-
-        expect(state.loading).toBeFalse();
       });
     });
   });

--- a/src/app/core/store/shopping/categories/categories.reducer.ts
+++ b/src/app/core/store/shopping/categories/categories.reducer.ts
@@ -1,22 +1,14 @@
 import { createReducer, on } from '@ngrx/store';
 
 import { CategoryTree, CategoryTreeHelper } from 'ish-core/models/category-tree/category-tree.model';
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
 
-import {
-  loadCategory,
-  loadCategoryFail,
-  loadCategorySuccess,
-  loadTopLevelCategoriesSuccess,
-} from './categories.actions';
+import { loadCategoryFail, loadCategorySuccess, loadTopLevelCategoriesSuccess } from './categories.actions';
 
 export interface CategoriesState {
   categories: CategoryTree;
-  loading: boolean;
 }
 
 export const initialState: CategoriesState = {
-  loading: false,
   categories: CategoryTreeHelper.empty(),
 };
 
@@ -29,16 +21,13 @@ function mergeCategories(
   return {
     ...state,
     categories,
-    loading: false,
   };
 }
 
 export const categoriesReducer = createReducer(
   initialState,
-  setLoadingOn(loadCategory),
   on(loadCategoryFail, (state: CategoriesState) => ({
     ...state,
-    loading: false,
   })),
   on(loadCategorySuccess, loadTopLevelCategoriesSuccess, mergeCategories)
 );

--- a/src/app/core/store/shopping/categories/categories.selectors.spec.ts
+++ b/src/app/core/store/shopping/categories/categories.selectors.spec.ts
@@ -22,7 +22,6 @@ import {
   getBreadcrumbForCategoryPage,
   getCategory,
   getCategoryEntities,
-  getCategoryLoading,
   getNavigationCategories,
   getSelectedCategory,
 } from './categories.selectors';
@@ -70,7 +69,6 @@ describe('Categories Selectors', () => {
   describe('with empty state', () => {
     it('should not select any categories when used', () => {
       expect(getCategoryEntities(store$.state)).toBeEmpty();
-      expect(getCategoryLoading(store$.state)).toBeFalse();
     });
 
     it('should not select any selected category when used', () => {
@@ -84,17 +82,12 @@ describe('Categories Selectors', () => {
       store$.dispatch(loadCategory({ categoryId: '' }));
     });
 
-    it('should set the state to loading', () => {
-      expect(getCategoryLoading(store$.state)).toBeTrue();
-    });
-
     describe('and reporting success', () => {
       beforeEach(() => {
         store$.dispatch(loadCategorySuccess({ categories: categoryTree([catA]) }));
       });
 
       it('should set loading to false', () => {
-        expect(getCategoryLoading(store$.state)).toBeFalse();
         expect(getCategoryEntities(store$.state)).toHaveProperty(catA.uniqueId);
       });
     });
@@ -105,7 +98,6 @@ describe('Categories Selectors', () => {
       });
 
       it('should not have loaded category on error', () => {
-        expect(getCategoryLoading(store$.state)).toBeFalse();
         expect(getCategoryEntities(store$.state)).toBeEmpty();
       });
     });
@@ -120,7 +112,6 @@ describe('Categories Selectors', () => {
     describe('but no current router state', () => {
       it('should return the category information when used', () => {
         expect(getCategoryEntities(store$.state)).toHaveProperty(catA.uniqueId);
-        expect(getCategoryLoading(store$.state)).toBeFalse();
         expect(getCategory(catA.uniqueId)(store$.state).uniqueId).toEqual(catA.uniqueId);
       });
 
@@ -141,7 +132,6 @@ describe('Categories Selectors', () => {
 
       it('should return the category information when used', () => {
         expect(getCategoryEntities(store$.state)).toHaveProperty(catA.uniqueId);
-        expect(getCategoryLoading(store$.state)).toBeFalse();
         expect(getCategory(catA.uniqueId)(store$.state).uniqueId).toEqual(catA.uniqueId);
       });
 

--- a/src/app/core/store/shopping/categories/categories.selectors.ts
+++ b/src/app/core/store/shopping/categories/categories.selectors.ts
@@ -39,8 +39,6 @@ export const getSelectedCategory = createSelectorFactory(projector => defaultMem
   createCategoryView
 );
 
-export const getCategoryLoading = createSelector(getCategoriesState, categories => categories.loading);
-
 export const getBreadcrumbForCategoryPage = createSelectorFactory(projector =>
   defaultMemoize(projector, undefined, isEqual)
 )(getSelectedCategory, getCategoryEntities, (category: CategoryView, entities: Dictionary<Category>) =>

--- a/src/app/core/store/shopping/filter/filter.actions.ts
+++ b/src/app/core/store/shopping/filter/filter.actions.ts
@@ -3,6 +3,7 @@ import { createAction } from '@ngrx/store';
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { ProductListingID } from 'ish-core/models/product-listing/product-listing.model';
 import { httpError, payload } from 'ish-core/utils/ngrx-creators';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 export const loadFilterForCategory = createAction(
   '[Filter Internal] Load Filter For Category',
@@ -21,16 +22,16 @@ export const loadFilterForSearch = createAction(
   payload<{ searchTerm: string }>()
 );
 
-export const applyFilter = createAction('[Filter] Apply Filter', payload<{ searchParameter: string }>());
+export const applyFilter = createAction('[Filter] Apply Filter', payload<{ searchParameter: URLFormParams }>());
 
 export const applyFilterSuccess = createAction(
   '[Filter API] Apply Filter Success',
-  payload<{ availableFilter: FilterNavigation; searchParameter: string }>()
+  payload<{ availableFilter: FilterNavigation; searchParameter: URLFormParams }>()
 );
 
 export const applyFilterFail = createAction('[Filter API] Apply Filter Fail', httpError());
 
 export const loadProductsForFilter = createAction(
   '[Filter Internal] Load Products For Filter',
-  payload<{ id: ProductListingID; searchParameter: string }>()
+  payload<{ id: ProductListingID; searchParameter: URLFormParams; page?: number; sorting?: string }>()
 );

--- a/src/app/core/store/shopping/filter/filter.effects.spec.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.spec.ts
@@ -3,7 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { Observable, of, throwError } from 'rxjs';
-import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
 import { PRODUCT_LISTING_ITEMS_PER_PAGE } from 'ish-core/configurations/injection-keys';
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
@@ -48,7 +48,7 @@ describe('Filter Effects', () => {
       }
     });
 
-    when(filterServiceMock.getFilteredProducts(anything())).thenCall(a => {
+    when(filterServiceMock.getFilteredProducts(anything(), anything(), anything())).thenCall(a => {
       if (a.name === 'invalid') {
         return throwError({ message: 'invalid' });
       } else {
@@ -59,8 +59,8 @@ describe('Filter Effects', () => {
       }
     });
 
-    when(filterServiceMock.applyFilter(anyString())).thenCall(a => {
-      if (a === 'invalid') {
+    when(filterServiceMock.applyFilter(anything())).thenCall(a => {
+      if (a.param[0] === 'invalid') {
         return throwError({ message: 'invalid' });
       } else {
         return of(filterNav);
@@ -110,20 +110,20 @@ describe('Filter Effects', () => {
 
   describe('applyFilter$', () => {
     it('should call the filterService for ApplyFilter action', done => {
-      const action = applyFilter({ searchParameter: 'b' });
+      const action = applyFilter({ searchParameter: { param: ['b'] } });
       actions$ = of(action);
 
       effects.applyFilter$.subscribe(() => {
-        verify(filterServiceMock.applyFilter('b')).once();
+        verify(filterServiceMock.applyFilter(deepEqual({ param: ['b'] }))).once();
         done();
       });
     });
 
     it('should map to action of type ApplyFilterSuccess', () => {
-      const action = applyFilter({ searchParameter: 'b' });
+      const action = applyFilter({ searchParameter: { param: ['b'] } });
       const completion = applyFilterSuccess({
         availableFilter: filterNav,
-        searchParameter: 'b',
+        searchParameter: { param: ['b'] },
       });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -132,7 +132,7 @@ describe('Filter Effects', () => {
     });
 
     it('should map invalid request to action of type ApplyFilterFail', () => {
-      const action = applyFilter({ searchParameter: 'invalid' });
+      const action = applyFilter({ searchParameter: { param: ['invalid'] } });
       const completion = applyFilterFail({ error: { message: 'invalid' } as HttpError });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -147,15 +147,16 @@ describe('Filter Effects', () => {
         id: {
           type: 'search',
           value: 'test',
-          filters: 'b*',
+          filters: { searchTerm: ['b*'] },
         },
-        searchParameter: 'b',
+
+        searchParameter: { param: ['b'] },
       });
       const completion = setProductListingPages({
         id: {
           type: 'search',
           value: 'test',
-          filters: 'b*',
+          filters: { searchTerm: ['b*'] },
         },
         1: ['123', '234'],
         itemCount: 2,

--- a/src/app/core/store/shopping/filter/filter.effects.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.ts
@@ -70,13 +70,16 @@ export class FilterEffects {
     this.actions$.pipe(
       ofType(loadProductsForFilter),
       mapToPayload(),
-      switchMap(({ id, searchParameter }) =>
-        this.filterService.getFilteredProducts(searchParameter).pipe(
-          mergeMap(({ productSKUs, total }) => [
+      switchMap(({ id, searchParameter, page, sorting }) =>
+        this.filterService.getFilteredProducts(searchParameter, page, sorting).pipe(
+          mergeMap(({ productSKUs, total, sortKeys }) => [
             setProductListingPages(
               this.productListingMapper.createPages(productSKUs, id.type, id.value, {
                 filters: id.filters,
                 itemCount: total,
+                startPage: page,
+                sortKeys,
+                sorting,
               })
             ),
           ]),

--- a/src/app/core/store/shopping/filter/filter.reducer.spec.ts
+++ b/src/app/core/store/shopping/filter/filter.reducer.spec.ts
@@ -75,7 +75,8 @@ describe('Filter Reducer', () => {
       const filter = { filter: [{ name: 'a' }] } as FilterNavigation;
       const action = applyFilterSuccess({
         availableFilter: filter,
-        searchParameter: 'b',
+
+        searchParameter: { param: ['b'] },
       });
       const state = filterReducer(initialState, action);
 

--- a/src/app/core/store/shopping/product-listing/product-listing.actions.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.actions.ts
@@ -3,6 +3,7 @@ import { createAction } from '@ngrx/store';
 import { ProductListingID, ProductListingType } from 'ish-core/models/product-listing/product-listing.model';
 import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
 import { payload } from 'ish-core/utils/ngrx-creators';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 export const setProductListingPages = createAction(
   '[Product Listing Internal] Set Product Listing Pages',
@@ -21,12 +22,12 @@ export const loadMoreProducts = createAction(
 
 export const loadMoreProductsForParams = createAction(
   '[Product Listing Internal] Load More Products For Params',
-  payload<{ id: ProductListingID; page: number; sorting: string; filters: string }>()
+  payload<{ id: ProductListingID; page: number; sorting: string; filters: URLFormParams }>()
 );
 
 export const setViewType = createAction('[Product Listing Internal] Set View Type', payload<{ viewType: ViewType }>());
 
 export const loadPagesForMaster = createAction(
   '[Product Listing Internal] Load Pages For Master',
-  payload<{ id: ProductListingID; filters: string; sorting: string }>()
+  payload<{ id: ProductListingID; filters: URLFormParams; sorting: string }>()
 );

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -75,6 +75,8 @@ describe('Product Listing Effects', () => {
     it('should fire all necessary actions for search page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: 'term' } }));
 
+      tick(0);
+
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
           id: {"type":"search","value":"term"}
@@ -94,6 +96,8 @@ describe('Product Listing Effects', () => {
 
     it('should fire all necessary actions for family page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'category', value: 'cat' } }));
+
+      tick(0);
 
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
@@ -115,7 +119,7 @@ describe('Product Listing Effects', () => {
 
   describe('action triggering with filters', () => {
     beforeEach(fakeAsync(() => {
-      router.navigateByUrl('/some?filters=blablubb');
+      router.navigateByUrl('/some?filters=param%3Dblablubb');
       tick(500);
       store$.reset();
     }));
@@ -123,38 +127,48 @@ describe('Product Listing Effects', () => {
     it('should fire all necessary actions for search page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: 'term' } }));
 
+      tick(0);
+
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
           id: {"type":"search","value":"term"}
         [Product Listing Internal] Load More Products For Params:
-          id: {"type":"search","value":"term"}
-          filters: "blablubb"
+          id: {"type":"search","value":"term","filters":{"param":[1],"sear...
+          filters: {"param":[1],"searchTerm":[1]}
           sorting: undefined
           page: undefined
         [Filter Internal] Load Products For Filter:
-          id: {"type":"search","value":"term","filters":"blablubb"}
-          searchParameter: "YmxhYmx1YmI="
+          id: {"type":"search","value":"term","filters":{"param":[1],"sear...
+          searchParameter: {"param":[1],"searchTerm":[1]}
+          page: undefined
+          sorting: undefined
         [Filter] Apply Filter:
-          searchParameter: "YmxhYmx1YmI="
+          searchParameter: {"param":[1],"searchTerm":[1]}
       `);
+      expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.param', ['blablubb']);
+      expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.searchTerm', ['term']);
     }));
 
     it('should fire all necessary actions for family page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'category', value: 'cat' } }));
 
+      tick(0);
+
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
           id: {"type":"category","value":"cat"}
         [Product Listing Internal] Load More Products For Params:
-          id: {"type":"category","value":"cat"}
-          filters: "blablubb"
+          id: {"type":"category","value":"cat","filters":{"param":[1]}}
+          filters: {"param":[1]}
           sorting: undefined
           page: undefined
         [Filter Internal] Load Products For Filter:
-          id: {"type":"category","value":"cat","filters":"blablubb"}
-          searchParameter: "YmxhYmx1YmI="
+          id: {"type":"category","value":"cat","filters":{"param":[1]}}
+          searchParameter: {"param":[1]}
+          page: undefined
+          sorting: undefined
         [Filter] Apply Filter:
-          searchParameter: "YmxhYmx1YmI="
+          searchParameter: {"param":[1]}
       `);
     }));
   });

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import b64u from 'b64u';
 import { isEqual } from 'lodash-es';
 import { distinctUntilChanged, filter, map, mapTo, mergeMap, switchMap, take } from 'rxjs/operators';
 
@@ -10,7 +9,8 @@ import {
   PRODUCT_LISTING_ITEMS_PER_PAGE,
 } from 'ish-core/configurations/injection-keys';
 import { ProductListingMapper } from 'ish-core/models/product-listing/product-listing.mapper';
-import { ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
+import { ProductListingView } from 'ish-core/models/product-listing/product-listing.model';
+import { Product, ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
 import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
 import { ProductMasterVariationsService } from 'ish-core/services/product-master-variations/product-master-variations.service';
 import { selectQueryParam, selectQueryParams } from 'ish-core/store/core/router';
@@ -24,6 +24,7 @@ import {
 import { getProduct, loadProductsForCategory } from 'ish-core/store/shopping/products';
 import { searchProducts } from 'ish-core/store/shopping/search';
 import { mapToPayload, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
+import { stringToFormParams } from 'ish-core/utils/url-form-params';
 
 import {
   loadMoreProducts,
@@ -67,21 +68,48 @@ export class ProductListingEffects {
     )
   );
 
+  /**
+   * determine params for search & category pages
+   *
+   * case #1
+   * refresh page (F5): initialPage is set by GET parameter "page" and will be used for the first time
+   * (initial page)
+   *
+   * case #2
+   * endless scroll: initialPage is resetted after first usage and params.page will be used for endless scroll
+   *
+   * extra
+   * the result is also the cachekey for caching productlists in loadMoreProducts$
+   */
   determineParams$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadMoreProducts),
       mapToPayload(),
-      switchMap(({ id, page }) =>
-        this.store.pipe(
+      switchMap(({ id, page }) => {
+        let initialPage = page; // scope variable (reset after first usage)
+        return this.store.pipe(
           select(selectQueryParams),
-          map(params => ({
-            id,
-            sorting: params.sorting || undefined,
-            page: +params.page || page || undefined,
-            filters: params.filters || undefined,
-          }))
-        )
-      ),
+          map(params => {
+            const filters = params.filters
+              ? {
+                  ...stringToFormParams(params.filters),
+                  ...(id.type === 'search' ? { searchTerm: [id.value] } : {}),
+                }
+              : undefined;
+
+            const p = initialPage || +params.page || undefined; // determine page
+
+            initialPage = 0; // reset scope variable
+
+            return {
+              id: { ...id, filters },
+              sorting: params.sorting || undefined,
+              page: p > 1 ? p : undefined, // same content for 0, 1 & undefined
+              filters,
+            };
+          })
+        );
+      }),
       distinctUntilChanged(isEqual),
       map(({ id, filters, sorting, page }) => loadMoreProductsForParams({ id, filters, sorting, page }))
     )
@@ -93,8 +121,8 @@ export class ProductListingEffects {
       mapToPayload(),
       switchMap(({ id, sorting, page, filters }) =>
         this.store.pipe(
-          select(getProductListingView, { ...id, sorting, filters }),
-          map(view => ({
+          select(getProductListingView, { ...id, sorting, page, filters }),
+          map((view: ProductListingView) => ({
             id,
             sorting,
             page,
@@ -103,19 +131,20 @@ export class ProductListingEffects {
           }))
         )
       ),
+      distinctUntilChanged((a, b) => isEqual({ ...a, viewAvailable: undefined }, { ...b, viewAvailable: undefined })),
       map(({ id, sorting, page, filters, viewAvailable }) => {
         if (viewAvailable) {
-          return setProductListingPages({ id: { sorting, filters, ...id } });
+          return setProductListingPages({ id: { page, sorting, filters, ...id } });
         }
         if (
           filters &&
           // TODO: work-around for different products/hits-result without filters
-          (id.type !== 'search' || (id.type === 'search' && filters !== `&@QueryTerm=${id.value}&OnlineFlag=1`)) &&
+          (id.type !== 'search' || this.isSearchFor(filters.searchTerm, id)) &&
           // TODO: work-around for client side computation of master variations
           ['search', 'category'].includes(id.type)
         ) {
-          const searchParameter = b64u.toBase64(b64u.encode(filters));
-          return loadProductsForFilter({ id: { ...id, filters }, searchParameter });
+          const searchParameter = filters;
+          return loadProductsForFilter({ id: { ...id, filters }, searchParameter, page, sorting });
         } else {
           switch (id.type) {
             case 'category':
@@ -144,11 +173,11 @@ export class ProductListingEffects {
         if (
           filters &&
           // TODO: work-around for different products/hits-result without filters
-          (type !== 'search' || (type === 'search' && filters !== `&@QueryTerm=${value}&OnlineFlag=1`)) &&
+          (type !== 'search' || this.isSearchFor(filters.searchTerm, { type, value })) &&
           // TODO: work-around for client side computation of master variations
           ['search', 'category'].includes(type)
         ) {
-          const searchParameter = b64u.toBase64(b64u.encode(filters));
+          const searchParameter = filters;
           return applyFilter({ searchParameter });
         } else {
           switch (type) {
@@ -178,7 +207,7 @@ export class ProductListingEffects {
       switchMap(({ id, filters }) =>
         this.store.pipe(
           select(getProduct, { sku: id.value }),
-          filter(p => ProductHelper.isSufficientlyLoaded(p, ProductCompletenessLevel.Detail)),
+          filter((p: Product) => ProductHelper.isSufficientlyLoaded(p, ProductCompletenessLevel.Detail)),
           filter(ProductHelper.hasVariations),
           filter(ProductHelper.isMasterProduct),
           take(1),
@@ -191,7 +220,7 @@ export class ProductListingEffects {
             return [
               setProductListingPages(
                 this.productListingMapper.createPages(products, id.type, id.value, {
-                  filters: filters ? b64u.toBase64(b64u.encode(filters)) : undefined,
+                  filters: filters ? filters : undefined,
                 })
               ),
               loadFilterSuccess({ filterNavigation }),
@@ -201,4 +230,8 @@ export class ProductListingEffects {
       )
     )
   );
+
+  private isSearchFor(searchTerm: string[], id: { type: string; value: string }): boolean {
+    return id.type === 'search' && searchTerm && searchTerm.includes(id.value);
+  }
 }

--- a/src/app/core/store/shopping/product-listing/product-listing.reducer.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.reducer.ts
@@ -7,11 +7,12 @@ import { loadProductsForFilter } from 'ish-core/store/shopping/filter';
 import { loadProductsForCategory, loadProductsForCategoryFail } from 'ish-core/store/shopping/products';
 import { searchProducts, searchProductsFail } from 'ish-core/store/shopping/search';
 import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { formParamsToString } from 'ish-core/utils/url-form-params';
 
 import { setProductListingPageSize, setProductListingPages, setViewType } from './product-listing.actions';
 
 export function serializeProductListingID(id: ProductListingID) {
-  return `${id.type}@${id.value}@${id.filters || id.sorting}`;
+  return `${id.type}@${id.value}@${formParamsToString(id.filters)}@${id.sorting}`;
 }
 
 export const adapter = createEntityAdapter<ProductListingType>({

--- a/src/app/core/store/shopping/product-listing/product-listing.selectors.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.selectors.ts
@@ -86,7 +86,7 @@ const createView = (data, itemsPerPage): ProductListingView => {
 };
 
 function calculateLookUpID(id: ProductListingID, settings: Pick<ProductListingID, 'filters' | 'sorting'>) {
-  const currentSettings = settings[serializeProductListingID({ type: id.type, value: id.value })] || {};
+  const currentSettings = settings[serializeProductListingID(id)] || {};
   return serializeProductListingID({ ...currentSettings, ...id });
 }
 
@@ -98,9 +98,6 @@ export const getProductListingView = createSelector(
     (entities, itemsPerPage, settings, id) =>
       entities && createView(entities[calculateLookUpID(id, settings)], itemsPerPage),
     (entities, _, settings, id: ProductListingID) =>
-      JSON.stringify([
-        entities[calculateLookUpID(id, settings)],
-        settings[serializeProductListingID({ type: id.type, value: id.value })],
-      ])
+      JSON.stringify([entities[calculateLookUpID(id, settings)], settings[serializeProductListingID(id)]])
   )
 );

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -3,9 +3,18 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { isEqual } from 'lodash-es';
 import { EMPTY } from 'rxjs';
-import { catchError, concatMap, debounceTime, distinctUntilChanged, map, sample, switchMap, tap } from 'rxjs/operators';
+import {
+  catchError,
+  concatMap,
+  debounceTime,
+  distinctUntilChanged,
+  map,
+  sample,
+  switchMap,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators';
 
 import { ProductListingMapper } from 'ish-core/models/product-listing/product-listing.mapper';
 import { ProductsService } from 'ish-core/services/products/products.service';
@@ -36,12 +45,12 @@ export class SearchEffects {
    */
   triggerSearch$ = createEffect(() =>
     this.store.pipe(
-      ofUrl(/^\/search.*/),
-      select(selectRouteParam('searchTerm')),
       sample(this.actions$.pipe(ofType(routerNavigatedAction))),
+      ofUrl(/^\/search.*/),
+      withLatestFrom(this.store.pipe(select(selectRouteParam('searchTerm')))),
+      map(([, searchTerm]) => searchTerm),
       whenTruthy(),
-      map(searchTerm => loadMoreProducts({ id: { type: 'search', value: searchTerm } })),
-      distinctUntilChanged(isEqual)
+      map(searchTerm => loadMoreProducts({ id: { type: 'search', value: searchTerm } }))
     )
   );
 

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -348,8 +348,6 @@ describe('Shopping Store', () => {
             sortKeys: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
-          [Product Listing Internal] Set Product Listing Pages:
-            id: {"type":"search","value":"something"}
         `);
       }));
 
@@ -534,8 +532,6 @@ describe('Shopping Store', () => {
           sortKeys: []
         [Filter API] Load Filter Success:
           filterNavigation: {}
-        [Product Listing Internal] Set Product Listing Pages:
-          id: {"type":"category","value":"A.123.456"}
       `);
     }));
 
@@ -590,9 +586,13 @@ describe('Shopping Store', () => {
             @ngrx/router-store/navigation:
               routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
               event: {"id":3,"url":"/category/A.123.456"}
+            [Product Listing] Load More Products:
+              id: {"type":"category","value":"A.123.456"}
             @ngrx/router-store/navigated:
               routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
               event: {"id":3,"url":"/category/A.123.456"}
+            [Product Listing] Load More Products:
+              id: {"type":"category","value":"A.123.456"}
           `);
         }));
       });
@@ -640,8 +640,6 @@ describe('Shopping Store', () => {
             sortKeys: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
-          [Product Listing Internal] Set Product Listing Pages:
-            id: {"type":"search","value":"something"}
         `);
       }));
 
@@ -660,9 +658,24 @@ describe('Shopping Store', () => {
             @ngrx/router-store/navigation:
               routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
               event: {"id":3,"url":"/category/A.123.456"}
+            [Product Listing] Load More Products:
+              id: {"type":"category","value":"A.123.456"}
+            [Product Listing Internal] Load More Products For Params:
+              id: {"type":"category","value":"A.123.456"}
+              filters: undefined
+              sorting: undefined
+              page: undefined
+            [Product Listing Internal] Set Product Listing Pages:
+              id: {"type":"category","value":"A.123.456"}
+            [Filter Internal] Load Filter For Category:
+              uniqueId: "A.123.456"
+            [Filter API] Load Filter Success:
+              filterNavigation: {}
             @ngrx/router-store/navigated:
               routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
               event: {"id":3,"url":"/category/A.123.456"}
+            [Product Listing] Load More Products:
+              id: {"type":"category","value":"A.123.456"}
           `);
         }));
       });
@@ -813,11 +826,11 @@ describe('Shopping Store', () => {
             sortKeys: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
-          [Product Listing Internal] Set Product Listing Pages:
-            id: {"type":"category","value":"A.123.456"}
           @ngrx/router-store/navigated:
             routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
             event: {"id":2,"url":"/category/A.123.456"}
+          [Product Listing] Load More Products:
+            id: {"type":"category","value":"A.123.456"}
         `);
       }));
 
@@ -1088,8 +1101,6 @@ describe('Shopping Store', () => {
           sortKeys: []
         [Filter API] Load Filter Success:
           filterNavigation: {}
-        [Product Listing Internal] Set Product Listing Pages:
-          id: {"type":"search","value":"something"}
       `);
     }));
   });

--- a/src/app/pages/category/category-page.component.html
+++ b/src/app/pages/category/category-page.component.html
@@ -17,5 +17,3 @@
     <h1>{{ category.name }}</h1>
   </ng-container>
 </ng-container>
-
-<ish-loading *ngIf="categoryLoading$ | async"></ish-loading>

--- a/src/app/pages/category/category-page.component.spec.ts
+++ b/src/app/pages/category/category-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
@@ -54,15 +54,6 @@ describe('Category Page Component', () => {
 
     expect(findAllIshElements(element)).toBeEmpty();
   });
-
-  it('should display loading when category is loading', fakeAsync(() => {
-    when(shoppingFacade.selectedCategoryLoading$).thenReturn(of(true));
-
-    tick(5000);
-    fixture.detectChanges();
-
-    expect(findAllIshElements(element)).toEqual(['ish-loading']);
-  }));
 
   it('should display categories when category has sub categories', () => {
     const category = { uniqueId: 'dummy', categoryPath: ['dummy'] } as Category;

--- a/src/app/pages/category/category-page.component.ts
+++ b/src/app/pages/category/category-page.component.ts
@@ -13,14 +13,12 @@ import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 })
 export class CategoryPageComponent implements OnInit {
   category$: Observable<CategoryView>;
-  categoryLoading$: Observable<boolean>;
   deviceType$: Observable<DeviceType>;
 
   constructor(private shoppingFacade: ShoppingFacade, private appFacade: AppFacade) {}
 
   ngOnInit() {
     this.category$ = this.shoppingFacade.selectedCategory$;
-    this.categoryLoading$ = this.shoppingFacade.selectedCategoryLoading$;
     this.deviceType$ = this.appFacade.deviceType$;
   }
 }

--- a/src/app/pages/category/category-products/category-products.component.html
+++ b/src/app/pages/category/category-products/category-products.component.html
@@ -6,7 +6,9 @@
   <div class="row">
     <div class="col-md-3">
       <div class="navigation-panel" [ngbCollapse]="isCollapsed">
-        <ish-filter-navigation></ish-filter-navigation>
+        <ish-category-navigation [uniqueId]="category.categoryPath[0]"></ish-category-navigation>
+        <br />
+        <ish-filter-navigation [showCategoryFilter]="false"></ish-filter-navigation>
       </div>
       <a class="d-md-none mobile-filter-toggle" (click)="toggle()">
         {{ 'search.mobile.filter.trigger' | translate }}

--- a/src/app/pages/category/category-products/category-products.component.spec.ts
+++ b/src/app/pages/category/category-products/category-products.component.spec.ts
@@ -12,6 +12,8 @@ import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/bre
 import { FilterNavigationComponent } from 'ish-shared/components/filter/filter-navigation/filter-navigation.component';
 import { ProductListingComponent } from 'ish-shared/components/product/product-listing/product-listing.component';
 
+import { CategoryNavigationComponent } from '../category-navigation/category-navigation.component';
+
 import { CategoryProductsComponent } from './category-products.component';
 
 describe('Category Products Component', () => {
@@ -25,6 +27,7 @@ describe('Category Products Component', () => {
       declarations: [
         CategoryProductsComponent,
         MockComponent(BreadcrumbComponent),
+        MockComponent(CategoryNavigationComponent),
         MockComponent(FaIconComponent),
         MockComponent(FilterNavigationComponent),
         MockComponent(NgbCollapse),

--- a/src/app/pages/search/search-page.component.html
+++ b/src/app/pages/search/search-page.component.html
@@ -1,9 +1,9 @@
 <ng-container *ngIf="searchTerm$ | async as searchTerm">
   <!-- search result with products -->
-  <ng-container *ngIf="numberOfItems$ | async as numberOfItems; else noResult">
+  <ng-container *ngIf="(numberOfItems$ | async) || (filterParams$ | async); else noResult">
     <ish-search-result
       [searchTerm]="searchTerm"
-      [totalItems]="numberOfItems"
+      [totalItems]="numberOfItems$ | async"
       [deviceType]="deviceType$ | async"
     ></ish-search-result>
   </ng-container>

--- a/src/app/pages/search/search-page.component.spec.ts
+++ b/src/app/pages/search/search-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
@@ -23,6 +24,7 @@ describe('Search Page Component', () => {
     when(shoppingFacade.searchTerm$).thenReturn(of('search'));
 
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
       declarations: [
         MockComponent(BreadcrumbComponent),
         MockComponent(SearchNoResultComponent),
@@ -45,6 +47,7 @@ describe('Search Page Component', () => {
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
+    when(shoppingFacade.searchItemsCount$).thenReturn(of(0));
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 

--- a/src/app/pages/search/search-page.component.ts
+++ b/src/app/pages/search/search-page.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
@@ -15,13 +17,19 @@ export class SearchPageComponent implements OnInit {
   numberOfItems$: Observable<number>;
   searchLoading$: Observable<boolean>;
   deviceType$: Observable<DeviceType>;
+  filterParams$: Observable<string>;
 
-  constructor(private shoppingFacade: ShoppingFacade, private appFacade: AppFacade) {}
+  constructor(
+    private shoppingFacade: ShoppingFacade,
+    private appFacade: AppFacade,
+    private activatedRoute: ActivatedRoute
+  ) {}
 
   ngOnInit() {
     this.searchTerm$ = this.shoppingFacade.searchTerm$;
     this.numberOfItems$ = this.shoppingFacade.searchItemsCount$;
     this.searchLoading$ = this.shoppingFacade.searchLoading$;
     this.deviceType$ = this.appFacade.deviceType$;
+    this.filterParams$ = this.activatedRoute.queryParamMap.pipe(map(x => x.get('filters')));
   }
 }

--- a/src/app/shared/components/filter/filter-checkbox/filter-checkbox.component.html
+++ b/src/app/shared/components/filter/filter-checkbox/filter-checkbox.component.html
@@ -1,6 +1,6 @@
 <!--- TODO: implement Show All-->
 <ul class="filter-list">
-  <ng-container *ngFor="let facet of filterElement.facets">
+  <ng-container *ngFor="let facet of getFacets()">
     <li class="filter-item filter-layer{{ facet.level }}" [ngClass]="{ 'filter-selected': facet.selected }">
       <div>
         <label class="filter-item-checkbox-label-native">
@@ -11,4 +11,12 @@
       </div>
     </li>
   </ng-container>
+  <li
+    class="filter-item"
+    *ngIf="filterElement.limitCount !== -1 && filterElement.facets.length > filterElement.limitCount"
+  >
+    <a class="btn-link" (click)="showAll = !showAll">{{
+      (showAll ? 'search.filter.show_less.link' : 'search.filter.show_all.link') | translate
+    }}</a>
+  </li>
 </ul>

--- a/src/app/shared/components/filter/filter-checkbox/filter-checkbox.component.spec.ts
+++ b/src/app/shared/components/filter/filter-checkbox/filter-checkbox.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 
 import { Filter } from 'ish-core/models/filter/filter.model';
@@ -15,6 +16,7 @@ describe('Filter Checkbox Component', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
       declarations: [FilterCheckboxComponent, MockComponent(FaIconComponent), MockComponent(NgbCollapse), SanitizePipe],
     }).compileComponents();
   }));
@@ -22,6 +24,7 @@ describe('Filter Checkbox Component', () => {
   beforeEach(() => {
     const filterElement = {
       name: 'Brands',
+      limitCount: -1,
       facets: [
         { name: 'AsusName', count: 4, displayName: 'Asus' },
         { name: 'LogitechName', count: 5, displayName: 'Logitech', selected: true },

--- a/src/app/shared/components/filter/filter-checkbox/filter-checkbox.component.ts
+++ b/src/app/shared/components/filter/filter-checkbox/filter-checkbox.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 
 import { Facet } from 'ish-core/models/facet/facet.model';
 import { Filter } from 'ish-core/models/filter/filter.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 /**
  * The Filter Checkbox Component displays a filter group. The items of the filter group are presented as checkboxes.
@@ -19,9 +20,39 @@ import { Filter } from 'ish-core/models/filter/filter.model';
 })
 export class FilterCheckboxComponent {
   @Input() filterElement: Filter;
-  @Output() applyFilter: EventEmitter<{ searchParameter: string }> = new EventEmitter();
+  @Output() applyFilter: EventEmitter<{ searchParameter: URLFormParams }> = new EventEmitter();
+
+  /**
+   * two-way-binding (banana in a box) [(showAll)]="showAllElements[element.name]"
+   */
+  @Output()
+  showAllChange = new EventEmitter<boolean>();
+  private showAllValue = false;
+  @Input()
+  get showAll() {
+    return this.showAllValue;
+  }
+  set showAll(val) {
+    this.showAllValue = val;
+    this.showAllChange.emit(this.showAllValue);
+  }
 
   filter(facet: Facet) {
     this.applyFilter.emit({ searchParameter: facet.searchParameter });
+  }
+
+  /**
+   * sort selected to top, increase limitCount to selectedCount on showLess
+   */
+  getFacets() {
+    const facets = [...this.filterElement.facets];
+
+    const selectedFacetsCount = facets.filter(x => x.selected).length;
+
+    return this.showAll || this.filterElement.limitCount === -1
+      ? facets
+      : facets
+          .sort((a, b) => (a.selected > b.selected ? -1 : a.selected < b.selected ? 1 : 0))
+          .slice(0, Math.max(this.filterElement.limitCount || 0, selectedFacetsCount));
   }
 }

--- a/src/app/shared/components/filter/filter-collapsable/filter-collapsable.component.ts
+++ b/src/app/shared/components/filter/filter-collapsable/filter-collapsable.component.ts
@@ -8,7 +8,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 export class FilterCollapsableComponent implements OnInit {
   @Input() title: string;
   @Input() collapsed: boolean;
-  @Output() collapsedChanged = new EventEmitter<boolean>();
+  @Output() collapsedChange = new EventEmitter<boolean>();
 
   isCollapsed = false;
 
@@ -18,6 +18,6 @@ export class FilterCollapsableComponent implements OnInit {
 
   toggle() {
     this.isCollapsed = !this.isCollapsed;
-    this.collapsedChanged.emit(this.isCollapsed);
+    this.collapsedChange.emit(this.isCollapsed);
   }
 }

--- a/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.spec.ts
@@ -18,6 +18,15 @@ describe('Filter Dropdown Component', () => {
     }).compileComponents();
   }));
 
+  const facet = (n, value) => ({
+    name: value,
+    searchParameter: { [n]: value },
+    displayName: value,
+    count: 0,
+    selected: false,
+    level: 0,
+  });
+
   beforeEach(() => {
     fixture = TestBed.createComponent(FilterDropdownComponent);
     component = fixture.componentInstance;
@@ -25,15 +34,7 @@ describe('Filter Dropdown Component', () => {
     component.filterElement = {
       name: 'Color',
       id: 'Color_of_Product',
-      facets: [
-        { displayName: 'Red', name: 'Red', selected: false, searchParameter: 'red' },
-        {
-          displayName: 'Blue',
-          name: 'Blue',
-          selected: true,
-          searchParameter: 'blue',
-        },
-      ] as Facet[],
+      facets: [facet('Color_of_Product', 'red'), { ...facet('Color_of_Product', 'blue'), selected: true }] as Facet[],
     } as Filter;
   });
 
@@ -58,9 +59,9 @@ describe('Filter Dropdown Component', () => {
           ><span>Color</span></a
         >
         <div aria-labelledby="dropdownMenuLink" ngbdropdownmenu="">
-          <a class="dropdown-item"> Red </a
+          <a class="dropdown-item"> red </a
           ><a class="dropdown-item selected">
-            Blue <fa-icon class="icon-checked" ng-reflect-icon="fas,check"></fa-icon
+            blue <fa-icon class="icon-checked" ng-reflect-icon="fas,check"></fa-icon
           ></a>
         </div>
       </div>

--- a/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.ts
+++ b/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 
 import { Facet } from 'ish-core/models/facet/facet.model';
 import { Filter } from 'ish-core/models/filter/filter.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 @Component({
   selector: 'ish-filter-dropdown',
@@ -12,7 +13,7 @@ import { Filter } from 'ish-core/models/filter/filter.model';
 export class FilterDropdownComponent implements OnInit {
   @Input() filterElement: Filter;
   @Input() placeholderType: 'groupName' | 'selectedFacets' = 'groupName';
-  @Output() applyFilter: EventEmitter<{ searchParameter: string }> = new EventEmitter();
+  @Output() applyFilter: EventEmitter<{ searchParameter: URLFormParams }> = new EventEmitter();
 
   placeholder = '';
   selectedFacets: Facet[] = [];

--- a/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.spec.ts
+++ b/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.spec.ts
@@ -25,22 +25,23 @@ describe('Filter Navigation Badges Component', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement;
 
+    const facet = (n, value, selected) => ({
+      name: value,
+      searchParameter: { [n]: value },
+      displayName: value,
+      count: 0,
+      selected,
+      level: 0,
+    });
     component.filterNavigation = {
       filter: [
         {
           name: 'Color',
-          facets: [
-            { name: 'Red', searchParameter: 'red' },
-            { name: 'Blue', searchParameter: 'blue', selected: true },
-            { name: 'Black', searchParameter: 'black', selected: true },
-          ],
+          facets: [facet('Color', 'red', false), facet('Color', 'blue', true), facet('Color', 'black', true)],
         },
         {
           name: 'HDD',
-          facets: [
-            { name: '123', searchParameter: '123' },
-            { name: '456', searchParameter: '456', selected: true },
-          ],
+          facets: [facet('HDD', '123', false), facet('HDD', '456', true)],
         },
       ] as Filter[],
     } as FilterNavigation;
@@ -60,12 +61,12 @@ describe('Filter Navigation Badges Component', () => {
         <div class="col-md-10 col-xs-12">
           <div class="filter-navigation-badges">
             <a>
-              Color: Blue <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon
+              Color: blue <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon
             ></a>
           </div>
           <div class="filter-navigation-badges">
             <a>
-              Color: Black <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon
+              Color: black <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon
             ></a>
           </div>
           <div class="filter-navigation-badges">

--- a/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.ts
+++ b/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 @Component({
   selector: 'ish-filter-navigation-badges',
@@ -9,7 +10,7 @@ import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navig
 })
 export class FilterNavigationBadgesComponent implements OnChanges {
   @Input() filterNavigation: FilterNavigation;
-  @Output() applyFilter = new EventEmitter<{ searchParameter: string }>();
+  @Output() applyFilter = new EventEmitter<{ searchParameter: URLFormParams }>();
   @Output() clearFilters = new EventEmitter<void>();
   selected: { searchParameter: string; facetName: string; filterName: string }[];
 
@@ -32,7 +33,7 @@ export class FilterNavigationBadgesComponent implements OnChanges {
           );
   }
 
-  apply(select: { searchParameter: string; facetName: string; filterName: string }) {
+  apply(select: { searchParameter: URLFormParams; facetName: string; filterName: string }) {
     this.applyFilter.emit({ searchParameter: select.searchParameter });
   }
 

--- a/src/app/shared/components/filter/filter-navigation-horizontal/filter-navigation-horizontal.component.ts
+++ b/src/app/shared/components/filter/filter-navigation-horizontal/filter-navigation-horizontal.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { Filter } from 'ish-core/models/filter/filter.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 @Component({
   selector: 'ish-filter-navigation-horizontal',
@@ -10,7 +11,7 @@ import { Filter } from 'ish-core/models/filter/filter.model';
 })
 export class FilterNavigationHorizontalComponent {
   @Input() filterNavigation: FilterNavigation;
-  @Output() applyFilter = new EventEmitter<{ searchParameter: string }>();
+  @Output() applyFilter = new EventEmitter<{ searchParameter: URLFormParams }>();
 
   trackByFn(_, item: Filter) {
     return item.id;

--- a/src/app/shared/components/filter/filter-navigation-sidebar/filter-navigation-sidebar.component.html
+++ b/src/app/shared/components/filter/filter-navigation-sidebar/filter-navigation-sidebar.component.html
@@ -1,12 +1,13 @@
 <div *ngIf="filterNavigation" class="filter-panel">
   <div *ngFor="let element of filterNavigation.filter" [ngSwitch]="element.displayType">
-    <ish-filter-collapsable
-      [title]="element.name"
-      [collapsed]="collapsedElements[element.name]"
-      (collapsedChanged)="collapsedElements[element.name] = $event"
-    >
+    <ish-filter-collapsable [title]="element.name" [(collapsed)]="collapsedElements[element.name]">
       <!-- default: text & text_clear -->
-      <ish-filter-text *ngSwitchDefault [filterElement]="element" (applyFilter)="applyFilter.emit($event)">
+      <ish-filter-text
+        *ngSwitchDefault
+        [filterElement]="element"
+        (applyFilter)="applyFilter.emit($event)"
+        [(showAll)]="showAllElements[element.name]"
+      >
       </ish-filter-text>
 
       <!-- checkbox -->
@@ -14,6 +15,7 @@
         *ngSwitchCase="'checkbox'"
         [filterElement]="element"
         (applyFilter)="applyFilter.emit($event)"
+        [(showAll)]="showAllElements[element.name]"
       >
       </ish-filter-checkbox>
 

--- a/src/app/shared/components/filter/filter-navigation-sidebar/filter-navigation-sidebar.component.ts
+++ b/src/app/shared/components/filter/filter-navigation-sidebar/filter-navigation-sidebar.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 @Component({
   selector: 'ish-filter-navigation-sidebar',
@@ -9,10 +10,15 @@ import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navig
 })
 export class FilterNavigationSidebarComponent {
   @Input() filterNavigation: FilterNavigation;
-  @Output() applyFilter = new EventEmitter<{ searchParameter: string }>();
+  @Output() applyFilter = new EventEmitter<{ searchParameter: URLFormParams }>();
 
   /**
    * keeps the collapsed state of subcomponents when changing filters
    */
   collapsedElements = {};
+
+  /**
+   * keeps the show all state of subcomponents when changing filters
+   */
+  showAllElements = {};
 }

--- a/src/app/shared/components/filter/filter-navigation/filter-navigation.component.spec.ts
+++ b/src/app/shared/components/filter/filter-navigation/filter-navigation.component.spec.ts
@@ -39,6 +39,9 @@ describe('Filter Navigation Component', () => {
     fixture = TestBed.createComponent(FilterNavigationComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
+
+    const filterNavigation = { filter: [{ displayType: 'dropdown' } as Filter] } as FilterNavigation;
+    when(shoppingFacade.currentFilter$(true)).thenReturn(of(filterNavigation));
   });
 
   it('should be created', () => {
@@ -49,13 +52,14 @@ describe('Filter Navigation Component', () => {
 
   it('should not display anything when filter is not set', () => {
     fixture.detectChanges();
-    expect(findAllIshElements(element)).toBeEmpty();
+    expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+      Array [
+        "ish-filter-navigation-sidebar",
+      ]
+    `);
   });
 
   it('should display sidebar component for default mode', () => {
-    const filterNavigation = { filter: [{ displayType: 'dropdown' } as Filter] } as FilterNavigation;
-    when(shoppingFacade.currentFilter$).thenReturn(of(filterNavigation));
-
     fixture.detectChanges();
 
     expect(findAllIshElements(element)).toMatchInlineSnapshot(`
@@ -66,9 +70,6 @@ describe('Filter Navigation Component', () => {
   });
 
   it('should display horizontal components if set', () => {
-    const filterNavigation = { filter: [{ displayType: 'dropdown' } as Filter] } as FilterNavigation;
-    when(shoppingFacade.currentFilter$).thenReturn(of(filterNavigation));
-
     component.orientation = 'horizontal';
     fixture.detectChanges();
 

--- a/src/app/shared/components/filter/filter-navigation/filter-navigation.component.ts
+++ b/src/app/shared/components/filter/filter-navigation/filter-navigation.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import b64u from 'b64u';
 import { Observable } from 'rxjs';
 
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
+import { URLFormParams, formParamsToString } from 'ish-core/utils/url-form-params';
 
 @Component({
   selector: 'ish-filter-navigation',
@@ -14,20 +14,22 @@ import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navig
 export class FilterNavigationComponent implements OnInit {
   @Input() fragmentOnRouting: string;
   @Input() orientation: 'sidebar' | 'horizontal' = 'sidebar';
+  @Input() showCategoryFilter = true;
 
   filter$: Observable<FilterNavigation>;
 
   constructor(private shoppingFacade: ShoppingFacade, private router: Router, private activatedRoute: ActivatedRoute) {}
 
   ngOnInit() {
-    this.filter$ = this.shoppingFacade.currentFilter$;
+    this.filter$ = this.shoppingFacade.currentFilter$(this.showCategoryFilter);
   }
 
-  applyFilter(event: { searchParameter: string }) {
+  applyFilter(event: { searchParameter: URLFormParams }) {
+    const params = formParamsToString(event.searchParameter);
     this.router.navigate([], {
       queryParamsHandling: 'merge',
       relativeTo: this.activatedRoute,
-      queryParams: { filters: b64u.decode(b64u.fromBase64(event.searchParameter)), page: 1 },
+      queryParams: { filters: params, page: 1 },
       fragment: this.fragmentOnRouting,
     });
   }

--- a/src/app/shared/components/filter/filter-swatch-images/filter-swatch-images.component.spec.ts
+++ b/src/app/shared/components/filter/filter-swatch-images/filter-swatch-images.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
-import { FilterValueMap } from 'ish-core/models/filter/filter.interface';
 import { Filter } from 'ish-core/models/filter/filter.model';
 import { SanitizePipe } from 'ish-core/pipes/sanitize.pipe';
 
@@ -21,13 +20,9 @@ describe('Filter Swatch Images Component', () => {
     const filterElement = {
       name: 'Color',
       facets: [
-        { name: 'Black', count: 4, displayName: 'Black' },
-        { name: 'Red', count: 5, displayName: 'Red', selected: true },
+        { name: 'Black', count: 4, displayName: 'Black', mappedValue: 'black', mappedType: 'colorcode' },
+        { name: 'Red', count: 5, displayName: 'Red', mappedValue: 'red', mappedType: 'colorcode', selected: true },
       ],
-      filterValueMap: {
-        Black: { type: 'colorcode', mapping: 'black' },
-        Red: { type: 'colorcode', mapping: 'red' },
-      } as FilterValueMap,
     } as Filter;
     fixture = TestBed.createComponent(FilterSwatchImagesComponent);
     component = fixture.componentInstance;

--- a/src/app/shared/components/filter/filter-swatch-images/filter-swatch-images.component.ts
+++ b/src/app/shared/components/filter/filter-swatch-images/filter-swatch-images.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 
 import { Facet } from 'ish-core/models/facet/facet.model';
 import { Filter } from 'ish-core/models/filter/filter.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 /**
  * The Filter Swatch Images Component displays filter group for colors. The facets of the filter group are presented as swatch images.
@@ -22,7 +23,7 @@ export class FilterSwatchImagesComponent {
    * The filter group.
    */
   @Input() filterElement: Filter;
-  @Output() applyFilter: EventEmitter<{ searchParameter: string }> = new EventEmitter();
+  @Output() applyFilter: EventEmitter<{ searchParameter: URLFormParams }> = new EventEmitter();
 
   /**
    * Applies a facet of the filter group and shows the new filtered result.
@@ -32,18 +33,10 @@ export class FilterSwatchImagesComponent {
   }
 
   getBackgroundColor(facet: Facet) {
-    return this.filterElement.filterValueMap[facet.displayName] &&
-      this.filterElement.filterValueMap[facet.displayName].type
-      ? this.filterElement.filterValueMap[facet.displayName].type === 'colorcode'
-        ? this.filterElement.filterValueMap[facet.displayName].mapping
-        : undefined
-      : facet.displayName.toLowerCase();
+    return facet.mappedType === 'colorcode' ? facet.mappedValue : undefined;
   }
 
   getBackgroundImage(facet: Facet) {
-    return this.filterElement.filterValueMap[facet.displayName] &&
-      this.filterElement.filterValueMap[facet.displayName].type === 'image'
-      ? this.filterElement.filterValueMap[facet.displayName].mapping
-      : undefined;
+    return facet.mappedType === 'image' ? facet.mappedValue : undefined;
   }
 }

--- a/src/app/shared/components/filter/filter-text/filter-text.component.html
+++ b/src/app/shared/components/filter/filter-text/filter-text.component.html
@@ -1,23 +1,16 @@
 <!--- TODO: implement Show All-->
 <ul class="filter-list">
-  <ng-container *ngFor="let facet of facets">
+  <ng-container *ngFor="let facet of getFacets()">
     <li class="filter-item filter-layer{{ facet.level }}" [ngClass]="{ 'filter-selected': facet.selected }">
       <!-- selected -->
-      <ng-container *ngIf="facet.selected && facet.level === maxLevel; else notSelectedBox">
-        <!-- taxonomic category-filter (last level not unselectable) -->
-        <ng-container *ngIf="filterElement.selectionType === 'taxonomic'; else textTemplate">
+      <ng-container *ngIf="facet.selected; else notSelectedBox">
+        <a (click)="filter(facet)" [attr.data-testing-id]="'filter-link-' + (facet.name | sanitize)">
           <span class="filter-item-name"> {{ facet.displayName }} </span>
           <span class="count"> ({{ facet.count }}) </span>
-        </ng-container>
-        <ng-template #textTemplate>
-          <a (click)="filter(facet)">
-            <span class="filter-item-name"> {{ facet.displayName }} </span>
-            <span class="count"> ({{ facet.count }}) </span>
-            <ng-container *ngIf="filterElement.displayType === 'text_clear'">
-              <fa-icon [icon]="['fas', 'times']" class="float-right filter-clear"></fa-icon>
-            </ng-container>
-          </a>
-        </ng-template>
+          <ng-container *ngIf="filterElement.displayType === 'text_clear'">
+            <fa-icon [icon]="['fas', 'times']" class="float-right filter-clear"></fa-icon>
+          </ng-container>
+        </a>
       </ng-container>
 
       <!-- not selected -->
@@ -25,7 +18,7 @@
         <a
           class="filter-item-name"
           (click)="filter(facet)"
-          [attr.data-testing-id]="'filter-link-' + (facet.displayName | sanitize)"
+          [attr.data-testing-id]="'filter-link-' + (facet.name | sanitize)"
         >
           {{ facet.displayName }}
           <ng-container *ngIf="facet.level === maxLevel"> ({{ facet.count }}) </ng-container>
@@ -33,4 +26,10 @@
       </ng-template>
     </li>
   </ng-container>
+  <!-- show all/less -->
+  <li class="filter-item" *ngIf="filterElement.limitCount !== -1 && facets.length > filterElement.limitCount">
+    <a class="btn-link" (click)="showAll = !showAll">{{
+      (showAll ? 'search.filter.show_less.link' : 'search.filter.show_all.link') | translate
+    }}</a>
+  </li>
 </ul>

--- a/src/app/shared/components/filter/filter-text/filter-text.component.spec.ts
+++ b/src/app/shared/components/filter/filter-text/filter-text.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 
 import { Filter } from 'ish-core/models/filter/filter.model';
@@ -14,6 +15,7 @@ describe('Filter Text Component', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
       declarations: [FilterTextComponent, MockComponent(FaIconComponent), SanitizePipe],
     }).compileComponents();
   }));
@@ -21,6 +23,7 @@ describe('Filter Text Component', () => {
   beforeEach(() => {
     const filterElement = {
       name: 'Brands',
+      limitCount: -1,
       facets: [
         { name: 'AsusName', level: 0, count: 4, displayName: 'Asus' },
         { name: 'LogitechName', level: 0, count: 5, displayName: 'Logitech', selected: true },
@@ -39,10 +42,12 @@ describe('Filter Text Component', () => {
     expect(element).toMatchInlineSnapshot(`
       <ul class="filter-list">
         <li class="filter-item filter-layer0">
-          <a class="filter-item-name" data-testing-id="filter-link-Asus"> Asus (4) </a>
+          <a class="filter-item-name" data-testing-id="filter-link-AsusName"> Asus (4) </a>
         </li>
         <li class="filter-item filter-layer0 filter-selected">
-          <a><span class="filter-item-name"> Logitech </span><span class="count"> (5) </span></a>
+          <a data-testing-id="filter-link-LogitechName"
+            ><span class="filter-item-name"> Logitech </span><span class="count"> (5) </span></a
+          >
         </li>
       </ul>
     `);

--- a/src/app/shared/components/filter/filter-text/filter-text.component.ts
+++ b/src/app/shared/components/filter/filter-text/filter-text.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 
 import { Facet } from 'ish-core/models/facet/facet.model';
 import { Filter } from 'ish-core/models/filter/filter.model';
+import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 /**
  * The Filter Text Component displays a filter group. The facets of the filter group are presented as links with optional clear-button.
@@ -19,7 +20,22 @@ import { Filter } from 'ish-core/models/filter/filter.model';
 })
 export class FilterTextComponent implements OnInit {
   @Input() filterElement: Filter;
-  @Output() applyFilter: EventEmitter<{ searchParameter: string }> = new EventEmitter();
+  @Output() applyFilter: EventEmitter<{ searchParameter: URLFormParams }> = new EventEmitter();
+
+  /**
+   * two-way-binding (banana in a box) [(showAll)]="showAllElements[element.name]"
+   */
+  @Output()
+  showAllChange = new EventEmitter<boolean>();
+  private showAllValue = false;
+  @Input()
+  get showAll() {
+    return this.showAllValue;
+  }
+  set showAll(val) {
+    this.showAllValue = val;
+    this.showAllChange.emit(this.showAllValue);
+  }
 
   maxLevel = 0;
   facets: Facet[] = [];
@@ -35,5 +51,22 @@ export class FilterTextComponent implements OnInit {
 
   filter(facet: Facet) {
     this.applyFilter.emit({ searchParameter: facet.searchParameter });
+  }
+
+  /**
+   * sort selected to top, increase limitCount to selectedCount on showLess
+   */
+  getFacets() {
+    const facets = [...this.facets];
+
+    if (this.showAll || this.maxLevel >= 1 || this.filterElement.limitCount === -1) {
+      return facets;
+    }
+
+    const selectedFacetsCount = facets.filter(x => x.selected).length;
+
+    return facets
+      .sort((a, b) => (a.selected > b.selected ? -1 : a.selected < b.selected ? 1 : 0))
+      .slice(0, Math.max(this.filterElement.limitCount || 0, selectedFacetsCount));
   }
 }

--- a/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.ts
+++ b/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { isEqual } from 'lodash-es';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -50,8 +51,10 @@ export class ProductListToolbarComponent implements OnInit, OnChanges, OnDestroy
   }
 
   ngOnChanges(c: SimpleChanges) {
+    if (c.sortKeys && !isEqual(c.sortKeys.currentValue, c.sortKeys.previousValue)) {
+      this.updateSortKeys(c.sortKeys);
+    }
     this.updateSortBy(c.sortBy);
-    this.updateSortKeys(c.sortKeys);
   }
 
   private updateSortBy(sortBy: SimpleChange) {

--- a/src/app/shared/components/product/product-list/product-list.component.html
+++ b/src/app/shared/components/product/product-list/product-list.component.html
@@ -1,4 +1,14 @@
 <div class="product-list row">
+  <div *ngIf="!products.length">
+    <ng-container *ngIf="!(listingLoading$ | async)">
+      {{ 'search.noresult.filtered_products.message' | translate }}
+    </ng-container>
+  </div>
+
+  <div *ngIf="listingLoading$ | async" class="product-list-loading">
+    <ish-loading [standalone]="true"></ish-loading>
+  </div>
+
   <ng-container *ngFor="let sku of products">
     <div *ngIf="isGrid" class="col-6 col-lg-4 product-list-item grid-view">
       <ish-product-item [configuration]="{ displayType: 'tile' }" [productSku]="sku" [category]="category">
@@ -10,4 +20,8 @@
       </ish-product-item>
     </div>
   </ng-container>
+
+  <div *ngIf="listingLoading$ | async" class="col-12">
+    <ish-loading [standalone]="true"></ish-loading>
+  </div>
 </div>

--- a/src/app/shared/components/product/product-list/product-list.component.ts
+++ b/src/app/shared/components/product/product-list/product-list.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
 
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { Category } from 'ish-core/models/category/category.model';
 import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
 
@@ -18,10 +20,18 @@ import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
   templateUrl: './product-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProductListComponent {
+export class ProductListComponent implements OnInit {
   @Input() products: string[];
   @Input() category?: Category;
   @Input() viewType?: ViewType = 'grid';
+
+  listingLoading$: Observable<boolean>;
+
+  constructor(private shoppingFacade: ShoppingFacade) {}
+
+  ngOnInit(): void {
+    this.listingLoading$ = this.shoppingFacade.productListingLoading$;
+  }
 
   get isList() {
     return this.viewType === 'list';

--- a/src/app/shared/components/product/product-listing/product-listing.component.html
+++ b/src/app/shared/components/product/product-listing/product-listing.component.html
@@ -22,7 +22,6 @@
       [viewType]="viewType$ | async"
     ></ish-product-list>
 
-    <ish-loading *ngIf="listingLoading$ | async" [standalone]="true"></ish-loading>
     <div class="row justify-content-center">
       <ish-product-list-paging
         *ngIf="!listing.allPagesAvailable()"

--- a/src/app/shared/components/product/product-listing/product-listing.component.ts
+++ b/src/app/shared/components/product/product-listing/product-listing.component.ts
@@ -14,7 +14,6 @@ import { whenFalsy, whenTruthy } from 'ish-core/utils/operators';
   templateUrl: './product-listing.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-// tslint:disable-next-line:ccp-no-markup-in-containers
 export class ProductListingComponent implements OnInit, OnChanges, OnDestroy {
   @Input() category?: Category;
   @Input() id: ProductListingID;

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -2872,5 +2872,6 @@
   "account.organization.user_management.new_user.confirmation": "Der Benutzer \"{{0}}\" wurde erstellt.",
   "account.organization.user_management.update_user.confirmation": "Der Benutzer \"{{0}}\" wurde geändert.",
   "subject.has.no.permission.assigned": "Sie verfügen nicht über die erforderlichen Rechte zur Durchführung dieser Aktion.",
-  "user.not.authenticated": "Sie sind für den Zugriff auf diese Seite nicht authentifiziert."
+  "user.not.authenticated": "Sie sind für den Zugriff auf diese Seite nicht authentifiziert.",
+  "search.noresult.filtered_products.message": "Leider konnten wir keine Produkte finden, die Ihrer Filterauswahl entsprechen."
 }

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -2876,5 +2876,6 @@
   "account.organization.user_management.new_user.confirmation": "The user \"{{0}}\" has been created.",
   "account.organization.user_management.update_user.confirmation": "The user \"{{0}}\" has been updated.",
   "subject.has.no.permission.assigned": "You do not have the required permission to perform this action.",
-  "user.not.authenticated": "You are not authenticated to access this page."
+  "user.not.authenticated": "You are not authenticated to access this page.",
+  "search.noresult.filtered_products.message": "We are sorry, we could not find any products that match your filter choice."
 }

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -2874,5 +2874,6 @@
   "account.organization.user_management.new_user.confirmation": " L’utilisateur \"{{0}}\" a été créé.",
   "account.organization.user_management.update_user.confirmation": "L’utilisateur \"{{0}}\" a été mise à jour.",
   "subject.has.no.permission.assigned": "Vous n’avez pas l’autorisation nécessaire d’effectuer cette action.",
-  "user.not.authenticated": "Vous n’êtes pas authentifié pour accéder à cette page."
+  "user.not.authenticated": "Vous n’êtes pas authentifié pour accéder à cette page.",
+  "search.noresult.filtered_products.message": "Nous sommes désolés, nous n’avons pu trouver aucun produit correspondant à votre choix de filtre."
 }

--- a/src/styles/pages/category/product-list.scss
+++ b/src/styles/pages/category/product-list.scss
@@ -2,6 +2,7 @@
 // PRODUCT LIST
 
 .product-list {
+  position: relative;
   padding: 0;
   margin: 0;
 
@@ -137,6 +138,14 @@
         color: $text-muted;
       }
     }
+  }
+
+  .product-list-loading {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    z-index: 1;
+    transform: translateX(-50%);
   }
 }
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Feature  


## What Is the New Behavior?

The new search filter navigation of the REST-based Storefront

Acceptance Criteria:

- The component displays all search filters relevant to its current context, either a category or a search result via search filter components.
- The component displays search filters only if their specified Minimum Count of filter options is exceeded.
- sort options on filtered lists
- show selected filter entry on top of its group
- pagination/endless scroll
- category navigation instead of category filter in categories
- style empty lists
- show less / show more
- _If filter groups are specified, the component displays filter groups and all it's related search filters below the filter group._

(issue: ISREST-377)

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No

depends on ICM 7.10.19

ToDo:
- [x] sort dropdown should not reset

closes: #327 