### PR TITLE
fix: use data.id for ContentPageletEntryPoint id (#151)

### DIFF
--- a/e2e/cypress/integration/specs/cms/server-html.mock.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/cms/server-html.mock.e2e-spec.ts
@@ -22,6 +22,7 @@ describe('Server Html', () => {
       response: {
         definitionQualifiedName: 'app_sf_responsive_cm:pwa.include.homepage.pagelet2-Include',
         displayName: 'PWA Homepage Content',
+        id: 'pwa.include.homepage.pagelet2-Include',
         link: {
           title: 'pwa.include.homepage.pagelet2-Include',
           type: 'Link',

--- a/src/app/core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper.spec.ts
+++ b/src/app/core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper.spec.ts
@@ -21,7 +21,7 @@ describe('Content Pagelet Entry Point Mapper', () => {
   it('should convert a complex example to complex type', () => {
     const input: ContentPageletEntryPointData = {
       link: {
-        title: 'include-id',
+        title: 'Readable Title',
         uri: 'uri://test',
         type: 'ContentInclude',
       },

--- a/src/app/core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper.ts
+++ b/src/app/core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper.ts
@@ -36,7 +36,7 @@ export class ContentPageletEntryPointMapper {
     const configurationParameters = this.contentConfigurationParameterMapper.fromData(data.configurationParameters);
 
     const pageletEntryPoint: ContentPageletEntryPoint = {
-      id: data.link.title,
+      id: data.id,
       definitionQualifiedName: data.definitionQualifiedName,
       displayName: data.displayName,
       domain: data.domain,


### PR DESCRIPTION

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #151


## What Is the New Behavior?

The ContentPageletEntryPoint id will be correctly used from data.id
## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No
