### PR TITLE
refactor: matcher for category url rewrite

### DIFF
--- a/src/app/core/routing/category/category.route.ts
+++ b/src/app/core/routing/category/category.route.ts
@@ -13,7 +13,7 @@ export function generateLocalizedCategorySlug(category: CategoryView) {
   return lastCat ? lastCat.replace(/ /g, '-') : '';
 }
 
-const categoryRouteFormat = new RegExp('^/(?!category/.*$)(.*)cat(.*)$');
+const categoryRouteFormat = /^\/(?!category\/.*$)(.*-)?cat(.*)$/;
 
 export function matchCategoryRoute(segments: UrlSegment[]): UrlMatchResult {
   // compatibility to old routes


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [x] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the categorie matcher should match the category.  

/Gift-Cards-&-Certificates-**cat**specials.GiftCardsCertifi**cat**es matches "es" instead of "specials.GiftCardsCertificates"

(Issue Number: ISREST-1018)


## What Is the New Behavior?


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No

