### PR TITLE
fix: remove personalized content from store

### DIFF
--- a/src/app/core/store/content/content-store.module.ts
+++ b/src/app/core/store/content/content-store.module.ts
@@ -5,6 +5,7 @@ import { ActionReducerMap, StoreModule } from '@ngrx/store';
 import { ContentState } from './content-store';
 import { IncludesEffects } from './includes/includes.effects';
 import { includesReducer } from './includes/includes.reducer';
+import { PageletsEffects } from './pagelets/pagelets.effects';
 import { pageletsReducer } from './pagelets/pagelets.reducer';
 import { PagesEffects } from './pages/pages.effects';
 import { pagesReducer } from './pages/pages.reducer';
@@ -15,7 +16,7 @@ export const contentReducers: ActionReducerMap<ContentState> = {
   pages: pagesReducer,
 };
 
-export const contentEffects = [IncludesEffects, PagesEffects];
+export const contentEffects = [IncludesEffects, PagesEffects, PageletsEffects];
 
 @NgModule({
   imports: [EffectsModule.forFeature(contentEffects), StoreModule.forFeature('content', contentReducers)],

--- a/src/app/core/store/content/includes/includes.actions.ts
+++ b/src/app/core/store/content/includes/includes.actions.ts
@@ -8,6 +8,7 @@ export enum IncludesActionTypes {
   LoadContentInclude = '[Content Include] Load Content Include',
   LoadContentIncludeFail = '[Content Include API] Load Content Include Fail',
   LoadContentIncludeSuccess = '[Content Include API] Load Content Include Success',
+  ResetContentIncludes = '[Content Include] Reset Content Includes',
 }
 
 export class LoadContentInclude implements Action {
@@ -25,4 +26,12 @@ export class LoadContentIncludeSuccess implements Action {
   constructor(public payload: { include: ContentPageletEntryPoint; pagelets: ContentPagelet[] }) {}
 }
 
-export type IncludesAction = LoadContentInclude | LoadContentIncludeFail | LoadContentIncludeSuccess;
+export class ResetContentIncludes implements Action {
+  readonly type = IncludesActionTypes.ResetContentIncludes;
+}
+
+export type IncludesAction =
+  | LoadContentInclude
+  | LoadContentIncludeFail
+  | LoadContentIncludeSuccess
+  | ResetContentIncludes;

--- a/src/app/core/store/content/includes/includes.effects.spec.ts
+++ b/src/app/core/store/content/includes/includes.effects.spec.ts
@@ -8,8 +8,14 @@ import { instance, mock, verify, when } from 'ts-mockito';
 import { ContentPageletEntryPoint } from 'ish-core/models/content-pagelet-entry-point/content-pagelet-entry-point.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { CMSService } from 'ish-core/services/cms/cms.service';
+import { LogoutUser } from 'ish-core/store/user';
 
-import { LoadContentInclude, LoadContentIncludeFail, LoadContentIncludeSuccess } from './includes.actions';
+import {
+  LoadContentInclude,
+  LoadContentIncludeFail,
+  LoadContentIncludeSuccess,
+  ResetContentIncludes,
+} from './includes.actions';
 import { IncludesEffects } from './includes.effects';
 
 describe('Includes Effects', () => {
@@ -72,6 +78,17 @@ describe('Includes Effects', () => {
       expect(effects.loadContentInclude$).toBeObservable(
         cold('a-a-a-a', { a: new LoadContentIncludeFail({ error: { message: 'ERROR' } as HttpError }) })
       );
+    });
+  });
+
+  describe('resetContentIncludesAfterLogout$', () => {
+    it('should map to action of type ResetAddresses if LogoutUser action triggered', () => {
+      const action = new LogoutUser();
+      const completion = new ResetContentIncludes();
+      actions$ = hot('-a-a-a', { a: action });
+      const expected$ = cold('-c-c-c', { c: completion });
+
+      expect(effects.resetContentIncludesAfterLogout$).toBeObservable(expected$);
     });
   });
 });

--- a/src/app/core/store/content/includes/includes.effects.ts
+++ b/src/app/core/store/content/includes/includes.effects.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { identity } from 'rxjs';
-import { groupBy, map, mergeMap, switchMap } from 'rxjs/operators';
+import { groupBy, map, mapTo, mergeMap, switchMap } from 'rxjs/operators';
 
 import { CMSService } from 'ish-core/services/cms/cms.service';
+import { UserActionTypes } from 'ish-core/store/user';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
 
 import * as includesActions from './includes.actions';
@@ -27,5 +28,11 @@ export class IncludesEffects {
         )
       )
     )
+  );
+
+  @Effect()
+  resetContentIncludesAfterLogout$ = this.actions$.pipe(
+    ofType(UserActionTypes.LogoutUser),
+    mapTo(new includesActions.ResetContentIncludes())
   );
 }

--- a/src/app/core/store/content/includes/includes.reducer.ts
+++ b/src/app/core/store/content/includes/includes.reducer.ts
@@ -40,6 +40,13 @@ export function includesReducer(state = initialState, action: IncludesAction): I
         loading: false,
       };
     }
+
+    case IncludesActionTypes.ResetContentIncludes: {
+      return {
+        ...includesAdapter.removeAll(state),
+        loading: false,
+      };
+    }
   }
 
   return state;

--- a/src/app/core/store/content/pagelets/index.ts
+++ b/src/app/core/store/content/pagelets/index.ts
@@ -1,3 +1,4 @@
 // tslint:disable no-barrel-files
 // API to access ngrx pagelets state
+export * from './pagelets.actions';
 export * from './pagelets.selectors';

--- a/src/app/core/store/content/pagelets/pagelets.actions.ts
+++ b/src/app/core/store/content/pagelets/pagelets.actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@ngrx/store';
+
+export enum PageletsActionTypes {
+  ResetPagelets = '[Pagelets] Reset Pagelets',
+}
+
+export class ResetPagelets implements Action {
+  readonly type = PageletsActionTypes.ResetPagelets;
+}
+
+export type PageletsAction = ResetPagelets;

--- a/src/app/core/store/content/pagelets/pagelets.effects.spec.ts
+++ b/src/app/core/store/content/pagelets/pagelets.effects.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { cold, hot } from 'jest-marbles';
+import { Observable } from 'rxjs';
+import { instance, mock } from 'ts-mockito';
+
+import { CMSService } from 'ish-core/services/cms/cms.service';
+import { LogoutUser } from 'ish-core/store/user';
+
+import { ResetPagelets } from './pagelets.actions';
+import { PageletsEffects } from './pagelets.effects';
+
+describe('Pagelets Effects', () => {
+  let actions$: Observable<Action>;
+  let effects: PageletsEffects;
+  let cmsServiceMock: CMSService;
+
+  beforeEach(() => {
+    cmsServiceMock = mock(CMSService);
+
+    TestBed.configureTestingModule({
+      providers: [
+        PageletsEffects,
+        provideMockActions(() => actions$),
+        { provide: CMSService, useFactory: () => instance(cmsServiceMock) },
+      ],
+    });
+    effects = TestBed.get(PageletsEffects);
+  });
+
+  describe('resetPageletsAfterLogout$', () => {
+    it('should map to action of type ResetPagelets if LogoutUser action triggered', () => {
+      const action = new LogoutUser();
+      const completion = new ResetPagelets();
+      actions$ = hot('-a-a-a', { a: action });
+      const expected$ = cold('-c-c-c', { c: completion });
+
+      expect(effects.resetPageletsAfterLogout$).toBeObservable(expected$);
+    });
+  });
+});

--- a/src/app/core/store/content/pagelets/pagelets.effects.ts
+++ b/src/app/core/store/content/pagelets/pagelets.effects.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { mapTo } from 'rxjs/operators';
+
+import { UserActionTypes } from 'ish-core/store/user';
+
+import * as pageletsActions from './pagelets.actions';
+
+@Injectable()
+export class PageletsEffects {
+  constructor(private actions$: Actions) {}
+
+  @Effect()
+  resetPageletsAfterLogout$ = this.actions$.pipe(
+    ofType(UserActionTypes.LogoutUser),
+    mapTo(new pageletsActions.ResetPagelets())
+  );
+}

--- a/src/app/core/store/content/pagelets/pagelets.reducer.ts
+++ b/src/app/core/store/content/pagelets/pagelets.reducer.ts
@@ -18,6 +18,9 @@ export function pageletsReducer(state = initialState, action: IncludesAction | P
     case PagesActionTypes.LoadContentPageSuccess: {
       return pageletsAdapter.upsertMany(action.payload.pagelets, state);
     }
+    case IncludesActionTypes.ResetContentIncludes: {
+      return pageletsAdapter.removeAll(state);
+    }
   }
 
   return state;

--- a/src/app/core/store/content/pages/pages.actions.ts
+++ b/src/app/core/store/content/pages/pages.actions.ts
@@ -9,6 +9,7 @@ export enum PagesActionTypes {
   LoadContentPage = '[Content Page] Load Content Page',
   LoadContentPageFail = '[Content Page API] Load Content Page Fail',
   LoadContentPageSuccess = '[Content Page API] Load Content Page Success',
+  ResetContentPages = '[Content Page] Reset Content Pages',
 }
 
 export class SelectContentPage implements Action {
@@ -30,4 +31,13 @@ export class LoadContentPageSuccess implements Action {
   constructor(public payload: { page: ContentPageletEntryPoint; pagelets: ContentPagelet[] }) {}
 }
 
-export type PageAction = SelectContentPage | LoadContentPage | LoadContentPageFail | LoadContentPageSuccess;
+export class ResetContentPages implements Action {
+  readonly type = PagesActionTypes.ResetContentPages;
+}
+
+export type PageAction =
+  | SelectContentPage
+  | LoadContentPage
+  | LoadContentPageFail
+  | LoadContentPageSuccess
+  | ResetContentPages;

--- a/src/app/core/store/content/pages/pages.effects.spec.ts
+++ b/src/app/core/store/content/pages/pages.effects.spec.ts
@@ -7,9 +7,10 @@ import { instance, mock, verify, when } from 'ts-mockito';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { CMSService } from 'ish-core/services/cms/cms.service';
+import { LogoutUser } from 'ish-core/store/user';
 import { ngrxTesting } from 'ish-core/utils/dev/ngrx-testing';
 
-import { LoadContentPage, LoadContentPageFail } from './pages.actions';
+import { LoadContentPage, LoadContentPageFail, ResetContentPages } from './pages.actions';
 import { PagesEffects } from './pages.effects';
 
 describe('Pages Effects', () => {
@@ -56,6 +57,17 @@ describe('Pages Effects', () => {
       expect(effects.loadContentPage$).toBeObservable(
         cold('a-a-a-a', { a: new LoadContentPageFail({ error: { message: 'ERROR' } as HttpError }) })
       );
+    });
+  });
+
+  describe('resetContentPagesAfterLogout$', () => {
+    it('should map to action of type ResetContentPages if LogoutUser action triggered', () => {
+      const action = new LogoutUser();
+      const completion = new ResetContentPages();
+      actions$ = hot('-a-a-a', { a: action });
+      const expected$ = cold('-c-c-c', { c: completion });
+
+      expect(effects.resetContentPagesAfterLogout$).toBeObservable(expected$);
     });
   });
 });

--- a/src/app/core/store/content/pages/pages.effects.ts
+++ b/src/app/core/store/content/pages/pages.effects.ts
@@ -2,9 +2,10 @@ import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { mapToParam, ofRoute } from 'ngrx-router';
-import { filter, map, mergeMap, withLatestFrom } from 'rxjs/operators';
+import { filter, map, mapTo, mergeMap, withLatestFrom } from 'rxjs/operators';
 
 import { CMSService } from 'ish-core/services/cms/cms.service';
+import { UserActionTypes } from 'ish-core/store/user';
 import { mapErrorToAction, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
 import * as pagesActions from './pages.actions';
@@ -41,5 +42,11 @@ export class PagesEffects {
     mapToPayloadProperty('contentPageId'),
     whenTruthy(),
     map(contentPageId => new pagesActions.LoadContentPage({ contentPageId }))
+  );
+
+  @Effect()
+  resetContentPagesAfterLogout$ = this.actions$.pipe(
+    ofType(UserActionTypes.LogoutUser),
+    mapTo(new pagesActions.ResetContentPages())
   );
 }

--- a/src/app/core/store/content/pages/pages.reducer.ts
+++ b/src/app/core/store/content/pages/pages.reducer.ts
@@ -49,6 +49,13 @@ export function pagesReducer(state = initialState, action: PageAction): PagesSta
         loading: false,
       };
     }
+
+    case PagesActionTypes.ResetContentPages: {
+      return {
+        ...pagesAdapter.removeAll(state),
+        loading: false,
+      };
+    }
   }
 
   return state;


### PR DESCRIPTION
<!-- To expedite issue processing please search open and closed issues before submitting a new one.
Existing issues often contain information about workarounds, resolution, or progress updates.
-->

**Steps to Reproduce the Bug**

To repeat the but, you should reduce your Request speed, eg. by using the devtools

1. add a new PageVariant to the About Us page, only visible for Registered Users
2. Open PWA, navigate to "About us" -> default view
3. Login, goto "About us" -> registered only view
4. Logout
5. goto "About us" 

**Actual Behavior**
<!-- Provide a clear and concise description of what the actual behavior is.-->
the page will show the registered only view until the default view is loaded from the server.

This could lead to some security issues, if content is visible for unauthorized targets.
This bug should not only affect pages, but includes and all their children as well 

**Expected Behavior**
<!-- Provide a clear and concise description of what you expected to happen.--> 
 
the page will show only the default view

