### PR TITLE
fix: searchbox prevent "null"

### DIFF
--- a/src/app/shell/header/search-box/search-box.component.html
+++ b/src/app/shell/header/search-box/search-box.component.html
@@ -8,7 +8,7 @@
     type="text"
     class="form-control searchTerm"
     (input)="searchSuggest($event.target.value)"
-    [value]="allSearchTerms$ | async"
+    [value]="(allSearchTerms$ | async) || ''"
     (focus)="hidePopup()"
     (blur)="hidePopup()"
     (keydown.esc)="hidePopup()"


### PR DESCRIPTION

![intershoppwa azurewebsites net_home (1)](https://user-images.githubusercontent.com/50739746/76735260-d2d84200-6764-11ea-9cb8-7c4a43d5f4a2.png)
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

searchbox shows "null" on first page load.


## What Is the New Behavior?

searchbox shows empty string on first page load.


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No

