### PR TITLE
fix: fix loading animation display for scrollable pages (#166)

### DIFF
--- a/src/app/shared/components/common/loading/loading.component.scss
+++ b/src/app/shared/components/common/loading/loading.component.scss
@@ -1,13 +1,11 @@
 .loading {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  position: fixed;
+  top: 37%;
+  left: 48%;
   z-index: 1;
-  min-width: 50px;
-  min-height: 50px;
-  background: #fff url('/assets/img/loading.gif') center center no-repeat;
+  width: 33px;
+  height: 33px;
+  background: #fff url('/assets/img/loading.gif') no-repeat;
   opacity: 0.5;
 }
 


### PR DESCRIPTION
closes #166

## PR Type
 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The loading animation is not visible for scroll able pages (like order list with many entries).

## What Is the New Behavior?
The loading animation is visible in any case where it is needed.

## Does this PR Introduce a Breaking Change?
 [ ] Yes  
 [X] No
