### PR TITLE
feat: display checkout/order prices according to the ICM pricing settings

### DIFF
--- a/src/app/core/models/basket-rebate/basket-rebate.mapper.spec.ts
+++ b/src/app/core/models/basket-rebate/basket-rebate.mapper.spec.ts
@@ -1,7 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
+import { getLoggedInCustomer } from 'ish-core/store/user';
+
 import { BasketRebateData } from './basket-rebate.interface';
 import { BasketRebateMapper } from './basket-rebate.mapper';
 
 describe('Basket Rebate Mapper', () => {
+  let basketRebateMapper: BasketRebateMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), BasketRebateMapper],
+    });
+
+    basketRebateMapper = TestBed.get(BasketRebateMapper);
+  });
+
   describe('fromData', () => {
     it(`should return BasketRebate when getting BasketRebateData`, () => {
       const basketRebateData = {
@@ -22,7 +37,7 @@ describe('Basket Rebate Mapper', () => {
         promotion: 'FreeShippingOnLEDTVs',
       } as BasketRebateData;
 
-      const basketRebate = BasketRebateMapper.fromData(basketRebateData);
+      const basketRebate = basketRebateMapper.fromData(basketRebateData);
 
       expect(basketRebate).toBeTruthy();
       expect(basketRebate.id).toBe(basketRebateData.id);

--- a/src/app/core/models/basket-rebate/basket-rebate.mapper.ts
+++ b/src/app/core/models/basket-rebate/basket-rebate.mapper.ts
@@ -1,14 +1,19 @@
+import { Injectable } from '@angular/core';
+
 import { BasketRebateData } from 'ish-core/models/basket-rebate/basket-rebate.interface';
 import { PriceMapper } from 'ish-core/models/price/price.mapper';
 
 import { BasketRebate } from './basket-rebate.model';
 
+@Injectable({ providedIn: 'root' })
 export class BasketRebateMapper {
-  static fromData(data: BasketRebateData): BasketRebate {
+  constructor(private priceMapper: PriceMapper) {}
+
+  fromData(data: BasketRebateData): BasketRebate {
     if (data) {
       return {
         id: data.id,
-        amount: PriceMapper.fromPriceItem(data.amount),
+        amount: this.priceMapper.fromPriceItem(data.amount),
         description: data.description,
         rebateType: data.promotionType,
         code: data.code,

--- a/src/app/core/models/basket-total/basket-total.mapper.spec.ts
+++ b/src/app/core/models/basket-total/basket-total.mapper.spec.ts
@@ -1,0 +1,172 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
+import { BasketBaseData, BasketData } from 'ish-core/models/basket/basket.interface';
+import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
+
+import { BasketTotalData } from './basket-total.interface';
+import { BasketTotalMapper } from './basket-total.mapper';
+import { BasketTotal } from './basket-total.model';
+
+describe('Basket Total Mapper', () => {
+  let basketTotalMapper: BasketTotalMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), BasketTotalMapper],
+    });
+
+    basketTotalMapper = TestBed.get(BasketTotalMapper);
+  });
+
+  const basketBaseData: BasketBaseData = {
+    id: 'basket_1234',
+    calculated: true,
+    lineItems: ['YikKAE8BKC0AAAFrIW8IyLLD'],
+    totals: {
+      grandTotal: {
+        gross: {
+          value: 141796.98,
+          currency: 'USD',
+        },
+        net: {
+          value: 141796.98,
+          currency: 'USD',
+        },
+        tax: {
+          value: 543.65,
+          currency: 'USD',
+        },
+      },
+      itemTotal: {
+        gross: {
+          value: 141796.98,
+          currency: 'USD',
+        },
+        net: {
+          value: 141796.98,
+          currency: 'USD',
+        },
+      },
+    } as BasketTotalData,
+    discounts: {
+      valueBasedDiscounts: ['discount_1'],
+    },
+    surcharges: {
+      itemSurcharges: [
+        {
+          name: 'item_surcharge',
+          amount: {
+            gross: {
+              value: 654.56,
+              currency: 'USD',
+            },
+            net: {
+              value: 647.56,
+              currency: 'USD',
+            },
+          },
+          description: 'Surcharge for battery deposit',
+        },
+      ],
+      bucketSurcharges: [
+        {
+          name: 'bucket_surcharge',
+          amount: {
+            gross: {
+              value: 64.56,
+              currency: 'USD',
+            },
+            net: {
+              value: 61.86,
+              currency: 'USD',
+            },
+          },
+          description: 'Bucket Surcharge for hazardous material',
+        },
+      ],
+    },
+  };
+
+  const basketIncludedData = {
+    lineItems: {
+      YikKAE8BKC0AAAFrIW8IyLLD: {
+        id: '382478392',
+        calculated: false,
+        position: 1,
+        freeGift: false,
+        hiddenGift: false,
+        quantity: { value: 4 },
+        product: '8182790134363',
+      } as LineItemData,
+    },
+    discounts: {
+      discount_1: {
+        id: 'discount_1',
+        promotionType: 'OrderValueOffDiscount',
+        amount: {
+          gross: {
+            currency: 'USD',
+            value: 11.9,
+          },
+          net: {
+            value: 10.56,
+            currency: 'USD',
+          },
+        },
+        code: 'INTERSHOP',
+        description: 'For orders over 200 USD, a 10 USD Order discount is guaranteed for the Promo Code "INTERSHOP".',
+        promotion: 'FreeShippingOnLEDTVs',
+      },
+    },
+    discounts_promotion: {
+      FreeShippingOnLEDTVs: {
+        id: 'FreeShippingOnLEDTVs',
+        couponCodeRequired: false,
+        currency: 'USD',
+        description: 'For LED TVs the shipping is free.',
+        externalUrl: 'URL',
+        icon: 'ICON',
+        legalContentMessage: 'Legal Content Message',
+        name: 'Free Shipping on LED TVs',
+        promotionType: 'ShippingPercentageOffDiscount',
+        ruleDescription: 'Buy any LED TV and the order ships free.',
+        title: 'FREE SHIPPING',
+        useExternalUrl: true,
+        disableMessages: false,
+      },
+    },
+  };
+
+  describe('getTotals', () => {
+    let totals: BasketTotal;
+    let basketData: BasketData;
+    beforeEach(() => {
+      basketData = {
+        data: { ...basketBaseData },
+        included: { ...basketIncludedData },
+      };
+    });
+
+    it(`should return totals when getting BasketData with totals`, () => {
+      totals = basketTotalMapper.getTotals(basketBaseData);
+      expect(totals).toBeTruthy();
+
+      expect(totals.total.value).toBe(basketData.data.totals.grandTotal.gross.value);
+      expect(totals.itemTotal.value).toBe(basketData.data.totals.itemTotal.gross.value);
+      expect(totals.itemSurchargeTotalsByType[0].amount.value).toBe(
+        basketData.data.surcharges.itemSurcharges[0].amount.gross.value
+      );
+      expect(totals.isEstimated).toBeFalse();
+    });
+
+    it(`should return totals when getting BasketData with discounts`, () => {
+      totals = basketTotalMapper.getTotals(basketBaseData, basketIncludedData.discounts);
+      expect(totals).toBeTruthy();
+
+      expect(totals.valueRebates[0].amount.value).toBePositive();
+      expect(totals.valueRebates[0].id).toEqual('discount_1');
+    });
+  });
+});

--- a/src/app/core/models/basket-total/basket-total.mapper.spec.ts
+++ b/src/app/core/models/basket-total/basket-total.mapper.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
+import { anything } from 'ts-mockito';
 
 import { BasketBaseData, BasketData } from 'ish-core/models/basket/basket.interface';
 import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
+import { getConfigParameter } from 'ish-core/store/configuration';
 import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { BasketTotalData } from './basket-total.interface';
@@ -14,7 +16,15 @@ describe('Basket Total Mapper', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), BasketTotalMapper],
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: getLoggedInCustomer, value: {} },
+            { selector: getConfigParameter(anything(), anything()), value: {} },
+          ],
+        }),
+        BasketTotalMapper,
+      ],
     });
 
     basketTotalMapper = TestBed.get(BasketTotalMapper);

--- a/src/app/core/models/basket-total/basket-total.mapper.ts
+++ b/src/app/core/models/basket-total/basket-total.mapper.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+
+import { BasketRebateData } from 'ish-core/models/basket-rebate/basket-rebate.interface';
+import { BasketRebateMapper } from 'ish-core/models/basket-rebate/basket-rebate.mapper';
+import { BasketTotal } from 'ish-core/models/basket-total/basket-total.model';
+import { BasketBaseData } from 'ish-core/models/basket/basket.interface';
+import { PriceMapper } from 'ish-core/models/price/price.mapper';
+
+@Injectable({ providedIn: 'root' })
+export class BasketTotalMapper {
+  constructor(private priceMapper: PriceMapper, private basketRebateMapper: BasketRebateMapper) {}
+
+  /**
+   * Helper method to determine a basket(order) total on the base of row data.
+   * @returns         The basket total.
+   */
+  getTotals(data: BasketBaseData, discounts?: { [id: string]: BasketRebateData }): BasketTotal {
+    const totalsData = data.totals;
+
+    return totalsData
+      ? {
+          itemTotal: this.priceMapper.fromPriceItem(totalsData.itemTotal),
+          undiscountedItemTotal: this.priceMapper.fromPriceItem(totalsData.undiscountedItemTotal),
+          shippingTotal: this.priceMapper.fromPriceItem(totalsData.shippingTotal),
+          undiscountedShippingTotal: this.priceMapper.fromPriceItem(totalsData.undiscountedShippingTotal),
+          paymentCostsTotal: this.priceMapper.fromPriceItem(totalsData.paymentCostsTotal),
+          dutiesAndSurchargesTotal: this.priceMapper.fromPriceItem(totalsData.surchargeTotal),
+          taxTotal: { ...totalsData.grandTotal.tax, type: 'Money' },
+          total: this.priceMapper.fromPriceItem(totalsData.grandTotal),
+
+          itemRebatesTotal: this.priceMapper.fromPriceItem(totalsData.itemValueDiscountsTotal),
+          valueRebatesTotal: this.priceMapper.fromPriceItem(totalsData.basketValueDiscountsTotal),
+          valueRebates:
+            data.discounts && data.discounts.valueBasedDiscounts && discounts
+              ? data.discounts.valueBasedDiscounts.map(discountId =>
+                  this.basketRebateMapper.fromData(discounts[discountId])
+                )
+              : undefined,
+
+          itemShippingRebatesTotal: this.priceMapper.fromPriceItem(totalsData.itemShippingDiscountsTotal),
+          shippingRebatesTotal: this.priceMapper.fromPriceItem(totalsData.basketShippingDiscountsTotal),
+          shippingRebates:
+            data.discounts && data.discounts.shippingBasedDiscounts && discounts
+              ? data.discounts.shippingBasedDiscounts.map(discountId =>
+                  this.basketRebateMapper.fromData(discounts[discountId])
+                )
+              : undefined,
+
+          itemSurchargeTotalsByType:
+            data.surcharges && data.surcharges.itemSurcharges
+              ? data.surcharges.itemSurcharges.map(surcharge => ({
+                  amount: this.priceMapper.fromPriceItem(surcharge.amount),
+                  displayName: surcharge.name,
+                  description: surcharge.description,
+                }))
+              : undefined,
+          bucketSurchargeTotalsByType:
+            data.surcharges && data.surcharges.bucketSurcharges
+              ? data.surcharges.bucketSurcharges.map(surcharge => ({
+                  amount: this.priceMapper.fromPriceItem(surcharge.amount),
+                  displayName: surcharge.name,
+                  description: surcharge.description,
+                }))
+              : undefined,
+          isEstimated: false,
+        }
+      : undefined;
+  }
+}

--- a/src/app/core/models/basket-total/basket-total.mapper.ts
+++ b/src/app/core/models/basket-total/basket-total.mapper.ts
@@ -26,7 +26,7 @@ export class BasketTotalMapper {
           paymentCostsTotal: this.priceMapper.fromPriceItem(totalsData.paymentCostsTotal),
           dutiesAndSurchargesTotal: this.priceMapper.fromPriceItem(totalsData.surchargeTotal),
           taxTotal: { ...totalsData.grandTotal.tax, type: 'Money' },
-          total: this.priceMapper.fromPriceItem(totalsData.grandTotal),
+          total: this.priceMapper.fromPriceItem(totalsData.grandTotal, 'gross'), // display the total always as gross price
 
           itemRebatesTotal: this.priceMapper.fromPriceItem(totalsData.itemValueDiscountsTotal),
           valueRebatesTotal: this.priceMapper.fromPriceItem(totalsData.basketValueDiscountsTotal),

--- a/src/app/core/models/basket-validation/basket-validation.mapper.spec.ts
+++ b/src/app/core/models/basket-validation/basket-validation.mapper.spec.ts
@@ -1,14 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
 import { AddressData } from 'ish-core/models/address/address.interface';
 import { BasketTotalData } from 'ish-core/models/basket-total/basket-total.interface';
 import { BasketBaseData } from 'ish-core/models/basket/basket.interface';
 import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
 import { ShippingMethodData } from 'ish-core/models/shipping-method/shipping-method.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { BasketValidationData } from './basket-validation.interface';
 import { BasketValidationMapper } from './basket-validation.mapper';
 import { BasketValidation } from './basket-validation.model';
 
 describe('Basket Validation Mapper', () => {
+  let basketValidationMapper: BasketValidationMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }),
+        BasketValidationMapper,
+      ],
+    });
+
+    basketValidationMapper = TestBed.get(BasketValidationMapper);
+  });
+
   const basketBaseData: BasketBaseData = {
     id: 'basket_1234',
     calculated: true,
@@ -159,7 +176,7 @@ describe('Basket Validation Mapper', () => {
     });
 
     it(`should return Basket Validation results when getting BasketValidationData`, () => {
-      basketValidation = BasketValidationMapper.fromData(basketValidationData);
+      basketValidation = basketValidationMapper.fromData(basketValidationData);
       expect(basketValidation).toBeTruthy();
       expect(basketValidation.results).toBeTruthy();
       expect(basketValidation.results.valid).toBeFalse();
@@ -170,7 +187,7 @@ describe('Basket Validation Mapper', () => {
     });
 
     it('should return (adjusted) Basket when basket was included', () => {
-      basketValidation = BasketValidationMapper.fromData(basketValidationData);
+      basketValidation = basketValidationMapper.fromData(basketValidationData);
 
       expect(basketValidation.basket.invoiceToAddress.id).toEqual('invoiceToAddress_123');
       expect(basketValidation.basket.commonShipToAddress.id).toEqual('commonShipToAddress_123');

--- a/src/app/core/models/basket-validation/basket-validation.mapper.spec.ts
+++ b/src/app/core/models/basket-validation/basket-validation.mapper.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
+import { anything } from 'ts-mockito';
 
 import { AddressData } from 'ish-core/models/address/address.interface';
 import { BasketTotalData } from 'ish-core/models/basket-total/basket-total.interface';
 import { BasketBaseData } from 'ish-core/models/basket/basket.interface';
 import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
 import { ShippingMethodData } from 'ish-core/models/shipping-method/shipping-method.interface';
+import { getConfigParameter } from 'ish-core/store/configuration';
 import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { BasketValidationData } from './basket-validation.interface';
@@ -18,7 +20,12 @@ describe('Basket Validation Mapper', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }),
+        provideMockStore({
+          selectors: [
+            { selector: getLoggedInCustomer, value: {} },
+            { selector: getConfigParameter(anything(), anything()), value: {} },
+          ],
+        }),
         BasketValidationMapper,
       ],
     });

--- a/src/app/core/models/basket-validation/basket-validation.mapper.ts
+++ b/src/app/core/models/basket-validation/basket-validation.mapper.ts
@@ -1,14 +1,19 @@
+import { Injectable } from '@angular/core';
+
 import { BasketData } from 'ish-core/models/basket/basket.interface';
 import { BasketMapper } from 'ish-core/models/basket/basket.mapper';
 
 import { BasketValidationData } from './basket-validation.interface';
 import { BasketValidation } from './basket-validation.model';
 
+@Injectable({ providedIn: 'root' })
 export class BasketValidationMapper {
-  static fromData(data: BasketValidationData): BasketValidation {
+  constructor(private basketMapper: BasketMapper) {}
+
+  fromData(data: BasketValidationData): BasketValidation {
     if (data) {
       return {
-        basket: BasketMapper.fromData(BasketValidationMapper.transform(data)),
+        basket: this.basketMapper.fromData(this.transform(data)),
         results: {
           valid: data.data.results && data.data.results.valid,
           adjusted: data.data.results && data.data.results.adjusted,
@@ -21,7 +26,7 @@ export class BasketValidationMapper {
   }
 
   // map basket from BasketValidationResult
-  private static transform(basketValidationData: BasketValidationData): BasketData {
+  private transform(basketValidationData: BasketValidationData): BasketData {
     return {
       data: basketValidationData.included
         ? basketValidationData.included.basket[basketValidationData.data.basket]

--- a/src/app/core/models/basket/basket.mapper.spec.ts
+++ b/src/app/core/models/basket/basket.mapper.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
+import { anything } from 'ts-mockito';
 
 import { AddressData } from 'ish-core/models/address/address.interface';
 import { BasketTotalData } from 'ish-core/models/basket-total/basket-total.interface';
 import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
 import { ShippingMethodData } from 'ish-core/models/shipping-method/shipping-method.interface';
+import { getConfigParameter } from 'ish-core/store/configuration';
 import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { BasketBaseData, BasketData } from './basket.interface';
@@ -16,7 +18,15 @@ describe('Basket Mapper', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), BasketMapper],
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: getLoggedInCustomer, value: {} },
+            { selector: getConfigParameter(anything(), anything()), value: {} },
+          ],
+        }),
+        BasketMapper,
+      ],
     });
 
     basketMapper = TestBed.get(BasketMapper);

--- a/src/app/core/models/line-item/line-item.mapper.spec.ts
+++ b/src/app/core/models/line-item/line-item.mapper.spec.ts
@@ -1,9 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
 import { OrderItemData } from 'ish-core/models/order-item/order-item.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { LineItemData } from './line-item.interface';
 import { LineItemMapper } from './line-item.mapper';
 
 describe('Line Item Mapper', () => {
+  let lineItemMapper: LineItemMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), LineItemMapper],
+    });
+
+    lineItemMapper = TestBed.get(LineItemMapper);
+  });
+
   describe('fromData', () => {
     it(`should return BasketItem when getting LineItemData`, () => {
       const lineItemData = {
@@ -25,7 +39,7 @@ describe('Line Item Mapper', () => {
           },
         },
       } as LineItemData;
-      const lineItem = LineItemMapper.fromData(lineItemData, undefined);
+      const lineItem = lineItemMapper.fromData(lineItemData, undefined);
 
       expect(lineItem).toBeTruthy();
       expect(lineItem.productSKU).toBe(lineItemData.product);
@@ -33,7 +47,7 @@ describe('Line Item Mapper', () => {
     });
 
     it(`should throw an error when getting no LineItemData`, () => {
-      expect(() => LineItemMapper.fromData(undefined, undefined)).toThrow();
+      expect(() => lineItemMapper.fromData(undefined, undefined)).toThrow();
     });
   });
 
@@ -58,7 +72,7 @@ describe('Line Item Mapper', () => {
           },
         },
       } as OrderItemData;
-      const basketItem = LineItemMapper.fromOrderItemData(orderItemData, undefined);
+      const basketItem = lineItemMapper.fromOrderItemData(orderItemData, undefined);
 
       expect(basketItem).toBeTruthy();
       expect(basketItem.productSKU).toBe(orderItemData.product);
@@ -66,7 +80,7 @@ describe('Line Item Mapper', () => {
     });
 
     it(`should throw an error when getting no OrderItemData`, () => {
-      expect(() => LineItemMapper.fromOrderItemData(undefined)).toThrow();
+      expect(() => lineItemMapper.fromOrderItemData(undefined)).toThrow();
     });
   });
 });

--- a/src/app/core/models/line-item/line-item.mapper.ts
+++ b/src/app/core/models/line-item/line-item.mapper.ts
@@ -1,3 +1,5 @@
+import { Injectable } from '@angular/core';
+
 import { BasketRebateData } from 'ish-core/models/basket-rebate/basket-rebate.interface';
 import { BasketRebateMapper } from 'ish-core/models/basket-rebate/basket-rebate.mapper';
 import { OrderItemData } from 'ish-core/models/order-item/order-item.interface';
@@ -6,51 +8,13 @@ import { PriceMapper } from 'ish-core/models/price/price.mapper';
 import { LineItemData } from './line-item.interface';
 import { LineItem } from './line-item.model';
 
+@Injectable({ providedIn: 'root' })
 export class LineItemMapper {
-  static fromData(data: LineItemData, rebateData?: { [id: string]: BasketRebateData }): LineItem {
-    if (data) {
-      return {
-        id: data.id,
-        position: data.position,
-        quantity: data.quantity,
-        price: data.pricing ? PriceMapper.fromPriceItem(data.pricing.price) : undefined,
-        singleBasePrice: data.pricing ? PriceMapper.fromPriceItem(data.pricing.singleBasePrice) : undefined,
-        itemSurcharges: data.surcharges
-          ? data.surcharges.map(surcharge => ({
-              amount: PriceMapper.fromPriceItem(surcharge.amount),
-              description: surcharge.description,
-              displayName: surcharge.name,
-            }))
-          : undefined,
-        valueRebates:
-          data.discounts && rebateData
-            ? data.discounts.map(discountId => BasketRebateMapper.fromData(rebateData[discountId]))
-            : undefined,
-        isHiddenGift: data.hiddenGift,
-        isFreeGift: data.freeGift,
-        totals:
-          data.calculated || data.calculated === undefined
-            ? {
-                salesTaxTotal: data.pricing.salesTaxTotal,
-                shippingTaxTotal: data.pricing.shippingTaxTotal,
-                shippingTotal: PriceMapper.fromPriceItem(data.pricing.shippingTotal),
-                total: PriceMapper.fromPriceItem(data.pricing.price),
-                undiscountedTotal: PriceMapper.fromPriceItem(data.pricing.undiscountedPrice),
-                valueRebatesTotal: PriceMapper.fromPriceItem(data.pricing.valueRebatesTotal),
-              }
-            : undefined,
+  constructor(private priceMapper: PriceMapper, private basketRebateMapper: BasketRebateMapper) {}
 
-        productSKU: data.product,
-        isQuantityFixed: data.quantityFixed,
-      };
-    } else {
-      throw new Error(`'LineItemData' is required for the mapping`);
-    }
-  }
-
-  static fromOrderItemData(data: OrderItemData, rebateData?: { [id: string]: BasketRebateData }): LineItem {
+  fromOrderItemData(data: OrderItemData, rebateData?: { [id: string]: BasketRebateData }): LineItem {
     if (data) {
-      const orderItem = LineItemMapper.fromData(data, rebateData);
+      const orderItem = this.fromData(data, rebateData);
 
       return {
         ...orderItem,
@@ -60,6 +24,47 @@ export class LineItemMapper {
       };
     } else {
       throw new Error(`'OrderItemData' is required for the mapping`);
+    }
+  }
+
+  fromData(data: LineItemData, rebateData?: { [id: string]: BasketRebateData }): LineItem {
+    if (data) {
+      return {
+        id: data.id,
+        position: data.position,
+        quantity: data.quantity,
+        price: data.pricing ? this.priceMapper.fromPriceItem(data.pricing.price) : undefined,
+        singleBasePrice: data.pricing ? this.priceMapper.fromPriceItem(data.pricing.singleBasePrice) : undefined,
+        itemSurcharges: data.surcharges
+          ? data.surcharges.map(surcharge => ({
+              amount: this.priceMapper.fromPriceItem(surcharge.amount),
+              description: surcharge.description,
+              displayName: surcharge.name,
+            }))
+          : undefined,
+        valueRebates:
+          data.discounts && rebateData
+            ? data.discounts.map(discountId => this.basketRebateMapper.fromData(rebateData[discountId]))
+            : undefined,
+        isHiddenGift: data.hiddenGift,
+        isFreeGift: data.freeGift,
+        totals:
+          data.calculated || data.calculated === undefined
+            ? {
+                salesTaxTotal: data.pricing.salesTaxTotal,
+                shippingTaxTotal: data.pricing.shippingTaxTotal,
+                shippingTotal: this.priceMapper.fromPriceItem(data.pricing.shippingTotal),
+                total: this.priceMapper.fromPriceItem(data.pricing.price),
+                undiscountedTotal: this.priceMapper.fromPriceItem(data.pricing.undiscountedPrice),
+                valueRebatesTotal: this.priceMapper.fromPriceItem(data.pricing.valueRebatesTotal),
+              }
+            : undefined,
+
+        productSKU: data.product,
+        isQuantityFixed: data.quantityFixed,
+      };
+    } else {
+      throw new Error(`'LineItemData' is required for the mapping`);
     }
   }
 }

--- a/src/app/core/models/order/order.mapper.spec.ts
+++ b/src/app/core/models/order/order.mapper.spec.ts
@@ -1,11 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
 import { AddressData } from 'ish-core/models/address/address.interface';
 import { OrderItemData } from 'ish-core/models/order-item/order-item.interface';
 import { ShippingMethodData } from 'ish-core/models/shipping-method/shipping-method.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { OrderBaseData, OrderData } from './order.interface';
 import { OrderMapper } from './order.mapper';
 
 describe('Order Mapper', () => {
+  let orderMapper: OrderMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), OrderMapper],
+    });
+
+    orderMapper = TestBed.get(OrderMapper);
+  });
+
   const orderBaseData = {
     documentNumber: '4711',
     creationDate: 0,
@@ -138,7 +152,7 @@ describe('Order Mapper', () => {
 
   describe('fromData', () => {
     it(`should return Order when getting OrderData`, () => {
-      const order = OrderMapper.fromData(orderData);
+      const order = orderMapper.fromData(orderData);
 
       expect(order).toBeTruthy();
       expect(order.id).toEqual(orderBaseData.id);

--- a/src/app/core/models/payment-method/payment-method.mapper.spec.ts
+++ b/src/app/core/models/payment-method/payment-method.mapper.spec.ts
@@ -1,4 +1,8 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
 import { PaymentInstrumentData } from 'ish-core/models/payment-instrument/payment-instrument.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import {
   PaymentMethodData,
@@ -8,6 +12,16 @@ import {
 import { PaymentMethodMapper } from './payment-method.mapper';
 
 describe('Payment Method Mapper', () => {
+  let paymentMethodMapper: PaymentMethodMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), PaymentMethodMapper],
+    });
+
+    paymentMethodMapper = TestBed.get(PaymentMethodMapper);
+  });
+
   describe('fromData', () => {
     const paymentMethodData = {
       data: [
@@ -91,7 +105,7 @@ describe('Payment Method Mapper', () => {
     ];
 
     it(`should return PaymentMethod when getting a PaymentMethodData`, () => {
-      const paymentMethod = PaymentMethodMapper.fromData(paymentMethodData)[0];
+      const paymentMethod = paymentMethodMapper.fromData(paymentMethodData)[0];
 
       expect(paymentMethod).toBeTruthy();
       expect(paymentMethod.id).toEqual('ISH_CreditCard');
@@ -109,14 +123,14 @@ describe('Payment Method Mapper', () => {
           code: 'restricition code',
         },
       ];
-      const paymentMethod = PaymentMethodMapper.fromData(paymentMethodData)[0];
+      const paymentMethod = paymentMethodMapper.fromData(paymentMethodData)[0];
       expect(paymentMethod.isRestricted).toBeTrue();
       expect(paymentMethod.restrictionCauses).toHaveLength(1);
     });
 
     it(`should return a payment method with parameter definitions if payment method has input parameters`, () => {
       paymentMethodData.data[0].parameterDefinitions = parametersData;
-      const paymentMethod = PaymentMethodMapper.fromData(paymentMethodData)[0];
+      const paymentMethod = paymentMethodMapper.fromData(paymentMethodData)[0];
 
       expect(paymentMethod.saveAllowed).toBeTrue();
       expect(paymentMethod.parameters).toHaveLength(3);

--- a/src/app/core/models/price/price.helper.spec.ts
+++ b/src/app/core/models/price/price.helper.spec.ts
@@ -6,36 +6,36 @@ describe('Price Helper', () => {
   function dataProviderValid() {
     return [
       {
-        p1: { type: 'M', currency: 'USD', value: 10 } as Price,
-        p2: { type: 'M', currency: 'USD', value: 9 } as Price,
-        diff: { type: 'M', currency: 'USD', value: 1 } as Price,
-        sum: { type: 'M', currency: 'USD', value: 19 } as Price,
-        min: { type: 'M', currency: 'USD', value: 9 } as Price,
-        max: { type: 'M', currency: 'USD', value: 10 } as Price,
+        p1: { type: 'Money', currency: 'USD', value: 10 } as Price,
+        p2: { type: 'Money', currency: 'USD', value: 9 } as Price,
+        diff: { type: 'Money', currency: 'USD', value: 1 } as Price,
+        sum: { type: 'Money', currency: 'USD', value: 19 } as Price,
+        min: { type: 'Money', currency: 'USD', value: 9 } as Price,
+        max: { type: 'Money', currency: 'USD', value: 10 } as Price,
       },
       {
-        p1: { type: 'M', currency: 'USD', value: 10.99 } as Price,
-        p2: { type: 'M', currency: 'USD', value: 9.45 } as Price,
-        diff: { type: 'M', currency: 'USD', value: 1.54 } as Price,
-        sum: { type: 'M', currency: 'USD', value: 20.44 } as Price,
-        min: { type: 'M', currency: 'USD', value: 9.45 } as Price,
-        max: { type: 'M', currency: 'USD', value: 10.99 } as Price,
+        p1: { type: 'Money', currency: 'USD', value: 10.99 } as Price,
+        p2: { type: 'Money', currency: 'USD', value: 9.45 } as Price,
+        diff: { type: 'Money', currency: 'USD', value: 1.54 } as Price,
+        sum: { type: 'Money', currency: 'USD', value: 20.44 } as Price,
+        min: { type: 'Money', currency: 'USD', value: 9.45 } as Price,
+        max: { type: 'Money', currency: 'USD', value: 10.99 } as Price,
       },
       {
-        p1: { type: 'M', currency: 'USD', value: 8 } as Price,
-        p2: { type: 'M', currency: 'USD', value: 9 } as Price,
-        diff: { type: 'M', currency: 'USD', value: -1 } as Price,
-        sum: { type: 'M', currency: 'USD', value: 17 } as Price,
-        min: { type: 'M', currency: 'USD', value: 8 } as Price,
-        max: { type: 'M', currency: 'USD', value: 9 } as Price,
+        p1: { type: 'Money', currency: 'USD', value: 8 } as Price,
+        p2: { type: 'Money', currency: 'USD', value: 9 } as Price,
+        diff: { type: 'Money', currency: 'USD', value: -1 } as Price,
+        sum: { type: 'Money', currency: 'USD', value: 17 } as Price,
+        min: { type: 'Money', currency: 'USD', value: 8 } as Price,
+        max: { type: 'Money', currency: 'USD', value: 9 } as Price,
       },
       {
-        p1: { type: 'M', currency: 'USD', value: 8.88888 } as Price,
-        p2: { type: 'F', currency: 'USD', value: 3.55555 } as Price,
-        diff: { type: 'M', currency: 'USD', value: 5.33 } as Price,
-        sum: { type: 'M', currency: 'USD', value: 12.44 } as Price,
-        min: { type: 'M', currency: 'USD', value: 3.56 } as Price,
-        max: { type: 'M', currency: 'USD', value: 8.89 } as Price,
+        p1: { type: 'Money', currency: 'USD', value: 8.88888 } as Price,
+        p2: { type: 'Money', currency: 'USD', value: 3.55555 } as Price,
+        diff: { type: 'Money', currency: 'USD', value: 5.33 } as Price,
+        sum: { type: 'Money', currency: 'USD', value: 12.44 } as Price,
+        min: { type: 'Money', currency: 'USD', value: 3.56 } as Price,
+        max: { type: 'Money', currency: 'USD', value: 8.89 } as Price,
       },
     ];
   }
@@ -44,27 +44,27 @@ describe('Price Helper', () => {
     return [
       {
         p1: undefined,
-        p2: { type: 'F', currency: 'USD', value: 9 } as Price,
+        p2: { type: 'ProductPrice', currency: 'USD', value: 9 } as Price,
         error: /.*undefined.*/,
       },
       {
-        p1: { type: 'F', currency: 'USD', value: 9 } as Price,
+        p1: { type: 'ProductPrice', currency: 'USD', value: 9 } as Price,
         p2: undefined,
         error: /.*undefined.*/,
       },
       {
-        p1: { type: 'F', currency: 'USD', value: 9 } as Price,
-        p2: { type: 'F', value: 9 } as Price,
+        p1: { type: 'ProductPrice', currency: 'USD', value: 9 } as Price,
+        p2: { type: 'ProductPrice', value: 9 } as Price,
         error: /.*undefined.*/,
       },
       {
-        p1: { type: 'F', currency: 'USD', value: 9 } as Price,
-        p2: { type: 'F', currency: 'USD' } as Price,
+        p1: { type: 'ProductPrice', currency: 'USD', value: 9 } as Price,
+        p2: { type: 'ProductPrice', currency: 'USD' } as Price,
         error: /.*undefined.*/,
       },
       {
-        p1: { type: 'M', currency: 'USD', value: 10 } as Price,
-        p2: { type: 'M', currency: 'EUR', value: 9 } as Price,
+        p1: { type: 'Money', currency: 'USD', value: 10 } as Price,
+        p2: { type: 'Money', currency: 'EUR', value: 9 } as Price,
         error: /.*currency.*/,
       },
     ];
@@ -143,7 +143,7 @@ describe('Price Helper', () => {
   });
 
   describe('invert', () => {
-    const price = { type: 'F', currency: 'USD', value: 9 } as Price;
+    const price = { type: 'Money', currency: 'USD', value: 9 } as Price;
 
     it('should return inverted price when called', () => {
       const invertedPrice = PriceHelper.invert(price);

--- a/src/app/core/models/price/price.mapper.spec.ts
+++ b/src/app/core/models/price/price.mapper.spec.ts
@@ -1,25 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
 import { PriceItem } from 'ish-core/models/price-item/price-item.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { PriceMapper } from './price.mapper';
 
 describe('Price Mapper', () => {
+  let priceMapper: PriceMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), PriceMapper],
+    });
+
+    priceMapper = TestBed.get(PriceMapper);
+  });
+
+  const priceItem = {
+    gross: {
+      value: 43.34,
+      currency: 'USD',
+    },
+    net: {
+      value: 40.34,
+      currency: 'USD',
+    },
+  } as PriceItem;
+
   describe('fromData', () => {
-    it(`should return Price when getting a PriceItem`, () => {
-      const priceItem = {
-        gross: {
-          value: 43.34,
-          currency: 'USD',
-        },
-        net: {
-          value: 40.34,
-          currency: 'USD',
-        },
-      } as PriceItem;
-      const price = PriceMapper.fromPriceItem(priceItem);
+    it(`should return gross Price when getting a PriceItem for an anonymous user`, () => {
+      const price = priceMapper.fromPriceItem(priceItem);
 
       expect(price).toBeTruthy();
-      expect(price.value).toBe(priceItem[PriceMapper.defaultPriceType].value);
+      expect(price.value).toBe(priceItem.gross.value);
       expect(price.currency).toBe('USD');
+    });
+
+    it(`should return net Price when getting a PriceItem with price type 'net'`, () => {
+      const price = priceMapper.fromPriceItem(priceItem, 'net');
+
+      expect(price).toBeTruthy();
+      expect(price.value).toBe(priceItem.net.value);
     });
   });
 });

--- a/src/app/core/models/price/price.mapper.spec.ts
+++ b/src/app/core/models/price/price.mapper.spec.ts
@@ -1,7 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
+import { anything } from 'ts-mockito';
 
 import { PriceItem } from 'ish-core/models/price-item/price-item.interface';
+import { getConfigParameter } from 'ish-core/store/configuration';
 import { getLoggedInCustomer } from 'ish-core/store/user';
 
 import { PriceMapper } from './price.mapper';
@@ -11,7 +13,15 @@ describe('Price Mapper', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }), PriceMapper],
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: getLoggedInCustomer, value: {} },
+            { selector: getConfigParameter(anything(), anything()), value: {} },
+          ],
+        }),
+        PriceMapper,
+      ],
     });
 
     priceMapper = TestBed.get(PriceMapper);

--- a/src/app/core/models/price/price.mapper.ts
+++ b/src/app/core/models/price/price.mapper.ts
@@ -1,21 +1,37 @@
-import { PriceItem } from 'ish-core/models/price-item/price-item.interface';
+import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
 
-import { Price } from './price.model';
+import { PriceItem } from 'ish-core/models/price-item/price-item.interface';
+import { getLoggedInCustomer } from 'ish-core/store/user';
+
+import { Price, PriceType } from './price.model';
 
 /**
  * Maps a price item to a gross or net price.
+ * If the price type is not given it is determined by the customer type of the logged in user.
+ * price type = 'gross' for private and anonymous users
+ * price type = 'net' for business users
  * @param priceItem A price Item.
- * @param priceType The price type (gross/net), default: gross
+ * @param priceType The price type (gross/net), optional
  * @returns         The price.
  */
+@Injectable({ providedIn: 'root' })
 export class PriceMapper {
-  static defaultPriceType = 'gross';
-  static fromPriceItem(dataItem: PriceItem, priceType: string = PriceMapper.defaultPriceType): Price {
-    if (dataItem && dataItem[priceType]) {
+  private isBusinessCustomer: boolean;
+
+  constructor(store: Store<{}>) {
+    store.pipe(select(getLoggedInCustomer)).subscribe(customer => {
+      this.isBusinessCustomer = customer && customer.isBusinessCustomer;
+    });
+  }
+
+  fromPriceItem(dataItem: PriceItem, priceType?: PriceType): Price {
+    const pType = priceType || this.isBusinessCustomer ? 'net' : 'gross';
+    if (dataItem && dataItem[pType]) {
       return {
         type: 'Money',
-        value: dataItem[priceType].value,
-        currency: dataItem[priceType].currency,
+        value: dataItem[pType].value,
+        currency: dataItem[pType].currency,
       };
     }
   }

--- a/src/app/core/models/price/price.mapper.ts
+++ b/src/app/core/models/price/price.mapper.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
+import { take } from 'rxjs/operators';
 
 import { PriceItem } from 'ish-core/models/price-item/price-item.interface';
+import { getConfigParameter } from 'ish-core/store/configuration';
 import { getLoggedInCustomer } from 'ish-core/store/user';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 import { Price, PriceType } from './price.model';
 
@@ -18,21 +21,63 @@ import { Price, PriceType } from './price.model';
 @Injectable({ providedIn: 'root' })
 export class PriceMapper {
   private isBusinessCustomer: boolean;
+  private isLoggedIn: boolean;
+  private privateCustomerPriceDisplayType: PriceType = 'gross';
+  private smbCustomerPriceDisplayType: PriceType = 'net';
+  private defaultCustomerTypeForPriceDisplay = 'PRIVATE';
 
   constructor(store: Store<{}>) {
     store.pipe(select(getLoggedInCustomer)).subscribe(customer => {
       this.isBusinessCustomer = customer && customer.isBusinessCustomer;
+      this.isLoggedIn = !!customer;
     });
+
+    store
+      .pipe(
+        select(getConfigParameter('pricing', 'privateCustomerPriceDisplayType')),
+        whenTruthy(),
+        take(1)
+      )
+      .subscribe((param: PriceType) => {
+        this.privateCustomerPriceDisplayType = param || this.privateCustomerPriceDisplayType;
+      });
+    store
+      .pipe(
+        select(getConfigParameter('pricing', 'smbCustomerPriceDisplayType')),
+        whenTruthy(),
+        take(1)
+      )
+      .subscribe((param: PriceType) => {
+        this.smbCustomerPriceDisplayType = param || this.smbCustomerPriceDisplayType;
+      });
+    store
+      .pipe(
+        select(getConfigParameter('pricing', 'defaultCustomerTypeForPriceDisplay')),
+        whenTruthy(),
+        take(1)
+      )
+      .subscribe(param => {
+        this.defaultCustomerTypeForPriceDisplay = param || this.defaultCustomerTypeForPriceDisplay;
+      });
   }
 
   fromPriceItem(dataItem: PriceItem, priceType?: PriceType): Price {
-    const pType = priceType || this.isBusinessCustomer ? 'net' : 'gross';
+    const pType =
+      priceType ||
+      this.determinePriceType(
+        this.isLoggedIn ? this.isBusinessCustomer : this.defaultCustomerTypeForPriceDisplay !== 'PRIVATE'
+      );
     if (dataItem && dataItem[pType]) {
       return {
         type: 'Money',
+        priceType: pType,
         value: dataItem[pType].value,
         currency: dataItem[pType].currency,
       };
     }
+  }
+
+  private determinePriceType(isBusinessCustomer: boolean): PriceType {
+    return isBusinessCustomer ? this.smbCustomerPriceDisplayType : this.privateCustomerPriceDisplayType;
   }
 }

--- a/src/app/core/models/price/price.model.ts
+++ b/src/app/core/models/price/price.model.ts
@@ -1,5 +1,7 @@
+export type PriceType = 'gross' | 'net';
+
 export interface Price {
-  type?: string;
+  type?: 'Money' | 'ProductPrice';
   value: number;
   currency: string;
 }

--- a/src/app/core/models/price/price.model.ts
+++ b/src/app/core/models/price/price.model.ts
@@ -2,6 +2,7 @@ export type PriceType = 'gross' | 'net';
 
 export interface Price {
   type?: 'Money' | 'ProductPrice';
+  priceType?: PriceType;
   value: number;
   currency: string;
 }

--- a/src/app/core/models/server-config/server-config.interface.ts
+++ b/src/app/core/models/server-config/server-config.interface.ts
@@ -1,0 +1,3 @@
+export interface ServerConfigData {
+  data: { [key: string]: string }[];
+}

--- a/src/app/core/models/server-config/server-config.mapper.spec.ts
+++ b/src/app/core/models/server-config/server-config.mapper.spec.ts
@@ -1,0 +1,24 @@
+import { ServerConfigData } from './server-config.interface';
+import { ServerConfigMapper } from './server-config.mapper';
+
+describe('Server Config Mapper', () => {
+  describe('fromData', () => {
+    const serverConfigData = {
+      data: [
+        { applicationType: 'intershop.B2CResponsive', id: 'application', urlIdentifier: '-' },
+        { acceleration: true, id: 'basket' },
+      ],
+    } as ServerConfigData;
+
+    it(`should return the ServerConfig when getting ServerConfigData`, () => {
+      const config = ServerConfigMapper.fromData(serverConfigData);
+
+      expect(config).toBeTruthy();
+      expect(config.application.id).toBe('application');
+      expect(config.basket.id).toBe('basket');
+
+      expect(config.application.applicationType).toBe('intershop.B2CResponsive');
+      expect(config.basket.acceleration).toBeTruthy();
+    });
+  });
+});

--- a/src/app/core/models/server-config/server-config.mapper.ts
+++ b/src/app/core/models/server-config/server-config.mapper.ts
@@ -1,0 +1,20 @@
+import { ServerConfigData } from './server-config.interface';
+import { ServerConfig } from './server-config.model';
+
+export class ServerConfigMapper {
+  static fromData(payload: ServerConfigData): ServerConfig {
+    const { data } = payload;
+
+    const config = {};
+
+    if (data && data.length) {
+      data.forEach(cdata => {
+        if (cdata && cdata.id) {
+          config[cdata.id] = cdata;
+        }
+      });
+      return config;
+    }
+    return;
+  }
+}

--- a/src/app/core/models/server-config/server-config.model.ts
+++ b/src/app/core/models/server-config/server-config.model.ts
@@ -1,0 +1,9 @@
+/**
+ * model for config data (parameters, services etc.) retrieved from the ICM server.
+ */
+
+export interface ServerConfig {
+  [id: string]: {
+    [key: string]: string | boolean;
+  };
+}

--- a/src/app/core/models/shipping-method/shipping-method.mapper.spec.ts
+++ b/src/app/core/models/shipping-method/shipping-method.mapper.spec.ts
@@ -1,7 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
+import { getLoggedInCustomer } from 'ish-core/store/user';
+
 import { ShippingMethodData } from './shipping-method.interface';
 import { ShippingMethodMapper } from './shipping-method.mapper';
 
 describe('Shipping Method Mapper', () => {
+  let shippingMethodMapper: ShippingMethodMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }),
+        ShippingMethodMapper,
+      ],
+    });
+
+    shippingMethodMapper = TestBed.get(ShippingMethodMapper);
+  });
+
   describe('fromData', () => {
     const shippingMethodData = {
       id: '4711',
@@ -20,7 +38,7 @@ describe('Shipping Method Mapper', () => {
     } as ShippingMethodData;
 
     it(`should return ShippingMethod when getting a ShippingMethodData`, () => {
-      const shippingMethod = ShippingMethodMapper.fromData(shippingMethodData);
+      const shippingMethod = shippingMethodMapper.fromData(shippingMethodData);
 
       expect(shippingMethod).toBeTruthy();
       expect(shippingMethod.name).toEqual('StdGround');
@@ -30,7 +48,7 @@ describe('Shipping Method Mapper', () => {
     it(`should return shippingTimeMin and Max when getting a ShippingMethodData`, () => {
       shippingMethodData.deliveryTimeMin = 'P6D';
       shippingMethodData.deliveryTimeMax = 'P14D';
-      const shippingMethod = ShippingMethodMapper.fromData(shippingMethodData);
+      const shippingMethod = shippingMethodMapper.fromData(shippingMethodData);
 
       expect(shippingMethod.shippingTimeMin).toEqual(6);
       expect(shippingMethod.shippingTimeMax).toEqual(14);
@@ -39,7 +57,7 @@ describe('Shipping Method Mapper', () => {
     it(`should not return shippingTimeMin and Max if shipping time is not a day in period format`, () => {
       shippingMethodData.deliveryTimeMin = '6';
       shippingMethodData.deliveryTimeMax = 'P14D12H';
-      const shippingMethod = ShippingMethodMapper.fromData(shippingMethodData);
+      const shippingMethod = shippingMethodMapper.fromData(shippingMethodData);
 
       expect(shippingMethod.shippingTimeMin).toBeUndefined();
       expect(shippingMethod.shippingTimeMax).toBeUndefined();

--- a/src/app/core/models/shipping-method/shipping-method.mapper.ts
+++ b/src/app/core/models/shipping-method/shipping-method.mapper.ts
@@ -1,16 +1,21 @@
+import { Injectable } from '@angular/core';
+
 import { PriceMapper } from 'ish-core/models/price/price.mapper';
 
 import { ShippingMethodData } from './shipping-method.interface';
 import { ShippingMethod } from './shipping-method.model';
 
+@Injectable({ providedIn: 'root' })
 export class ShippingMethodMapper {
-  static fromData(data: ShippingMethodData): ShippingMethod {
+  constructor(private priceMapper: PriceMapper) {}
+
+  fromData(data: ShippingMethodData): ShippingMethod {
     if (data) {
       return {
         name: data.name,
         id: data.id,
         description: data.description,
-        shippingCosts: PriceMapper.fromPriceItem(data.shippingCosts),
+        shippingCosts: this.priceMapper.fromPriceItem(data.shippingCosts),
         shippingTimeMin:
           data.deliveryTimeMin && data.deliveryTimeMin.match(/^P\d+D$/gi)
             ? +data.deliveryTimeMin.replace(/[PD]/gi, '')

--- a/src/app/core/services/basket/basket.service.spec.ts
+++ b/src/app/core/services/basket/basket.service.spec.ts
@@ -1,9 +1,12 @@
 import { HttpHeaders } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { of, throwError } from 'rxjs';
 import { anyString, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { Address } from 'ish-core/models/address/address.model';
 import { ApiService } from 'ish-core/services/api/api.service';
+import { getLoggedInCustomer } from 'ish-core/store/user';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 
 import { BasketItemUpdateType, BasketService } from './basket.service';
@@ -77,7 +80,16 @@ describe('Basket Service', () => {
 
   beforeEach(() => {
     apiService = mock(ApiService);
-    basketService = new BasketService(instance(apiService));
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ApiService, useFactory: () => instance(apiService) },
+        provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: {} }] }),
+        BasketService,
+      ],
+    });
+
+    basketService = TestBed.get(BasketService);
   });
 
   it("should get basket data when 'getBasket' is called", done => {

--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -69,7 +69,12 @@ type ValidationBasketIncludeType =
  */
 @Injectable({ providedIn: 'root' })
 export class BasketService {
-  constructor(private apiService: ApiService) {}
+  constructor(
+    private apiService: ApiService,
+    private basketMapper: BasketMapper,
+    private basketValidationMapper: BasketValidationMapper,
+    private shippingMethodMapper: ShippingMethodMapper
+  ) {}
 
   // http header for Basket API v1
   private basketHeaders = new HttpHeaders({
@@ -128,7 +133,7 @@ export class BasketService {
         headers: this.basketHeaders,
         params,
       })
-      .pipe(map(BasketMapper.fromData));
+      .pipe(map(basket => this.basketMapper.fromData(basket)));
   }
 
   getBasketByToken(apiToken: string): Observable<Basket> {
@@ -142,7 +147,7 @@ export class BasketService {
         runExclusively: true,
       })
       .pipe(
-        map(BasketMapper.fromData),
+        map(basket => this.basketMapper.fromData(basket)),
         // tslint:disable-next-line:ban
         catchError(() => EMPTY)
       );
@@ -161,7 +166,7 @@ export class BasketService {
           headers: this.basketHeaders,
         }
       )
-      .pipe(map(BasketMapper.fromData));
+      .pipe(map(basket => this.basketMapper.fromData(basket)));
   }
 
   /**
@@ -190,7 +195,7 @@ export class BasketService {
               params,
             }
           )
-          .pipe(map(mergeBasketData => BasketMapper.fromData(BasketMergeHelper.transform(mergeBasketData))))
+          .pipe(map(mergeBasketData => this.basketMapper.fromData(BasketMergeHelper.transform(mergeBasketData))))
       )
     );
   }
@@ -212,7 +217,7 @@ export class BasketService {
         headers: this.basketHeaders,
         params,
       })
-      .pipe(map(BasketMapper.fromData));
+      .pipe(map(basket => this.basketMapper.fromData(basket)));
   }
 
   /**
@@ -237,7 +242,7 @@ export class BasketService {
         headers: this.basketHeaders,
         params,
       })
-      .pipe(map(BasketValidationMapper.fromData));
+      .pipe(map(data => this.basketValidationMapper.fromData(data)));
   }
 
   /**
@@ -414,7 +419,7 @@ export class BasketService {
           })
           .pipe(
             unpackEnvelope<ShippingMethodData>('data'),
-            map(data => data.map(ShippingMethodMapper.fromData))
+            map(data => data.map(shippingData => this.shippingMethodMapper.fromData(shippingData)))
           )
       : this.apiService
           .get(`baskets/${basketId}/eligible-shipping-methods`, {
@@ -422,7 +427,7 @@ export class BasketService {
           })
           .pipe(
             unpackEnvelope<ShippingMethodData>('data'),
-            map(data => data.map(ShippingMethodMapper.fromData))
+            map(data => data.map(shippingData => this.shippingMethodMapper.fromData(shippingData)))
           );
   }
 

--- a/src/app/core/services/configuration/configuration.service.spec.ts
+++ b/src/app/core/services/configuration/configuration.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed, async } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+
+import { ApiService } from 'ish-core/services/api/api.service';
+
+import { ConfigurationService } from './configuration.service';
+
+describe('Configuration Service', () => {
+  let apiServiceMock: ApiService;
+  let configurationService: ConfigurationService;
+
+  beforeEach(async(() => {
+    apiServiceMock = mock(ApiService);
+    TestBed.configureTestingModule({
+      providers: [{ provide: ApiService, useFactory: () => instance(apiServiceMock) }],
+    });
+    configurationService = TestBed.get(ConfigurationService);
+  }));
+
+  it('should be created', () => {
+    expect(configurationService).toBeTruthy();
+  });
+
+  it("should get the server configuration when 'getServerConfiguration' is called", done => {
+    when(apiServiceMock.get(`configurations`, anything())).thenReturn(of({}));
+
+    configurationService.getServerConfiguration().subscribe(() => {
+      verify(apiServiceMock.get(`configurations`, anything())).once();
+      done();
+    });
+  });
+});

--- a/src/app/core/services/configuration/configuration.service.ts
+++ b/src/app/core/services/configuration/configuration.service.ts
@@ -1,0 +1,31 @@
+import { HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { ServerConfigMapper } from 'ish-core/models/server-config/server-config.mapper';
+import { ServerConfig } from 'ish-core/models/server-config/server-config.model';
+import { ApiService } from 'ish-core/services/api/api.service';
+
+@Injectable({ providedIn: 'root' })
+export class ConfigurationService {
+  constructor(private apiService: ApiService) {}
+
+  // http header for Configuration API v1
+  private configHeaders = new HttpHeaders({
+    'content-type': 'application/json',
+    Accept: 'application/vnd.intershop.configuration.v1+json',
+  });
+
+  /**
+   * Gets the ICM configuration parameters.
+   * @returns           The configuration object.
+   */
+  getServerConfiguration(): Observable<ServerConfig> {
+    return this.apiService
+      .get(`configurations`, {
+        headers: this.configHeaders,
+      })
+      .pipe(map(ServerConfigMapper.fromData));
+  }
+}

--- a/src/app/core/services/order/order.service.ts
+++ b/src/app/core/services/order/order.service.ts
@@ -27,7 +27,7 @@ type OrderIncludeType =
  */
 @Injectable({ providedIn: 'root' })
 export class OrderService {
-  constructor(private apiService: ApiService, private store: Store<{}>) {}
+  constructor(private apiService: ApiService, private orderMapper: OrderMapper, private store: Store<{}>) {}
 
   // http header for Order API v1
   private orderHeaders = new HttpHeaders({
@@ -73,7 +73,7 @@ export class OrderService {
         }
       )
       .pipe(
-        map(OrderMapper.fromData),
+        map(orderData => this.orderMapper.fromData(orderData)),
         withLatestFrom(this.store.pipe(select(getCurrentLocale))),
         concatMap(([order, currentLocale]) =>
           this.sendRedirectUrlsIfRequired(order, currentLocale && currentLocale.lang)
@@ -106,10 +106,10 @@ export class OrderService {
         },
       };
       return this.apiService
-        .patch(`orders/${order.id}`, body, {
+        .patch<OrderData>(`orders/${order.id}`, body, {
           headers: this.orderHeaders,
         })
-        .pipe(map(OrderMapper.fromData));
+        .pipe(map(orderData => this.orderMapper.fromData(orderData)));
     } else {
       return of(order);
     }
@@ -128,7 +128,7 @@ export class OrderService {
         headers: this.orderHeaders,
         params,
       })
-      .pipe(map(OrderMapper.fromListData));
+      .pipe(map(orderData => this.orderMapper.fromListData(orderData)));
   }
 
   /**
@@ -148,7 +148,7 @@ export class OrderService {
         headers: this.orderHeaders,
         params,
       })
-      .pipe(map(OrderMapper.fromData));
+      .pipe(map(orderData => this.orderMapper.fromData(orderData)));
   }
 
   /**
@@ -176,7 +176,7 @@ export class OrderService {
         runExclusively: true,
       })
       .pipe(
-        map(OrderMapper.fromData),
+        map(orderData => this.orderMapper.fromData(orderData)),
         // tslint:disable-next-line:ban
         catchError(() => EMPTY)
       );

--- a/src/app/core/services/payment/payment.service.ts
+++ b/src/app/core/services/payment/payment.service.ts
@@ -12,6 +12,7 @@ import { PaymentInstrumentData } from 'ish-core/models/payment-instrument/paymen
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
 import {
   PaymentMethodBaseData,
+  PaymentMethodData,
   PaymentMethodOptionsDataType,
 } from 'ish-core/models/payment-method/payment-method.interface';
 import { PaymentMethodMapper } from 'ish-core/models/payment-method/payment-method.mapper';
@@ -25,7 +26,11 @@ import { getCurrentLocale } from 'ish-core/store/locale';
  */
 @Injectable({ providedIn: 'root' })
 export class PaymentService {
-  constructor(private apiService: ApiService, private store: Store<{}>) {}
+  constructor(
+    private apiService: ApiService,
+    private paymentMethodMapper: PaymentMethodMapper,
+    private store: Store<{}>
+  ) {}
 
   // http header for Basket API v1
   private basketHeaders = new HttpHeaders({
@@ -46,11 +51,11 @@ export class PaymentService {
     const params = new HttpParams().set('include', 'paymentInstruments');
 
     return this.apiService
-      .get(`baskets/${basketId}/eligible-payment-methods`, {
+      .get<PaymentMethodData>(`baskets/${basketId}/eligible-payment-methods`, {
         headers: this.basketHeaders,
         params,
       })
-      .pipe(map(PaymentMethodMapper.fromData));
+      .pipe(map(data => this.paymentMethodMapper.fromData(data)));
   }
 
   /**

--- a/src/app/core/store/checkout/checkout-store.spec.ts
+++ b/src/app/core/store/checkout/checkout-store.spec.ts
@@ -27,6 +27,7 @@ import { User } from 'ish-core/models/user/user.model';
 import { AddressService } from 'ish-core/services/address/address.service';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { CategoriesService } from 'ish-core/services/categories/categories.service';
+import { ConfigurationService } from 'ish-core/services/configuration/configuration.service';
 import { CountryService } from 'ish-core/services/country/country.service';
 import { FilterService } from 'ish-core/services/filter/filter.service';
 import { OrderService } from 'ish-core/services/order/order.service';
@@ -133,6 +134,9 @@ describe('Checkout Store', () => {
 
     const categoriesServiceMock = mock(CategoriesService);
     when(categoriesServiceMock.getTopLevelCategories(anyNumber())).thenReturn(of(categoryTree()));
+
+    const configurationServiceMock = mock(ConfigurationService);
+    when(configurationServiceMock.getServerConfiguration()).thenReturn(EMPTY);
 
     const countryServiceMock = mock(CountryService);
     when(countryServiceMock.getCountries()).thenReturn(of([{ countryCode: 'DE', name: 'Germany' }]));
@@ -247,6 +251,7 @@ describe('Checkout Store', () => {
         { provide: PaymentService, useFactory: () => instance(mock(PaymentService)) },
         { provide: OrderService, useFactory: () => instance(orderServiceMock) },
         { provide: CategoriesService, useFactory: () => instance(categoriesServiceMock) },
+        { provide: ConfigurationService, useFactory: () => instance(configurationServiceMock) },
         { provide: CountryService, useFactory: () => instance(countryServiceMock) },
         { provide: ProductsService, useFactory: () => instance(productsServiceMock) },
         { provide: PromotionsService, useFactory: () => instance(promotionsServiceMock) },

--- a/src/app/core/store/configuration/configuration.actions.ts
+++ b/src/app/core/store/configuration/configuration.actions.ts
@@ -1,13 +1,26 @@
 import { Action } from '@ngrx/store';
 
+import { HttpError } from 'ish-core/models/http-error/http-error.model';
+
 import { ConfigurationState } from './configuration.reducer';
 
 export enum ConfigurationActionTypes {
+  LoadServerConfig = '[Configuration Internal] Get the ICM configuration',
+  LoadServerConfigFail = '[Configuration API] Get the ICM configuration Fail',
   ApplyConfiguration = '[Configuration] Apply Configuration',
   SetGTMToken = '[Configuration] Set Google Tag Manager Token',
 }
 
 type ConfigurationType = Partial<ConfigurationState>;
+
+export class LoadServerConfig implements Action {
+  readonly type = ConfigurationActionTypes.LoadServerConfig;
+}
+
+export class LoadServerConfigFail implements Action {
+  readonly type = ConfigurationActionTypes.LoadServerConfigFail;
+  constructor(public payload: { error: HttpError }) {}
+}
 
 export class ApplyConfiguration implements Action {
   readonly type = ConfigurationActionTypes.ApplyConfiguration;
@@ -15,8 +28,8 @@ export class ApplyConfiguration implements Action {
 }
 
 export class SetGTMToken implements Action {
-  type = ConfigurationActionTypes.SetGTMToken;
+  readonly type = ConfigurationActionTypes.SetGTMToken;
   constructor(public payload: { gtmToken: string }) {}
 }
 
-export type ConfigurationAction = ApplyConfiguration | SetGTMToken;
+export type ConfigurationAction = LoadServerConfig | LoadServerConfigFail | ApplyConfiguration | SetGTMToken;

--- a/src/app/core/store/configuration/configuration.reducer.ts
+++ b/src/app/core/store/configuration/configuration.reducer.ts
@@ -1,33 +1,49 @@
+import { HttpError } from 'ish-core/models/http-error/http-error.model';
+import { ServerConfig } from 'ish-core/models/server-config/server-config.model';
+
 import { ConfigurationAction, ConfigurationActionTypes } from './configuration.actions';
 
 export interface ConfigurationState {
   baseURL?: string;
   server?: string;
   serverStatic?: string;
+  serverConfig?: ServerConfig;
   channel?: string;
   application?: string;
   features?: string[];
   gtmToken?: string;
   theme?: string;
+  error?: HttpError;
 }
 
 const initialState: ConfigurationState = {
   baseURL: undefined,
   server: undefined,
   serverStatic: undefined,
+  serverConfig: undefined,
   channel: undefined,
   application: undefined,
   features: [],
   gtmToken: undefined,
   theme: undefined,
+  error: undefined,
 };
 
 export function configurationReducer(state = initialState, action: ConfigurationAction): ConfigurationState {
-  if (action.type === ConfigurationActionTypes.ApplyConfiguration) {
-    return { ...state, ...action.payload };
-  } else if (action.type === ConfigurationActionTypes.SetGTMToken) {
-    const { gtmToken } = action.payload;
-    return { ...state, gtmToken };
+  switch (action.type) {
+    case ConfigurationActionTypes.ApplyConfiguration: {
+      return { ...state, error: undefined, ...action.payload };
+    }
+
+    case ConfigurationActionTypes.SetGTMToken: {
+      const { gtmToken } = action.payload;
+      return { ...state, gtmToken };
+    }
+
+    case ConfigurationActionTypes.LoadServerConfigFail: {
+      const { error } = action.payload;
+      return { ...state, error };
+    }
   }
 
   return state;

--- a/src/app/core/store/configuration/configuration.selectors.ts
+++ b/src/app/core/store/configuration/configuration.selectors.ts
@@ -58,3 +58,8 @@ export const getTheme = createSelector(
   getConfigurationState,
   state => state.theme
 );
+
+export const isServerConfigurationLoaded = createSelector(
+  getConfigurationState,
+  state => !!state.serverConfig
+);

--- a/src/app/core/store/configuration/configuration.selectors.ts
+++ b/src/app/core/store/configuration/configuration.selectors.ts
@@ -63,3 +63,14 @@ export const isServerConfigurationLoaded = createSelector(
   getConfigurationState,
   state => !!state.serverConfig
 );
+
+export const getConfigParameter = (group: string, attr: string) =>
+  createSelector(
+    getConfigurationState,
+    state =>
+      state &&
+      state.serverConfig &&
+      state.serverConfig[group] &&
+      state.serverConfig[group][attr] &&
+      state.serverConfig[group][attr].toString()
+  );

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -23,6 +23,7 @@ import { Product } from 'ish-core/models/product/product.model';
 import { Promotion } from 'ish-core/models/promotion/promotion.model';
 import { AddressService } from 'ish-core/services/address/address.service';
 import { CategoriesService } from 'ish-core/services/categories/categories.service';
+import { ConfigurationService } from 'ish-core/services/configuration/configuration.service';
 import { CountryService } from 'ish-core/services/country/country.service';
 import { FilterService } from 'ish-core/services/filter/filter.service';
 import { OrderService } from 'ish-core/services/order/order.service';
@@ -115,6 +116,9 @@ describe('Shopping Store', () => {
       }
     });
 
+    const configurationServiceMock = mock(ConfigurationService);
+    when(configurationServiceMock.getServerConfiguration()).thenReturn(EMPTY);
+
     const countryServiceMock = mock(CountryService);
     when(countryServiceMock.getCountries()).thenReturn(EMPTY);
 
@@ -192,6 +196,7 @@ describe('Shopping Store', () => {
       ],
       providers: [
         { provide: CategoriesService, useFactory: () => instance(categoriesServiceMock) },
+        { provide: ConfigurationService, useFactory: () => instance(configurationServiceMock) },
         { provide: CountryService, useFactory: () => instance(countryServiceMock) },
         { provide: ProductsService, useFactory: () => instance(productsServiceMock) },
         { provide: PromotionsService, useFactory: () => instance(promotionsServiceMock) },
@@ -240,6 +245,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Load top level categories:
           depth: 1
         [Shopping] Load top level categories success:
@@ -272,6 +278,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/category/A.123"
             path: "category/:categoryUniqueId"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Select Category:
             categoryId: "A.123"
           [Shopping] Load Category:
@@ -325,6 +332,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/search/something"
             path: "search/:searchTerm"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Set Search Term:
             searchTerm: "something"
           [ProductListing] Load More Products:
@@ -369,6 +377,7 @@ describe('Shopping Store', () => {
               data: {}
               url: "/product/P2"
               path: "product/:sku"
+            [Configuration Internal] Get the ICM configuration
             [Shopping] Select Product:
               sku: "P2"
             [Recently Viewed] Add Product to Recently:
@@ -408,6 +417,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Select Category:
           categoryId: "A.123"
         [Shopping] Load top level categories:
@@ -448,6 +458,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/compare"
             path: "compare"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Deselect Category
         `);
       }));
@@ -483,6 +494,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Select Category:
           categoryId: "A.123.456"
         [Shopping] Load top level categories:
@@ -555,6 +567,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/category/A.123.456/product/P1"
             path: "category/:categoryUniqueId/product/:sku"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Select Product:
             sku: "P1"
           [Recently Viewed] Add Product to Recently:
@@ -586,6 +599,7 @@ describe('Shopping Store', () => {
               data: {}
               url: "/category/A.123.456"
               path: "category/:categoryUniqueId"
+            [Configuration Internal] Get the ICM configuration
             [ProductListing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
             [Shopping] Select Product:
@@ -610,6 +624,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/search/something"
             path: "search/:searchTerm"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Deselect Category
           [Shopping] Set Search Term:
             searchTerm: "something"
@@ -655,6 +670,7 @@ describe('Shopping Store', () => {
               data: {}
               url: "/category/A.123.456"
               path: "category/:categoryUniqueId"
+            [Configuration Internal] Get the ICM configuration
             [Shopping] Select Category:
               categoryId: "A.123.456"
             [ProductListing] Load More Products:
@@ -696,6 +712,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/compare"
             path: "compare"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Deselect Category
         `);
       }));
@@ -731,6 +748,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Select Category:
           categoryId: "A.123.456"
         [Shopping] Load top level categories:
@@ -788,6 +806,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/category/A.123.456"
             path: "category/:categoryUniqueId"
+          [Configuration Internal] Get the ICM configuration
           [ProductListing] Load More Products:
             id: {"type":"category","value":"A.123.456"}
           [Shopping] Select Product:
@@ -845,6 +864,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/compare"
             path: "compare"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Deselect Category
           [Shopping] Select Product:
             sku: undefined
@@ -882,6 +902,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Load top level categories:
           depth: 1
         [Shopping] Select Product:
@@ -919,6 +940,7 @@ describe('Shopping Store', () => {
             data: {}
             url: "/compare"
             path: "compare"
+          [Configuration Internal] Get the ICM configuration
           [Shopping] Select Product:
             sku: undefined
         `);
@@ -955,6 +977,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Select Category:
           categoryId: "A.123.456"
         [Shopping] Load top level categories:
@@ -988,6 +1011,7 @@ describe('Shopping Store', () => {
           data: {}
           url: "/error"
           path: "error"
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Deselect Category
         [Shopping] Select Product:
           sku: undefined
@@ -1028,6 +1052,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Select Category:
           categoryId: "A.123.XXX"
         [Shopping] Load top level categories:
@@ -1044,6 +1069,7 @@ describe('Shopping Store', () => {
           data: {}
           url: "/error"
           path: "error"
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Deselect Category
       `);
     }));
@@ -1076,6 +1102,7 @@ describe('Shopping Store', () => {
           deviceType: "pc"
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: undefined
+        [Configuration Internal] Get the ICM configuration
         [Shopping] Load top level categories:
           depth: 1
         [Shopping] Set Search Term:

--- a/src/app/extensions/quoting/models/quote-request-item/quote-request-item.mapper.spec.ts
+++ b/src/app/extensions/quoting/models/quote-request-item/quote-request-item.mapper.spec.ts
@@ -1,3 +1,4 @@
+import { QuoteRequestItemData } from './quote-request-item.interface';
 import { QuoteRequestItemMapper } from './quote-request-item.mapper';
 
 describe('Quote Request Item Mapper', () => {
@@ -36,7 +37,7 @@ describe('Quote Request Item Mapper', () => {
           currency: 'USD',
         },
         productSKU: '9438012',
-      };
+      } as QuoteRequestItemData;
       const quoteRequestItem = QuoteRequestItemMapper.fromData(quoteRequestItemData, 'test');
 
       expect(quoteRequestItem).toBeTruthy();

--- a/src/app/extensions/quoting/services/quote-request/quote-request.service.spec.ts
+++ b/src/app/extensions/quoting/services/quote-request/quote-request.service.spec.ts
@@ -223,12 +223,12 @@ describe('Quote Request Service', () => {
     it("should get line item of quote request when 'getQuoteRequestItem' is called", done => {
       const quoteRequestItem = {
         singlePrice: {
-          type: 'test',
+          type: 'Money',
           value: 1,
           currency: 'EUR',
         },
         totalPrice: {
-          type: 'test',
+          type: 'Money',
           value: 1,
           currency: 'EUR',
         },

--- a/src/app/extensions/quoting/services/quote/quote.service.spec.ts
+++ b/src/app/extensions/quoting/services/quote/quote.service.spec.ts
@@ -83,12 +83,12 @@ describe('Quote Service', () => {
           items: [
             {
               singlePrice: {
-                type: 'test',
+                type: 'Money',
                 value: 1,
                 currency: 'EUR',
               },
               totalPrice: {
-                type: 'test',
+                type: 'Money',
                 value: 1,
                 currency: 'EUR',
               },

--- a/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
+++ b/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
@@ -52,7 +52,12 @@
     <!-- Tax -->
     <!-- ToDo: display tax in dependence of price calculation preferences -->
     <ng-container *ngIf="totals.taxTotal && totals.taxTotal.value">
-      <dt class="col-6">{{ 'checkout.tax.text' | translate }}</dt>
+      <dt class="col-6">
+        <ng-container *ngIf="totals.itemTotal.priceType === 'net'; else vatIncluded">{{
+          'checkout.tax.text' | translate
+        }}</ng-container>
+        <ng-template #vatIncluded>{{ 'checkout.tax.TaxesLabel.TotalOrderVat' | translate }}</ng-template>
+      </dt>
       <dd class="col-6">{{ totals.taxTotal | ishPrice }}</dd>
     </ng-container>
 

--- a/src/app/shared/components/basket/line-item-description/line-item-description.component.html
+++ b/src/app/shared/components/basket/line-item-description/line-item-description.component.html
@@ -38,22 +38,22 @@
 
       <!-- ship window message -->
       <ish-product-shipment [product]="pli.product"></ish-product-shipment>
-
-      <!-- surcharges -->
-      <div *ngFor="let surcharge of pli.itemSurcharges">
-        {{ surcharge.displayName }} <span *ngIf="!surcharge.displayName">{{ surcharge.text }}</span>
-        <span class="text-nowrap"> {{ surcharge.amount | ishPrice }} </span>
-        <ng-template #SurchargeDescription> <span [innerHTML]="surcharge.description"></span> </ng-template>
-        <a
-          class="details-tooltip"
-          [ngbPopover]="SurchargeDescription"
-          [popoverTitle]="surcharge.displayName"
-          placement="top"
-        >
-          {{ 'shopping_cart.detail.text' | translate }}
-          <fa-icon [icon]="['fas', 'info-circle']"></fa-icon>
-        </a>
-      </div>
     </ng-container>
+
+    <!-- surcharges -->
+    <div *ngFor="let surcharge of pli.itemSurcharges">
+      {{ surcharge.displayName }} <span *ngIf="!surcharge.displayName">{{ surcharge.text }}</span>
+      <span class="text-nowrap"> {{ surcharge.amount | ishPrice }} </span>
+      <ng-template #SurchargeDescription> <span [innerHTML]="surcharge.description"></span> </ng-template>
+      <a
+        class="details-tooltip"
+        [ngbPopover]="SurchargeDescription"
+        [popoverTitle]="surcharge.displayName"
+        placement="top"
+      >
+        {{ 'shopping_cart.detail.text' | translate }}
+        <fa-icon [icon]="['fas', 'info-circle']"></fa-icon>
+      </a>
+    </div>
   </ng-container>
 </ng-container>

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -1519,7 +1519,7 @@
   "checkout.tax.TaxesLabel.Estimated_SalesTax": "Estimated Sales Tax",
   "checkout.tax.TaxesLabel.Estimated_TotalOrderVat": "VAT incl. in Order Total",
   "checkout.tax.TaxesLabel.SalesTax": "Sales Tax",
-  "checkout.tax.TaxesLabel.TotalOrderVat": "VAT incl. in Order Total",
+  "checkout.tax.TaxesLabel.TotalOrderVat": "VAT incl. in Total",
   "checkout.tax.TaxesLabel.TotalOrderVat.short": "VAT incl.",
   "checkout.tax.calculated_at_checkout.text": "will be calculated at checkout",
   "checkout.tax.duLabel": "Duties and Fees",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [ ] Bugfix  
 [x] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
The prices in the checkout and myAccount/orders will always be displayed as gross prices.

Issue Number: 


## What Is the New Behavior?
The prices in the checkout and myAccount/orders will displayed according to the appropriate ICM settings (to be found in the back office under preferences/pricing)


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No


## Other Information
required an ICM release 7.10.17
