### PR TITLE
feat: delete payment instrument link on checkout payment page

### DIFF
--- a/e2e/cypress/integration/specs/checkout/checkout-payments.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/checkout-payments.b2c.e2e-spec.ts
@@ -104,7 +104,7 @@ describe('Checkout Payment', () => {
       at(CheckoutPaymentPage, page => page.content.should('contain', '****************0001'));
     });
 
-    xit('should delete a direct debit transfer', () => {
+    it('should delete a direct debit transfer', () => {
       at(CheckoutPaymentPage, page => {
         page.paymentInstrument('ISH_DEBIT_TRANSFER').delete();
 

--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
@@ -87,13 +87,12 @@
                   <label class="form-check-label " [for]="'paymentOption_' + paymentInstrument.id">
                     {{ paymentInstrument.accountIdentifier }}
                   </label>
-                  <!-- ToDo: enable this link if pwa runs against ICM 7.10.16+ -->
-                  <!--<a
+                  <a
                     class="float-right"
                     (click)="deleteBasketPayment(paymentInstrument)"
                     data-testing-id="delete-payment-link"
                     >{{ 'checkout.payment.method.delete.link' | translate }}</a
-                  >-->
+                  >
                 </div>
               </li>
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [ ] Bugfix  
 [x] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
There is no possibility to remove a payment instrument on checkout payment page after you have added one.

Issue Number: ISREST-1024


## What Is the New Behavior?
There is a link to delete a payment instrument on checkout payment page. If the payment instrument is saved at the customer's profile it is also deleted from the profile.

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No


## Other Information
