### PR TITLE
fix: if payment failed after order creation navigate to checkout paym…

### DIFF
--- a/src/app/core/store/orders/orders.effects.spec.ts
+++ b/src/app/core/store/orders/orders.effects.spec.ts
@@ -403,6 +403,28 @@ describe('Orders Effects', () => {
     });
   });
 
+  describe('selectOrderAfterRedirectFailed', () => {
+    it('should navigate to /checkout/payment if order creation failed after redirect', fakeAsync(() => {
+      const action = new orderActions.SelectOrderAfterRedirectFail(undefined);
+      actions$ = of(action);
+
+      effects.selectOrderAfterRedirectFailed$.subscribe(noop, fail, noop);
+
+      tick(500);
+
+      expect(location.path()).toEqual('/checkout/payment?redirect=failure');
+    }));
+
+    it('should map to action of type LoadBasket', () => {
+      const action = new orderActions.SelectOrderAfterRedirectFail(undefined);
+      const completion = new LoadBasket();
+      actions$ = hot('-a-a-a', { a: action });
+      const expected$ = cold('-c-c-c', { c: completion });
+
+      expect(effects.selectOrderAfterRedirectFailed$).toBeObservable(expected$);
+    });
+  });
+
   describe('resetOrdersAfterLogout$', () => {
     it('should map to action of type ResetOrders if LogoutUser action triggered', () => {
       const action = new LogoutUser();

--- a/src/app/core/store/orders/orders.effects.ts
+++ b/src/app/core/store/orders/orders.effects.ts
@@ -223,6 +223,17 @@ export class OrdersEffects {
     )
   );
 
+  @Effect()
+  selectOrderAfterRedirectFailed$ = this.actions$.pipe(
+    ofType(ordersActions.OrdersActionTypes.SelectOrderAfterRedirectFail),
+    tap(() =>
+      this.router.navigate(['/checkout/payment'], {
+        queryParams: { redirect: 'failure' },
+      })
+    ),
+    mapTo(new LoadBasket())
+  );
+
   /**
    * Trigger ResetOrders action after LogoutUser.
    */


### PR DESCRIPTION
…ent page and display a message

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->

Precondition: The user pays with a payment method that requires a redirect after checkout

## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After order submission and the redirect an empty receipt page ist shown.

Issue Number: IS-989

## What Is the New Behavior?
After order submission and the redirect the checkout payment page is shown with an error message.

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No


## Other Information
