### PR TITLE
fix: prevent error after login on checkout address page

### DIFF
--- a/src/app/core/models/basket/basket.interface.ts
+++ b/src/app/core/models/basket/basket.interface.ts
@@ -16,6 +16,7 @@ export interface BasketBaseData {
   invoiceToAddress?: string;
   commonShipToAddress?: string;
   commonShippingMethod?: string;
+  customer?: string;
   discounts?: {
     dynamicMessages?: string[];
     shippingBasedDiscounts?: string[];

--- a/src/app/core/models/basket/basket.mapper.spec.ts
+++ b/src/app/core/models/basket/basket.mapper.spec.ts
@@ -15,6 +15,7 @@ describe('Basket Mapper', () => {
     invoiceToAddress: 'urn_invoiceToAddress_123',
     commonShipToAddress: 'urn_commonShipToAddress_123',
     commonShippingMethod: 'shipping_method_123',
+    customer: 'Heimroth',
     lineItems: ['YikKAE8BKC0AAAFrIW8IyLLD'],
     totals: {
       grandTotal: {
@@ -169,6 +170,7 @@ describe('Basket Mapper', () => {
       basket = BasketMapper.fromData(basketData);
       expect(basket).toBeTruthy();
 
+      expect(basket.customerNo).toBe(basketData.data.customer);
       expect(basket.totals.itemTotal.gross).toBe(basketData.data.totals.itemTotal.gross.value);
       expect(basket.totals.itemSurchargeTotalsByType[0].amount.gross).toBe(
         basketData.data.surcharges.itemSurcharges[0].amount.gross.value

--- a/src/app/core/models/basket/basket.mapper.ts
+++ b/src/app/core/models/basket/basket.mapper.ts
@@ -38,6 +38,7 @@ export class BasketMapper {
         included && included.commonShippingMethod && data.commonShippingMethod
           ? ShippingMethodMapper.fromData(included.commonShippingMethod[data.commonShippingMethod])
           : undefined,
+      customerNo: data.customer,
       lineItems:
         included && included.lineItems && data.lineItems && data.lineItems.length
           ? data.lineItems.map(lineItemId =>

--- a/src/app/core/models/basket/basket.model.ts
+++ b/src/app/core/models/basket/basket.model.ts
@@ -20,6 +20,7 @@ interface AbstractBasket<T> {
   invoiceToAddress?: Address;
   commonShipToAddress?: Address;
   commonShippingMethod?: ShippingMethod;
+  customerNo?: string;
   lineItems?: T[];
   payment?: Payment;
   promotionCodes?: string[];

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
@@ -27,6 +27,7 @@ describe('Basket Invoice Address Widget Component', () => {
 
   beforeEach(async(() => {
     checkoutFacade = mock(CheckoutFacade);
+    when(checkoutFacade.basket$).thenReturn(EMPTY);
     when(checkoutFacade.basketInvoiceAddress$).thenReturn(EMPTY);
 
     accountFacade = mock(AccountFacade);

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { BehaviorSubject, Observable, Subject, combineLatest } from 'rxjs';
-import { filter, map, take, takeUntil } from 'rxjs/operators';
+import { filter, map, switchMapTo, take, takeUntil } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { Address } from 'ish-core/models/address/address.model';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 /**
  * Standalone widget component for selecting and setting the basket invoice address in the checkout.
@@ -54,6 +55,8 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
           : 'checkout.addresses.select_invoice_address.button'
       )
     );
+
+    // prepare data for invoice select drop down
     this.addresses$ = combineLatest([this.accountFacade.addresses$(), this.invoiceAddress$]).pipe(
       map(
         ([addresses, invoiceAddress]) =>
@@ -64,10 +67,19 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
       )
     );
 
-    combineLatest([this.addresses$, this.invoiceAddress$])
+    // preassign an invoice address if the user has only one invoice address
+    this.checkoutFacade.basket$
       .pipe(
-        filter(([addresses]) => addresses && !!addresses.length),
-        take(1)
+        whenTruthy(),
+        // prevent assigning the address at an anonymous basket after login
+        filter(basket => !!basket.customerNo),
+        take(1),
+        switchMapTo(
+          combineLatest([this.addresses$, this.invoiceAddress$]).pipe(
+            filter(([addresses]) => addresses && !!addresses.length),
+            take(1)
+          )
+        )
       )
       .subscribe(([addresses, invoiceAddress]) => {
         if (!invoiceAddress && addresses.length === 1) {

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
@@ -28,6 +28,7 @@ describe('Basket Shipping Address Widget Component', () => {
 
   beforeEach(async(() => {
     checkoutFacade = mock(CheckoutFacade);
+    when(checkoutFacade.basket$).thenReturn(EMPTY);
     when(checkoutFacade.basketShippingAddress$).thenReturn(EMPTY);
 
     accountFacade = mock(AccountFacade);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->

## Precondition:
The user has exactly one invoice and shipping address.
The user adds some products to the basket and starts the checkout process.
He logs out, adds some products to the basket as anonymous user and starts the checkout process.
On the first checkout page he logs in.

## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
An error occurred (basket not found).
There is a console error that requests failed.

Issue Number: ISREST-1032

## What Is the New Behavior?
There is no error any more, neither on screen nor in the console.


## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No


## Other Information
