### PR TITLE
Revert "fix: fix loading animation display for longer pages (#166, #170)"

### DIFF
--- a/src/app/shared/components/common/loading/loading.component.scss
+++ b/src/app/shared/components/common/loading/loading.component.scss
@@ -1,11 +1,13 @@
 .loading {
-  position: fixed;
-  top: 37%;
-  left: 48%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1;
-  width: 33px;
-  height: 33px;
-  background: #fff url('/assets/img/loading.gif') no-repeat;
+  min-width: 50px;
+  min-height: 50px;
+  background: #fff url('/assets/img/loading.gif') center center no-repeat;
   opacity: 0.5;
 }
 


### PR DESCRIPTION
Reverting changes of pull request #170. Needs to be fixed in a different way that will not break all other cases that were fine before. See reopend #166 for explanation.