### PR TITLE
fix: repair service worker boot-up with correct configuration

### DIFF
--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -48,6 +48,8 @@ server {
         add_header X-icm-features $FEATURES always;
         add_header X-icm-default-lang $LANG always;
 
+        rewrite ^.*/index.html$ /loading;
+
         rewrite ^/$ /home;
         if ($request_uri !~* ";lang=") {
             rewrite ^(.*)$ "$1;lang=$LANG";

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -6,7 +6,7 @@
       "name": "app",
       "installMode": "prefetch",
       "resources": {
-        "files": ["/favicon.ico", "/*.css", "/*.js"]
+        "files": ["/favicon.ico", "/index.html", "/*.css", "/*.js"]
       }
     },
     {

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -6,7 +6,12 @@ import { debounce, debounceTime, filter, map, switchMap, tap } from 'rxjs/operat
 import { ProductListingID } from 'ish-core/models/product-listing/product-listing.model';
 import { ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
 import { AddProductToBasket } from 'ish-core/store/checkout/basket';
-import { getCategoryLoading, getSelectedCategory, getTopLevelCategories } from 'ish-core/store/shopping/categories';
+import {
+  LoadTopLevelCategories,
+  getCategoryLoading,
+  getSelectedCategory,
+  getTopLevelCategories,
+} from 'ish-core/store/shopping/categories';
 import {
   AddToCompare,
   RemoveFromCompare,
@@ -49,7 +54,10 @@ export class ShoppingFacade {
   constructor(private store: Store<{}>) {}
 
   // CATEGORY
-  topLevelCategories$ = this.store.pipe(select(getTopLevelCategories));
+  topLevelCategories$() {
+    this.store.dispatch(new LoadTopLevelCategories());
+    return this.store.pipe(select(getTopLevelCategories));
+  }
   selectedCategory$ = this.store.pipe(select(getSelectedCategory));
   selectedCategoryLoading$ = this.store.pipe(
     select(getCategoryLoading),

--- a/src/app/core/store/shopping/categories/categories.actions.ts
+++ b/src/app/core/store/shopping/categories/categories.actions.ts
@@ -14,7 +14,6 @@ export enum CategoriesActionTypes {
 
 export class LoadTopLevelCategories implements Action {
   readonly type = CategoriesActionTypes.LoadTopLevelCategories;
-  constructor(public payload: { depth: number }) {}
 }
 
 export class LoadTopLevelCategoriesFail implements Action {

--- a/src/app/core/store/shopping/categories/categories.effects.spec.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.spec.ts
@@ -4,11 +4,10 @@ import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { routerNavigatedAction } from '@ngrx/router-store';
 import { Action, Store, combineReducers } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { Observable, noop, of, throwError } from 'rxjs';
-import { instance, mock, verify, when } from 'ts-mockito';
+import { anyNumber, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH } from 'ish-core/configurations/injection-keys';
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
@@ -45,8 +44,8 @@ describe('Categories Effects', () => {
       of(categoryTree([{ uniqueId: '123', categoryPath: ['123'] } as Category]))
     );
     when(categoriesServiceMock.getCategory('invalid')).thenReturn(throwError({ message: 'invalid category' }));
-    when(categoriesServiceMock.getTopLevelCategories(2)).thenReturn(of(TOP_LEVEL_CATEGORIES));
-    when(categoriesServiceMock.getTopLevelCategories(-1)).thenReturn(throwError({ message: 'invalid number' }));
+    when(categoriesServiceMock.getTopLevelCategories(anyNumber())).thenReturn(of(TOP_LEVEL_CATEGORIES));
+
     TestBed.configureTestingModule({
       declarations: [DummyComponent],
       imports: [
@@ -196,49 +195,24 @@ describe('Categories Effects', () => {
     });
   });
 
-  describe('loadTopLevelWhenUnavailable$', () => {
-    let depth: number;
-
-    beforeEach(() => {
-      depth = TestBed.get(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH);
-    });
-
-    it('should load top level categories retrying for every routing action', () => {
-      const completion = new fromActions.LoadTopLevelCategories({ depth });
-
-      // tslint:disable-next-line: no-any
-      actions$ = hot('        ----a---a--a', { a: routerNavigatedAction({ payload: {} as any }) });
-      const expected$ = cold('----a---a--a', { a: completion });
-
-      expect(effects.loadTopLevelWhenUnavailable$).toBeObservable(expected$);
-    });
-
-    it('should not load top level categories when already available', () => {
-      store$.dispatch(new fromActions.LoadTopLevelCategoriesSuccess({ categories: categoryTree() }));
-
-      // tslint:disable-next-line: no-any
-      actions$ = hot('        ----a---a--a', { a: routerNavigatedAction({ payload: {} as any }) });
-      const expected$ = cold('------------');
-
-      expect(effects.loadTopLevelWhenUnavailable$).toBeObservable(expected$);
-    });
-  });
-
   describe('loadTopLevelCategories$', () => {
     it('should call the categoriesService for LoadTopLevelCategories action', done => {
-      const depth = 2;
-      const action = new fromActions.LoadTopLevelCategories({ depth });
+      const action = new fromActions.LoadTopLevelCategories();
       actions$ = of(action);
 
       effects.loadTopLevelCategories$.subscribe(() => {
-        verify(categoriesServiceMock.getTopLevelCategories(depth)).once();
+        verify(categoriesServiceMock.getTopLevelCategories(anyNumber())).once();
+        expect(capture(categoriesServiceMock.getTopLevelCategories).last()).toMatchInlineSnapshot(`
+          Array [
+            1,
+          ]
+        `);
         done();
       });
     });
 
     it('should map to action of type LoadCategorySuccess', () => {
-      const depth = 2;
-      const action = new fromActions.LoadTopLevelCategories({ depth });
+      const action = new fromActions.LoadTopLevelCategories();
       const completion = new fromActions.LoadTopLevelCategoriesSuccess({ categories: TOP_LEVEL_CATEGORIES });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -247,8 +221,10 @@ describe('Categories Effects', () => {
     });
 
     it('should map invalid request to action of type LoadCategoryFail', () => {
-      const depth = -1;
-      const action = new fromActions.LoadTopLevelCategories({ depth });
+      when(categoriesServiceMock.getTopLevelCategories(anyNumber())).thenReturn(
+        throwError({ message: 'invalid number' })
+      );
+      const action = new fromActions.LoadTopLevelCategories();
       const completion = new fromActions.LoadTopLevelCategoriesFail({
         error: { message: 'invalid number' } as HttpError,
       });

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -7,7 +7,6 @@ import {
   distinctUntilChanged,
   filter,
   map,
-  mapTo,
   mergeMap,
   switchMap,
   switchMapTo,
@@ -22,7 +21,7 @@ import { CategoriesService } from 'ish-core/services/categories/categories.servi
 import { selectRouteParam } from 'ish-core/store/router';
 import { LoadMoreProducts } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
-import { mapErrorToAction, mapToPayloadProperty, mapToProperty, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
+import { mapErrorToAction, mapToPayloadProperty, mapToProperty, whenTruthy } from 'ish-core/utils/operators';
 
 import * as actions from './categories.actions';
 import * as selectors from './categories.selectors';
@@ -79,19 +78,10 @@ export class CategoriesEffects {
   );
 
   @Effect()
-  loadTopLevelWhenUnavailable$ = this.actions$.pipe(
-    ofType(routerNavigatedAction),
-    switchMapTo(this.store.pipe(select(selectors.isTopLevelCategoriesLoaded))),
-    whenFalsy(),
-    mapTo(new actions.LoadTopLevelCategories({ depth: this.mainNavigationMaxSubCategoriesDepth }))
-  );
-
-  @Effect()
   loadTopLevelCategories$ = this.actions$.pipe(
     ofType<actions.LoadTopLevelCategories>(actions.CategoriesActionTypes.LoadTopLevelCategories),
-    mapToPayloadProperty('depth'),
-    switchMap(limit =>
-      this.categoryService.getTopLevelCategories(limit).pipe(
+    switchMap(() =>
+      this.categoryService.getTopLevelCategories(this.mainNavigationMaxSubCategoriesDepth).pipe(
         map(categories => new actions.LoadTopLevelCategoriesSuccess({ categories })),
         mapErrorToAction(actions.LoadTopLevelCategoriesFail)
       )

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -156,6 +156,7 @@ describe('Shopping Store', () => {
           {
             path: 'error',
             component: DummyComponent,
+            data: { headerType: 'simple' },
           },
           {
             path: 'category/:categoryUniqueId',
@@ -235,14 +236,9 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigated:
           routerState: {"url":"/home","params":{},"queryParams":{},"data":{}}
           event: {"id":1,"url":"/home"}
-        [Shopping] Load top level categories:
-          depth: 1
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
       `);
 
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(3);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'B']);
+      expect(getCategoryIds(store.state)).toBeEmpty();
       expect(getProductIds(store.state)).toBeEmpty();
     }));
 
@@ -254,8 +250,13 @@ describe('Shopping Store', () => {
       }));
 
       it('should load necessary data when going to a category page', fakeAsync(() => {
-        expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-        expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+        expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123",
+            "A.123.456",
+            "A",
+          ]
+        `);
         expect(getProductIds(store.state)).toBeEmpty();
       }));
 
@@ -387,8 +388,13 @@ describe('Shopping Store', () => {
     }));
 
     it('should load necessary data when going to a category page', fakeAsync(() => {
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+      expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+        Array [
+          "A.123",
+          "A.123.456",
+          "A",
+        ]
+      `);
       expect(getProductIds(store.state)).toBeEmpty();
     }));
 
@@ -414,10 +420,6 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigated:
           routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
           event: {"id":1,"url":"/category/A.123"}
-        [Shopping] Load top level categories:
-          depth: 1
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
       `);
     }));
 
@@ -429,8 +431,13 @@ describe('Shopping Store', () => {
       }));
 
       it('should not load anything additionally when going to compare page', fakeAsync(() => {
-        expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-        expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+        expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123",
+            "A.123.456",
+            "A",
+          ]
+        `);
         expect(getProductIds(store.state)).toBeEmpty();
       }));
 
@@ -462,8 +469,13 @@ describe('Shopping Store', () => {
     }));
 
     it('should load all products and required categories when going to a family page', fakeAsync(() => {
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+      expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123.456",
+            "A",
+            "A.123",
+          ]
+        `);
       expect(getProductIds(store.state)).toEqual(['P1', 'P2']);
     }));
 
@@ -497,12 +509,8 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigated:
           routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
           event: {"id":1,"url":"/category/A.123.456"}
-        [Shopping] Load top level categories:
-          depth: 1
         [ProductListing] Load More Products:
           id: {"type":"category","value":"A.123.456"}
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
         [ProductListing Internal] Load More Products For Params:
           id: {"type":"category","value":"A.123.456"}
           filters: undefined
@@ -665,8 +673,13 @@ describe('Shopping Store', () => {
       }));
 
       it('should not load anything additionally when going to compare page', fakeAsync(() => {
-        expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-        expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+        expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123.456",
+            "A",
+            "A.123",
+          ]
+        `);
         expect(getProductIds(store.state)).toEqual(['P1', 'P2']);
       }));
 
@@ -698,8 +711,13 @@ describe('Shopping Store', () => {
     }));
 
     it('should load the product and its required categories when going to a product page', fakeAsync(() => {
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+      expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123.456",
+            "A",
+            "A.123",
+          ]
+        `);
       expect(getProductIds(store.state)).toEqual(['P1']);
     }));
 
@@ -740,10 +758,6 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigated:
           routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
           event: {"id":1,"url":"/category/A.123.456/product/P1"}
-        [Shopping] Load top level categories:
-          depth: 1
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
       `);
     }));
 
@@ -759,8 +773,13 @@ describe('Shopping Store', () => {
       }));
 
       it('should load the sibling products when they are not yet loaded', fakeAsync(() => {
-        expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-        expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+        expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123.456",
+            "A",
+            "A.123",
+          ]
+        `);
         expect(getProductIds(store.state)).toEqual(['P1', 'P2']);
       }));
 
@@ -817,8 +836,13 @@ describe('Shopping Store', () => {
       }));
 
       it('should not load anything additionally when going to compare page', fakeAsync(() => {
-        expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-        expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+        expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+          Array [
+            "A.123.456",
+            "A",
+            "A.123",
+          ]
+        `);
         expect(getProductIds(store.state)).toEqual(['P1']);
       }));
 
@@ -850,8 +874,7 @@ describe('Shopping Store', () => {
     }));
 
     it('should load the product ang top level categories when going to a product page', fakeAsync(() => {
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(3);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'B']);
+      expect(getCategoryIds(store.state)).toBeEmpty();
       expect(getProductIds(store.state)).toEqual(['P1']);
     }));
 
@@ -876,10 +899,6 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigated:
           routerState: {"url":"/product/P1","params":{"sku":"P1"},"queryParams":{},...
           event: {"id":1,"url":"/product/P1"}
-        [Shopping] Load top level categories:
-          depth: 1
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
       `);
     }));
 
@@ -891,8 +910,7 @@ describe('Shopping Store', () => {
       }));
 
       it('should not load anything additionally when going to compare page', fakeAsync(() => {
-        expect(getCategoryIds(store.state)).toBeArrayOfSize(3);
-        expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'B']);
+        expect(getCategoryIds(store.state)).toBeEmpty();
         expect(getProductIds(store.state)).toEqual(['P1']);
       }));
 
@@ -924,8 +942,13 @@ describe('Shopping Store', () => {
     }));
 
     it('should load only family page content and redirect to error when product was not found', fakeAsync(() => {
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(4);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'A.123.456', 'B']);
+      expect(getCategoryIds(store.state)).toMatchInlineSnapshot(`
+        Array [
+          "A.123.456",
+          "A",
+          "A.123",
+        ]
+      `);
       expect(getProductIds(store.state)).toBeEmpty();
     }));
 
@@ -965,15 +988,11 @@ describe('Shopping Store', () => {
         [Shopping] Load Category Success:
           categories: tree(A.123,A.123.456)
         @ngrx/router-store/navigation:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{}}
+          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
           event: {"id":2,"url":"/error"}
         @ngrx/router-store/navigated:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{}}
+          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
           event: {"id":2,"url":"/error"}
-        [Shopping] Load top level categories:
-          depth: 1
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
       `);
     }));
 
@@ -994,8 +1013,7 @@ describe('Shopping Store', () => {
     }));
 
     it('should load only some categories and redirect to error when category was not found', fakeAsync(() => {
-      expect(getCategoryIds(store.state)).toBeArrayOfSize(3);
-      expect(getCategoryIds(store.state)).toIncludeAllMembers(['A', 'A.123', 'B']);
+      expect(getCategoryIds(store.state)).toBeEmpty();
       expect(getProductIds(store.state)).toBeEmpty();
     }));
 
@@ -1022,15 +1040,11 @@ describe('Shopping Store', () => {
           routerState: {"url":"","params":{},"queryParams":{},"data":{}}
           event: {"id":2,"url":"/error"}
         @ngrx/router-store/navigation:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{}}
+          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
           event: {"id":2,"url":"/error"}
         @ngrx/router-store/navigated:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{}}
+          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
           event: {"id":2,"url":"/error"}
-        [Shopping] Load top level categories:
-          depth: 1
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
       `);
     }));
 
@@ -1064,12 +1078,8 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigated:
           routerState: {"url":"/search/something","params":{"searchTerm":"something...
           event: {"id":1,"url":"/search/something"}
-        [Shopping] Load top level categories:
-          depth: 1
         [ProductListing] Load More Products:
           id: {"type":"search","value":"something"}
-        [Shopping] Load top level categories success:
-          categories: tree(A,A.123,B)
         [ProductListing Internal] Load More Products For Params:
           id: {"type":"search","value":"something"}
           filters: undefined

--- a/src/app/pages/app-routing.module.ts
+++ b/src/app/pages/app-routing.module.ts
@@ -8,6 +8,7 @@ import { LogoutGuard } from 'ish-core/guards/logout.guard';
 
 const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'loading', loadChildren: () => import('./loading/loading-page.module').then(m => m.LoadingPageModule) },
   {
     path: 'home',
     loadChildren: () => import('./home/home-page.module').then(m => m.HomePageModule),

--- a/src/app/pages/loading/loading-page.component.html
+++ b/src/app/pages/loading/loading-page.component.html
@@ -1,0 +1,2 @@
+<ish-loading></ish-loading>
+<p style="height: 400px;"></p>

--- a/src/app/pages/loading/loading-page.component.spec.ts
+++ b/src/app/pages/loading/loading-page.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
+
+import { LoadingComponent } from 'ish-shared/components/common/loading/loading.component';
+
+import { LoadingPageComponent } from './loading-page.component';
+
+describe('Loading Page Component', () => {
+  let component: LoadingPageComponent;
+  let fixture: ComponentFixture<LoadingPageComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [LoadingPageComponent, MockComponent(LoadingComponent)],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoadingPageComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+});

--- a/src/app/pages/loading/loading-page.component.ts
+++ b/src/app/pages/loading/loading-page.component.ts
@@ -1,0 +1,8 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'ish-loading-page',
+  templateUrl: './loading-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LoadingPageComponent {}

--- a/src/app/pages/loading/loading-page.module.ts
+++ b/src/app/pages/loading/loading-page.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { SharedModule } from 'ish-shared/shared.module';
+
+import { LoadingPageComponent } from './loading-page.component';
+
+const loadingPageRoutes: Routes = [
+  {
+    path: '',
+    component: LoadingPageComponent,
+    data: {
+      wrapperClass: 'errorpage',
+      headerType: 'simple',
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(loadingPageRoutes), SharedModule],
+  declarations: [LoadingPageComponent],
+})
+export class LoadingPageModule {}

--- a/src/app/shell/header/header-navigation/header-navigation.component.spec.ts
+++ b/src/app/shell/header/header-navigation/header-navigation.component.spec.ts
@@ -52,7 +52,7 @@ describe('Header Navigation Component', () => {
       createCategoryView(categories, 'C'),
     ];
 
-    when(shoppingFacade.topLevelCategories$).thenReturn(of(topLevelCategories));
+    when(shoppingFacade.topLevelCategories$()).thenReturn(of(topLevelCategories));
   });
 
   it('should be created', () => {

--- a/src/app/shell/header/header-navigation/header-navigation.component.ts
+++ b/src/app/shell/header/header-navigation/header-navigation.component.ts
@@ -20,7 +20,7 @@ export class HeaderNavigationComponent implements OnInit {
   constructor(private shoppingFacade: ShoppingFacade) {}
 
   ngOnInit() {
-    this.categories$ = this.shoppingFacade.topLevelCategories$;
+    this.categories$ = this.shoppingFacade.topLevelCategories$();
   }
 
   /**

--- a/src/app/shell/header/header/header.component.spec.ts
+++ b/src/app/shell/header/header/header.component.spec.ts
@@ -1,11 +1,12 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockComponent } from 'ng-mocks';
+import { of } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
 
+import { AppFacade } from 'ish-core/facades/app.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
-import { coreReducers } from 'ish-core/store/core-store.module';
 import { findAllIshElements } from 'ish-core/utils/dev/html-query-utils';
-import { ngrxTesting } from 'ish-core/utils/dev/ngrx-testing';
 import { HeaderCheckoutComponent } from 'ish-shell/header/header-checkout/header-checkout.component';
 import { HeaderDefaultComponent } from 'ish-shell/header/header-default/header-default.component';
 import { HeaderSimpleComponent } from 'ish-shell/header/header-simple/header-simple.component';
@@ -16,16 +17,21 @@ describe('Header Component', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
   let element: HTMLElement;
+  let appFacade: AppFacade;
 
   beforeEach(async(() => {
+    appFacade = mock(AppFacade);
+    when(appFacade.headerType$).thenReturn(of(undefined));
+
     TestBed.configureTestingModule({
-      imports: [FeatureToggleModule, RouterTestingModule, ngrxTesting({ reducers: coreReducers })],
+      imports: [FeatureToggleModule, RouterTestingModule],
       declarations: [
         HeaderComponent,
         MockComponent(HeaderCheckoutComponent),
         MockComponent(HeaderDefaultComponent),
         MockComponent(HeaderSimpleComponent),
       ],
+      providers: [{ provide: AppFacade, useFactory: () => instance(appFacade) }],
     }).compileComponents();
   }));
 
@@ -43,6 +49,20 @@ describe('Header Component', () => {
 
   it('should render default header component if no headerType is set', () => {
     fixture.detectChanges();
-    expect(findAllIshElements(element)).toContain('ish-header-default');
+    expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+      Array [
+        "ish-header-default",
+      ]
+    `);
+  });
+
+  it('should render simple header component if set', () => {
+    when(appFacade.headerType$).thenReturn(of('simple'));
+    fixture.detectChanges();
+    expect(findAllIshElements(element)).toMatchInlineSnapshot(`
+      Array [
+        "ish-header-simple",
+      ]
+    `);
   });
 });


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Service Worker will boot up with settings from `environment.prod.ts` regardless of what was provided by environment variables, when `index.html` caching was enabled.

Issue Number: 
Relates to #181 

## What Is the New Behavior?

nginx provides a minimal `index.html` response with just the application shell and state transfer containing configuration data.

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No

