### PR TITLE
WIP: fix: variation select

### DIFF
--- a/src/app/core/models/product-variation/product-variation.helper.spec.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.spec.ts
@@ -2,43 +2,65 @@ import { VariationProductView } from 'ish-core/models/product-view/product-view.
 
 import { ProductVariationHelper } from './product-variation.helper';
 
-describe('Product Variation Helper', () => {
-  it('should build variation option groups for variation product', () => {
-    const variationProduct = {
+const variationProduct = {
+  sku: '222',
+  productMasterSKU: 'M111',
+  variableVariationAttributes: [
+    { name: 'Attr 1', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a1' },
+    { name: 'Attr 2', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a2' },
+  ],
+  productMaster: () => ({
+    sku: 'M111',
+    variationAttributeValues: [
+      { name: 'Attr 1', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a1' },
+      { name: 'Attr 1', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a1' },
+      { name: 'Attr 2', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a2' },
+      { name: 'Attr 2', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a2' },
+      { name: 'Attr 2', type: 'VariationAttribute', value: 'C', variationAttributeId: 'a2' },
+    ],
+  }),
+  variations: () => [
+    {
       sku: '222',
-      productMasterSKU: 'M111',
+      variableVariationAttributes: [
+        { name: 'Attr 1', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a1' },
+        { name: 'Attr 2', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a2' },
+      ],
+    },
+    {
+      sku: '333',
+      attributes: [{ name: 'defaultVariation', type: 'Boolean', value: true }],
+      variableVariationAttributes: [
+        { name: 'Attr 1', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a1' },
+        { name: 'Attr 2', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a2' },
+      ],
+    },
+    {
+      sku: '444',
       variableVariationAttributes: [
         { name: 'Attr 1', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a1' },
-        { name: 'Attr 2', type: 'VariationAttribute', value: 'D', variationAttributeId: 'a2' },
+        { name: 'Attr 2', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a2' },
       ],
-      productMaster: () => ({
-        sku: 'M111',
-        variationAttributeValues: [
-          { name: 'Attr 1', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a1' },
-          { name: 'Attr 1', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a1' },
-          { name: 'Attr 2', type: 'VariationAttribute', value: 'C', variationAttributeId: 'a2' },
-          { name: 'Attr 2', type: 'VariationAttribute', value: 'D', variationAttributeId: 'a2' },
-        ],
-      }),
-      variations: () => [
-        {
-          sku: '222',
-          variableVariationAttributes: [
-            { name: 'Attr 1', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a1' },
-            { name: 'Attr 2', type: 'VariationAttribute', value: 'D', variationAttributeId: 'a2' },
-          ],
-        },
-        {
-          sku: '333',
-          attributes: [{ name: 'defaultVariation', type: 'Boolean', value: true }],
-          variableVariationAttributes: [
-            { name: 'Attr 1', type: 'VariationAttribute', value: 'A', variationAttributeId: 'a1' },
-            { name: 'Attr 2', type: 'VariationAttribute', value: 'D', variationAttributeId: 'a2' },
-          ],
-        },
+    },
+    {
+      sku: '555',
+      variableVariationAttributes: [
+        { name: 'Attr 1', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a1' },
+        { name: 'Attr 2', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a2' },
       ],
-    } as VariationProductView;
+    },
+    {
+      sku: '666',
+      variableVariationAttributes: [
+        { name: 'Attr 1', type: 'VariationAttribute', value: 'B', variationAttributeId: 'a1' },
+        { name: 'Attr 2', type: 'VariationAttribute', value: 'C', variationAttributeId: 'a2' },
+      ],
+    },
+  ],
+} as VariationProductView;
 
+describe('Product Variation Helper', () => {
+  it('should build variation option groups for variation product', () => {
     const expectedGroups = [
       {
         id: 'a1',
@@ -49,14 +71,14 @@ describe('Product Variation Helper', () => {
             value: 'A',
             type: 'a1',
             alternativeCombination: false,
-            active: false,
+            active: true,
           },
           {
             label: 'B',
             value: 'B',
             type: 'a1',
             alternativeCombination: false,
-            active: true,
+            active: false,
           },
         ],
       },
@@ -65,18 +87,25 @@ describe('Product Variation Helper', () => {
         label: 'Attr 2',
         options: [
           {
+            label: 'A',
+            value: 'A',
+            type: 'a2',
+            alternativeCombination: false,
+            active: true,
+          },
+          {
+            label: 'B',
+            value: 'B',
+            type: 'a2',
+            alternativeCombination: false,
+            active: false,
+          },
+          {
             label: 'C',
             value: 'C',
             type: 'a2',
             alternativeCombination: true,
             active: false,
-          },
-          {
-            label: 'D',
-            value: 'D',
-            type: 'a2',
-            alternativeCombination: false,
-            active: true,
           },
         ],
       },
@@ -84,5 +113,25 @@ describe('Product Variation Helper', () => {
 
     const result = ProductVariationHelper.buildVariationOptionGroups(variationProduct);
     expect(result).toEqual(expectedGroups);
+  });
+
+  it('should find possible variation on variation option group selection', () => {
+    // perfect match
+    expect(
+      ProductVariationHelper.findPossibleVariationForSelection({ a1: 'A', a2: 'B' }, variationProduct).sku
+    ).toEqual('333');
+
+    // possible varations
+    expect(
+      ProductVariationHelper.findPossibleVariationForSelection({ a1: 'A', a2: 'C' }, variationProduct).sku
+    ).toEqual('333');
+
+    expect(
+      ProductVariationHelper.findPossibleVariationForSelection({ a1: 'A', a2: 'C' }, variationProduct, 'a1').sku
+    ).toEqual('333');
+
+    expect(
+      ProductVariationHelper.findPossibleVariationForSelection({ a1: 'A', a2: 'C' }, variationProduct, 'a2').sku
+    ).toEqual('666');
   });
 });

--- a/src/app/core/models/product-variation/product-variation.helper.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.ts
@@ -3,7 +3,6 @@ import { groupBy } from 'lodash-es';
 import { VariationProductMasterView, VariationProductView } from 'ish-core/models/product-view/product-view.model';
 import { objectToArray } from 'ish-core/utils/functions';
 
-import { VariationAttribute } from './variation-attribute.model';
 import { VariationOptionGroup } from './variation-option-group.model';
 import { VariationSelectOption } from './variation-select-option.model';
 import { VariationSelection } from './variation-selection.model';
@@ -17,18 +16,10 @@ export class ProductVariationHelper {
   // TODO: Refactor this to a more functional style
   private static alternativeCombinationCheck(option: VariationSelectOption, product: VariationProductView): boolean {
     let quality: number;
-    const selectedProductAttributes: VariationAttribute[] = [];
     const perfectMatchQuality = product.variableVariationAttributes.length;
 
-    // remove option related attribute type since it should not be involved in combination check.
-    for (const attribute of product.variableVariationAttributes) {
-      if (attribute.variationAttributeId !== option.type) {
-        selectedProductAttributes.push(attribute);
-      }
-    }
-
     // loop all selected product attributes ignoring the ones related to currently checked option.
-    for (const selectedAttribute of selectedProductAttributes) {
+    for (const selectedAttribute of product.variableVariationAttributes) {
       // loop all possible variations
       for (const variation of product.variations()) {
         quality = 0;
@@ -41,11 +32,13 @@ export class ProductVariationHelper {
             attribute.value === selectedAttribute.value
           ) {
             quality += 1;
+            continue;
           }
 
           // increment quality if variation attribute matches currently checked option.
           if (attribute.variationAttributeId === option.type && attribute.value === option.value) {
             quality += 1;
+            continue;
           }
         }
 

--- a/src/app/pages/product/product-detail/product-detail.component.ts
+++ b/src/app/pages/product/product-detail/product-detail.component.ts
@@ -24,7 +24,7 @@ export class ProductDetailComponent implements OnInit, OnDestroy {
   @Input() variationOptions: VariationOptionGroup[];
   @Output() productToBasket = new EventEmitter<{ sku: string; quantity: number }>();
   @Output() productToCompare = new EventEmitter<string>();
-  @Output() selectVariation = new EventEmitter<VariationSelection>();
+  @Output() selectVariation = new EventEmitter<{ selection: VariationSelection; changedAttribute?: string }>();
   @Output() quantityChange = new EventEmitter<number>();
 
   productDetailForm: FormGroup;
@@ -61,7 +61,7 @@ export class ProductDetailComponent implements OnInit, OnDestroy {
     this.productToCompare.emit(this.product.sku);
   }
 
-  variationSelected(selection: VariationSelection) {
-    this.selectVariation.emit(selection);
+  variationSelected(event: { selection: VariationSelection; changedAttribute?: string }) {
+    this.selectVariation.emit(event);
   }
 }

--- a/src/app/pages/product/product-page.component.spec.ts
+++ b/src/app/pages/product/product-page.component.spec.ts
@@ -165,7 +165,7 @@ describe('Product Page Component', () => {
 
     fixture.detectChanges();
 
-    component.variationSelected(selection, product);
+    component.variationSelected({ selection }, product);
     tick(500);
 
     expect(location.path()).toMatchInlineSnapshot(`"/sku333"`);

--- a/src/app/pages/product/product-page.component.ts
+++ b/src/app/pages/product/product-page.component.ts
@@ -116,8 +116,15 @@ export class ProductPageComponent implements OnInit, OnDestroy {
     this.shoppingFacade.addProductToCompare(sku);
   }
 
-  variationSelected(selection: VariationSelection, product: VariationProductView) {
-    const variation = ProductVariationHelper.findPossibleVariationForSelection(selection, product);
+  variationSelected(
+    event: { selection: VariationSelection; changedAttribute?: string },
+    product: VariationProductView
+  ) {
+    const variation = ProductVariationHelper.findPossibleVariationForSelection(
+      event.selection,
+      product,
+      event.changedAttribute
+    );
     this.redirectToVariation(variation);
   }
 

--- a/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.ts
+++ b/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.ts
@@ -110,9 +110,13 @@ export class LineItemEditDialogComponent implements OnInit, OnDestroy, OnChanges
   /**
    * handle form-change for variations
    */
-  variationSelected(selection: VariationSelection) {
+  variationSelected(event: { selection: VariationSelection; changedAttribute?: string }) {
     this.variation$.pipe(take(1)).subscribe((product: VariationProductView) => {
-      const { sku } = ProductVariationHelper.findPossibleVariationForSelection(selection, product);
+      const { sku } = ProductVariationHelper.findPossibleVariationForSelection(
+        event.selection,
+        product,
+        event.changedAttribute
+      );
       this.sku$.next(sku);
     });
   }

--- a/src/app/shared/components/product/product-item/product-item.component.spec.ts
+++ b/src/app/shared/components/product/product-item/product-item.component.spec.ts
@@ -78,7 +78,7 @@ describe('Product Item Component', () => {
 
         const emitter = spy(component.productSkuChange);
 
-        component.replaceVariation({ HDD: '256' });
+        component.replaceVariation({ selection: { HDD: '256' } });
 
         verify(emitter.emit(anything())).once();
         const [sku] = capture(emitter.emit).last();
@@ -88,7 +88,7 @@ describe('Product Item Component', () => {
       it('should trigger add product to cart with right sku', () => {
         expect(() => fixture.detectChanges()).not.toThrow();
 
-        component.replaceVariation({ HDD: '256' });
+        component.replaceVariation({ selection: { HDD: '256' } });
         component.addToBasket(4);
 
         verify(shoppingFacade.addProductToBasket(anything(), anything())).once();

--- a/src/app/shared/components/product/product-item/product-item.component.ts
+++ b/src/app/shared/components/product/product-item/product-item.component.ts
@@ -126,14 +126,18 @@ export class ProductItemComponent implements OnInit, OnChanges, OnDestroy {
     this.sku$.pipe(take(1)).subscribe(sku => this.shoppingFacade.addProductToBasket(sku, quantity));
   }
 
-  replaceVariation(selection: VariationSelection) {
+  replaceVariation(event: { selection: VariationSelection; changedAttribute?: string }) {
     this.product$
       .pipe(
         take(1),
         filter<VariationProductView>(product => ProductHelper.isVariationProduct(product))
       )
       .subscribe(product => {
-        const { sku } = ProductVariationHelper.findPossibleVariationForSelection(selection, product);
+        const { sku } = ProductVariationHelper.findPossibleVariationForSelection(
+          event.selection,
+          product,
+          event.changedAttribute
+        );
         this.productSkuChange.emit(sku);
       });
   }

--- a/src/app/shared/components/product/product-row/product-row.component.ts
+++ b/src/app/shared/components/product/product-row/product-row.component.ts
@@ -47,7 +47,7 @@ export class ProductRowComponent implements OnInit, OnDestroy {
   @Input() isInCompareList: boolean;
   @Output() compareToggle = new EventEmitter<void>();
   @Output() productToBasket = new EventEmitter<number>();
-  @Output() selectVariation = new EventEmitter<VariationSelection>();
+  @Output() selectVariation = new EventEmitter<{ selection: VariationSelection; changedAttribute?: string }>();
 
   isMasterProduct = ProductHelper.isMasterProduct;
 
@@ -81,9 +81,9 @@ export class ProductRowComponent implements OnInit, OnDestroy {
     this.compareToggle.emit();
   }
 
-  variationSelected(selection: VariationSelection) {
+  variationSelected(event: { selection: VariationSelection; changedAttribute?: string }) {
     if (ProductHelper.isVariationProduct(this.product)) {
-      this.selectVariation.emit(selection);
+      this.selectVariation.emit(event);
     }
   }
 }

--- a/src/app/shared/components/product/product-tile/product-tile.component.ts
+++ b/src/app/shared/components/product/product-tile/product-tile.component.ts
@@ -36,7 +36,7 @@ export class ProductTileComponent {
   @Input() isInCompareList: boolean;
   @Output() compareToggle = new EventEmitter<void>();
   @Output() productToBasket = new EventEmitter<number>();
-  @Output() selectVariation = new EventEmitter<VariationSelection>();
+  @Output() selectVariation = new EventEmitter<{ selection: VariationSelection; changedAttribute?: string }>();
 
   isMasterProduct = ProductHelper.isMasterProduct;
 
@@ -48,8 +48,8 @@ export class ProductTileComponent {
     this.compareToggle.emit();
   }
 
-  variationSelected(selection: VariationSelection) {
-    this.selectVariation.emit(selection);
+  variationSelected(event: { selection: VariationSelection; changedAttribute?: string }) {
+    this.selectVariation.emit(event);
   }
 
   get variationCount() {

--- a/src/app/shared/components/product/product-variation-select/product-variation-select.component.html
+++ b/src/app/shared/components/product/product-variation-select/product-variation-select.component.html
@@ -26,12 +26,14 @@
           [formControlName]="group.id"
           [attr.data-testing-id]="group.id"
         >
-          <option *ngFor="let option of group.options" [value]="option.value">
-            {{ option.label }}
-            <ng-container *ngIf="option.alternativeCombination">
-              - {{ 'product.available_in_different_configuration' | translate }}
-            </ng-container>
-          </option>
+          <ng-container *ngFor="let option of group.options">
+            <option *ngIf="!option.alternativeCombination || variationOptions.length > 1" [value]="option.value">
+              {{ option.label }}
+              <ng-container *ngIf="option.alternativeCombination">
+                - {{ 'product.available_in_different_configuration' | translate }}
+              </ng-container>
+            </option>
+          </ng-container>
         </select>
       </div>
     </div>

--- a/src/app/shared/components/product/product-variation-select/product-variation-select.component.spec.ts
+++ b/src/app/shared/components/product/product-variation-select/product-variation-select.component.spec.ts
@@ -105,8 +105,11 @@ describe('Product Variation Select Component', () => {
 
     component.selectVariation.subscribe(selection => {
       expect(selection).toEqual({
-        a1: 'A',
-        a2: 'D',
+        changedAttribute: 'a1',
+        selection: {
+          a1: 'A',
+          a2: 'D',
+        },
       });
       done();
     });


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [x] Feature  


## What Is the New Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Bugfix in case of one variation attribute all options were "not available" any time. Additional new behaviour in case of one variation attribute is hiding "not available" options. (ISREST-756)  

"not available" selections should not be possible. (ISREST-725 & ISREST-1019)  
Now it is possible to find a possible variation based on the changed attribute.

In case of just one variation attribute and only one option now it reloads the component/page (second commit & cornercase)

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No

