### PR TITLE
fix: hide loading spinner after order creation failed

### DIFF
--- a/src/app/core/store/checkout/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket-validation.effects.spec.ts
@@ -177,9 +177,10 @@ describe('Basket Validation Effects', () => {
 
     it('should map to action of type CreateOrder if targetStep is 5 (order creation)', () => {
       const action = new basketActions.ContinueCheckout({ targetStep: 5 });
-      const completion = new CreateOrder({ basketId: BasketMockData.getBasket().id });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      const completion1 = new CreateOrder({ basketId: BasketMockData.getBasket().id });
+      const completion2 = new basketActions.ContinueCheckoutSuccess({ targetRoute: undefined, basketValidation });
+      actions$ = hot('-a----a----a', { a: action });
+      const expected$ = cold('-(cd)-(cd)-(cd)', { c: completion1, d: completion2 });
 
       expect(effects.validateBasketAndContinueCheckout$).toBeObservable(expected$);
     });

--- a/src/app/core/store/checkout/basket/basket-validation.effects.ts
+++ b/src/app/core/store/checkout/basket/basket-validation.effects.ts
@@ -85,12 +85,15 @@ export class BasketValidationEffects {
         }
       }
       return this.basketService.validateBasket(basketId, scopes).pipe(
-        map(basketValidation =>
+        concatMap(basketValidation =>
           basketValidation.results.valid
             ? targetStep === 5 && !basketValidation.results.adjusted
-              ? new CreateOrder({ basketId })
-              : new basketActions.ContinueCheckoutSuccess({ targetRoute, basketValidation })
-            : new basketActions.ContinueCheckoutWithIssues({ targetRoute, basketValidation })
+              ? [
+                  new CreateOrder({ basketId }),
+                  new basketActions.ContinueCheckoutSuccess({ targetRoute: undefined, basketValidation }),
+                ]
+              : [new basketActions.ContinueCheckoutSuccess({ targetRoute, basketValidation })]
+            : [new basketActions.ContinueCheckoutWithIssues({ targetRoute, basketValidation })]
         ),
         mapErrorToAction(basketActions.ContinueCheckoutFail)
       );


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the order creation fails after submitting the order, e.g. because of a failed payment authorization, the loading spinner remains on page until the next operation on the basket has been executed.

Issue Number: ISREST-1003

## What Is the New Behavior?
The loading spinner disappears after server communication has finished.

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [] Yes  
 [x] No


## Other Information
