### PR TITLE
refactor: remove basketId from basket service

### DIFF
--- a/src/app/core/services/payment/payment.service.spec.ts
+++ b/src/app/core/services/payment/payment.service.spec.ts
@@ -80,28 +80,20 @@ describe('Payment Service', () => {
     it("should get basket eligible payment methods for a basket when 'getBasketEligiblePaymentMethods' is called", done => {
       when(apiService.get(anything(), anything())).thenReturn(of({ data: [] }));
 
-      paymentService.getBasketEligiblePaymentMethods(basketMock.data.id).subscribe(() => {
-        verify(apiService.get(`baskets/${basketMock.data.id}/eligible-payment-methods`, anything())).once();
+      paymentService.getBasketEligiblePaymentMethods().subscribe(() => {
+        verify(apiService.get(`baskets/current/eligible-payment-methods`, anything())).once();
         done();
       });
     });
 
     it("should set a payment to the basket when 'setBasketPayment' is called", done => {
       when(
-        apiService.put(
-          `baskets/${basketMock.data.id}/payments/open-tender?include=paymentMethod`,
-          anything(),
-          anything()
-        )
+        apiService.put(`baskets/current/payments/open-tender?include=paymentMethod`, anything(), anything())
       ).thenReturn(of([]));
 
-      paymentService.setBasketPayment(basketMock.data.id, basketMock.data.payment.name).subscribe(() => {
+      paymentService.setBasketPayment(basketMock.data.payment.name).subscribe(() => {
         verify(
-          apiService.put(
-            `baskets/${basketMock.data.id}/payments/open-tender?include=paymentMethod`,
-            anything(),
-            anything()
-          )
+          apiService.put(`baskets/current/payments/open-tender?include=paymentMethod`, anything(), anything())
         ).once();
         done();
       });
@@ -109,29 +101,19 @@ describe('Payment Service', () => {
 
     it("should create a payment instrument for the basket when 'createBasketPayment' is called", done => {
       when(
-        apiService.post(
-          `baskets/${basketMock.data.id}/payment-instruments?include=paymentMethod`,
-          anything(),
-          anything()
-        )
+        apiService.post(`baskets/current/payment-instruments?include=paymentMethod`, anything(), anything())
       ).thenReturn(of([]));
 
-      paymentService.createBasketPayment(basketMock.data.id, newPaymentInstrument).subscribe(() => {
+      paymentService.createBasketPayment(newPaymentInstrument).subscribe(() => {
         verify(
-          apiService.post(
-            `baskets/${basketMock.data.id}/payment-instruments?include=paymentMethod`,
-            anything(),
-            anything()
-          )
+          apiService.post(`baskets/current/payment-instruments?include=paymentMethod`, anything(), anything())
         ).once();
         done();
       });
     });
 
     it("should update a basket payment when 'updateBasketPayment' is called", done => {
-      when(apiService.patch(`baskets/${basketMock.data.id}/payments/open-tender`, anything(), anything())).thenReturn(
-        of({})
-      );
+      when(apiService.patch(`baskets/current/payments/open-tender`, anything(), anything())).thenReturn(of({}));
 
       const params = {
         redirect: 'success',
@@ -139,8 +121,8 @@ describe('Payment Service', () => {
         param2: '456',
       };
 
-      paymentService.updateBasketPayment(basketMock.data.id, params).subscribe(() => {
-        verify(apiService.patch(`baskets/${basketMock.data.id}/payments/open-tender`, anything(), anything())).once();
+      paymentService.updateBasketPayment(params).subscribe(() => {
+        verify(apiService.patch(`baskets/current/payments/open-tender`, anything(), anything())).once();
         done();
       });
     });

--- a/src/app/core/store/checkout/basket/basket-addresses.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket-addresses.effects.spec.ts
@@ -98,7 +98,7 @@ describe('Basket Addresses Effects', () => {
 
   describe('createAddressForBasket$ for an anonymous user', () => {
     beforeEach(() => {
-      when(basketServiceMock.createBasketAddress('current', anything())).thenReturn(of(BasketMockData.getAddress()));
+      when(basketServiceMock.createBasketAddress(anything())).thenReturn(of(BasketMockData.getAddress()));
     });
     it('should call the basketService if user is not logged in', done => {
       const address = BasketMockData.getAddress();
@@ -106,7 +106,7 @@ describe('Basket Addresses Effects', () => {
       actions$ = of(action);
 
       effects.createAddressForBasket$.subscribe(() => {
-        verify(basketServiceMock.createBasketAddress('current', anything())).once();
+        verify(basketServiceMock.createBasketAddress(anything())).once();
         done();
       });
     });
@@ -241,7 +241,7 @@ describe('Basket Addresses Effects', () => {
 
   describe('updateBasketAddress$ for anonymous user', () => {
     beforeEach(() => {
-      when(basketServiceMock.updateBasketAddress(anyString(), anything())).thenReturn(of(BasketMockData.getAddress()));
+      when(basketServiceMock.updateBasketAddress(anything())).thenReturn(of(BasketMockData.getAddress()));
     });
 
     it('should call the basketService for updateBasketAddress', done => {
@@ -250,7 +250,7 @@ describe('Basket Addresses Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketAddress$.subscribe(() => {
-        verify(basketServiceMock.updateBasketAddress('current', anything())).once();
+        verify(basketServiceMock.updateBasketAddress(anything())).once();
         done();
       });
     });
@@ -269,9 +269,7 @@ describe('Basket Addresses Effects', () => {
 
     it('should map invalid request to action of type UpdateCustomerAddressFail', () => {
       const address = BasketMockData.getAddress();
-      when(basketServiceMock.updateBasketAddress(anyString(), anything())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(basketServiceMock.updateBasketAddress(anything())).thenReturn(throwError({ message: 'invalid' }));
 
       const action = new basketActions.UpdateBasketAddress({ address });
       const completion = new UpdateCustomerAddressFail({ error: { message: 'invalid' } as HttpError });

--- a/src/app/core/store/checkout/basket/basket-addresses.effects.ts
+++ b/src/app/core/store/checkout/basket/basket-addresses.effects.ts
@@ -47,7 +47,7 @@ export class BasketAddressesEffects {
         );
         // create address at basket for anonymous user
       } else {
-        return this.basketService.createBasketAddress('current', action.payload.address).pipe(
+        return this.basketService.createBasketAddress(action.payload.address).pipe(
           map(
             newAddress =>
               new basketActions.CreateBasketAddressSuccess({ address: newAddress, scope: action.payload.scope })
@@ -126,7 +126,7 @@ export class BasketAddressesEffects {
         // create address at basket for anonymous user
       } else {
         return this.basketService
-          .updateBasketAddress('current', address)
+          .updateBasketAddress(address)
           .pipe(
             concatMapTo([
               new UpdateCustomerAddressSuccess({ address }),

--- a/src/app/core/store/checkout/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket-items.effects.spec.ts
@@ -81,7 +81,7 @@ describe('Basket Items Effects', () => {
 
   describe('addItemsToBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.addItemsToBasket(anyString(), anything())).thenReturn(of(undefined));
+      when(basketServiceMock.addItemsToBasket(anything())).thenReturn(of(undefined));
     });
 
     it('should call the basketService for addItemsToBasket', done => {
@@ -99,51 +99,7 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.addItemsToBasket$.subscribe(() => {
-        verify(basketServiceMock.addItemsToBasket('BID', items)).once();
-        done();
-      });
-    });
-
-    it('should call the basketService for addItemsToBasket with specific basketId when basketId set', done => {
-      store$.dispatch(
-        new basketActions.LoadBasketSuccess({
-          basket: {
-            id: 'BID',
-            lineItems: [],
-          } as Basket,
-        })
-      );
-
-      const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
-      const basketId = 'BID';
-      const action = new basketActions.AddItemsToBasket({ items, basketId });
-      actions$ = of(action);
-
-      effects.addItemsToBasket$.subscribe(() => {
-        verify(basketServiceMock.addItemsToBasket('BID', items)).once();
-        done();
-      });
-    });
-
-    it('should not call the basketService for addItemsToBasket if no basket in store', () => {
-      const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
-      const action = new basketActions.AddItemsToBasket({ items });
-      actions$ = of(action);
-
-      effects.addItemsToBasket$.subscribe(fail, fail);
-
-      verify(basketServiceMock.addItemsToBasket('BID', anything())).never();
-    });
-
-    it('should call the basketService for createBasket when no basket is present', done => {
-      when(basketServiceMock.createBasket()).thenReturn(of({} as Basket));
-
-      const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
-      const action = new basketActions.AddItemsToBasket({ items });
-      actions$ = of(action);
-
-      effects.createBasketBeforeAddItemsToBasket$.subscribe(() => {
-        verify(basketServiceMock.createBasket()).once();
+        verify(basketServiceMock.addItemsToBasket(items)).once();
         done();
       });
     });
@@ -168,7 +124,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should map invalid request to action of type AddItemsToBasketFail', () => {
-      when(basketServiceMock.addItemsToBasket(anyString(), anything())).thenReturn(throwError({ message: 'invalid' }));
+      when(basketServiceMock.addItemsToBasket(anything())).thenReturn(throwError({ message: 'invalid' }));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -191,7 +147,7 @@ describe('Basket Items Effects', () => {
 
   describe('loadProductsForAddItemsToBasket$', () => {
     it('should trigger product loading actions for line items if AddItemsToBasket action is triggered', () => {
-      when(basketServiceMock.getBasket(anything())).thenReturn(of());
+      when(basketServiceMock.getBasket()).thenReturn(of());
 
       const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
       const action = new basketActions.AddItemsToBasket({ items });
@@ -217,7 +173,7 @@ describe('Basket Items Effects', () => {
 
   describe('updateBasketItems$', () => {
     beforeEach(() => {
-      when(basketServiceMock.updateBasketItem(anyString(), anyString(), anything())).thenReturn(of([{} as BasketInfo]));
+      when(basketServiceMock.updateBasketItem(anyString(), anything())).thenReturn(of([{} as BasketInfo]));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -258,10 +214,9 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketItems$.subscribe(() => {
-        verify(basketServiceMock.updateBasketItem('BID', payload.lineItemUpdates[1].itemId, anything())).thrice();
+        verify(basketServiceMock.updateBasketItem(payload.lineItemUpdates[1].itemId, anything())).thrice();
         expect(capture(basketServiceMock.updateBasketItem).first()).toMatchInlineSnapshot(`
           Array [
-            "BID",
             "BIID",
             Object {
               "product": undefined,
@@ -274,7 +229,6 @@ describe('Basket Items Effects', () => {
         `);
         expect(capture(basketServiceMock.updateBasketItem).second()).toMatchInlineSnapshot(`
           Array [
-            "BID",
             "BIID",
             Object {
               "product": undefined,
@@ -287,7 +241,6 @@ describe('Basket Items Effects', () => {
         `);
         expect(capture(basketServiceMock.updateBasketItem).third()).toMatchInlineSnapshot(`
           Array [
-            "BID",
             "BIID",
             Object {
               "product": undefined,
@@ -303,7 +256,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should call the basketService for deleteBasketItem if quantity = 0', done => {
-      when(basketServiceMock.deleteBasketItem(anyString(), anyString())).thenReturn(of());
+      when(basketServiceMock.deleteBasketItem(anyString())).thenReturn(of());
 
       const payload = {
         lineItemUpdates: [
@@ -317,7 +270,7 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketItems$.subscribe(() => {
-        verify(basketServiceMock.deleteBasketItem('BID', payload.lineItemUpdates[0].itemId)).once();
+        verify(basketServiceMock.deleteBasketItem(payload.lineItemUpdates[0].itemId)).once();
         done();
       });
     });
@@ -341,9 +294,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should map invalid request to action of type UpdateBasketItemsFail', () => {
-      when(basketServiceMock.updateBasketItem(anyString(), anyString(), anything())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(basketServiceMock.updateBasketItem(anyString(), anything())).thenReturn(throwError({ message: 'invalid' }));
 
       const payload = {
         lineItemUpdates: [
@@ -386,7 +337,7 @@ describe('Basket Items Effects', () => {
 
   describe('deleteBasketItem$', () => {
     beforeEach(() => {
-      when(basketServiceMock.deleteBasketItem(anyString(), anyString())).thenReturn(of(undefined));
+      when(basketServiceMock.deleteBasketItem(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -404,7 +355,7 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.deleteBasketItem$.subscribe(() => {
-        verify(basketServiceMock.deleteBasketItem('BID', 'BIID')).once();
+        verify(basketServiceMock.deleteBasketItem('BIID')).once();
         done();
       });
     });
@@ -420,7 +371,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should map invalid request to action of type DeleteBasketItemFail', () => {
-      when(basketServiceMock.deleteBasketItem(anyString(), anyString())).thenReturn(throwError({ message: 'invalid' }));
+      when(basketServiceMock.deleteBasketItem(anyString())).thenReturn(throwError({ message: 'invalid' }));
 
       const itemId = 'BIID';
       const action = new basketActions.DeleteBasketItem({ itemId });

--- a/src/app/core/store/checkout/basket/basket-payment.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket-payment.effects.spec.ts
@@ -65,9 +65,7 @@ describe('Basket Payment Effects', () => {
 
   describe('loadBasketEligiblePaymentMethods$', () => {
     beforeEach(() => {
-      when(paymentServiceMock.getBasketEligiblePaymentMethods(anyString())).thenReturn(
-        of([BasketMockData.getPaymentMethod()])
-      );
+      when(paymentServiceMock.getBasketEligiblePaymentMethods()).thenReturn(of([BasketMockData.getPaymentMethod()]));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -84,7 +82,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.loadBasketEligiblePaymentMethods$.subscribe(() => {
-        verify(paymentServiceMock.getBasketEligiblePaymentMethods('BID')).once();
+        verify(paymentServiceMock.getBasketEligiblePaymentMethods()).once();
         done();
       });
     });
@@ -101,9 +99,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketEligiblePaymentMethodsFail', () => {
-      when(paymentServiceMock.getBasketEligiblePaymentMethods(anyString())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(paymentServiceMock.getBasketEligiblePaymentMethods()).thenReturn(throwError({ message: 'invalid' }));
       const action = new basketActions.LoadBasketEligiblePaymentMethods();
       const completion = new basketActions.LoadBasketEligiblePaymentMethodsFail({
         error: {
@@ -119,7 +115,7 @@ describe('Basket Payment Effects', () => {
 
   describe('setPaymentAtBasket$ - set payment at basket for the first time', () => {
     beforeEach(() => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(of(undefined));
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -138,7 +134,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.setPaymentAtBasket$.subscribe(() => {
-        verify(paymentServiceMock.setBasketPayment('BID', id)).once();
+        verify(paymentServiceMock.setBasketPayment(id)).once();
         done();
       });
     });
@@ -154,9 +150,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type SetPaymentFail', () => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(throwError({ message: 'invalid' }));
       const action = new basketActions.SetBasketPayment({ id: 'newPayment' });
       const completion = new basketActions.SetBasketPaymentFail({ error: { message: 'invalid' } as HttpError });
       actions$ = hot('-a-a-a', { a: action });
@@ -168,7 +162,7 @@ describe('Basket Payment Effects', () => {
 
   describe('setPaymentAtBasket$ - change payment method at basket', () => {
     beforeEach(() => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(of(undefined));
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(new basketActions.LoadBasketSuccess({ basket: BasketMockData.getBasket() }));
     });
@@ -179,7 +173,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.setPaymentAtBasket$.subscribe(() => {
-        verify(paymentServiceMock.setBasketPayment('4711', id)).once();
+        verify(paymentServiceMock.setBasketPayment(id)).once();
         done();
       });
     });
@@ -195,9 +189,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid addBasketPayment request to action of type SetPaymentFail', () => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(throwError({ message: 'invalid' }));
       const action = new basketActions.SetBasketPayment({ id: 'newPayment' });
       const completion = new basketActions.SetBasketPaymentFail({ error: { message: 'invalid' } as HttpError });
       actions$ = hot('-a-a-a', { a: action });
@@ -225,7 +217,7 @@ describe('Basket Payment Effects', () => {
     const customer = { customerNo: 'patricia' } as Customer;
 
     beforeEach(() => {
-      when(paymentServiceMock.createBasketPayment(anyString(), anything())).thenReturn(
+      when(paymentServiceMock.createBasketPayment(anything())).thenReturn(
         of({ id: 'newPaymentInstrumentId' } as PaymentInstrument)
       );
       when(paymentServiceMock.createUserPayment(anyString(), anything())).thenReturn(
@@ -249,7 +241,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.createBasketPaymentInstrument$.subscribe(() => {
-        verify(paymentServiceMock.createBasketPayment('BID', anything())).once();
+        verify(paymentServiceMock.createBasketPayment(anything())).once();
         done();
       });
     });
@@ -274,9 +266,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type CreateBasketPaymentFail', () => {
-      when(paymentServiceMock.createBasketPayment(anyString(), anything())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(paymentServiceMock.createBasketPayment(anything())).thenReturn(throwError({ message: 'invalid' }));
       const action = new basketActions.CreateBasketPayment({ paymentInstrument, saveForLater: false });
       const completion = new basketActions.CreateBasketPaymentFail({ error: { message: 'invalid' } as HttpError });
       actions$ = hot('-a-a-a', { a: action });
@@ -350,7 +340,7 @@ describe('Basket Payment Effects', () => {
     };
 
     beforeEach(() => {
-      when(paymentServiceMock.updateBasketPayment(anyString(), anything())).thenReturn(of(payment));
+      when(paymentServiceMock.updateBasketPayment(anything())).thenReturn(of(payment));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -368,7 +358,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketPayment$.subscribe(() => {
-        verify(paymentServiceMock.updateBasketPayment('BID', anything())).once();
+        verify(paymentServiceMock.updateBasketPayment(anything())).once();
         done();
       });
     });
@@ -384,9 +374,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type UpdateBasketPaymentFail', () => {
-      when(paymentServiceMock.updateBasketPayment(anyString(), anything())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(paymentServiceMock.updateBasketPayment(anything())).thenReturn(throwError({ message: 'invalid' }));
       const action = new basketActions.UpdateBasketPayment({ params });
       const completion = new basketActions.UpdateBasketPaymentFail({ error: { message: 'invalid' } as HttpError });
       actions$ = hot('-a-a-a', { a: action });

--- a/src/app/core/store/checkout/basket/basket-payment.effects.ts
+++ b/src/app/core/store/checkout/basket/basket-payment.effects.ts
@@ -21,9 +21,8 @@ export class BasketPaymentEffects {
   @Effect()
   loadBasketEligiblePaymentMethods$ = this.actions$.pipe(
     ofType(basketActions.BasketActionTypes.LoadBasketEligiblePaymentMethods),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([, basketid]) =>
-      this.paymentService.getBasketEligiblePaymentMethods(basketid).pipe(
+    concatMap(() =>
+      this.paymentService.getBasketEligiblePaymentMethods().pipe(
         map(result => new basketActions.LoadBasketEligiblePaymentMethodsSuccess({ paymentMethods: result })),
         mapErrorToAction(basketActions.LoadBasketEligiblePaymentMethodsFail)
       )
@@ -37,10 +36,9 @@ export class BasketPaymentEffects {
   setPaymentAtBasket$ = this.actions$.pipe(
     ofType<basketActions.SetBasketPayment>(basketActions.BasketActionTypes.SetBasketPayment),
     mapToPayloadProperty('id'),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([paymentInstrumentId, basketid]) =>
+    concatMap(paymentInstrumentId =>
       this.paymentService
-        .setBasketPayment(basketid, paymentInstrumentId)
+        .setBasketPayment(paymentInstrumentId)
         .pipe(mapTo(new basketActions.SetBasketPaymentSuccess()), mapErrorToAction(basketActions.SetBasketPaymentFail))
     )
   );
@@ -58,12 +56,11 @@ export class BasketPaymentEffects {
       paymentInstrument: payload.paymentInstrument,
       customerNo: customer && customer.customerNo,
     })),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([payload, basketid]) => {
+    concatMap(payload => {
       const createPayment$ =
         payload.customerNo && payload.saveForLater
           ? this.paymentService.createUserPayment(payload.customerNo, payload.paymentInstrument)
-          : this.paymentService.createBasketPayment(basketid, payload.paymentInstrument);
+          : this.paymentService.createBasketPayment(payload.paymentInstrument);
 
       return createPayment$.pipe(
         concatMap(pi => [
@@ -101,10 +98,9 @@ export class BasketPaymentEffects {
   updateBasketPayment$ = this.actions$.pipe(
     ofType<basketActions.UpdateBasketPayment>(basketActions.BasketActionTypes.UpdateBasketPayment),
     mapToPayloadProperty('params'),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([params, basketid]) =>
+    concatMap(params =>
       this.paymentService
-        .updateBasketPayment(basketid, params)
+        .updateBasketPayment(params)
         .pipe(
           mapTo(new basketActions.UpdateBasketPaymentSuccess()),
           mapErrorToAction(basketActions.UpdateBasketPaymentFail)

--- a/src/app/core/store/checkout/basket/basket-promotion-code.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket-promotion-code.effects.spec.ts
@@ -58,7 +58,7 @@ describe('Basket Promotion Code Effects', () => {
 
   describe('addPromotionCodeToBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.addPromotionCodeToBasket(anyString(), anyString())).thenReturn(of(undefined));
+      when(basketServiceMock.addPromotionCodeToBasket(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -76,7 +76,7 @@ describe('Basket Promotion Code Effects', () => {
       actions$ = of(action);
 
       effects.addPromotionCodeToBasket$.subscribe(() => {
-        verify(basketServiceMock.addPromotionCodeToBasket('BID', 'CODE')).once();
+        verify(basketServiceMock.addPromotionCodeToBasket('CODE')).once();
         done();
       });
     });
@@ -92,9 +92,7 @@ describe('Basket Promotion Code Effects', () => {
     });
 
     it('should map invalid request to action of type AddPromotionCodeToBasketFail', () => {
-      when(basketServiceMock.addPromotionCodeToBasket(anyString(), anyString())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(basketServiceMock.addPromotionCodeToBasket(anyString())).thenReturn(throwError({ message: 'invalid' }));
 
       const code = 'CODE';
       const action = new basketActions.AddPromotionCodeToBasket({ code });
@@ -108,7 +106,7 @@ describe('Basket Promotion Code Effects', () => {
 
   describe('removePromotionCodeFromBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.removePromotionCodeFromBasket(anyString(), anyString())).thenReturn(of(undefined));
+      when(basketServiceMock.removePromotionCodeFromBasket(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -126,7 +124,7 @@ describe('Basket Promotion Code Effects', () => {
       actions$ = of(action);
 
       effects.removePromotionCodeFromBasket$.subscribe(() => {
-        verify(basketServiceMock.removePromotionCodeFromBasket('BID', 'CODE')).once();
+        verify(basketServiceMock.removePromotionCodeFromBasket('CODE')).once();
         done();
       });
     });
@@ -142,9 +140,7 @@ describe('Basket Promotion Code Effects', () => {
     });
 
     it('should map invalid request to action of type RemovePromotionCodeFromBasketFail', () => {
-      when(basketServiceMock.removePromotionCodeFromBasket(anyString(), anyString())).thenReturn(
-        throwError({ message: 'invalid' })
-      );
+      when(basketServiceMock.removePromotionCodeFromBasket(anyString())).thenReturn(throwError({ message: 'invalid' }));
 
       const code = 'CODE';
       const action = new basketActions.RemovePromotionCodeFromBasket({ code });

--- a/src/app/core/store/checkout/basket/basket-promotion-code.effects.ts
+++ b/src/app/core/store/checkout/basket/basket-promotion-code.effects.ts
@@ -1,17 +1,15 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Store, select } from '@ngrx/store';
-import { concatMap, mapTo, withLatestFrom } from 'rxjs/operators';
+import { concatMap, mapTo } from 'rxjs/operators';
 
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
 
 import * as basketActions from './basket.actions';
-import { getCurrentBasketId } from './basket.selectors';
 
 @Injectable()
 export class BasketPromotionCodeEffects {
-  constructor(private actions$: Actions, private store: Store, private basketService: BasketService) {}
+  constructor(private actions$: Actions, private basketService: BasketService) {}
 
   /**
    * Add promotion code to the current basket.
@@ -20,10 +18,9 @@ export class BasketPromotionCodeEffects {
   addPromotionCodeToBasket$ = this.actions$.pipe(
     ofType<basketActions.AddPromotionCodeToBasket>(basketActions.BasketActionTypes.AddPromotionCodeToBasket),
     mapToPayloadProperty('code'),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([code, basketId]) =>
+    concatMap(code =>
       this.basketService
-        .addPromotionCodeToBasket(basketId, code)
+        .addPromotionCodeToBasket(code)
         .pipe(
           mapTo(new basketActions.AddPromotionCodeToBasketSuccess()),
           mapErrorToAction(basketActions.AddPromotionCodeToBasketFail)
@@ -47,10 +44,9 @@ export class BasketPromotionCodeEffects {
   removePromotionCodeFromBasket$ = this.actions$.pipe(
     ofType<basketActions.RemovePromotionCodeFromBasket>(basketActions.BasketActionTypes.RemovePromotionCodeFromBasket),
     mapToPayloadProperty('code'),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([code, basketId]) =>
+    concatMap(code =>
       this.basketService
-        .removePromotionCodeFromBasket(basketId, code)
+        .removePromotionCodeFromBasket(code)
         .pipe(
           mapTo(new basketActions.RemovePromotionCodeFromBasketSuccess()),
           mapErrorToAction(basketActions.RemovePromotionCodeFromBasketFail)

--- a/src/app/core/store/checkout/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket-validation.effects.spec.ts
@@ -6,7 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, Store, combineReducers } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { Observable, noop, of, throwError } from 'rxjs';
-import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { BasketValidation } from 'ish-core/models/basket-validation/basket-validation.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
@@ -76,7 +76,7 @@ describe('Basket Validation Effects', () => {
     };
 
     beforeEach(() => {
-      when(basketServiceMock.validateBasket(anything(), anything())).thenReturn(of(basketValidation));
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidation));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -91,7 +91,7 @@ describe('Basket Validation Effects', () => {
       actions$ = of(action);
 
       effects.validateBasket$.subscribe(() => {
-        verify(basketServiceMock.validateBasket(BasketMockData.getBasket().id, anything())).once();
+        verify(basketServiceMock.validateBasket(anything())).once();
         done();
       });
     });
@@ -109,7 +109,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map invalid request to action of type ContinueCheckoutFail', () => {
-      when(basketServiceMock.validateBasket(anyString(), anything())).thenReturn(throwError({ message: 'invalid' }));
+      when(basketServiceMock.validateBasket(anything())).thenReturn(throwError({ message: 'invalid' }));
 
       const action = new basketActions.ValidateBasket({ scopes: ['Products'] });
       const completion = new basketActions.ContinueCheckoutFail({ error: { message: 'invalid' } as HttpError });
@@ -143,7 +143,7 @@ describe('Basket Validation Effects', () => {
     };
 
     beforeEach(() => {
-      when(basketServiceMock.validateBasket(anything(), anything())).thenReturn(of(basketValidation));
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidation));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -158,7 +158,7 @@ describe('Basket Validation Effects', () => {
       actions$ = of(action);
 
       effects.validateBasketAndContinueCheckout$.subscribe(() => {
-        verify(basketServiceMock.validateBasket(BasketMockData.getBasket().id, anything())).once();
+        verify(basketServiceMock.validateBasket(anything())).once();
         done();
       });
     });
@@ -186,7 +186,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map invalid request to action of type ContinueCheckoutFail', () => {
-      when(basketServiceMock.validateBasket(anyString(), anything())).thenReturn(throwError({ message: 'invalid' }));
+      when(basketServiceMock.validateBasket(anything())).thenReturn(throwError({ message: 'invalid' }));
 
       const action = new basketActions.ContinueCheckout({ targetStep: 1 });
       const completion = new basketActions.ContinueCheckoutFail({ error: { message: 'invalid' } as HttpError });

--- a/src/app/core/store/checkout/basket/basket.actions.ts
+++ b/src/app/core/store/checkout/basket/basket.actions.ts
@@ -73,7 +73,6 @@ export enum BasketActionTypes {
 
 export class LoadBasket implements Action {
   readonly type = BasketActionTypes.LoadBasket;
-  constructor(public payload?: { id: string }) {}
 }
 
 export class LoadBasketByAPIToken implements Action {
@@ -139,7 +138,7 @@ export class AddProductToBasket implements Action {
 
 export class AddItemsToBasket implements Action {
   readonly type = BasketActionTypes.AddItemsToBasket;
-  constructor(public payload: { items: { sku: string; quantity: number; unit: string }[]; basketId?: string }) {}
+  constructor(public payload: { items: { sku: string; quantity: number; unit: string }[] }) {}
 }
 
 export class AddItemsToBasketFail implements Action {

--- a/src/app/core/store/checkout/basket/basket.effects.spec.ts
+++ b/src/app/core/store/checkout/basket/basket.effects.spec.ts
@@ -67,23 +67,22 @@ describe('Basket Effects', () => {
 
   describe('loadBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.getBasket(anyString())).thenCall((id: string) => of({ id } as Basket));
+      when(basketServiceMock.getBasket()).thenCall((id: string = 'BID') => of({ id } as Basket));
     });
 
     it('should call the basketService for loadBasket', done => {
-      const id = 'BID';
-      const action = new basketActions.LoadBasket({ id });
+      const action = new basketActions.LoadBasket();
       actions$ = of(action);
 
       effects.loadBasket$.subscribe(() => {
-        verify(basketServiceMock.getBasket(id)).once();
+        verify(basketServiceMock.getBasket()).once();
         done();
       });
     });
 
     it('should map to action of type LoadBasketSuccess', () => {
       const id = 'BID';
-      const action = new basketActions.LoadBasket({ id });
+      const action = new basketActions.LoadBasket();
       const completion = new basketActions.LoadBasketSuccess({ basket: { id } as Basket });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -92,8 +91,8 @@ describe('Basket Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketFail', () => {
-      when(basketServiceMock.getBasket(anyString())).thenReturn(throwError({ message: 'invalid' }));
-      const action = new basketActions.LoadBasket({ id: 'BID' });
+      when(basketServiceMock.getBasket()).thenReturn(throwError({ message: 'invalid' }));
+      const action = new basketActions.LoadBasket();
       const completion = new basketActions.LoadBasketFail({ error: { message: 'invalid' } as HttpError });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -129,7 +128,7 @@ describe('Basket Effects', () => {
 
   describe('loadProductsForBasket$', () => {
     it('should trigger product loading actions for line items if LoadBasketSuccess action triggered', () => {
-      when(basketServiceMock.getBasket(anything())).thenReturn(of());
+      when(basketServiceMock.getBasket()).thenReturn(of());
 
       const action = new basketActions.LoadBasketSuccess({
         basket: {
@@ -155,7 +154,7 @@ describe('Basket Effects', () => {
       expect(effects.loadProductsForBasket$).toBeObservable(expected$);
     });
     it('should trigger product loading actions for line items if MergeBasketSuccess action triggered', () => {
-      when(basketServiceMock.getBasket(anything())).thenReturn(of());
+      when(basketServiceMock.getBasket()).thenReturn(of());
 
       const action = new basketActions.MergeBasketSuccess({
         basket: {
@@ -184,7 +183,7 @@ describe('Basket Effects', () => {
 
   describe('loadBasketEligibleShippingMethods$', () => {
     beforeEach(() => {
-      when(basketServiceMock.getBasketEligibleShippingMethods(anyString(), anything())).thenReturn(
+      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
         of([BasketMockData.getShippingMethod()])
       );
 
@@ -203,7 +202,7 @@ describe('Basket Effects', () => {
       actions$ = of(action);
 
       effects.loadBasketEligibleShippingMethods$.subscribe(() => {
-        verify(basketServiceMock.getBasketEligibleShippingMethods('BID', undefined)).once();
+        verify(basketServiceMock.getBasketEligibleShippingMethods(undefined)).once();
         done();
       });
     });
@@ -220,7 +219,7 @@ describe('Basket Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketEligibleShippingMethodsFail', () => {
-      when(basketServiceMock.getBasketEligibleShippingMethods(anyString(), anything())).thenReturn(
+      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
         throwError({ message: 'invalid' })
       );
       const action = new basketActions.LoadBasketEligibleShippingMethods();
@@ -238,7 +237,7 @@ describe('Basket Effects', () => {
 
   describe('updateBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.updateBasket(anyString(), anything())).thenReturn(of(BasketMockData.getBasket()));
+      when(basketServiceMock.updateBasket(anything())).thenReturn(of(BasketMockData.getBasket()));
 
       store$.dispatch(
         new basketActions.LoadBasketSuccess({
@@ -251,13 +250,12 @@ describe('Basket Effects', () => {
     });
 
     it('should call the basketService for updateBasket', done => {
-      const basketId = 'BID';
       const update = { invoiceToAddress: '7654' };
       const action = new basketActions.UpdateBasket({ update });
       actions$ = of(action);
 
       effects.updateBasket$.subscribe(() => {
-        verify(basketServiceMock.updateBasket(basketId, update)).once();
+        verify(basketServiceMock.updateBasket(update)).once();
         done();
       });
     });
@@ -275,7 +273,7 @@ describe('Basket Effects', () => {
 
     it('should map invalid request to action of type UpdateBasketFail', () => {
       const update = { commonShippingMethod: 'shippingId' };
-      when(basketServiceMock.updateBasket(anyString(), anything())).thenReturn(throwError({ message: 'invalid' }));
+      when(basketServiceMock.updateBasket(anything())).thenReturn(throwError({ message: 'invalid' }));
 
       const action = new basketActions.UpdateBasket({ update });
       const completion = new basketActions.UpdateBasketFail({ error: { message: 'invalid' } as HttpError });

--- a/src/app/core/store/checkout/basket/basket.effects.ts
+++ b/src/app/core/store/checkout/basket/basket.effects.ts
@@ -11,7 +11,7 @@ import { UserActionTypes, getLastAPITokenBeforeLogin } from 'ish-core/store/user
 import { mapErrorToAction, mapToPayloadProperty, whenFalsy } from 'ish-core/utils/operators';
 
 import * as basketActions from './basket.actions';
-import { getCurrentBasket, getCurrentBasketId } from './basket.selectors';
+import { getCurrentBasket } from './basket.selectors';
 
 @Injectable()
 export class BasketEffects {
@@ -23,9 +23,8 @@ export class BasketEffects {
   @Effect()
   loadBasket$ = this.actions$.pipe(
     ofType<basketActions.LoadBasket>(basketActions.BasketActionTypes.LoadBasket),
-    mapToPayloadProperty('id'),
-    mergeMap(id =>
-      this.basketService.getBasket(id).pipe(
+    mergeMap(() =>
+      this.basketService.getBasket().pipe(
         map(basket => new basketActions.LoadBasketSuccess({ basket })),
         mapErrorToAction(basketActions.LoadBasketFail)
       )
@@ -67,7 +66,7 @@ export class BasketEffects {
     ofType(basketActions.BasketActionTypes.LoadBasketEligibleShippingMethods),
     withLatestFrom(this.store.pipe(select(getCurrentBasket))),
     concatMap(([, basket]) =>
-      this.basketService.getBasketEligibleShippingMethods(basket.id, basket.bucketId).pipe(
+      this.basketService.getBasketEligibleShippingMethods(basket.bucketId).pipe(
         map(result => new basketActions.LoadBasketEligibleShippingMethodsSuccess({ shippingMethods: result })),
         mapErrorToAction(basketActions.LoadBasketEligibleShippingMethodsFail)
       )
@@ -81,9 +80,8 @@ export class BasketEffects {
   updateBasket$ = this.actions$.pipe(
     ofType<basketActions.UpdateBasket>(basketActions.BasketActionTypes.UpdateBasket),
     mapToPayloadProperty('update'),
-    withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    concatMap(([update, currentBasketId]) =>
-      this.basketService.updateBasket(currentBasketId, update).pipe(
+    concatMap(update =>
+      this.basketService.updateBasket(update).pipe(
         concatMap(basket => [new basketActions.LoadBasketSuccess({ basket }), new basketActions.ResetBasketErrors()]),
         mapErrorToAction(basketActions.UpdateBasketFail)
       )

--- a/src/app/core/store/checkout/basket/basket.reducer.spec.ts
+++ b/src/app/core/store/checkout/basket/basket.reducer.spec.ts
@@ -18,7 +18,7 @@ describe('Basket Reducer', () => {
   describe('LoadBasket actions', () => {
     describe('LoadBasket action', () => {
       it('should set loading to true', () => {
-        const action = new fromActions.LoadBasket({ id: 'test' });
+        const action = new fromActions.LoadBasket();
         const state = basketReducer(initialState, action);
 
         expect(state.loading).toBeTrue();

--- a/src/app/core/store/checkout/checkout-store.spec.ts
+++ b/src/app/core/store/checkout/checkout-store.spec.ts
@@ -132,7 +132,7 @@ describe('Checkout Store', () => {
     when(countryServiceMock.getCountries()).thenReturn(of([{ countryCode: 'DE', name: 'Germany' }]));
 
     const basketServiceMock = mock(BasketService);
-    when(basketServiceMock.getBasket(anything())).thenCall(() => {
+    when(basketServiceMock.getBasket()).thenCall(() => {
       const newBasket = {
         ...basket,
       };
@@ -154,7 +154,7 @@ describe('Checkout Store', () => {
 
       return of(newBasket);
     });
-    when(basketServiceMock.getBasket(anything())).thenCall(() => {
+    when(basketServiceMock.getBasket()).thenCall(() => {
       const newBasket = {
         ...basket,
       };
@@ -198,7 +198,7 @@ describe('Checkout Store', () => {
       return of(newBasket);
     });
 
-    when(basketServiceMock.addItemsToBasket(anything(), anything())).thenReturn(of(undefined));
+    when(basketServiceMock.addItemsToBasket(anything())).thenReturn(of(undefined));
 
     const productsServiceMock = mock(ProductsService);
     when(productsServiceMock.getProduct(anything())).thenReturn(of(product));
@@ -285,13 +285,6 @@ describe('Checkout Store', () => {
             quantity: 1
           [Basket Internal] Add Items To Basket:
             items: [{"sku":"test","quantity":1,"unit":"pcs."}]
-          [Shopping] Load Product:
-            sku: "test"
-          [Basket Internal] Add Items To Basket:
-            items: [{"sku":"test","quantity":1,"unit":"pcs."}]
-            basketId: "test"
-          [Shopping] Load Product Success:
-            product: {"name":"test","shortDescription":"test","longDescription":"...
           [Basket API] Add Items To Basket Success:
             info: undefined
           [Shopping] Load Product:

--- a/src/app/extensions/quoting/services/quote/quote.service.ts
+++ b/src/app/extensions/quoting/services/quote/quote.service.ts
@@ -122,14 +122,13 @@ export class QuoteService {
   /**
    * Add quote to basket.
    * @param quoteId   The id of the quote that should be added to basket.
-   * @param basketId  The id of the basket which the quote should be added to.
    * @returns         Link to the updated basket items.
    */
-  addQuoteToBasket(quoteId: string, basketId: string): Observable<Link> {
+  addQuoteToBasket(quoteId: string): Observable<Link> {
     const body = {
       quoteID: quoteId,
     };
 
-    return this.apiService.post(`baskets/${basketId}/items`, body);
+    return this.apiService.post(`baskets/current/items`, body);
   }
 }

--- a/src/app/extensions/quoting/store/quote/quote.actions.ts
+++ b/src/app/extensions/quoting/store/quote/quote.actions.ts
@@ -90,7 +90,7 @@ export class CreateQuoteRequestFromQuoteSuccess implements Action {
 
 export class AddQuoteToBasket implements Action {
   readonly type = QuoteActionTypes.AddQuoteToBasket;
-  constructor(public payload: { quoteId: string; basketId?: string }) {}
+  constructor(public payload: { quoteId: string }) {}
 }
 
 export class AddQuoteToBasketFail implements Action {

--- a/src/app/extensions/quoting/store/quote/quote.effects.spec.ts
+++ b/src/app/extensions/quoting/store/quote/quote.effects.spec.ts
@@ -310,7 +310,7 @@ describe('Quote Effects', () => {
 
   describe('addQuoteToBasket$', () => {
     it('should call the basketService for addQuoteToBasket', done => {
-      when(quoteServiceMock.addQuoteToBasket(anyString(), anyString())).thenReturn(of({} as Link));
+      when(quoteServiceMock.addQuoteToBasket(anyString())).thenReturn(of({} as Link));
       store$.dispatch(
         new LoadBasketSuccess({
           basket: {
@@ -325,7 +325,7 @@ describe('Quote Effects', () => {
       actions$ = of(action);
 
       effects.addQuoteToBasket$.subscribe(() => {
-        verify(quoteServiceMock.addQuoteToBasket(quoteId, 'BID')).once();
+        verify(quoteServiceMock.addQuoteToBasket(quoteId)).once();
         done();
       });
     });
@@ -344,7 +344,7 @@ describe('Quote Effects', () => {
     });
 
     it('should map to action of type AddQuoteToBasketSuccess', () => {
-      when(quoteServiceMock.addQuoteToBasket(anyString(), anyString())).thenReturn(of({} as Link));
+      when(quoteServiceMock.addQuoteToBasket(anyString())).thenReturn(of({} as Link));
 
       store$.dispatch(
         new LoadBasketSuccess({
@@ -365,7 +365,7 @@ describe('Quote Effects', () => {
     });
 
     it('should map invalid request to action of type AddQuoteToBasketFail', () => {
-      when(quoteServiceMock.addQuoteToBasket(anyString(), anyString())).thenReturn(throwError({ message: 'invalid' }));
+      when(quoteServiceMock.addQuoteToBasket(anyString())).thenReturn(throwError({ message: 'invalid' }));
 
       store$.dispatch(
         new LoadBasketSuccess({

--- a/src/app/extensions/quoting/store/quote/quote.effects.ts
+++ b/src/app/extensions/quoting/store/quote/quote.effects.ts
@@ -150,9 +150,9 @@ export class QuoteEffects {
     ofType<actions.AddQuoteToBasket>(actions.QuoteActionTypes.AddQuoteToBasket),
     mapToPayload(),
     withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    filter(([payload, currentBasketId]) => !!currentBasketId || !!payload.basketId),
-    concatMap(([payload, currentBasketId]) =>
-      this.quoteService.addQuoteToBasket(payload.quoteId, currentBasketId || payload.basketId).pipe(
+    filter(([, currentBasketId]) => !!currentBasketId),
+    concatMap(([payload]) =>
+      this.quoteService.addQuoteToBasket(payload.quoteId).pipe(
         map(link => new actions.AddQuoteToBasketSuccess({ link })),
         mapErrorToAction(actions.AddQuoteToBasketFail)
       )
@@ -168,11 +168,9 @@ export class QuoteEffects {
     ofType<actions.AddQuoteToBasket>(actions.QuoteActionTypes.AddQuoteToBasket),
     mapToPayload(),
     withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-    filter(([payload, basketId]) => !basketId && !payload.basketId),
+    filter(([, basketId]) => !basketId),
     mergeMap(([{ quoteId }]) =>
-      this.basketService
-        .createBasket()
-        .pipe(map(basket => new actions.AddQuoteToBasket({ quoteId, basketId: basket.id })))
+      this.basketService.createBasket().pipe(map(_ => new actions.AddQuoteToBasket({ quoteId })))
     )
   );
 

--- a/src/app/pages/basket/basket-page.component.spec.ts
+++ b/src/app/pages/basket/basket-page.component.spec.ts
@@ -58,7 +58,7 @@ describe('Basket Page Component', () => {
   });
 
   it('should render loading component if there is no basket', () => {
-    store$.dispatch(new LoadBasket({ id: 'BASKET_ID' }));
+    store$.dispatch(new LoadBasket());
     fixture.detectChanges();
     expect(element.querySelector('ish-loading')).toBeTruthy();
   });


### PR DESCRIPTION
## PR Type

 [x] Refactoring (no functional changes, no API changes)

## What is the new behavior?

The basket service provides API to supply the basketId, but the shop basically only uses a single basket, so these methods can be refactored.

