### PR TITLE
fix: prevent wishlist request for anonymous user

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -1,3 +1,4 @@
+import { isPlatformServer } from '@angular/common';
 import {
   HttpErrorResponse,
   HttpEvent,
@@ -6,7 +7,7 @@ import {
   HttpRequest,
   HttpResponse,
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, throwError, timer } from 'rxjs';
 import { catchError, switchMapTo, tap } from 'rxjs/operators';
@@ -19,7 +20,7 @@ import { ResetAPIToken, SetAPIToken } from 'ish-core/store/user';
  */
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(private store: Store<{}>) {}
+  constructor(private store: Store<{}>, @Inject(PLATFORM_ID) private platformId: string) {}
 
   private static isAuthTokenError(err: unknown) {
     return (
@@ -41,6 +42,9 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (isPlatformServer(this.platformId)) {
+      return next.handle(req);
+    }
     return next.handle(req).pipe(
       // tslint:disable-next-line:ban
       catchError(err => {

--- a/src/app/extensions/wishlists/store/wishlist/wishlist.effects.ts
+++ b/src/app/extensions/wishlists/store/wishlist/wishlist.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { filter, map, mapTo, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, filter, map, mapTo, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { SuccessMessage } from 'ish-core/store/messages';
 import { selectRouteParam } from 'ish-core/store/router';
@@ -188,6 +188,7 @@ export class WishlistEffects {
   loadWishlistsAfterLogin$ = this.store.pipe(
     select(getUserAuthorized),
     whenTruthy(),
+    debounceTime(1000),
     mapTo(new wishlistsActions.LoadWishlists())
   );
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix

## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The e2e test `e2e/cypress/integration/specs/system/retain-authentication.b2c.e2e-spec.ts` detected a race-condition where the ReST API call for getting the user's wishlists is made with the wrong authentication token when feverishly refreshing the page and waiting for the user to be restored from the cookie.

## What Is the New Behavior?

Getting wishlists is debounced for a second. This also prevents hammering the ICM.

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No
