### PR TITLE
fix: prevent mixed locale due to race condition using ngx-translate service use with SSR

### DIFF
--- a/src/app/core/store/configuration/configuration.effects.spec.ts
+++ b/src/app/core/store/configuration/configuration.effects.spec.ts
@@ -133,10 +133,12 @@ describe('Configuration Effects', () => {
 
   describe('setLocale$', () => {
     it('should call TranslateService when locale was initialized', done => {
-      verify(translateServiceMock.use(anything())).once();
-      const params = capture(translateServiceMock.use).last();
-      expect(params[0]).toEqual('en_US');
-      setTimeout(done, 1000);
+      setTimeout(() => {
+        verify(translateServiceMock.use(anything())).once();
+        const params = capture(translateServiceMock.use).last();
+        expect(params[0]).toEqual('en_US');
+        done();
+      }, 1000);
     });
   });
 

--- a/src/app/core/store/configuration/configuration.effects.ts
+++ b/src/app/core/store/configuration/configuration.effects.ts
@@ -7,6 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { defer, fromEvent, iif, merge } from 'rxjs';
 import {
   concatMap,
+  debounceTime,
   distinctUntilChanged,
   map,
   mapTo,
@@ -100,8 +101,10 @@ export class ConfigurationEffects {
   setLocale$ = this.store.pipe(
     select(getCurrentLocale),
     mapToProperty('lang'),
-    whenTruthy(),
     distinctUntilChanged(),
+    // https://github.com/ngx-translate/core/issues/1030
+    debounceTime(0),
+    whenTruthy(),
     tap(lang => this.translateService.use(lang))
   );
 


### PR DESCRIPTION

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix

## What Is the Current Behavior?

race-condition using ngx-translate ngx-translate/core/issues/1030


## What Is the New Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #207

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No


## Other Information

Community Contribution 🎉 