### PR TITLE
feat: set captcha authorization key for 'contact us' REST requests

### DIFF
--- a/e2e/cypress/integration/pages/contact/contact.page.ts
+++ b/e2e/cypress/integration/pages/contact/contact.page.ts
@@ -37,7 +37,7 @@ export class ContactPage {
       .blur();
     // tslint:disable-next-line:ban
     cy.get('select[data-testing-id="subject"]').select(subject);
-    cy.get('textarea[data-testing-id="comments"]')
+    cy.get('textarea[data-testing-id="comment"]')
       .clear()
       .type(comments)
       .blur();

--- a/src/app/core/models/contact/contact.model.ts
+++ b/src/app/core/models/contact/contact.model.ts
@@ -9,4 +9,6 @@ export interface Contact {
   order?: string;
   subject: string;
   comment: string;
+  captcha?: string;
+  captchaAction?: string;
 }

--- a/src/app/core/services/api/api.service.spec.ts
+++ b/src/app/core/services/api/api.service.spec.ts
@@ -148,9 +148,25 @@ describe('Api Service', () => {
       req.flush({});
       expect(req.request.method).toEqual('DELETE');
     });
+
+    it('should set Captcha V2 authorization header key when apiService.appendCaptchaHeaders method is called.', () => {
+      const httpHeader = apiService.appendCaptchaHeaders('captchatoken', undefined);
+
+      expect(httpHeader.get(ApiService.AUTHORIZATION_HEADER_KEY)).toEqual(
+        'CAPTCHA g-recaptcha-response=captchatoken foo=bar'
+      );
+    });
+
+    it('should set Captcha V3 authorization header key when apiService.appendCaptchaHeaders method is called.', () => {
+      const httpHeader = apiService.appendCaptchaHeaders('captchatoken', 'create_account');
+
+      expect(httpHeader.get(ApiService.AUTHORIZATION_HEADER_KEY)).toEqual(
+        'CAPTCHA recaptcha_token=captchatoken action=create_account'
+      );
+    });
   });
 
-  describe('API Service Helper Methods', () => {
+  describe('Api Service', () => {
     describe('constructUrlForPath()', () => {
       const BASE_URL = 'http://example.org/site';
       const JP = { lang: 'jp', currency: 'YEN' } as Locale;
@@ -207,7 +223,7 @@ describe('Api Service', () => {
     });
   });
 
-  describe('API Service Pipable Operators', () => {
+  describe('Api Service', () => {
     let httpTestingController: HttpTestingController;
     let apiService: ApiService;
 
@@ -392,7 +408,7 @@ describe('Api Service', () => {
     });
   });
 
-  describe('API Service Headers', () => {
+  describe('Api Service', () => {
     const REST_URL = 'http://www.example.org/WFS/site/-';
     let apiService: ApiService;
     let store$: Store<{}>;

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -285,4 +285,26 @@ export class ApiService {
       options
     );
   }
+
+  /**
+   * provides the request header for the appropriate captcha service
+   @param   captcha       captcha token for captcha V2 and V3
+   @param   captchaAction captcha action for captcha V3
+   @returns HttpHeader    http header with captcha Authorization key
+   */
+  appendCaptchaHeaders(captcha: string, captchaAction: string): HttpHeaders {
+    let headers = new HttpHeaders();
+    // captcha V3
+    if (captchaAction) {
+      headers = headers.set(
+        ApiService.AUTHORIZATION_HEADER_KEY,
+        `CAPTCHA recaptcha_token=${captcha} action=${captchaAction}`
+      );
+      // captcha V2
+    } else {
+      // TODO: remove second parameter 'foo=bar' that currently only resolves a shortcoming of the server side implemenation that still requires two parameters
+      headers = headers.set(ApiService.AUTHORIZATION_HEADER_KEY, `CAPTCHA g-recaptcha-response=${captcha} foo=bar`);
+    }
+    return headers;
+  }
 }

--- a/src/app/core/services/contact/contact.service.ts
+++ b/src/app/core/services/contact/contact.service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { Contact } from 'ish-core/models/contact/contact.model';
-import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import { ApiService, AvailableOptions, unpackEnvelope } from 'ish-core/services/api/api.service';
 
 @Injectable({ providedIn: 'root' })
 export class ContactService {
@@ -23,6 +23,14 @@ export class ContactService {
    * Send contact us request, when a customer want to get in contact with the shop
    */
   createContactRequest(contactData: Contact): Observable<void> {
-    return this.apiService.post(`contact`, contactData, { skipApiErrorHandling: true });
+    const options: AvailableOptions = {
+      skipApiErrorHandling: true,
+    };
+
+    if (contactData.captcha) {
+      options.headers = this.apiService.appendCaptchaHeaders(contactData.captcha, contactData.captchaAction);
+    }
+
+    return this.apiService.post(`contact`, { ...contactData, captcha: undefined, captchaAction: undefined }, options);
   }
 }

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -97,7 +97,7 @@ export class UserService {
 
     if (body.captchaResponse) {
       return this.apiService.post<void>('customers', newCustomer, {
-        headers: this.appendCaptchaHeaders(body.captchaResponse, body.captchaAction),
+        headers: this.apiService.appendCaptchaHeaders(body.captchaResponse, body.captchaAction),
       });
       // without captcha
     } else {
@@ -198,7 +198,7 @@ export class UserService {
     };
 
     if (data.captcha) {
-      options.headers = this.appendCaptchaHeaders(data.captcha, data.captchaAction);
+      options.headers = this.apiService.appendCaptchaHeaders(data.captcha, data.captchaAction);
     }
 
     return this.apiService.post('security/reminder', { answer: '', ...data }, options);
@@ -213,22 +213,5 @@ export class UserService {
       skipApiErrorHandling: true,
     };
     return this.apiService.post('security/password', data, options);
-  }
-
-  // provides the request header for the appropriate captcha service
-  private appendCaptchaHeaders(captcha: string, captchaAction: string): HttpHeaders {
-    let headers = new HttpHeaders();
-    // captcha V3
-    if (captchaAction) {
-      headers = headers.set(
-        ApiService.AUTHORIZATION_HEADER_KEY,
-        `CAPTCHA recaptcha_token=${captcha} action=${captchaAction}`
-      );
-      // captcha V2
-    } else {
-      // TODO: remove second parameter 'foo=bar' that currently only resolves a shortcoming of the server side implemenation that still requires two parameters
-      headers = headers.set(ApiService.AUTHORIZATION_HEADER_KEY, `CAPTCHA g-recaptcha-response=${captcha} foo=bar`);
-    }
-    return headers;
   }
 }

--- a/src/app/pages/contact/contact-form/contact-form.component.html
+++ b/src/app/pages/contact/contact-form/contact-form.component.html
@@ -29,7 +29,7 @@
     [translateOptionLabels]="true"
   ></ish-select>
   <ish-textarea
-    controlName="comments"
+    controlName="comment"
     [errorMessages]="{ required: 'helpdesk.contactus.comments.error' }"
     [form]="contactForm"
     label="helpdesk.contactus.comments.label"

--- a/src/app/pages/contact/contact-form/contact-form.component.spec.ts
+++ b/src/app/pages/contact/contact-form/contact-form.component.spec.ts
@@ -69,7 +69,7 @@ describe('Contact Form Component', () => {
     component.contactForm.get('phone').setValue('123456');
     component.contactForm.get('order').setValue('456789');
     component.contactForm.get('subject').setValue('Return');
-    component.contactForm.get('comments').setValue('want to return stuff');
+    component.contactForm.get('comment').setValue('want to return stuff');
     component.submitForm();
     verify(emitter.emit(anything())).once();
   });

--- a/src/app/pages/contact/contact-form/contact-form.component.ts
+++ b/src/app/pages/contact/contact-form/contact-form.component.ts
@@ -22,7 +22,7 @@ export class ContactFormComponent implements OnChanges, OnInit {
   @Input() subjects: string[] = [];
   @Input() user: User;
   /** The contact request to send. */
-  @Output() request = new EventEmitter<{ contact: Contact; captcha?: string }>();
+  @Output() request = new EventEmitter<Contact>();
 
   subjectOptions: SelectOption[];
 
@@ -43,18 +43,9 @@ export class ContactFormComponent implements OnChanges, OnInit {
   /** emit contact request, when for is valid or mark form as dirty, when form is invalid */
   submitForm() {
     if (this.contactForm.valid) {
-      const formValue = this.contactForm.value;
-      const contact: Contact = {
-        name: formValue.name,
-        email: formValue.email,
-        phone: formValue.phone,
-        subject: formValue.subject,
-        comment: formValue.comments,
-        order: formValue.order,
-      };
+      const contact: Contact = this.contactForm.value;
 
-      /* ToDo: send captcha data if captcha is supported by REST, see #IS-28299 */
-      this.request.emit({ contact });
+      this.request.emit(contact);
     } else {
       markAsDirtyRecursive(this.contactForm);
       this.submitted = true;
@@ -77,7 +68,7 @@ export class ContactFormComponent implements OnChanges, OnInit {
       phone: [phone, Validators.required],
       order: [''],
       subject: ['', Validators.required],
-      comments: ['', Validators.required],
+      comment: ['', Validators.required],
       captcha: [''],
       captchaAction: ['contact_us'],
     });

--- a/src/app/pages/contact/contact-page.component.ts
+++ b/src/app/pages/contact/contact-page.component.ts
@@ -52,8 +52,8 @@ export class ContactPageComponent implements OnInit, OnDestroy {
   }
 
   /** dispatch contact request */
-  createRequest(request: { contact: Contact; captcha?: string }) {
-    this.accountFacade.createContact(request.contact);
+  createRequest(contact: Contact) {
+    this.accountFacade.createContact(contact);
     this.router.navigate([], { queryParams: { submitted: true } });
   }
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md  
[ ] Tests for the changes have been added (for bug fixes / features)  
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!-- 
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x". 
-->

 [x] Bugfix  
 [ ] Feature  
 [ ] Code style update (formatting, local variables)  
 [ ] Refactoring (no functional changes, no API changes)  
 [ ] Build-related changes  
 [ ] CI-related changes  
 [ ] Documentation content changes  
 [ ] Application / infrastructure changes  
 [ ] Other: <!--Please describe.-->


## What Is the Current Behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The contact us form doesn't work if an ICM captcha service is enabled

## What Is the New Behavior?
The contact us form supports reCaptcha V2 and reCaptcha V3. It has to be configured in the environment.ts file according to the activated ICM captcha service.

## Does this PR Introduce a Breaking Change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

 [ ] Yes  
 [x] No


## Other Information
