### PR TITLE
fix: Concardis DirectDebit cannot be assigned to basket

### DIFF
--- a/src/app/core/models/payment-method/payment-method.mapper.ts
+++ b/src/app/core/models/payment-method/payment-method.mapper.ts
@@ -41,7 +41,7 @@ export class PaymentMethodMapper {
             : undefined,
         parameters: data.parameterDefinitions ? PaymentMethodMapper.mapParameter(data.parameterDefinitions) : undefined,
         hostedPaymentPageParameters:
-          data.id === 'Concardis_DirectDebit'
+          data.serviceID === 'Concardis_DirectDebit'
             ? PaymentMethodMapper.mapSEPAMandateInformation(data.hostedPaymentPageParameters)
             : data.hostedPaymentPageParameters,
       }));
@@ -148,6 +148,7 @@ export class PaymentMethodMapper {
     if (!paymentData.capabilities || !paymentData.capabilities.length) {
       return true;
     }
+
     // excluded by the invalidCapabilities list
     return !paymentData.capabilities.some(data => invalidCapabilities.includes(data));
   }


### PR DESCRIPTION
## PR Type

 [x] Bugfix  
 
## What Is the Current Behavior?
On the checkout payment page the Concardis direct debit payment method does not display the mandate text. This leads to the effect that this payment method can not apply for the basket.
Furthermore, when setting the PWA to German/EUR we get the error ": Cannot read the property 'value' of undefined" on the payment page.

Issue Number: [233](https://github.com/intershop/intershop-pwa/issues/233) -> ISREST-1035, ISREST-1036


## What Is the New Behavior?
The mandate text is displayed on the Concardis direct debit payment method.

## Does this PR Introduce a Breaking Change?

 [ ] Yes  
 [ x] No