### PR TITLE
fix: use exhaustMap for user login to prevent creating multiple sessions

### DIFF
--- a/src/app/core/store/user/user.effects.ts
+++ b/src/app/core/store/user/user.effects.ts
@@ -10,6 +10,7 @@ import {
   concatMapTo,
   debounce,
   debounceTime,
+  exhaustMap,
   filter,
   first,
   map,
@@ -63,7 +64,7 @@ export class UserEffects {
   loginUser$ = this.actions$.pipe(
     ofType<userActions.LoginUser>(userActions.UserActionTypes.LoginUser),
     mapToPayloadProperty('credentials'),
-    mergeMap(credentials =>
+    exhaustMap(credentials =>
       this.userService.signinUser(credentials).pipe(
         map(data => new userActions.LoginUserSuccess(data)),
         mapUserErrorToActionIfPossible(userActions.LoginUserFail)


### PR DESCRIPTION

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Triggering logins multiple times sends request for each login and a server session is created.

## What Is the New Behavior?

Login is only triggered once and further login attempts are ignored while another one is running.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
