### PR TITLE
ng-module-sorted-fields improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,10 @@ jobs:
       - name: Compile Cypress Tests
         run: (cd e2e && npx tsc -p cypress/tsconfig.json)
 
-      - name: Escalate TSLint Rules
+      - name: Run Escalated TSLint Rules
         run: |
           node scripts/tslint-hard
-
-      - name: Lint by action
-        uses: mooyoul/tslint-actions@v1.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          project: 'tsconfig.json'
+          npm run lint
 
       - name: Find Dead Code
         run: npx ts-node scripts/find-dead-code

--- a/angular.json
+++ b/angular.json
@@ -127,8 +127,9 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": ["tsconfig.all.json"],
-            "exclude": ["**/node_modules/**"]
+            "tsConfig": ["tsconfig.json"],
+            "exclude": ["**/node_modules/**"],
+            "format": "stylish"
           }
         },
         "server": {

--- a/e2e/test-schematics.sh
+++ b/e2e/test-schematics.sh
@@ -60,7 +60,6 @@ stat src/app/extensions/awesome/shared/group/dummy/dummy.component.ts
 
 npx ng g lazy-component extensions/awesome/shared/group/dummy/dummy.component.ts
 stat src/app/extensions/awesome/exports/group/lazy-dummy/lazy-dummy.component.ts
-npm run lint -- --format stylish --fix --files src/app/extensions/awesome/exports/group/lazy-dummy/lazy-dummy.component.ts
 grep "LazyDummyComponent" src/app/extensions/awesome/exports/awesome-exports.module.ts
 
 
@@ -87,7 +86,7 @@ stat src/app/shared/cms/components/audio/audio.component.ts
 grep "AudioComponent" src/app/shared/cms/cms.module.ts
 grep "AudioComponent" src/app/shared/shared.module.ts
 
-npx tslint -p tsconfig.all.json
+npm run lint
 
 node schematics/customization/add custom
 npx ng g customized-copy shell/footer/footer

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "ng lint",
     "format": "node docs/check-sentence-newline && stylelint \"**/*.{css,scss}\" --fix && prettier --loglevel warn --write \"**/*.*\"",
     "dead-code": "npx ts-node scripts/find-dead-code.ts",
-    "check": "npm run lint -- --fix --format stylish && npm run format && tsc --project tsconfig.all.json && npm run build && npm run dead-code && npm run test",
+    "check": "npm run lint -- --fix && npm run format && tsc --project tsconfig.all.json && npm run build && npm run dead-code && npm run test",
     "changelog": "npx -p conventional-changelog-cli conventional-changelog -n intershop-changelog.js -i CHANGELOG.md -s",
     "3rd-party-licenses": "npm ci && npx license-checker --csv --out 3rd-party-licenses.txt --customPath templates/3rd-party-licenses_format.json",
     "3rd-party-licenses:summary": "npx license-checker --summary",

--- a/schematics/src/utils/lint-fix.ts
+++ b/schematics/src/utils/lint-fix.ts
@@ -27,7 +27,7 @@ export function applyLintFix(): Rule {
       new TslintFixTask({
         ignoreErrors: true,
         silent: true,
-        tsConfigPath: 'tsconfig.all.json',
+        tsConfigPath: 'tsconfig.json',
         files: [...files],
       })
     );

--- a/src/app/core/services/api/api.service.spec.ts
+++ b/src/app/core/services/api/api.service.spec.ts
@@ -26,8 +26,8 @@ describe('Api Service', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
+        // https://angular.io/guide/http#testing-http-requests
         imports: [
-          // https://angular.io/guide/http#testing-http-requests
           HttpClientTestingModule,
           ngrxTesting({
             reducers: { configuration: configurationReducer },
@@ -394,8 +394,8 @@ describe('Api Service', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
+        // https://angular.io/guide/http#testing-http-requests
         imports: [
-          // https://angular.io/guide/http#testing-http-requests
           HttpClientTestingModule,
           ngrxTesting({
             reducers: { configuration: configurationReducer, user: userReducer },

--- a/tslint-rules/.gitignore
+++ b/tslint-rules/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /package-lock.json
+/test

--- a/tslint-rules/jest.config.js
+++ b/tslint-rules/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  watchPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/'],
 };

--- a/tslint-rules/src/ngModuleSortedFieldsRule.spec.ts
+++ b/tslint-rules/src/ngModuleSortedFieldsRule.spec.ts
@@ -1,0 +1,409 @@
+import { TestRuleExecutor } from './testRuleExecutor';
+
+describe('NgModuleSortedFieldsRule', () => {
+  let linter: TestRuleExecutor;
+
+  beforeEach(() => {
+    linter = new TestRuleExecutor('ng-module-sorted-fields');
+  });
+
+  describe('in NgModule fields', () => {
+    it('should not detect error when supplying sorted imports', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [A, B, C],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should not detect error when supplying sorted imports in expanded array', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [
+    A,
+    B,
+    C,
+  ],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should not detect error when supplying sorted imports in expanded array with complex typing', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [
+    A,
+    B,
+    C,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: translateFactory,
+        deps: [HttpClient],
+      },
+    }),
+  ],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should not detect error when supplying single element imports in expanded array with complex typing', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: translateFactory,
+        deps: [HttpClient],
+      },
+    }),
+  ],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should detect error when supplying unsorted imports', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+@NgModule({
+  imports: [C, B, A],
+}) export class TestModule {}`
+      );
+      const result = linter.lint();
+
+      expect(result.output).toContain('list is not sorted');
+    });
+
+    it('should sort imports when fixing source file', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [C, B, A],
+}) export class TestModule {}`
+        )
+        .fix();
+
+      expect(result.output).toContain('Fixed 1 error');
+
+      expect(result.content).toContain('[A, B, C]');
+    });
+
+    it('should sort imports when fixing source file with partially unsorted members', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [F, A, B, D, C, E, G],
+}) export class TestModule {}`
+        )
+        .fix();
+
+      expect(result.content).toContain('[A, B, C, D, E, F, G]');
+    });
+
+    it('should sort imports when fixing source file with expanded array of unsorted members', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+@NgModule({
+  imports: [
+    C,
+    B,
+    A,
+  ],
+}) export class TestModule {}`
+        )
+        .fix();
+
+      expect(result.content).toContain(`[
+    A,
+    B,
+    C,
+  ]`);
+    });
+
+    it('should sort imports when fixing source file with expanded array of partially unsorted members', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+@NgModule({
+  imports: [
+    F,
+    A,
+    B,
+    D,
+    C,
+    E,
+    G,
+  ],
+}) export class TestModule {}`
+      );
+
+      const result = linter.fix();
+      expect(result.content).toContain(`[
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+  ]`);
+    });
+  });
+
+  describe('in TestBed module', () => {
+    it('should not detect error when supplying sorted entries', () => {
+      const result = linter
+        .addSourceFile('test.spec.ts', `TestBed.configureTestingModule({ imports: [A, B, C]});`)
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should detect error when supplying unsorted entries', () => {
+      const result = linter
+        .addSourceFile('test.spec.ts', `TestBed.configureTestingModule({ imports: [B, C, A]});`)
+        .lint();
+
+      expect(result.errorCount).toEqual(1);
+    });
+
+    it('should fix sorting when supplying unsorted entries', () => {
+      const result = linter
+        .addSourceFile('test.spec.ts', `TestBed.configureTestingModule({ imports: [B, C, A]});`)
+        .fix();
+
+      expect(result.content).toContain('[A, B, C]');
+    });
+  });
+
+  describe('in NgModule arrays', () => {
+    it('should not detect error when supplying sorted entries', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+const exportedComponents = [A, B, C];
+@NgModule({
+  exports: [...exportedComponents],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should not detect error when supplying sorted entries in expanded array', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+const exportedComponents = [
+  A,
+  B,
+  C,
+];
+
+@NgModule({
+  exports: [...exportedComponents],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should detect error when supplying unsorted entries', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+const exportedComponents = [C, B, A];
+@NgModule({
+  exports: [...exportedComponents],
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.output).toContain('list is not sorted');
+    });
+
+    it('should sort array when supplying unsorted entries', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+const exportedComponents = [C, B, A];
+@NgModule({
+  exports: [...exportedComponents],
+}) export class TestModule {}`
+        )
+        .fix();
+
+      expect(result.content).toContain('[A, B, C]');
+    });
+  });
+
+  describe('integrate into spread arrays', () => {
+    it('should detect error when supplying component directly instead of into matching spread array', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+const declaredComponents = [A, C];
+@NgModule({
+  declarations: [...declaredComponents, B],
+}) export class TestModule {}`
+      );
+
+      const result = linter.lint();
+      expect(result.errorCount).toEqual(2);
+      expect(result.failures[0].fix.text).toEqual('...declaredComponents');
+      expect(result.failures[1].fix.text).toEqual('A, B, C');
+
+      const fix = linter.fix();
+      expect(fix.content).not.toContain('[...declaredComponents, B]');
+      expect(fix.content).toContain('[...declaredComponents]');
+      expect(fix.content).toContain('[A, B, C]');
+    });
+
+    it('should detect and fix error when supplying component directly instead of into matching spread arrays', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+const exportedComponents = [A, C];
+@NgModule({
+  exports: [...exportedComponents, B],
+  declarations: [...exportedComponents, B],
+}) export class TestModule {}`
+      );
+
+      const result = linter.lint();
+      expect(result.errorCount).toEqual(3);
+      expect(result.failures[0].fix.text).toEqual('...exportedComponents');
+      expect(result.failures[1].fix.text).toEqual('...exportedComponents');
+      expect(result.failures[2].fix.text).toEqual('A, B, C');
+
+      const fix = linter.fix();
+      expect(fix.content).not.toContain('[...exportedComponents, B]');
+      expect(fix.content).toContain('[...exportedComponents]');
+      expect(fix.content).toContain('[A, B, C]');
+    });
+
+    it('should detect error when supplying component directly instead of into matching spread arrays', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+const exportedComponents = [A, C];
+const declaredComponents = [D];
+@NgModule({
+  exports: [...exportedComponents],
+  declarations: [...declaredComponents, ...exportedComponents, B],
+}) export class TestModule {}`
+      );
+
+      const result = linter.lint();
+      expect(result.errorCount).toEqual(2);
+      expect(result.failures[0].fix.text).toEqual('...declaredComponents, ...exportedComponents');
+      expect(result.failures[1].fix.text).toEqual('B, D');
+
+      const fix = linter.fix();
+      expect(fix.content).not.toContain('[...declaredComponents, ...exportedComponents, B]');
+      expect(fix.content).toContain('[...declaredComponents, ...exportedComponents]');
+      expect(fix.content).toContain('[A, C]');
+      expect(fix.content).toContain('[B, D]');
+    });
+
+    it('should not detect error when supplying component directly instead without matching spread array', () => {
+      const result = linter
+        .addSourceFile(
+          'module.ts',
+          `
+const exportedComponents = [A, C];
+@NgModule({
+  exports: [...exportedComponents, B],
+  declarations: [...exportedComponents]
+}) export class TestModule {}`
+        )
+        .lint();
+
+      expect(result.errorCount).toEqual(0);
+    });
+
+    it('should add new element with correct whitespace to matching spread array', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+const declaredComponents = [
+  A,
+  C,
+];
+@NgModule({
+  declarations: [...declaredComponents, B],
+}) export class TestModule {}`
+      );
+
+      const fix = linter.fix();
+      expect(fix.content).not.toContain('[...declaredComponents, B]');
+      expect(fix.content).toContain('[...declaredComponents]');
+      expect(fix.content).toContain(`[
+  A,
+  B,
+  C,
+]`);
+    });
+
+    it('should break array when resulting element line length exceeds maximal size', () => {
+      linter.addSourceFile(
+        'module.ts',
+        `
+const declaredComponents = [AAAAAAAAAAAAAAAAAAAAAAAAAAAAA, CCCCCCCCCCCCCCCCCCCCCCCCCCC];
+@NgModule({
+  declarations: [...declaredComponents, BBBBBBBBBBBBBBBBBBBBBBBBB, DDDDDDDDDDDDDDDDDDDDDDD, EEEEEEEEEEEEEEEE],
+}) export class TestModule {}`
+      );
+
+      const fix = linter.fix();
+      expect(fix.content).not.toContain('[...declaredComponents,');
+      expect(fix.content).toContain('[...declaredComponents]');
+      expect(fix.content).toContain(`
+const declaredComponents = [
+  AAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+  BBBBBBBBBBBBBBBBBBBBBBBBB,
+  CCCCCCCCCCCCCCCCCCCCCCCCCCC,
+  DDDDDDDDDDDDDDDDDDDDDDD,
+  EEEEEEEEEEEEEEEE,
+]`);
+    });
+  });
+});

--- a/tslint-rules/src/testRuleExecutor.ts
+++ b/tslint-rules/src/testRuleExecutor.ts
@@ -1,0 +1,108 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import * as rimraf from 'rimraf';
+import { Linter, Replacement } from 'tslint';
+import * as ts from 'typescript';
+
+export class TestRuleExecutor {
+  private tmpDir: string;
+  private sourcePath: string;
+  // tslint:disable-next-line: no-any
+  private ruleConfig: any = true;
+
+  constructor(private ruleName: string) {
+    this.tmpDir = join(process.cwd(), 'test', ruleName);
+    if (existsSync(this.tmpDir)) {
+      rimraf.sync(this.tmpDir);
+    }
+    mkdirSync(this.tmpDir, { recursive: true });
+
+    mkdirSync(this.rulesDirectory);
+    writeFileSync(join(this.rulesDirectory, 'index.js'), "exports.rulesDirectory = '.';", { encoding: 'utf-8' });
+
+    const camelized = ruleName.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+    this.transpileSource(camelized + 'Rule');
+    this.transpileSource('ruleHelpers');
+  }
+
+  get rulesDirectory() {
+    return join(this.tmpDir, 'rules');
+  }
+
+  private transpileSource(name: string) {
+    const rulePath = join(process.cwd(), 'src', name + '.ts');
+    const ruleSource = readFileSync(rulePath, { encoding: 'utf-8' });
+    const transpiled = ts.transpileModule(ruleSource, { compilerOptions: { module: ts.ModuleKind.CommonJS } })
+      .outputText;
+    writeFileSync(join(this.rulesDirectory, name + '.js'), transpiled, { encoding: 'utf-8' });
+  }
+
+  addSourceFile(path: string, source: string) {
+    this.sourcePath = join(this.tmpDir, path);
+    writeFileSync(this.sourcePath, source, { encoding: 'utf-8' });
+    return this;
+  }
+
+  // tslint:disable-next-line: no-any
+  setRuleConfig(ruleConfig: any) {
+    this.ruleConfig = ruleConfig;
+  }
+
+  private readSource() {
+    return readFileSync(this.sourcePath, { encoding: 'utf-8' });
+  }
+
+  // tslint:disable-next-line: no-any
+  private run(fix: boolean) {
+    const lintOptions = {
+      fix,
+      formatter: 'prose',
+    };
+
+    const linter = new Linter(lintOptions);
+    linter.lint(this.sourcePath, this.readSource(), {
+      rules: new Map().set(this.ruleName, this.ruleConfig),
+      rulesDirectory: [this.rulesDirectory],
+      jsRules: new Map(),
+      extends: [],
+    });
+
+    return linter.getResult();
+  }
+
+  // tslint:disable-next-line: no-any
+  lint() {
+    const result = this.run(false);
+
+    return {
+      output: result.output.replace(new RegExp(this.sourcePath, 'g'), '').trim().replace(/ in$/, ''),
+      errorCount: result.errorCount,
+      warningCount: result.warningCount,
+      failures:
+        result.failures &&
+        result.failures.map(f => ({
+          failure: f.getFailure(),
+          fix: Array.isArray(f.getFix()) ? (f.getFix()[0] as Replacement) : (f.getFix() as Replacement),
+        })),
+    };
+  }
+
+  // tslint:disable-next-line: no-any
+  fix() {
+    const result = this.run(true);
+
+    return {
+      content: this.readSource(),
+      output: result.output.replace(new RegExp(this.sourcePath, 'g'), '').trim().replace(/ in$/, ''),
+      errorCount: result.errorCount,
+      warningCount: result.warningCount,
+      fixes: result.fixes && result.fixes.map(f => ({ failure: f.getFailure() })),
+      failures:
+        result.failures &&
+        result.failures.map(f => ({
+          failure: f.getFailure(),
+          fix: Array.isArray(f.getFix()) ? (f.getFix()[0] as Replacement) : (f.getFix() as Replacement),
+        })),
+    };
+  }
+}

--- a/tslint-rules/tsconfig.json
+++ b/tslint-rules/tsconfig.json
@@ -13,5 +13,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/test*.ts"]
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature
[x] Code style update (formatting, local variables)

## What Is the Current Behavior?

TSLint rule ng-module-sorted-fields does not respect `declaredComponents` arrays like in `ShellModule`.

## What Is the New Behavior?

- TSLint rule ng-module-sorted-fields sorts fields
- Unit Testing for tslint-rules

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
