### PR TITLE
fix(schematics): handle imports of complex typings for input decorated fields in lazy-component schematic

### DIFF
--- a/schematics/src/lazy-component/factory.ts
+++ b/schematics/src/lazy-component/factory.ts
@@ -66,9 +66,8 @@ export function createLazyComponent(options: Options): Rule {
       }));
 
       const importTypes = bindingNodes
-        .map(node => node.getChildAt(3))
-        .filter(node => ts.isTypeReferenceNode(node))
-        .map(node => node.getText());
+        .map(node => tsquery(node, 'TypeReference > Identifier').map(identifier => identifier.getText()))
+        .reduce((acc, val) => acc.concat(...val), []);
 
       if (importTypes.length) {
         const importDeclarations = tsquery(componentSource, 'ImportDeclaration') as ts.ImportDeclaration[];
@@ -82,7 +81,6 @@ export function createLazyComponent(options: Options): Rule {
               : [],
           }))
           .filter(decl => decl.types.length);
-        // .forEach(t => console.log(t));
       }
     }
 

--- a/schematics/src/lazy-component/factory_spec.ts
+++ b/schematics/src/lazy-component/factory_spec.ts
@@ -188,8 +188,11 @@ describe('Lazy Component Schematic', () => {
       appTree.overwrite(
         '/src/app/extensions/ext/shared/group/dummy/dummy.component.ts',
         `import { ChangeDetectionStrategy, Component, Input, Output } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { Product, ProductHelper } from 'ish-core/models/product/product.model';
+import { User } from 'ish-core/models/user/user.model';
+import { Customer } from 'ish-core/models/customer/customer.model';
 
 @Component({
   selector: 'ish-dummy',
@@ -202,6 +205,8 @@ export class DummyComponent {
   @Input() complexTyped: 'a' | 'b';
   @Input() complexTypedInitialized: 'a' | 'b' = 'a';
   @Input() importTyped: Product;
+  @Input() importComplexTyped: User[];
+  @Input() importGenericTyped: Observable<Customer[]>;
 }
 `
       );
@@ -222,6 +227,8 @@ export class DummyComponent {
       expect(componentContent).toContain("@Input() complexTyped: 'a' | 'b';");
       expect(componentContent).toContain("@Input() complexTypedInitialized: 'a' | 'b' = 'a';");
       expect(componentContent).toContain('@Input() importTyped: Product;');
+      expect(componentContent).toContain('@Input() importComplexTyped: User[];');
+      expect(componentContent).toContain('@Input() importGenericTyped: Observable<Customer[]>;');
     });
 
     it('should transfer inputs', () => {
@@ -230,10 +237,15 @@ export class DummyComponent {
       expect(componentContent).toContain('component.instance.complexTyped = this.complexTyped');
       expect(componentContent).toContain('component.instance.complexTypedInitialized = this.complexTypedInitialized');
       expect(componentContent).toContain('component.instance.importTyped = this.importTyped');
+      expect(componentContent).toContain('component.instance.importComplexTyped = this.importComplexTyped');
+      expect(componentContent).toContain('component.instance.importGenericTyped = this.importGenericTyped');
     });
 
     it('should copy imports', () => {
       expect(componentContent).toContain("import { Product } from 'ish-core/models/product/product.model';");
+      expect(componentContent).toContain("import { User } from 'ish-core/models/user/user.model';");
+      expect(componentContent).toContain("import { Observable } from 'rxjs';");
+      expect(componentContent).toContain("import { Customer } from 'ish-core/models/customer/customer.model';");
     });
   });
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[x] Feature

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The lazy-component schematic does not correctly handle imports for complex typed inputs like:
```typescript
  @Input() importComplexTyped: User[];
  @Input() importGenericTyped: Observable<Customer[]>;
```

## What Is the New Behavior?

It does!

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
