### PR TITLE
deps: update Bootstrap 4.4.1 to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8771,9 +8771,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.0.tgz",
+      "integrity": "sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "angular2-uuid": "^1.1.1",
     "angulartics2": "^9.0.0",
     "b64u": "^3.0.0",
-    "bootstrap": "^4.4.1",
+    "bootstrap": "^4.5.0",
     "core-js": "^3.6.5",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",


### PR DESCRIPTION
deps: update Bootstrap 4.4.1 to 4.5.0 (only the styling part of Bootstrap is used and affected)