### PR TITLE
chore: disabled display of users birthday in profile settings

### DIFF
--- a/src/app/pages/account-profile/account-profile/account-profile.component.html
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.html
@@ -110,12 +110,13 @@
           <!-- Phone -->
           <dt class="col-md-4">{{ 'account.profile.phone.label' | translate }}</dt>
           <dd class="col-md-8" data-testing-id="phone-field">{{ user.phoneHome }}</dd>
-          <!-- Birthday -->
+
+          <!-- Birthday
           <dt class="col-md-4">{{ 'account.profile.birthday.label' | translate }}</dt>
-          <!-- display: inline -->
           <dd class="col-md-8" data-testing-id="birthday-field">{{
             user.birthday ? (user.birthday | ishDate) : ('account.profile.birthday.not_available' | translate)
           }}</dd>
+          -->
         </dl>
       </div>
     </div>


### PR DESCRIPTION
disabled display of users birthday in profile settings as long as the birthday input is not handled in the PWA, neither in the registration nor in the profile editting