### PR TITLE
fix: add to order template on product row

### DIFF
--- a/src/app/shared/components/product/product-row/product-row.component.html
+++ b/src/app/shared/components/product/product-row/product-row.component.html
@@ -50,6 +50,7 @@
           <ish-lazy-product-add-to-order-template
             *ngIf="configuration.displayAddToOrderTemplate"
             displayType="icon"
+            [quantity]="1"
             class="btn-link"
             [product]="product"
           ></ish-lazy-product-add-to-order-template>


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user clicks on 'add to order template' icon button on a subcategory page (product row view) the order template will be created but the product won't be assigned to this order template.

Issue Number: Closes #271 

## What Is the New Behavior?
The product is added to order template.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
