### PR TITLE
build: ignore generated compodoc output

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -30,6 +30,7 @@ browserslist
 /dist
 /out-tsc
 /coverage
+/docs/compodoc
 /junit.xml
 /tslint-rules/dist
 /tslint-rules/test

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,7 +5,7 @@
     "stylelint-config-recess-order",
     "stylelint-prettier/recommended"
   ],
-  "ignoreFiles": ["**/node_modules/**", "**/dist/**"],
+  "ignoreFiles": ["**/node_modules/**", "**/dist/**", "**/compodoc/**"],
   "rules": {
     "at-rule-no-vendor-prefix": true,
     "color-named": "never",


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[x] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

Generated compodoc output will be ignored by stylelint and prettier.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No

