### PR TITLE
fix: Correcting field type for error message key.

### DIFF
--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
@@ -156,7 +156,7 @@ export class PaymentConcardisDirectdebitComponent extends PaymentConcardisCompon
           this.errorMessage.accountholder.messageKey = this.getErrorMessage(
             this.errorMessage.accountholder.code,
             'sepa',
-            'bic',
+            'accountholder',
             this.errorMessage.accountholder.message
           );
           this.handleErrors('accountHolder', this.errorMessage.accountholder.messageKey);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The field type for account holder error message key was wrong.

## What Is the New Behavior?
The field type has been corrected for account holder message key.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information
