### PR TITLE
feat: Implement save for later checkbox for Direct Debit

### DIFF
--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.html
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.html
@@ -1,14 +1,12 @@
 <formly-form [form]="parameterForm" [options]="options" [model]="model" [fields]="getFieldConfig()">
   <div class="offset-md-4 col-md-8">
-    <div class="form-group">
-      <ish-checkbox
-        *ngIf="paymentMethod && paymentMethod.saveAllowed"
-        [form]="parameterForm"
-        controlName="saveForLater"
-        label="checkout.save_edit.checkbox.label"
-        data-testing-id="save-for-later-input"
-      ></ish-checkbox>
-    </div>
+    <ish-checkbox
+      *ngIf="paymentMethod && paymentMethod.saveAllowed"
+      [form]="parameterForm"
+      controlName="saveForLater"
+      label="checkout.save_edit.checkbox.label"
+      data-testing-id="save-for-later-input"
+    ></ish-checkbox>
     <div class="form-group">
       <button type="button" class="btn btn-primary" (click)="submitNewPaymentInstrument()">
         {{ 'checkout.account.submit.button.label' | translate }}

--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.html
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.html
@@ -1,6 +1,15 @@
 <formly-form [form]="parameterForm" [options]="options" [model]="model" [fields]="getFieldConfig()">
   <div class="offset-md-4 col-md-8">
     <div class="form-group">
+      <ish-checkbox
+        *ngIf="paymentMethod && paymentMethod.saveAllowed"
+        [form]="parameterForm"
+        controlName="saveForLater"
+        label="checkout.save_edit.checkbox.label"
+        data-testing-id="save-for-later-input"
+      ></ish-checkbox>
+    </div>
+    <div class="form-group">
       <button type="button" class="btn btn-primary" (click)="submitNewPaymentInstrument()">
         {{ 'checkout.account.submit.button.label' | translate }}
       </button>

--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
@@ -174,7 +174,7 @@ export class PaymentConcardisDirectdebitComponent extends PaymentConcardisCompon
           { name: 'mandateText', value: result.attributes.mandate.mandateText },
           { name: 'mandateCreatedDateTime', value: result.attributes.mandate.createdDateTime },
         ],
-        saveAllowed: false,
+        saveAllowed: this.paymentMethod.saveAllowed && this.parameterForm.get('saveForLater').value,
       });
     }
     this.cd.detectChanges();

--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
@@ -189,10 +189,14 @@ export class PaymentConcardisDirectdebitComponent extends PaymentConcardisCompon
       markAsDirtyRecursive(this.parameterForm);
       return;
     }
-
     const parameters = Object.entries(this.parameterForm.controls)
       .filter(([, control]) => control.enabled && control.value)
       .map(([key, control]) => ({ name: key, value: control.value }));
+
+    let directDebitType = 'SINGLE';
+    if (this.paymentMethod.saveAllowed && this.parameterForm.get('saveForLater').value) {
+      directDebitType = 'FIRST';
+    }
 
     let paymentData: {
       accountHolder: string;
@@ -209,7 +213,7 @@ export class PaymentConcardisDirectdebitComponent extends PaymentConcardisCompon
           ? parameters.find(p => p.name === 'mandateReference').value
           : undefined,
         mandateText: this.getParamValue('mandateText', ''),
-        directDebitType: this.getParamValue('directDebitType', ''),
+        directDebitType,
       },
     };
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Save for later checkbox was not available for Concardis direct debit.

## What Is the New Behavior?
Save for later checkbox is visible and working for Concardis direct debit.
## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information

Requires Concardis Payment Connector 1.11.x - still unreleased