### PR TITLE
refactor: use camelize for feature switch naming with the extension schematic

### DIFF
--- a/schematics/src/extension/files/__name@dasherize__/exports/__name@dasherize__-exports.module.ts.template
+++ b/schematics/src/extension/files/__name@dasherize__/exports/__name@dasherize__-exports.module.ts.template
@@ -8,7 +8,7 @@ import { LAZY_FEATURE_MODULE } from 'ish-core/utils/module-loader/module-loader.
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: '<%= dasherize(name) %>', location: import('../store/<%= dasherize(name) %>-store.module') },
+      useValue: { feature: '<%= camelize(name) %>', location: import('../store/<%= dasherize(name) %>-store.module') },
       multi: true,
     },
   ],


### PR DESCRIPTION
extension schematic fix for feature switch naming from `dasherize` to the intended `camelize`