### PR TITLE
fix: inconsistent breadcrumb updates on category, search & product page

### DIFF
--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -115,11 +115,16 @@ export class CategoriesEffects {
   );
 
   setBreadcrumbForCategoryPage$ = createEffect(() =>
-    this.store.pipe(
-      ofCategoryUrl(),
-      select(getBreadcrumbForCategoryPage),
-      whenTruthy(),
-      map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      switchMapTo(
+        this.store.pipe(
+          ofCategoryUrl(),
+          select(getBreadcrumbForCategoryPage),
+          whenTruthy(),
+          map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+        )
+      )
     )
   );
 }

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Dictionary } from '@ngrx/entity';
+import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { identity } from 'rxjs';
 import {
@@ -14,6 +15,7 @@ import {
   groupBy,
   map,
   mergeMap,
+  switchMapTo,
   tap,
   throttleTime,
   withLatestFrom,
@@ -331,11 +333,16 @@ export class ProductsEffects {
   );
 
   setBreadcrumbForProductPage$ = createEffect(() =>
-    this.store.pipe(
-      ofProductUrl(),
-      select(getBreadcrumbForProductPage),
-      whenTruthy(),
-      map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      switchMapTo(
+        this.store.pipe(
+          ofProductUrl(),
+          select(getBreadcrumbForProductPage),
+          whenTruthy(),
+          map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+        )
+      )
     )
   );
 

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -12,6 +12,7 @@ import {
   map,
   sample,
   switchMap,
+  switchMapTo,
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -109,14 +110,21 @@ export class SearchEffects {
   );
 
   setSearchBreadcrumb$ = createEffect(() =>
-    this.store.pipe(
-      ofUrl(/^\/search.*/),
-      select(selectRouteParam('searchTerm')),
-      whenTruthy(),
-      switchMap(searchTerm =>
-        this.translateService
-          .get('search.breadcrumbs.your_search.label')
-          .pipe(map(translation => setBreadcrumbData({ breadcrumbData: [{ text: `${translation} ${searchTerm}` }] })))
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      switchMapTo(
+        this.store.pipe(
+          ofUrl(/^\/search.*/),
+          select(selectRouteParam('searchTerm')),
+          whenTruthy(),
+          switchMap(searchTerm =>
+            this.translateService
+              .get('search.breadcrumbs.your_search.label')
+              .pipe(
+                map(translation => setBreadcrumbData({ breadcrumbData: [{ text: `${translation} ${searchTerm}` }] }))
+              )
+          )
+        )
       )
     )
   );

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -280,6 +280,8 @@ describe('Shopping Store', () => {
           @ngrx/router-store/navigated:
             routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
             event: {"id":2,"url":"/category/A.123"}
+          [Viewconf Internal] Set Breadcrumb Data:
+            breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123"}]
         `);
       }));
     });
@@ -328,6 +330,8 @@ describe('Shopping Store', () => {
             event: {"id":2,"url":"/search/something"}
           [Product Listing] Load More Products:
             id: {"type":"search","value":"something"}
+          [Viewconf Internal] Set Breadcrumb Data:
+            breadcrumbData: [{"text":"search.breadcrumbs.your_search.label something"}]
           [Product Listing Internal] Load More Products For Params:
             id: {"type":"search","value":"something"}
             filters: undefined
@@ -413,15 +417,13 @@ describe('Shopping Store', () => {
           categories: tree(A.123,A.123.456)
         [Categories Internal] Load Category:
           categoryId: "A"
-        [Viewconf Internal] Set Breadcrumb Data:
-          breadcrumbData: [{"text":"nA123"}]
         [Categories API] Load Category Success:
           categories: tree(A,A.123)
-        [Viewconf Internal] Set Breadcrumb Data:
-          breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123"}]
         @ngrx/router-store/navigated:
           routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
           event: {"id":1,"url":"/category/A.123"}
+        [Viewconf Internal] Set Breadcrumb Data:
+          breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123"}]
       `);
     }));
 
@@ -497,19 +499,17 @@ describe('Shopping Store', () => {
           categoryId: "A"
         [Categories Internal] Load Category:
           categoryId: "A.123"
-        [Viewconf Internal] Set Breadcrumb Data:
-          breadcrumbData: [{"text":"nA123456"}]
         [Categories API] Load Category Success:
           categories: tree(A,A.123)
         [Categories API] Load Category Success:
           categories: tree(A.123,A.123.456)
-        [Viewconf Internal] Set Breadcrumb Data:
-          breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
         @ngrx/router-store/navigated:
           routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
           event: {"id":1,"url":"/category/A.123.456"}
         [Product Listing] Load More Products:
           id: {"type":"category","value":"A.123.456"}
+        [Viewconf Internal] Set Breadcrumb Data:
+          breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
         [Product Listing Internal] Load More Products For Params:
           id: {"type":"category","value":"A.123.456"}
           filters: undefined
@@ -588,11 +588,15 @@ describe('Shopping Store', () => {
               event: {"id":3,"url":"/category/A.123.456"}
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
+            [Viewconf Internal] Set Breadcrumb Data:
+              breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
             @ngrx/router-store/navigated:
               routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
               event: {"id":3,"url":"/category/A.123.456"}
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
+            [Viewconf Internal] Set Breadcrumb Data:
+              breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
           `);
         }));
       });
@@ -620,6 +624,8 @@ describe('Shopping Store', () => {
             event: {"id":2,"url":"/search/something"}
           [Product Listing] Load More Products:
             id: {"type":"search","value":"something"}
+          [Viewconf Internal] Set Breadcrumb Data:
+            breadcrumbData: [{"text":"search.breadcrumbs.your_search.label something"}]
           [Product Listing Internal] Load More Products For Params:
             id: {"type":"search","value":"something"}
             filters: undefined
@@ -660,6 +666,8 @@ describe('Shopping Store', () => {
               event: {"id":3,"url":"/category/A.123.456"}
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
+            [Viewconf Internal] Set Breadcrumb Data:
+              breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
             [Product Listing Internal] Load More Products For Params:
               id: {"type":"category","value":"A.123.456"}
               filters: undefined
@@ -676,6 +684,8 @@ describe('Shopping Store', () => {
               event: {"id":3,"url":"/category/A.123.456"}
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
+            [Viewconf Internal] Set Breadcrumb Data:
+              breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
           `);
         }));
       });
@@ -800,10 +810,10 @@ describe('Shopping Store', () => {
           @ngrx/router-store/navigation:
             routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
             event: {"id":2,"url":"/category/A.123.456"}
-          [Viewconf Internal] Set Breadcrumb Data:
-            breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
           [Product Listing] Load More Products:
             id: {"type":"category","value":"A.123.456"}
+          [Viewconf Internal] Set Breadcrumb Data:
+            breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
           [Product Listing Internal] Load More Products For Params:
             id: {"type":"category","value":"A.123.456"}
             filters: undefined
@@ -831,6 +841,8 @@ describe('Shopping Store', () => {
             event: {"id":2,"url":"/category/A.123.456"}
           [Product Listing] Load More Products:
             id: {"type":"category","value":"A.123.456"}
+          [Viewconf Internal] Set Breadcrumb Data:
+            breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
         `);
       }));
 
@@ -1074,13 +1086,13 @@ describe('Shopping Store', () => {
         @ngrx/router-store/navigation:
           routerState: {"url":"/search/something","params":{"searchTerm":"something...
           event: {"id":1,"url":"/search/something"}
-        [Viewconf Internal] Set Breadcrumb Data:
-          breadcrumbData: [{"text":"search.breadcrumbs.your_search.label something"}]
         @ngrx/router-store/navigated:
           routerState: {"url":"/search/something","params":{"searchTerm":"something...
           event: {"id":1,"url":"/search/something"}
         [Product Listing] Load More Products:
           id: {"type":"search","value":"something"}
+        [Viewconf Internal] Set Breadcrumb Data:
+          breadcrumbData: [{"text":"search.breadcrumbs.your_search.label something"}]
         [Product Listing Internal] Load More Products For Params:
           id: {"type":"search","value":"something"}
           filters: undefined


### PR DESCRIPTION
<!-- To expedite issue processing please search open and closed issues before submitting a new one.
Existing issues often contain information about workarounds, resolution, or progress updates.
-->

**Actual Behavior**

https://drive.google.com/file/d/1XuHs2z3H1G3dcldcUT-KoOFtTzJs0cMC/view

The second usage of a spezific page e.g. category "Notebooks" does not update the breadcrumb.  
Potentially affects all breadcrumbs.


<!-- Provide a clear and concise description of what the actual behavior is.-->

**Expected Behavior**

Breadcrumb should work as expected

<!-- Provide a clear and concise description of what you expected to happen.-->

**Steps to Reproduce the Bug**

Steps to reproduce the behavior:

1. Go to category "Notebooks"
2. Click on first product
3. Click browser back or breadcrumb "Notebooks"

or

1. Go to first product of category "Notebooks" and refresh Page (F5)
2. Click on breadcrumb "Notebooks"
3. Click on first product or browser back 

closes: #316 