### PR TITLE
feat: SSO with Auth0 for B2C

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
 
 env:
-  ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8080
+  ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8081
 
 jobs:
   CancelPrevious:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
 
 env:
-  ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8080
+  ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8081
 
 jobs:
   CancelPrevious:

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ kb_sync_latest_only
 - [Concept - SEO](./concepts/search-engine-optimization.md)
 - [Guide - Forms](./guides/forms.md)
 - [Concept - Deployment Scenarios for Angular Applications](./concepts/deployment-angular.md)
+- [Concept - Single Sign-On (SSO) for PWA](./concepts/sso.md)
 
 ### Developing
 
@@ -72,3 +73,4 @@ kb_sync_latest_only
 - [Guide - Client-Side Error Monitoring with Sentry](./guides/sentry-error-monitoring.md)
 - [Guide - Extended Product Configurations with Tacton](./guides/tacton-product-configuration.md)
 - [Guide - Monitoring with Prometheus](./guides/prometheus-monitoring.md)
+- [Guide - SSO with Auth0 for PWA](./guides/sso-auth0.md)

--- a/docs/concepts/sso.md
+++ b/docs/concepts/sso.md
@@ -7,10 +7,10 @@ kb_sync_latest_only
 
 # Single Sign-On (SSO) for PWA
 
-The Intershop Commerce Management supports logging in clients via SSO (see [Concept - Single Sign-On (SSO)][kb-concept-sso]).
+Intershop Commerce Management supports logging in clients via SSO (see [Concept - Single Sign-On (SSO)][kb-concept-sso]).
 
 The PWA uses the library [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc#readme) to support an easy configuration for providing access to identity providers.
-After setting up the ICM side with the identity provider, an implementation for the interface [`IdentityProvider`](../../src/app/core/identity-provider/identity-provider.interface.ts) has to be added provided in the [`IdentityProviderModule`](../../src/app/core/identity-provider.module.ts).
+After setting up the ICM side with the identity provider, an implementation for the interface [`IdentityProvider`](../../src/app/core/identity-provider/identity-provider.interface.ts), provided in the [`IdentityProviderModule`](../../src/app/core/identity-provider.module.ts), has to be added.
 
 For development purposes the configuration can be added to the Angular CLI environment files:
 
@@ -25,8 +25,8 @@ For development purposes the configuration can be added to the Angular CLI envir
   },
 ```
 
-For production this configuration should be provided via environment variables to the SSR process (see [Building and Running Server-Side Rendering][ssr-startup]).
-The usage of identity providers can also be provided in the multi-channel configuration (see [Building and Running nginx Docker Image][nginx-startup]).
+For production, this configuration should be provided to the SSR process via environment variables (see [Building and Running Server-Side Rendering][ssr-startup]).
+The usage of identity providers can also be set in the multi-channel configuration (see [Building and Running nginx Docker Image][nginx-startup]).
 
 # Further References
 

--- a/docs/concepts/sso.md
+++ b/docs/concepts/sso.md
@@ -1,0 +1,42 @@
+<!--
+kb_concepts
+kb_pwa
+kb_everyone
+kb_sync_latest_only
+-->
+
+# Single Sign-On (SSO) for PWA
+
+The Intershop Commerce Management supports logging in clients via SSO (see [Concept - Single Sign-On (SSO)][kb-concept-sso]).
+
+The PWA uses the library [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc#readme) to support an easy configuration for providing access to identity providers.
+After setting up the ICM side with the identity provider, an implementation for the interface [`IdentityProvider`](../../src/app/core/identity-provider/identity-provider.interface.ts) has to be added provided in the [`IdentityProviderModule`](../../src/app/core/identity-provider.module.ts).
+
+For development purposes the configuration can be added to the Angular CLI environment files:
+
+```typescript
+  identityProvider: 'MyProvider',
+  identityProviders: {
+    'MyProvider': {
+      type: 'auth0',
+      domain: 'some-domain.auth0.com',
+      clientID: 'ASDF12345',
+    }
+  },
+```
+
+For production this configuration should be provided via environment variables to the SSR process (see [Building and Running Server-Side Rendering][ssr-startup]).
+The usage of identity providers can also be provided in the multi-channel configuration (see [Building and Running nginx Docker Image][nginx-startup]).
+
+# Further References
+
+- PWA
+  - [Guide - SSO with Auth0 for PWA](../guides/sso-auth0.md)
+  - [Guide - Building and Running Server-Side Rendering][ssr-startup]
+  - [Guide - Building and Running nginx Docker Image][nginx-startup]
+- ICM
+  - [Concept - Single Sign-On (SSO)][kb-concept-sso]
+
+[kb-concept-sso]: https://support.intershop.com/kb/index.php/Display/29A407
+[ssr-startup]: ../guides/ssr-startup.md
+[nginx-startup]: ../guides/nginx-startup.md

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -45,11 +45,11 @@ The `channel` property is also mandatory.
 
 All other properties are optional:
 
-- **application**: the ICM application
-- **identityProvider**: the active identity provider for this site
-- **features**: comma-separated list of activated features
-- **lang**: the default language as defined in the Angular CLI environment
-- **theme**: the theme used for the channel (format: `<theme-name>(|<icon-color>)?`)
+- **application**: The ICM application
+- **identityProvider**: The active identity provider for this site
+- **features**: Comma-separated list of activated features
+- **lang**: The default language as defined in the Angular CLI environment
+- **theme**: The theme used for the channel (format: `<theme-name>(|<icon-color>)?`)
 
 Multiple channels can also be configured via context paths, which re-configure the PWA upstream to use a different `baseHref` for each channel.
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -42,7 +42,14 @@ The first way of supplying a configuration for domains is to add multiple domain
 The domain is interpreted as a regular expression.
 Subdomains (`b2b\..+`) as well as top level domains (`.+\.com`) can be supplied.
 The `channel` property is also mandatory.
-All other properties are optional.
+
+All other properties are optional:
+
+- **application**: the ICM application
+- **identityProvider**: the active identity provider for this site
+- **features**: comma-separated list of activated features
+- **lang**: the default language as defined in the Angular CLI environment
+- **theme**: the theme used for the channel (format: `<theme-name>(|<icon-color>)?`)
 
 Multiple channels can also be configured via context paths, which re-configure the PWA upstream to use a different `baseHref` for each channel.
 
@@ -99,4 +106,5 @@ If the cache should also be disabled for static resources, the page speed featur
 - [Concept - Multi-Site Handling](../concepts/multi-site-handling.md)
 - [Concept - Configuration](../concepts/configuration.md)
 - [Concept - Logging](../concepts/logging.md)
+- [Concept - Single Sign-On (SSO) for PWA](../concepts/sso.md)
 - [Guide - Monitoring with Prometheus](./prometheus-monitoring.md)

--- a/docs/guides/sso-auth0.md
+++ b/docs/guides/sso-auth0.md
@@ -1,0 +1,29 @@
+<!--
+kb_guide
+kb_pwa
+kb_everyone
+kb_sync_latest_only
+-->
+
+# SSO with Auth0 for PWA
+
+Follow [this guide](https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/authorization-servers/auth0.html) to set up an application in the Auth0 configuration.
+
+The PWA implementation for this Identity Provider is located in [`Auth0IdentityProvider`](../../src/app/core/identity-provider/auth0.identity-provider.ts).
+
+Use the fields "Domain" and "Client ID" for configuring the provider:
+
+```typescript
+  identityProvider: 'MyProvider',
+  identityProviders: {
+    'MyProvider': {
+      type: 'auth0',
+      domain: 'some-domain.auth0.com',
+      clientID: 'ASDF12345',
+    }
+  },
+```
+
+# Further References
+
+- [Concept - Single Sign-On (SSO) for PWA](../concepts/sso.md)

--- a/docs/guides/sso-auth0.md
+++ b/docs/guides/sso-auth0.md
@@ -9,7 +9,7 @@ kb_sync_latest_only
 
 Follow [this guide](https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/authorization-servers/auth0.html) to set up an application in the Auth0 configuration.
 
-The PWA implementation for this Identity Provider is located in [`Auth0IdentityProvider`](../../src/app/core/identity-provider/auth0.identity-provider.ts).
+The PWA implementation for this identity provider is located in [`Auth0IdentityProvider`](../../src/app/core/identity-provider/auth0.identity-provider.ts).
 
 Use the fields "Domain" and "Client ID" for configuring the provider:
 

--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -29,30 +29,36 @@ Only empty strings count as inactive.
 
 If the format is _switch_, the property is switched on by supplying `on`, `1`, `yes` or `true` (checked case-insensitive), anything else is considered `off`.
 
-|                     | parameter       | format               | comment                                                                     |
-| ------------------- | --------------- | -------------------- | --------------------------------------------------------------------------- |
-| **SSR Specific**    | PORT            | number               | Port for running the application                                            |
-|                     | SSL             | any                  | Enables TLS (expects `server.crt` and `server.key` in `dist` folder)        |
-| **General**         | ICM_BASE_URL    | string               | Sets the base URL for the ICM                                               |
-|                     | ICM_CHANNEL     | string               | Overrides the default channel                                               |
-|                     | ICM_APPLICATION | string               | Overrides the default application                                           |
-|                     | FEATURES        | comma-separated list | Overrides active features                                                   |
-|                     | THEME           | string               | Overrides the default theme                                                 |
-| **Debug** :warning: | TRUST_ICM       | any                  | Use this if ICM is deployed with an insecure certificate                    |
-|                     | LOGGING         | switch               | Enable extra log output                                                     |
-| **Hybrid Approach** | SSR_HYBRID      | any                  | Enable running PWA and ICM in [Hybrid Mode](../concepts/hybrid-approach.md) |
-|                     | PROXY_ICM       | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)                |
-| **Third party**     | GTM_TOKEN       | string               | Token for Google Tag Manager                                                |
-|                     | SENTRY_DSN      | string               | Sentry DSN URL for using Sentry Error Monitor                               |
-|                     | PROMETHEUS      | switch               | Expose Prometheus metrics                                                   |
+|                     | parameter             | format               | comment                                                              |
+| ------------------- | --------------------- | -------------------- | -------------------------------------------------------------------- |
+| **SSR Specific**    | PORT                  | number               | Port for running the application                                     |
+|                     | SSL                   | any                  | Enables TLS (expects `server.crt` and `server.key` in `dist` folder) |
+| **General**         | ICM_BASE_URL          | string               | Sets the base URL for the ICM                                        |
+|                     | ICM_CHANNEL           | string               | Overrides the default channel                                        |
+|                     | ICM_APPLICATION       | string               | Overrides the default application                                    |
+|                     | FEATURES              | comma-separated list | Overrides active features                                            |
+|                     | THEME                 | string               | Overrides the default theme                                          |
+| **Debug** :warning: | TRUST_ICM             | any                  | Use this if ICM is deployed with an insecure certificate             |
+|                     | LOGGING               | switch               | Enable extra log output                                              |
+| **Hybrid Approach** | SSR_HYBRID            | any                  | Enable running PWA and ICM in [Hybrid Mode][concept-hybrid]          |
+|                     | PROXY_ICM             | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)         |
+| **Third party**     | GTM_TOKEN             | string               | Token for Google Tag Manager                                         |
+|                     | SENTRY_DSN            | string               | Sentry DSN URL for using Sentry Error Monitor                        |
+|                     | PROMETHEUS            | switch               | Expose Prometheus metrics                                            |
+|                     | ICM_IDENTITY_PROVIDER | string               | ID of Identity Provider for [SSO][concept-sso]                       |
+|                     | IDENTITY_PROVIDERS    | JSON                 | Configuration of Identity Providers for [SSO][concept-sso]           |
 
 # Further References
 
 - [Concept - Configuration](../concepts/configuration.md)
-- [Concept - Hybrid Approach](../concepts/hybrid-approach.md)
+- [Concept - Hybrid Approach][concept-hybrid]
 - [Concept - Logging](../concepts/logging.md)
+- [Concept - Single Sign-On (SSO) for PWA][concept-sso]
 - [Guide - Client-Side Error Monitoring with Sentry](./sentry-error-monitoring.md)
 - [Guide - Google Tag Manager](./google-tag-manager.md)
 - [Guide - Monitoring with Prometheus](./prometheus-monitoring.md)
 - [Youtube - Server Side Rendering and Pre Rendering with Angular Universal](https://youtu.be/-VDOAjzLcvQ)
 - [Google Developers - Rendering on the Web](https://developers.google.com/web/updates/2019/02/rendering-on-the-web)
+
+[concept-sso]: ../concepts/sso.md
+[concept-hybrid]: ../concepts/hybrid-approach.md

--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -39,12 +39,12 @@ If the format is _switch_, the property is switched on by supplying `on`, `1`, `
 |                     | FEATURES              | comma-separated list | Overrides active features                                            |
 |                     | THEME                 | string               | Overrides the default theme                                          |
 | **Debug** :warning: | TRUST_ICM             | any                  | Use this if ICM is deployed with an insecure certificate             |
-|                     | LOGGING               | switch               | Enable extra log output                                              |
-| **Hybrid Approach** | SSR_HYBRID            | any                  | Enable running PWA and ICM in [Hybrid Mode][concept-hybrid]          |
+|                     | LOGGING               | switch               | Enables extra log output                                             |
+| **Hybrid Approach** | SSR_HYBRID            | any                  | Enables running PWA and ICM in [Hybrid Mode][concept-hybrid]         |
 |                     | PROXY_ICM             | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)         |
 | **Third party**     | GTM_TOKEN             | string               | Token for Google Tag Manager                                         |
 |                     | SENTRY_DSN            | string               | Sentry DSN URL for using Sentry Error Monitor                        |
-|                     | PROMETHEUS            | switch               | Expose Prometheus metrics                                            |
+|                     | PROMETHEUS            | switch               | Exposes Prometheus metrics                                           |
 |                     | ICM_IDENTITY_PROVIDER | string               | ID of Identity Provider for [SSO][concept-sso]                       |
 |                     | IDENTITY_PROVIDERS    | JSON                 | Configuration of Identity Providers for [SSO][concept-sso]           |
 

--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -3,6 +3,7 @@
 {{ define "LOCATION_TEMPLATE" }}
         {{- $channel := .channel }}
         {{- $application := "default" }}{{ if (has . "application") }}{{ $application = .application }}{{ end }}
+        {{- $identityProvider := "ICM" }}{{ if (has . "identityProvider") }}{{ $identityProvider = .identityProvider }}{{ end }}
         {{- $lang := "default" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
         {{- $features := "default" }}{{ if (has . "features") }}{{ $features = .features }}{{ end }}
         {{- $theme := "default" }}{{ if (has . "theme") }}{{ $theme = .theme }}{{ end }}
@@ -29,7 +30,7 @@
 
         rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang={{ $lang }}';
 
-        set $default_rewrite_params ';icmHost=default;channel={{ $channel }};application={{ $application }};features={{ $features }};theme={{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
+        set $default_rewrite_params ';icmHost=default;channel={{ $channel }};application={{ $application }};identityProvider={{ $identityProvider }};features={{ $features }};theme={{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
 
         rewrite '^(.*)$' '$1$default_rewrite_params' break;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7609,6 +7609,14 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "angular-oauth2-oidc": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/angular-oauth2-oidc/-/angular-oauth2-oidc-10.0.3.tgz",
+      "integrity": "sha512-9wC8I3e3cN6rMBOlo5JB2y3Fd2erp8pJ67t4vEVzyPbnRG6BJ4rreSOznSL9zw/2SjhC9kRV2OfFie29CUCzEg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "angular2-uuid": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/angular2-uuid/-/angular2-uuid-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@rx-angular/state": "^1.4.1",
     "@sentry/browser": "^5.27.1",
     "@trademe/ng-defer-load": "^8.2.1",
+    "angular-oauth2-oidc": "^10.0.3",
     "angular2-uuid": "^1.1.1",
     "angulartics2": "^10.0.0",
     "b64u": "^3.0.0",

--- a/src/app/core/configurations/configuration.meta.ts
+++ b/src/app/core/configurations/configuration.meta.ts
@@ -19,7 +19,7 @@ class SimpleParamMap {
 }
 
 function extractConfigurationParameters(state: ConfigurationState, paramMap: SimpleParamMap) {
-  const keys: (keyof ConfigurationState)[] = ['channel', 'application', 'theme', 'lang'];
+  const keys: (keyof ConfigurationState)[] = ['channel', 'application', 'theme', 'lang', 'identityProvider'];
   const properties: Partial<ConfigurationState> = keys
     .filter(key => paramMap.has(key) && paramMap.get(key) !== 'default')
     .map(key => ({ [key]: paramMap.get(key) }))

--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -1,7 +1,9 @@
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { Store, select } from '@ngrx/store';
+import { OAuthModule } from 'angular-oauth2-oidc';
 import { first, tap } from 'rxjs/operators';
 
+import { Auth0IdentityProvider } from './identity-provider/auth0.identity-provider';
 import { ICMIdentityProvider } from './identity-provider/icm.identity-provider';
 import { IDENTITY_PROVIDER_IMPLEMENTOR, IdentityProviderFactory } from './identity-provider/identity-provider.factory';
 import { getIdentityProvider } from './store/core/configuration';
@@ -20,6 +22,7 @@ export function identityProviderFactoryInitializer(store: Store, identityProvide
 }
 
 @NgModule({
+  imports: [OAuthModule.forRoot({ resourceServer: { sendAccessToken: false } })],
   providers: [
     {
       provide: APP_INITIALIZER,
@@ -33,6 +36,14 @@ export function identityProviderFactoryInitializer(store: Store, identityProvide
       useValue: {
         type: 'ICM',
         implementor: ICMIdentityProvider,
+      },
+    },
+    {
+      provide: IDENTITY_PROVIDER_IMPLEMENTOR,
+      multi: true,
+      useValue: {
+        type: 'auth0',
+        implementor: Auth0IdentityProvider,
       },
     },
   ],

--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -1,35 +1,13 @@
-import { APP_INITIALIZER, NgModule } from '@angular/core';
-import { Store, select } from '@ngrx/store';
+import { NgModule } from '@angular/core';
 import { OAuthModule } from 'angular-oauth2-oidc';
-import { first, tap } from 'rxjs/operators';
 
 import { Auth0IdentityProvider } from './identity-provider/auth0.identity-provider';
 import { ICMIdentityProvider } from './identity-provider/icm.identity-provider';
-import { IDENTITY_PROVIDER_IMPLEMENTOR, IdentityProviderFactory } from './identity-provider/identity-provider.factory';
-import { getIdentityProvider } from './store/core/configuration';
-import { whenTruthy } from './utils/operators';
-
-export function identityProviderFactoryInitializer(store: Store, identityProviderFactory: IdentityProviderFactory) {
-  return () =>
-    store
-      .pipe(
-        select(getIdentityProvider),
-        whenTruthy(),
-        first(),
-        tap(config => identityProviderFactory.init(config))
-      )
-      .toPromise();
-}
+import { IDENTITY_PROVIDER_IMPLEMENTOR } from './identity-provider/identity-provider.factory';
 
 @NgModule({
   imports: [OAuthModule.forRoot({ resourceServer: { sendAccessToken: false } })],
   providers: [
-    {
-      provide: APP_INITIALIZER,
-      useFactory: identityProviderFactoryInitializer,
-      deps: [Store, IdentityProviderFactory],
-      multi: true,
-    },
     {
       provide: IDENTITY_PROVIDER_IMPLEMENTOR,
       multi: true,

--- a/src/app/core/identity-provider/auth0.identity-provider.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.ts
@@ -1,0 +1,155 @@
+import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store, select } from '@ngrx/store';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { UUID } from 'angular2-uuid';
+import { Observable, throwError, timer } from 'rxjs';
+import { catchError, concatMap, first, map, switchMap, switchMapTo, take, tap } from 'rxjs/operators';
+
+import { HttpError } from 'ish-core/models/http-error/http-error.model';
+import { ApiService } from 'ish-core/services/api/api.service';
+import { getUserAuthorized, loadUserByAPIToken } from 'ish-core/store/customer/user';
+import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { whenTruthy } from 'ish-core/utils/operators';
+
+import { IdentityProvider } from './identity-provider.interface';
+
+export interface Auth0Config {
+  type: 'auth0';
+  domain: string;
+  clientID: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class Auth0IdentityProvider implements IdentityProvider {
+  constructor(
+    private oauthService: OAuthService,
+    private apiService: ApiService,
+    private store: Store,
+    private router: Router,
+    private apiTokenService: ApiTokenService
+  ) {}
+
+  getCapabilities() {
+    return {
+      editPassword: false,
+      editEmail: false,
+      editProfile: false,
+    };
+  }
+
+  init(config: Auth0Config) {
+    this.oauthService.configure({
+      // Your Auth0 app's domain
+      // Important: Don't forget to start with https:// AND the trailing slash!
+      issuer: `https://${config.domain}/`,
+
+      // The app's clientId configured in Auth0
+      clientId: config.clientID,
+
+      // The app's redirectUri configured in Auth0
+      redirectUri: window.location.origin + '/loading',
+
+      // logout redirect URL
+      postLogoutRedirectUri: window.location.origin,
+
+      // Scopes ("rights") the Angular application wants get delegated
+      // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+      scope: 'openid email profile',
+
+      // Using Authorization Code Flow
+      // (PKCE is activated by default for authorization code flow)
+      responseType: 'code',
+
+      // Your Auth0 account's logout url
+      // Derive it from your application's domain
+      logoutUrl: `https://${config.domain}/v2/logout`,
+    });
+
+    this.apiTokenService
+      .restore$(['basket', 'order'])
+      .pipe(
+        tap(() => {
+          this.oauthService.setupAutomaticSilentRefresh();
+          this.oauthService.loadDiscoveryDocumentAndTryLogin();
+        }),
+        switchMapTo(
+          timer(0, 200).pipe(
+            map(() => this.oauthService.getIdToken()),
+            take(100),
+            whenTruthy(),
+            take(1)
+          )
+        ),
+        whenTruthy(),
+        switchMap(idToken =>
+          this.apiService
+            .post('users/processtoken', {
+              id_token: idToken,
+              options: ['UPDATE'],
+            })
+            .pipe(
+              catchError((httpError: HttpError) =>
+                httpError?.status >= 400 && httpError?.status < 500
+                  ? // user does not exist -> create
+                    this.apiService
+                      .post<{ id: string }>('users/processtoken', {
+                        id_token: idToken,
+                        options: ['CREATE_USER'],
+                      })
+                      .pipe(
+                        concatMap(({ id: userId }) =>
+                          this.apiService.post('/privatecustomers', { userId, customerNo: UUID.UUID() })
+                        )
+                      )
+                  : throwError(httpError)
+              ),
+              tap(() => {
+                this.store.dispatch(loadUserByAPIToken());
+              }),
+              switchMapTo(this.store.pipe(select(getUserAuthorized), whenTruthy(), first()))
+            )
+        )
+      )
+      .subscribe(() => {
+        this.apiTokenService.removeApiToken();
+        if (this.router.url.startsWith('/loading')) {
+          this.router.navigateByUrl('/account');
+        }
+      });
+  }
+
+  triggerLogin() {
+    this.router.navigateByUrl('/loading');
+    return this.oauthService.loadDiscoveryDocumentAndLogin();
+  }
+
+  triggerLogout() {
+    this.oauthService.revokeTokenAndLogout(
+      {
+        client_id: this.oauthService.clientId,
+        returnTo: this.oauthService.postLogoutRedirectUri,
+      },
+      true
+    );
+    return this.router.parseUrl('/loading');
+  }
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (!this.oauthService.getIdToken()) {
+      // fallback to standard handling
+      return this.apiTokenService.intercept(req, next);
+    }
+
+    const newRequest =
+      this.oauthService.getIdToken() &&
+      !req.url.endsWith('users/processtoken') &&
+      !req.headers.has(ApiService.TOKEN_HEADER_KEY)
+        ? req.clone({
+            headers: req.headers.set(ApiService.AUTHORIZATION_HEADER_KEY, 'Bearer ' + this.oauthService.getIdToken()),
+          })
+        : req;
+    return next.handle(newRequest);
+  }
+}

--- a/src/app/core/identity-provider/auth0.identity-provider.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.ts
@@ -1,5 +1,6 @@
+import { APP_BASE_HREF } from '@angular/common';
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { OAuthService } from 'angular-oauth2-oidc';
@@ -28,7 +29,8 @@ export class Auth0IdentityProvider implements IdentityProvider {
     private apiService: ApiService,
     private store: Store,
     private router: Router,
-    private apiTokenService: ApiTokenService
+    private apiTokenService: ApiTokenService,
+    @Inject(APP_BASE_HREF) private baseHref: string
   ) {}
 
   getCapabilities() {
@@ -40,6 +42,8 @@ export class Auth0IdentityProvider implements IdentityProvider {
   }
 
   init(config: Auth0Config) {
+    const effectiveOrigin = this.baseHref === '/' ? window.location.origin : window.location.origin + this.baseHref;
+
     this.oauthService.configure({
       // Your Auth0 app's domain
       // Important: Don't forget to start with https:// AND the trailing slash!
@@ -49,10 +53,10 @@ export class Auth0IdentityProvider implements IdentityProvider {
       clientId: config.clientID,
 
       // The app's redirectUri configured in Auth0
-      redirectUri: window.location.origin + '/loading',
+      redirectUri: effectiveOrigin + '/loading',
 
       // logout redirect URL
-      postLogoutRedirectUri: window.location.origin,
+      postLogoutRedirectUri: effectiveOrigin,
 
       // Scopes ("rights") the Angular application wants get delegated
       // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

--- a/src/app/core/identity-provider/icm.identity-provider.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.ts
@@ -9,7 +9,7 @@ import { selectQueryParam } from 'ish-core/store/core/router';
 import { logoutUser } from 'ish-core/store/customer/user';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 
-import { IdentityProvider, TriggerReturnType } from './identity-provider.interface';
+import { IdentityProvider } from './identity-provider.interface';
 
 @Injectable({ providedIn: 'root' })
 export class ICMIdentityProvider implements IdentityProvider {
@@ -36,11 +36,11 @@ export class ICMIdentityProvider implements IdentityProvider {
     });
   }
 
-  triggerLogin(): TriggerReturnType {
+  triggerLogin() {
     return true;
   }
 
-  triggerLogout(): TriggerReturnType {
+  triggerLogout() {
     this.store.dispatch(logoutUser());
     this.apiTokenService.removeApiToken();
     return this.store.pipe(
@@ -50,7 +50,7 @@ export class ICMIdentityProvider implements IdentityProvider {
     );
   }
 
-  triggerRegister(): TriggerReturnType {
+  triggerRegister() {
     return true;
   }
 

--- a/src/app/core/identity-provider/icm.identity-provider.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.ts
@@ -19,6 +19,7 @@ export class ICMIdentityProvider implements IdentityProvider {
     return {
       editPassword: true,
       editEmail: true,
+      editProfile: true,
     };
   }
 

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -1,6 +1,11 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Inject, Injectable, InjectionToken, Injector, PLATFORM_ID, Type } from '@angular/core';
+import { Store, select } from '@ngrx/store';
 import { noop } from 'rxjs';
+import { first } from 'rxjs/operators';
+
+import { getIdentityProvider } from 'ish-core/store/core/configuration';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 import { IdentityProvider } from './identity-provider.interface';
 
@@ -10,33 +15,25 @@ export const IDENTITY_PROVIDER_IMPLEMENTOR = new InjectionToken<{ type: string; 
 
 @Injectable({ providedIn: 'root' })
 export class IdentityProviderFactory {
-  private config: { type: string };
   private instance: IdentityProvider;
 
-  constructor(private injector: Injector, @Inject(PLATFORM_ID) private platformId: string) {}
+  constructor(private store: Store, private injector: Injector, @Inject(PLATFORM_ID) platformId: string) {
+    if (isPlatformBrowser(platformId)) {
+      this.store.pipe(select(getIdentityProvider), whenTruthy(), first()).subscribe(config => {
+        const provider = this.injector
+          .get<{ type: string; implementor: Type<IdentityProvider> }[]>(IDENTITY_PROVIDER_IMPLEMENTOR, [])
+          .find(p => p.type === config?.type);
 
-  getInstance() {
-    return this.instance;
-  }
+        if (!provider) {
+          console.error('did not find identity provider for config', config);
+        } else {
+          const instance = this.injector.get(provider.implementor);
+          instance.init(config);
 
-  init(config: { type: string }) {
-    if (isPlatformBrowser(this.platformId)) {
-      this.config = config;
-
-      const provider = this.injector
-        .get<{ type: string; implementor: Type<IdentityProvider> }[]>(IDENTITY_PROVIDER_IMPLEMENTOR, [])
-        .find(p => p.type === this.config?.type);
-
-      if (!provider) {
-        console.error('did not find identity provider for config', this.config);
-      } else {
-        const instance = this.injector.get(provider.implementor);
-        instance.init(this.config);
-
-        this.instance = instance;
-      }
+          this.instance = instance;
+        }
+      });
     } else {
-      // provide dummy instance for server side
       this.instance = {
         init: noop,
         intercept: (req, next) => next.handle(req),
@@ -45,5 +42,9 @@ export class IdentityProviderFactory {
         getCapabilities: () => ({}),
       };
     }
+  }
+
+  getInstance() {
+    return this.instance;
   }
 }

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -1,6 +1,8 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
-import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
+
+type TriggerReturnType = Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
 
 export interface IdentityProviderCapabilities {
   editPassword?: boolean;
@@ -22,17 +24,17 @@ export interface IdentityProvider {
   /**
    * Route Guard for login
    */
-  triggerLogin(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
+  triggerLogin(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
 
   /**
    * Route guard for register. If not provided, login logic is reused.
    */
-  triggerRegister?(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
+  triggerRegister?(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
 
   /**
    * Route guard for logout
    */
-  triggerLogout(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
+  triggerLogout(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
 
   /**
    * Interceptor for all API requests directed to the ICM

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -9,15 +9,33 @@ export interface IdentityProviderCapabilities {
 }
 
 export interface IdentityProvider {
+  /**
+   * Initialization logic.
+   */
   init(config): void;
 
+  /**
+   * Capabilities for the identity provider.
+   */
   getCapabilities(): IdentityProviderCapabilities;
 
+  /**
+   * Route Guard for login
+   */
   triggerLogin(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
 
+  /**
+   * Route guard for register. If not provided, login logic is reused.
+   */
   triggerRegister?(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
 
+  /**
+   * Route guard for logout
+   */
   triggerLogout(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
 
+  /**
+   * Interceptor for all API requests directed to the ICM
+   */
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>>;
 }

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 export interface IdentityProviderCapabilities {
   editPassword?: boolean;
   editEmail?: boolean;
+  editProfile?: boolean;
 }
 
 export type TriggerReturnType = Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -1,5 +1,5 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
-import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 
 export interface IdentityProviderCapabilities {
@@ -8,18 +8,16 @@ export interface IdentityProviderCapabilities {
   editProfile?: boolean;
 }
 
-export type TriggerReturnType = Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
-
 export interface IdentityProvider {
   init(config): void;
 
   getCapabilities(): IdentityProviderCapabilities;
 
-  triggerLogin(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
+  triggerLogin(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
 
-  triggerRegister?(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
+  triggerRegister?(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
 
-  triggerLogout(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
+  triggerLogout(route: ActivatedRouteSnapshot, state: RouterStateSnapshot);
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>>;
 }

--- a/src/app/core/store/customer/addresses/addresses.effects.spec.ts
+++ b/src/app/core/store/customer/addresses/addresses.effects.spec.ts
@@ -35,7 +35,7 @@ describe('Addresses Effects', () => {
   beforeEach(() => {
     addressServiceMock = mock(AddressService);
 
-    when(addressServiceMock.getCustomerAddresses(anyString())).thenReturn(of([{ urn: 'test' } as Address]));
+    when(addressServiceMock.getCustomerAddresses()).thenReturn(of([{ urn: 'test' } as Address]));
     when(addressServiceMock.createCustomerAddress(anyString(), anything())).thenReturn(of({ urn: 'test' } as Address));
     when(addressServiceMock.deleteCustomerAddress(anyString(), anything())).thenReturn(of('123'));
 
@@ -60,7 +60,7 @@ describe('Addresses Effects', () => {
       actions$ = of(action);
 
       effects.loadAddresses$.subscribe(() => {
-        verify(addressServiceMock.getCustomerAddresses('patricia')).once();
+        verify(addressServiceMock.getCustomerAddresses()).once();
         done();
       });
     });

--- a/src/app/core/store/customer/addresses/addresses.effects.ts
+++ b/src/app/core/store/customer/addresses/addresses.effects.ts
@@ -27,9 +27,8 @@ export class AddressesEffects {
   loadAddresses$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadAddresses),
-      withLatestFrom(this.store.pipe(select(getLoggedInCustomer))),
-      switchMap(([, customer]) =>
-        this.addressService.getCustomerAddresses(customer.customerNo).pipe(
+      switchMap(() =>
+        this.addressService.getCustomerAddresses().pipe(
           map(addresses => loadAddressesSuccess({ addresses })),
           mapErrorToAction(loadAddressesFail)
         )

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -7,7 +7,7 @@ import { concatMap, filter, map, mapTo, mergeMap, sample, startWith, switchMap, 
 
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { RouterState } from 'ish-core/store/core/router/router.reducer';
-import { loginUser, loginUserSuccess } from 'ish-core/store/customer/user';
+import { loadUserByAPIToken, loginUser, loginUserSuccess } from 'ish-core/store/customer/user';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
 
@@ -112,7 +112,7 @@ export class BasketEffects {
   private anonymousBasket$ = createEffect(
     () =>
       combineLatest([this.store.pipe(select(getCurrentBasketId)), this.apiTokenService.apiToken$]).pipe(
-        sample(this.actions$.pipe(ofType(loginUser))),
+        sample(this.actions$.pipe(ofType(loginUser, loadUserByAPIToken))),
         startWith([undefined, undefined])
       ),
     { dispatch: false }

--- a/src/app/pages/account-profile/account-profile/account-profile.component.html
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.html
@@ -124,6 +124,7 @@
   </div>
   <div class="col-2 col-lg-4">
     <a
+      *ishIdentityProviderCapability="'editProfile'"
       routerLink="/account/profile/user"
       class="btn-tool"
       title="{{ 'account.profile.update.link' | translate }}"

--- a/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
@@ -5,7 +5,7 @@ import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { IdentityProviderCapabilityDirective } from 'ish-core/directives/identity-provider-capability.directive';
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
-import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+import { IdentityProviderModule } from 'ish-core/identity-provider.module';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { User } from 'ish-core/models/user/user.model';
 
@@ -27,17 +27,7 @@ describe('Account Profile Component', () => {
         MockComponent(FaIconComponent),
         MockDirective(ServerHtmlDirective),
       ],
-      imports: [TranslateModule.forRoot()],
-      providers: [
-        {
-          provide: IdentityProviderFactory,
-          useValue: {
-            getInstance: () => ({
-              getCapabilities: () => ({ editEmail: true, editPassword: true, editProfile: true }),
-            }),
-          } as IdentityProviderFactory,
-        },
-      ],
+      imports: [IdentityProviderModule.forTesting(), TranslateModule.forRoot()],
     }).compileComponents();
   });
 

--- a/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
@@ -32,7 +32,9 @@ describe('Account Profile Component', () => {
         {
           provide: IdentityProviderFactory,
           useValue: {
-            getInstance: () => ({ getCapabilities: () => ({ editEmail: true, editPassword: true }) }),
+            getInstance: () => ({
+              getCapabilities: () => ({ editEmail: true, editPassword: true, editProfile: true }),
+            }),
           } as IdentityProviderFactory,
         },
       ],

--- a/src/app/shared/address-forms/components/address-form/address-form.factory.ts
+++ b/src/app/shared/address-forms/components/address-form/address-form.factory.ts
@@ -10,20 +10,20 @@ export abstract class AddressFormFactory {
     return new FormGroup({});
   }
 
-  getGroup(param: { isBusinessAddress?: boolean; value? }): FormGroup {
+  getGroup(param?: { isBusinessAddress?: boolean; value? }): FormGroup {
     // get formGroup according to the country specific factory
     const newGroup = this.group();
 
     // add countryCode form controls
     newGroup.addControl('countryCode', new FormControl(''));
 
-    if (param.isBusinessAddress) {
+    if (param?.isBusinessAddress) {
       newGroup.addControl('companyName1', new FormControl('', Validators.required));
       newGroup.addControl('companyName2', new FormControl(''));
     }
 
     // apply values to the new form
-    if (param.value) {
+    if (param?.value) {
       newGroup.patchValue(param.value);
     }
     return newGroup;

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -1,3 +1,4 @@
+import { Auth0Config } from 'ish-core/identity-provider/auth0.identity-provider';
 import { CookieConsentOptions } from 'ish-core/models/cookies/cookies.model';
 import { Locale } from 'ish-core/models/locale/locale.model';
 import { DeviceType, ViewType } from 'ish-core/models/viewtype/viewtype.types';
@@ -91,10 +92,12 @@ export interface Environment {
 
   // client-side configuration for identity providers
   identityProviders?: {
-    [name: string]: {
-      type: string;
-      [key: string]: unknown;
-    };
+    [name: string]:
+      | {
+          type: string;
+          [key: string]: unknown;
+        }
+      | Auth0Config;
   };
 }
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature
[x] Refactoring (no functional changes, no API changes)

## What Is the New Behavior?

- SSO support via Auth0

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] Yes
[ ] No

## Other Information

## Limitations
- support only B2C users
- No changes of email possible, email provided from IDP is used
- No customer approval supported
- Only one IDP supported
- Redirect to loading page to determine next page
- No creation of customers via Backoffice supported
- When using Auth0 username/password login, the name of the user must be changed from email to something useful, otherwise the user cannot set preferred payments or addresses.

## Open Questions / Issues:
- [x] Do we need to have capability for anonymous shopping (cart + checkout) for Auth0? This would result in a mixed scenario. - Yes
- [x] Auth0 Registration: subheading "Contact Information" differs from Registration Pages subheading "Address". Do we really want to introduce the new localization key?
- [x] Checking if a user is new is done by checking if the ICM generated users generated address hat no first address line. Why generate user in the first place? -> https://jira.intershop.de/browse/IS-31067
- [x] logging in at ICM has to be retried multiple times till it finally succeeds -> https://jira.intershop.de/browse/IS-31115
- [x] ICM always overwrites some of users fields on login (firstName, lastName, ...)


## TODO:
- [x] introduce IdentityProvider abstraction to switch between standard handling and Auth0 handling
- ICM Identity Provider
- [x] abstract APIToken Service in restore.effects
- [x] move all user-related standard handling for API Token to ICM Identity Provider (so it can be "switched off")
- Auth0 Identity Provider
- [x] Login/logout via Auth0
- [x] send retrieved ID Token to ICM to recover/create User
- [x] New users are directed to registration form to complete their profile
- [x] Returning users are directed to the ~~previously visited page~~ myaccount (standard behavior)
- [x] abstract TAC component
- [x] Add to cart redirects to login
- [x] Disable edit email in profile settings
- [x] Hide edit password in profile settings
- [x] missing/invalid fields error for registration (maybe default preferredLanguage missing?)
- [x] register link should also lead to Auth0
- [x] mixed scenario for Auth0 identity provider (anonymous shopping, merge basket)
- [x] remove workaround for IS-30270 (CMS w/o pgid)
- [x] Documentation
- [x] switch identity provider via Multi-Channel