### PR TITLE
feat: styled toast messages for success and error messages

### DIFF
--- a/e2e/cypress/integration/pages/account/registration.page.ts
+++ b/e2e/cypress/integration/pages/account/registration.page.ts
@@ -105,6 +105,6 @@ export class RegistrationPage {
   }
 
   get errorText() {
-    return cy.get('div.alert');
+    return cy.get('.toast-container .toast-error');
   }
 }

--- a/src/app/core/store/core/messages/messages.effects.spec.ts
+++ b/src/app/core/store/core/messages/messages.effects.spec.ts
@@ -1,10 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { ToastrService } from 'ngx-toastr';
 import { Observable, of } from 'rxjs';
 import { anything, instance, mock, verify } from 'ts-mockito';
+
+import { getDeviceType } from 'ish-core/store/core/configuration';
+import { isStickyHeader } from 'ish-core/store/core/viewconf';
 
 import { displaySuccessMessage } from './messages.actions';
 import { MessagesEffects } from './messages.effects';
@@ -23,6 +27,12 @@ describe('Messages Effects', () => {
         MessagesEffects,
         provideMockActions(() => actions$),
         { provide: ToastrService, useFactory: () => instance(toastrServiceMock) },
+        provideMockStore({
+          selectors: [
+            { selector: isStickyHeader, value: false },
+            { selector: getDeviceType, value: 'desktop' },
+          ],
+        }),
       ],
     });
 

--- a/src/app/core/store/core/messages/messages.effects.ts
+++ b/src/app/core/store/core/messages/messages.effects.ts
@@ -7,6 +7,7 @@ import { IndividualConfig, ToastrService } from 'ngx-toastr';
 import { Subject, combineLatest } from 'rxjs';
 import { tap, withLatestFrom } from 'rxjs/operators';
 
+import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 import { getDeviceType } from 'ish-core/store/core/configuration';
 import { isStickyHeader } from 'ish-core/store/core/viewconf';
 import { mapToPayload } from 'ish-core/utils/operators';
@@ -106,7 +107,7 @@ export class MessagesEffects {
 
   private composeToastServiceArguments(
     payload: MessagesPayloadType,
-    deviceType: string,
+    deviceType: DeviceType,
     duration?: number
   ): [string, string, Partial<IndividualConfig>] {
     const timeOut = payload.duration ?? duration ?? 5000;
@@ -124,7 +125,7 @@ export class MessagesEffects {
         closeButton: timeOut === 0,
         enableHtml: true,
         tapToDismiss: true,
-        positionClass: deviceType !== 'mobile' ? 'toast-top-full-width' : 'toast-bottom-center',
+        positionClass: deviceType === 'desktop' ? 'toast-top-full-width' : 'toast-bottom-center',
       },
     ];
   }

--- a/src/app/shared/components/common/error-message/error-message.component.html
+++ b/src/app/shared/components/common/error-message/error-message.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="error" role="alert" class="alert alert-danger">
+<div *ngIf="error && !toast" role="alert" class="alert alert-danger">
   <span *ngIf="error.message; else translationMissing" [ishServerHtml]="error.message"></span>
   <ng-template #translationMissing>
     <span [ishServerHtml]="error.code | translate"></span>

--- a/src/app/shared/components/common/error-message/error-message.component.spec.ts
+++ b/src/app/shared/components/common/error-message/error-message.component.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockDirective } from 'ng-mocks';
+import { anything, instance, mock, verify } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { MessageFacade } from 'ish-core/facades/message.facade';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 
 import { ErrorMessageComponent } from './error-message.component';
@@ -11,11 +13,14 @@ describe('Error Message Component', () => {
   let component: ErrorMessageComponent;
   let fixture: ComponentFixture<ErrorMessageComponent>;
   let element: HTMLElement;
+  let messageFacade: MessageFacade;
 
   beforeEach(async(() => {
+    messageFacade = mock(MessageFacade);
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
       declarations: [ErrorMessageComponent, MockDirective(ServerHtmlDirective)],
+      providers: [{ provide: MessageFacade, useFactory: () => instance(messageFacade) }],
     }).compileComponents();
   }));
 
@@ -36,9 +41,21 @@ describe('Error Message Component', () => {
     expect(element.querySelector('[role="alert"]')).toBeFalsy();
   });
 
-  it('should render an error if an error occurs', () => {
+  it('should render an error if an error occurs and toast is false', () => {
     component.error = makeHttpError({ message: 'Test Error' });
+    component.toast = false;
+
+    component.ngOnChanges();
     fixture.detectChanges();
     expect(element.querySelector('[role="alert"]')).toBeTruthy();
+  });
+
+  it('should trigger error toast if an error occurs and toast is true', () => {
+    component.error = makeHttpError({ message: 'Test Error' });
+    component.toast = true;
+
+    component.ngOnChanges();
+    fixture.detectChanges();
+    verify(messageFacade.error(anything())).once();
   });
 });

--- a/src/app/shared/components/common/error-message/error-message.component.ts
+++ b/src/app/shared/components/common/error-message/error-message.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 
+import { MessageFacade } from 'ish-core/facades/message.facade';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 
 /**
@@ -13,6 +14,23 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
   templateUrl: './error-message.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ErrorMessageComponent {
+export class ErrorMessageComponent implements OnChanges {
   @Input() error: HttpError;
+  @Input() toast = true;
+
+  constructor(private messagesFacade: MessageFacade) {}
+
+  ngOnChanges() {
+    if (this.toast) {
+      this.displayToast();
+    }
+  }
+
+  private displayToast() {
+    if (this.error) {
+      this.messagesFacade.error({
+        message: this.error.message || this.error.code,
+      });
+    }
+  }
 }

--- a/src/app/shared/components/login/login-form/login-form.component.html
+++ b/src/app/shared/components/login/login-form/login-form.component.html
@@ -1,4 +1,4 @@
-<ish-error-message [error]="loginError$ | async"></ish-error-message>
+<ish-error-message [error]="loginError$ | async" [toast]="false"></ish-error-message>
 
 <form name="LoginUserForm" [formGroup]="form" class="form-horizontal" (ngSubmit)="loginUser()">
   <!--<p>{{ 'account.login.message' | translate }}</p>--><!-- Decision is pending, whether this message should be shown or not -->

--- a/src/styles/global/toasts.scss
+++ b/src/styles/global/toasts.scss
@@ -24,16 +24,11 @@
     }
 
     & > div {
-      width: 100%;
-      max-width: 540px;
+      width: 100% !important;
       margin-top: $top-header-height;
       font-size: $font-size-base;
       line-height: $line-height-base;
       opacity: 1;
-
-      @media (min-width: $screen-sm-min) {
-        max-width: calc(#{$screen-sm-min} - 1.5 * #{$grid-gutter-width});
-      }
 
       @media (min-width: $screen-md-min) {
         max-width: calc(#{$screen-md-min} - 2 * #{$grid-gutter-width});

--- a/src/styles/global/toasts.scss
+++ b/src/styles/global/toasts.scss
@@ -1,12 +1,62 @@
-.toast-container .toast .toast-close-button {
-  top: 0;
-  background-color: inherit;
-  border: none;
-  opacity: 1;
-}
-
 .toast-container {
-  line-height: 1;
+  z-index: 1030; // appears on top of the page but below the modal windows
+
+  .toast .toast-close-button {
+    top: 0;
+    background-color: inherit;
+    border: none;
+    opacity: 1;
+  }
+
+  &.toast-top-full-width {
+    position: absolute;
+    top: 130px;
+
+    &.toast-sticky {
+      position: fixed;
+      top: 0;
+
+      & > div {
+        @media (max-width: $screen-sm-max) {
+          margin-top: $header-height-mobile;
+        }
+      }
+    }
+
+    & > div {
+      width: 100%;
+      max-width: 540px;
+      margin-top: $top-header-height;
+      font-size: $font-size-base;
+      line-height: $line-height-base;
+      opacity: 1;
+
+      @media (min-width: $screen-sm-min) {
+        max-width: calc(#{$screen-sm-min} - 1.5 * #{$grid-gutter-width});
+      }
+
+      @media (min-width: $screen-md-min) {
+        max-width: calc(#{$screen-md-min} - 2 * #{$grid-gutter-width});
+      }
+
+      @media (min-width: $screen-lg-min) {
+        max-width: calc(1170px - #{$grid-gutter-width});
+      }
+
+      & + div {
+        margin-top: $space-default / 2;
+      }
+    }
+  }
+
+  &.toast-bottom-center {
+    position: fixed;
+    bottom: 0;
+
+    & > div {
+      width: 100% !important;
+    }
+  }
 }
 
 .toast-error {
@@ -25,25 +75,4 @@
   width: 100%;
   background-color: theme-color-level('success', $alert-border-level);
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="#{$toastViewBox}" fill="#{$toast-success-color}">#{$toast-success-icon}</svg>');
-}
-
-.toast-container.toast-top-full-width > div {
-  width: 100%;
-  max-width: 540px;
-  margin-top: 50px;
-  font-size: $font-size-base * 1.25;
-  opacity: 1;
-
-  @media (min-width: $screen-sm-min) {
-    max-width: calc(#{$screen-sm-min} - 1.5 * #{$grid-gutter-width});
-    margin-top: 40px;
-  }
-
-  @media (min-width: $screen-md-min) {
-    max-width: calc(#{$screen-md-min} - 2 * #{$grid-gutter-width});
-  }
-
-  @media (min-width: $screen-lg-min) {
-    max-width: calc(1170px - #{$grid-gutter-width});
-  }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

- error messages are mostly displayed inline
- some success messages are displayed as toasts, but only in the top right corner

## What Is the New Behavior?

- toast messages used and styled more consistently

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## TODO:
- [x] error messages should not fade out
- [x] go to URLs provided in toast message
- [x] adapt cypress tests
- [x] adapt font size
- [x] add cross action icon for error messages (to indicate that you can click it away)
- [x] In which cases should it be switched off? (e.g. errors in modals, info messages) tbd.
- [x] mobile layout (bottom?)

To be discussed:
- [ ] consistent toast positioning when sticky header is disabled (under header when header is in view, top of screen otherwise)
there is no simple solution, maybe postponed after header rework

Toasts are not used (yet):
- in the checkout because of the divergent header
- for information messages - consider to create a general info-message component in future for it
- success messages in modals are not replaced, e.g. add product to wish list/order template


VD Template:
![toast](https://user-images.githubusercontent.com/66066967/89395857-247e6a80-d70e-11ea-8a64-227c9be7c765.jpg)
