### PR TITLE
chore: disable obsolete nginx modpagespeed local_storage_cache optimization

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
   rm -r /var/cache/apt /var/lib/apt/lists
 COPY --from=buildstep /usr/local/nginx /usr/local/nginx
 COPY --from=configstep / /
-ENV NPSC_ENABLE_FILTERS=in_place_optimize_for_browser,prioritize_critical_css,inline_preview_images,lazyload_images,rewrite_images,rewrite_css,remove_comments,local_storage_cache,move_css_to_head,move_css_above_scripts,collapse_whitespace,combine_javascript,extend_cache NPSC_JsPreserveURLs=off NPSC_ImagePreserveURLs=on NPSC_ForceCaching=off
+ENV NPSC_ENABLE_FILTERS=in_place_optimize_for_browser,prioritize_critical_css,inline_preview_images,lazyload_images,rewrite_images,rewrite_css,remove_comments,move_css_to_head,move_css_above_scripts,collapse_whitespace,combine_javascript,extend_cache NPSC_JsPreserveURLs=off NPSC_ImagePreserveURLs=on NPSC_ForceCaching=off
 
 EXPOSE 80 443
 


### PR DESCRIPTION
The nginx modpagespeed local_storage_cache optimization is not actually doing anything for the PWA but writes an obsolete cookie, see https://www.modpagespeed.com/doc/filter-local-storage-cache. So we should remove it at all.
