### PR TITLE
refactor: allow numbers as loading for ngrx reducer helpers

### DIFF
--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.reducer.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.reducer.ts.template
@@ -5,7 +5,7 @@ import { <%= classify(entity) %> } from '<% if(!extension) { %>ish-core<% } else
 
 <% } %>
 import { createReducer<% if(entity) { %>, on<% } %> } from '@ngrx/store';
-import { <% if(entity) { %>setErrorOn, <% } %>setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { <% if(entity) { %>setErrorOn, unsetLoadingAndErrorOn, <% } %>setLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { load<%= classify(name) %><% if(entity) { %>, load<%= classify(name) %>Fail, load<%= classify(name) %>Success<% } %> } from './<%= dasherize(name) %>.actions';
 <% if(entity) { %>
@@ -33,12 +33,6 @@ export const <%= camelize(name) %>Reducer = createReducer(
   initialState,
   setLoadingOn(load<%= classify(name) %>)<% if(entity) { %>,
   setErrorOn(load<%= classify(name) %>Fail),
-  on(load<%= classify(name) %>Success, (state: <%= classify(name) %>State, action) => {
-    const { <%= camelize(name) %> } = action.payload;
-    return {
-      ...<%= camelize(name) %>Adapter.upsertMany(<%= camelize(name) %>, state),
-      loading: false,
-      error: undefined,
-    };
-  })<% } %>
+  unsetLoadingAndErrorOn(load<%= classify(name) %>Success),
+  on(load<%= classify(name) %>Success, (state, action) => <%= camelize(name) %>Adapter.upsertMany(action.payload.<%= camelize(name) %>, state))<% } %>
 );

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.selectors.spec.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.selectors.spec.ts.template
@@ -40,7 +40,7 @@ describe('<%= classify(name) %> Selectors', () => {
     });
 <% } %>  });
 
-  describe('Load<%= classify(name) %>', () =>{
+  describe('load<%= classify(name) %>', () =>{
     const action = load<%= classify(name) %>();
 
     beforeEach(() => {

--- a/src/app/core/store/customer/addresses/addresses.reducer.ts
+++ b/src/app/core/store/customer/addresses/addresses.reducer.ts
@@ -9,7 +9,7 @@ import {
   deleteBasketShippingAddress,
   updateBasketAddress,
 } from 'ish-core/store/customer/basket';
-import { setErrorOn, setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
 
 import {
   createCustomerAddress,
@@ -48,40 +48,20 @@ export const addressesReducer = createReducer(
     deleteBasketShippingAddress
   ),
   setErrorOn(loadAddressesFail, createCustomerAddressFail, updateCustomerAddressFail, deleteCustomerAddressFail),
-  on(loadAddressesSuccess, (state: AddressesState, action) => {
-    const { addresses } = action.payload;
-
-    return {
-      ...addressAdapter.setAll(addresses, state),
-      error: undefined,
-      loading: false,
-    };
-  }),
-  on(createCustomerAddressSuccess, createBasketAddressSuccess, (state: AddressesState, action) => {
-    const { address } = action.payload;
-
-    return {
-      ...addressAdapter.addOne(address, state),
-      loading: false,
-      error: undefined,
-    };
-  }),
-  on(updateCustomerAddressSuccess, (state: AddressesState, action) => {
-    const { address } = action.payload;
-
-    return {
-      ...addressAdapter.updateOne({ id: address.id, changes: address }, state),
-      loading: false,
-      error: undefined,
-    };
-  }),
-  on(deleteCustomerAddressSuccess, (state: AddressesState, action) => {
-    const { addressId } = action.payload;
-
-    return {
-      ...addressAdapter.removeOne(addressId, state),
-      loading: false,
-      error: undefined,
-    };
-  })
+  unsetLoadingAndErrorOn(
+    loadAddressesSuccess,
+    createCustomerAddressSuccess,
+    updateCustomerAddressSuccess,
+    deleteCustomerAddressSuccess
+  ),
+  on(loadAddressesSuccess, (state: AddressesState, action) => addressAdapter.setAll(action.payload.addresses, state)),
+  on(
+    createCustomerAddressSuccess,
+    createBasketAddressSuccess,
+    updateCustomerAddressSuccess,
+    (state: AddressesState, action) => addressAdapter.upsertOne(action.payload.address, state)
+  ),
+  on(deleteCustomerAddressSuccess, (state: AddressesState, action) =>
+    addressAdapter.removeOne(action.payload.addressId, state)
+  )
 );

--- a/src/app/core/utils/ngrx-creators.spec.ts
+++ b/src/app/core/utils/ngrx-creators.spec.ts
@@ -1,0 +1,171 @@
+import { createAction, createReducer } from '@ngrx/store';
+import { noop } from 'rxjs';
+
+import { makeHttpError } from './dev/api-service-utils';
+import { httpError, payload, setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from './ngrx-creators';
+
+describe('Ngrx Creators', () => {
+  const load = createAction('[Test] Load');
+  const loadSuccess = createAction('[Test API] Load Success', payload<{ entities: unknown[] }>());
+  const loadFail = createAction('[Test API] Load Fail', httpError());
+
+  describe('with boolean loading', () => {
+    const initialState = { loading: false, error: undefined };
+    const reducer = createReducer(
+      initialState,
+      setLoadingOn(load),
+      setErrorOn(loadFail),
+      unsetLoadingAndErrorOn(loadSuccess)
+    );
+
+    describe('on load action', () => {
+      it('should set loading to true when reducing load action', () => {
+        const state = reducer(initialState, load());
+        expect(state).toMatchInlineSnapshot(`
+          Object {
+            "error": undefined,
+            "loading": true,
+          }
+        `);
+      });
+
+      describe('on load success', () => {
+        it('should set loading to false on load success', () => {
+          const state = reducer({ ...initialState, loading: true }, loadSuccess({ entities: [] }));
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": undefined,
+              "loading": false,
+            }
+          `);
+        });
+      });
+
+      describe('on load fail', () => {
+        it('should set error to error and loading to false on load fail', () => {
+          const state = reducer(
+            { ...initialState, loading: true },
+            loadFail({ error: makeHttpError({ message: 'ERROR' }) })
+          );
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": Object {
+                "message": "ERROR",
+                "name": "HttpErrorResponse",
+              },
+              "loading": false,
+            }
+          `);
+        });
+      });
+    });
+  });
+
+  describe('with number loading', () => {
+    const initialState = { loading: 0, error: undefined };
+    const reducer = createReducer(
+      initialState,
+      setLoadingOn(load),
+      setErrorOn(loadFail),
+      unsetLoadingAndErrorOn(loadSuccess)
+    );
+
+    describe('on load action', () => {
+      it('should increase loading when reducing load action', () => {
+        const state = reducer(initialState, load());
+        expect(state).toMatchInlineSnapshot(`
+          Object {
+            "error": undefined,
+            "loading": 1,
+          }
+        `);
+      });
+
+      describe('on load success', () => {
+        it('should decrease loading on load success', () => {
+          const state = reducer({ ...initialState, loading: 1 }, loadSuccess({ entities: [] }));
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": undefined,
+              "loading": 0,
+            }
+          `);
+        });
+      });
+
+      describe('on load fail', () => {
+        it('should set error to error and decrease loading on load fail', () => {
+          const state = reducer(
+            { ...initialState, loading: 1 },
+            loadFail({ error: makeHttpError({ message: 'ERROR' }) })
+          );
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": Object {
+                "message": "ERROR",
+                "name": "HttpErrorResponse",
+              },
+              "loading": 0,
+            }
+          `);
+        });
+      });
+
+      describe('on second load action', () => {
+        it('should increase loading more when reducing second load action', () => {
+          const state = reducer({ ...initialState, loading: 1 }, load());
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": undefined,
+              "loading": 2,
+            }
+          `);
+        });
+      });
+    });
+
+    describe('dev warning', () => {
+      let consoleSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        consoleSpy = jest.spyOn(console, 'warn').mockImplementationOnce(noop);
+      });
+
+      afterEach(() => {
+        consoleSpy.mockClear();
+      });
+
+      describe('on load success', () => {
+        it('should warn when loading would be decreased below 0', () => {
+          const state = reducer({ ...initialState, loading: 0 }, loadSuccess({ entities: [] }));
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": undefined,
+              "loading": 0,
+            }
+          `);
+          expect(consoleSpy).toHaveBeenCalled();
+        });
+      });
+
+      describe('on load fail', () => {
+        it('should warn when loading would be decreased below 0', () => {
+          const state = reducer(
+            { ...initialState, loading: 0 },
+            loadFail({ error: makeHttpError({ message: 'ERROR' }) })
+          );
+          expect(state).toMatchInlineSnapshot(`
+            Object {
+              "error": Object {
+                "message": "ERROR",
+                "name": "HttpErrorResponse",
+              },
+              "loading": 0,
+            }
+          `);
+          expect(consoleSpy).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/src/app/core/utils/ngrx-creators.ts
+++ b/src/app/core/utils/ngrx-creators.ts
@@ -10,10 +10,10 @@ export function httpError<P = {}>() {
   return (args: { error: HttpError } & P) => ({ payload: { ...args } });
 }
 
-export function setLoadingOn<S extends { loading: boolean }>(...actionCreators: ActionCreator[]): On<S> {
+export function setLoadingOn<S extends { loading: boolean | number }>(...actionCreators: ActionCreator[]): On<S> {
   const stateFnc = (state: S) => ({
     ...state,
-    loading: true,
+    loading: typeof state.loading === 'boolean' ? true : state.loading + 1,
   });
   if (actionCreators.length === 1) {
     return on(actionCreators[0], stateFnc);
@@ -22,13 +22,35 @@ export function setLoadingOn<S extends { loading: boolean }>(...actionCreators: 
   }
 }
 
-export function setErrorOn<S extends { loading: boolean; error: HttpError }>(
+function calculateLoading<T extends boolean | number, S extends { loading: T }>(state: S): T {
+  if (typeof state.loading === 'number' && state.loading - 1 < 0) {
+    console.warn('State loading would be decreased below 0.');
+  }
+  return (typeof state.loading === 'boolean' ? false : Math.max((state.loading as number) - 1, 0)) as T;
+}
+
+export function unsetLoadingAndErrorOn<S extends { loading: boolean | number }>(
+  ...actionCreators: ActionCreator[]
+): On<S> {
+  const stateFnc = (state: S) => ({
+    ...state,
+    loading: calculateLoading(state),
+    error: undefined,
+  });
+  if (actionCreators.length === 1) {
+    return on(actionCreators[0], stateFnc);
+  } else {
+    return on(actionCreators[0], ...actionCreators.splice(1), stateFnc);
+  }
+}
+
+export function setErrorOn<S extends { loading: boolean | number; error: HttpError }>(
   ...actionCreators: ActionCreator[]
 ): On<S> {
   const stateFnc = (state: S, action: { payload: { error: HttpError }; type: string }) => ({
     ...state,
     error: action.payload.error,
-    loading: false,
+    loading: calculateLoading(state),
   });
   if (actionCreators.length === 1) {
     return on(actionCreators[0], stateFnc);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`loading` in reducers is boolean by default

## What Is the New Behavior?

`loading` can also be number for multiple parallel loading actions.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
