### PR TITLE
fix(schematics): enable customized-copy schematic for subfolders

### DIFF
--- a/e2e/test-schematics.sh
+++ b/e2e/test-schematics.sh
@@ -89,10 +89,21 @@ grep "AudioComponent" src/app/shared/shared.module.ts
 npm run lint
 
 node schematics/customization/add custom
+# format without source folder prefix from project root
 npx ng g customized-copy shell/footer/footer
 
 stat src/app/shell/footer/custom-footer/custom-footer.component.ts
 grep 'custom-footer' src/app/app.component.html
+
+# format with source folder prefix from project root
+npx ng g customized-copy src/app/shared/components/basket/basket-promotion
+stat src/app/shared/components/basket/custom-basket-promotion/custom-basket-promotion.component.html
+grep 'custom-basket-promotion' src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
+
+# from subfolder
+(cd src/app/pages/checkout-review && npx ng g customized-copy checkout-review)
+stat src/app/pages/checkout-review/custom-checkout-review/custom-checkout-review.component.html
+grep 'custom-checkout-review' src/app/pages/checkout-review/checkout-review-page.component.html
 
 sed -i -e "s%icmBaseURL.*%icmBaseURL: 'http://localhost:4200',%g" src/environments/environment.prod.ts
 

--- a/schematics/src/helpers/customized-copy/factory.ts
+++ b/schematics/src/helpers/customized-copy/factory.ts
@@ -24,9 +24,11 @@ export function customize(options: Options): Rule {
 
     const workspace = await getWorkspace(host);
     const project = workspace.projects.get(options.project);
-    const from = options.from.replace(/\/$/, '');
     const sourceRoot = project.sourceRoot;
-    const dir = host.getDir(`${sourceRoot}/app/${from}`);
+    const from = `${
+      options.path ? options.path + '/' : !options.from?.startsWith(sourceRoot + '/app/') ? sourceRoot + '/app/' : ''
+    }${options.from.replace(/\/$/, '')}`;
+    const dir = host.getDir(from);
 
     const fromName = basename(dir.path);
 

--- a/schematics/src/helpers/customized-copy/schema.json
+++ b/schematics/src/helpers/customized-copy/schema.json
@@ -11,6 +11,11 @@
       },
       "visible": false
     },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "visible": false
+    },
     "from": {
       "type": "string",
       "description": "The folder of the component source.",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

Schematic `customized-copy` does not work when executed from subfolder.

## What Is the New Behavior?

Fixed.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Thank you for reporting @franciscomdrito :wink:
