### PR TITLE
fix(schematics): respect original component selector when generating lazy components

### DIFF
--- a/e2e/test-schematics.sh
+++ b/e2e/test-schematics.sh
@@ -105,6 +105,11 @@ grep 'custom-basket-promotion' src/app/shared/components/basket/basket-cost-summ
 stat src/app/pages/checkout-review/custom-checkout-review/custom-checkout-review.component.html
 grep 'custom-checkout-review' src/app/pages/checkout-review/checkout-review-page.component.html
 
+npx ng g customized-copy src/app/extensions/quoting/shared/quote-widget
+stat src/app/extensions/quoting/shared/custom-quote-widget/custom-quote-widget.component.ts
+# TODO
+# grep 'custom-lazy-quote-widget' src/app/pages/account-overview/account-overview/account-overview.component.html
+
 sed -i -e "s%icmBaseURL.*%icmBaseURL: 'http://localhost:4200',%g" src/environments/environment.prod.ts
 
 if grep mockServerAPI src/environments/environment.prod.ts
@@ -119,6 +124,7 @@ grep '"serviceWorker": false' angular.json
 grep 'serviceWorker: false' src/environments/environment.prod.ts
 
 git add -A
+npm run clean
 npx lint-staged
 npx tsc --project tsconfig.all.json
 


### PR DESCRIPTION


<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

All lazy components are generated with the customization prefix when starting a customization via script.

## What Is the New Behavior?

Original selectors of components are respected.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

Thanks again to @franciscomdrito for reporting 👍 
