### PR TITLE
fix: use product name for basket line item name and order line item name for orders

### DIFF
--- a/src/app/core/models/basket/basket.model.ts
+++ b/src/app/core/models/basket/basket.model.ts
@@ -6,7 +6,7 @@ import { LineItem, LineItemView } from 'ish-core/models/line-item/line-item.mode
 import { Payment } from 'ish-core/models/payment/payment.model';
 import { ShippingMethod } from 'ish-core/models/shipping-method/shipping-method.model';
 
-interface AbstractBasket<T> {
+export interface AbstractBasket<T> {
   id: string;
   purchaseCurrency?: string;
   dynamicMessages?: string[];

--- a/src/app/core/models/line-item/line-item.mapper.ts
+++ b/src/app/core/models/line-item/line-item.mapper.ts
@@ -1,6 +1,7 @@
 import { BasketRebateData } from 'ish-core/models/basket-rebate/basket-rebate.interface';
 import { BasketRebateMapper } from 'ish-core/models/basket-rebate/basket-rebate.mapper';
 import { OrderItemData } from 'ish-core/models/order-item/order-item.interface';
+import { OrderLineItem } from 'ish-core/models/order/order.model';
 import { PriceItemMapper } from 'ish-core/models/price-item/price-item.mapper';
 import { PriceMapper } from 'ish-core/models/price/price.mapper';
 
@@ -49,7 +50,7 @@ export class LineItemMapper {
     }
   }
 
-  static fromOrderItemData(data: OrderItemData, rebateData?: { [id: string]: BasketRebateData }): LineItem {
+  static fromOrderItemData(data: OrderItemData, rebateData?: { [id: string]: BasketRebateData }): OrderLineItem {
     if (data) {
       const orderItem = LineItemMapper.fromData(data, rebateData);
 

--- a/src/app/core/models/line-item/line-item.model.ts
+++ b/src/app/core/models/line-item/line-item.model.ts
@@ -35,11 +35,6 @@ export interface LineItem {
   isHiddenGift: boolean;
   isFreeGift: boolean;
 
-  // attributes needed for order line items
-  name?: string;
-  description?: string;
-  fulfillmentStatus?: string;
-
   // attributes needed for quote feature
   originSingleBasePrice?: PriceItem;
 

--- a/src/app/core/models/order/order.model.ts
+++ b/src/app/core/models/order/order.model.ts
@@ -1,6 +1,13 @@
-import { Basket } from 'ish-core/models/basket/basket.model';
+import { AbstractBasket } from 'ish-core/models/basket/basket.model';
+import { LineItem } from 'ish-core/models/line-item/line-item.model';
 
-export interface Order extends Basket {
+export interface OrderLineItem extends LineItem {
+  name: string;
+  description: string;
+  fulfillmentStatus: string;
+}
+
+export interface Order extends AbstractBasket<OrderLineItem> {
   documentNo: string;
   creationDate: number;
   orderCreation: {

--- a/src/app/core/store/customer/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.spec.ts
@@ -239,7 +239,6 @@ describe('Basket Items Effects', () => {
             lineItems: [
               {
                 id: 'BIID',
-                name: 'NAME',
                 quantity: { value: 1 },
                 productSKU: 'SKU',
                 price: undefined,

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -52,7 +52,6 @@ describe('Customer Store', () => {
 
   const lineItem = {
     id: 'test',
-    name: 'test',
     position: 1,
     quantity: { type: 'test', value: 1, unit: 'pcs.' },
     productSKU: 'test',

--- a/src/app/core/utils/dev/basket-mock-data.ts
+++ b/src/app/core/utils/dev/basket-mock-data.ts
@@ -24,7 +24,6 @@ export class BasketMockData {
   static getBasketItem(): LineItemView {
     return {
       id: '4712',
-      name: 'pli name',
       quantity: { value: 10 },
       productSKU: '4713',
       singleBasePrice: { gross: 3, net: 2, currency: 'USD', type: 'PriceItem' },

--- a/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.html
+++ b/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.html
@@ -3,7 +3,7 @@
     <ng-container *ngIf="isItemVisible(i)">
       <!-- product name and price -->
       <div class="col-8" *ngIf="product$(pli.productSKU) | async as product">
-        <a [routerLink]="product | ishProductRoute"> {{ pli.name }} </a>
+        <a [routerLink]="product | ishProductRoute"> {{ product.name }} </a>
       </div>
       <div class="col-4 text-right">{{ pli.totals.total | ishPrice }}</div>
 

--- a/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.spec.ts
+++ b/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.spec.ts
@@ -22,7 +22,7 @@ describe('Basket Items Summary Component', () => {
 
   beforeEach(async () => {
     const shoppingFacade = mock(ShoppingFacade);
-    when(shoppingFacade.product$(anything(), anything())).thenCall(sku => of({ sku }));
+    when(shoppingFacade.product$(anything(), anything())).thenCall(sku => of({ sku, name: 'SKU:' + sku }));
 
     await TestBed.configureTestingModule({
       declarations: [
@@ -54,7 +54,7 @@ describe('Basket Items Summary Component', () => {
   it('should render basket product line items if basket items are there', () => {
     fixture.detectChanges();
     expect(element.querySelector('.cart-summary-checkout')).toBeTruthy();
-    expect(element.querySelector('.cart-summary-checkout').textContent).toContain('pli name');
+    expect(element.querySelector('.cart-summary-checkout').textContent).toContain('SKU:4713');
   });
 
   it('should not show anything if there are no basket items', () => {

--- a/src/app/shared/components/line-item/line-item-list/line-item-list.component.ts
+++ b/src/app/shared/components/line-item/line-item-list/line-item-list.component.ts
@@ -6,6 +6,7 @@ import { debounceTime } from 'rxjs/operators';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { LineItemView } from 'ish-core/models/line-item/line-item.model';
+import { OrderLineItem } from 'ish-core/models/order/order.model';
 import { Price } from 'ish-core/models/price/price.model';
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
@@ -32,7 +33,7 @@ import { SpecialValidators } from 'ish-shared/forms/validators/special-validator
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LineItemListComponent {
-  @Input() lineItems: LineItemView[];
+  @Input() lineItems: Partial<LineItemView & OrderLineItem>[];
   @Input() editable = true;
   @Input() total: Price;
   @Input() lineItemViewType?: 'simple' | 'availability';

--- a/src/app/shell/header/mini-basket/mini-basket.component.html
+++ b/src/app/shell/header/mini-basket/mini-basket.component.html
@@ -32,7 +32,7 @@
               </a>
             </div>
             <div class="mini-product-info">
-              <a [routerLink]="product | ishProductRoute" (click)="collapse()"> {{ lineItem.name }} </a>
+              <a [routerLink]="product | ishProductRoute" (click)="collapse()"> {{ product.name }} </a>
               <div class="product-price">{{ lineItem.price | ishPrice }}</div>
               <div class="cart-pli-data">
                 <span>{{ 'shopping_cart.pli.qty.label' | translate }}</span> {{ lineItem.quantity.value }}

--- a/src/app/shell/header/mini-basket/mini-basket.component.spec.ts
+++ b/src/app/shell/header/mini-basket/mini-basket.component.spec.ts
@@ -94,7 +94,7 @@ describe('Mini Basket Component', () => {
     component.open();
     fixture.detectChanges();
     expect(element.textContent.replace(/ /g, '')).toMatchInlineSnapshot(
-      `"30items/$141,796.98pliname$3.00x10pliname$3.00x10pliname$3.00x10VIEWCART"`
+      `"30items/$141,796.98$3.00x10$3.00x10$3.00x10VIEWCART"`
     );
   });
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

#373 introduced a bug, where line item names are no longer displayed for mini-basket and basket-item-summary components.

## What Is the New Behavior?

Product name is displayed for basket line items and supplied order line item names are used for order line items.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
