### PR TITLE
fix: display payment costs according to the configured display type (…

### DIFF
--- a/src/app/core/models/payment-method/payment-method.mapper.spec.ts
+++ b/src/app/core/models/payment-method/payment-method.mapper.spec.ts
@@ -101,8 +101,8 @@ describe('Payment Method Mapper', () => {
 
       expect(paymentMethod).toBeTruthy();
       expect(paymentMethod.id).toEqual('ISH_CreditCard');
-      expect(paymentMethod.paymentCosts.value).toBePositive();
-      expect(paymentMethod.paymentCostsThreshold.value).toBePositive();
+      expect(paymentMethod.paymentCosts.net).toBePositive();
+      expect(paymentMethod.paymentCostsThreshold.net).toBePositive();
       expect(paymentMethod.isRestricted).toBeFalse();
       expect(paymentMethod.saveAllowed).toBeFalse();
     });

--- a/src/app/core/models/payment-method/payment-method.mapper.ts
+++ b/src/app/core/models/payment-method/payment-method.mapper.ts
@@ -33,8 +33,8 @@ export class PaymentMethodMapper {
         isRestricted: data.restricted,
         saveAllowed: data.saveAllowed && !!data.parameterDefinitions && !!data.parameterDefinitions.length,
         restrictionCauses: data.restrictions,
-        paymentCosts: PriceItemMapper.fromSpecificPriceItem(data.paymentCosts, 'net'),
-        paymentCostsThreshold: PriceItemMapper.fromSpecificPriceItem(data.paymentCostsThreshold, 'net'),
+        paymentCosts: PriceItemMapper.fromPriceItem(data.paymentCosts),
+        paymentCostsThreshold: PriceItemMapper.fromPriceItem(data.paymentCostsThreshold),
         paymentInstruments:
           included && included.paymentInstruments && data.paymentInstruments
             ? data.paymentInstruments.map(id => included.paymentInstruments[id])

--- a/src/app/core/models/payment-method/payment-method.model.ts
+++ b/src/app/core/models/payment-method/payment-method.model.ts
@@ -2,7 +2,7 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
 import { PaymentRestriction } from 'ish-core/models/payment-restriction/payment-restriction.model';
-import { Price } from 'ish-core/models/price/price.model';
+import { PriceItem } from 'ish-core/models/price-item/price-item.model';
 
 export interface PaymentMethod {
   id: string;
@@ -11,8 +11,8 @@ export interface PaymentMethod {
   saveAllowed?: boolean;
   description?: string;
   capabilities?: string[];
-  paymentCosts?: Price;
-  paymentCostsThreshold?: Price;
+  paymentCosts?: PriceItem;
+  paymentCostsThreshold?: PriceItem;
   isRestricted?: boolean;
   restrictionCauses?: PaymentRestriction[];
   paymentInstruments?: PaymentInstrument[];

--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
@@ -32,12 +32,11 @@
               <p *ngIf="paymentMethod.description">{{ paymentMethod.description }}</p>
               <p *ngIf="paymentCostThresholdReached(paymentMethod); else displayPaymentCosts">
                 {{ 'checkout.payment.payment_cost_threshold.amount_reached' | translate }}
-                &nbsp;
                 {{ basket.totals.total | ishPrice }}
               </p>
               <ng-template #displayPaymentCosts>
                 <div *ngIf="!paymentMethod.isRestricted; else displayRestrictions">
-                  <p *ngIf="paymentMethod.paymentCosts && paymentMethod.paymentCosts.value">
+                  <p *ngIf="paymentMethod.paymentCosts">
                     {{ 'checkout.payment.method.charges.text' | translate }}&nbsp;{{
                       paymentMethod.paymentCosts | ishPrice
                     }}&nbsp;

--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.ts
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.ts
@@ -137,8 +137,11 @@ export class CheckoutPaymentComponent implements OnInit, OnChanges, OnDestroy {
    */
   paymentCostThresholdReached(paymentMethod: PaymentMethod): boolean {
     const basketTotalPrice = PriceItemHelper.selectType(this.basket.totals.total, this.priceType);
+
     if (paymentMethod.paymentCostsThreshold && basketTotalPrice) {
-      return paymentMethod.paymentCostsThreshold.value <= basketTotalPrice.value;
+      return (
+        PriceItemHelper.selectType(paymentMethod.paymentCostsThreshold, this.priceType)?.value <= basketTotalPrice.value
+      );
     }
     return false;
   }


### PR DESCRIPTION
…gross/net)

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
On the checkout payment page the payment costs are always shown as net prices in the payment selection widget.

Issue Number: Closes #

## What Is the New Behavior?
The payment costs are shown according to the price display type (gross/net). The price display type can be configured in the ICM back office.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
