### PR TITLE
Refactor/service remove basket id 2

### DIFF
--- a/src/app/core/services/basket/basket.service.spec.ts
+++ b/src/app/core/services/basket/basket.service.spec.ts
@@ -52,11 +52,11 @@ describe('Basket Service', () => {
   });
 
   it("should get basket data when 'getBasket' is called", done => {
-    when(apiService.get(`baskets/${basketMockData.data.id}`, anything())).thenReturn(of(basketMockData));
+    when(apiService.get(`baskets/current`, anything())).thenReturn(of(basketMockData));
 
-    basketService.getBasket(basketMockData.data.id).subscribe(data => {
+    basketService.getBasket().subscribe(data => {
       expect(data.id).toEqual(basketMockData.data.id);
-      verify(apiService.get(`baskets/${basketMockData.data.id}`, anything())).once();
+      verify(apiService.get(`baskets/current`, anything())).once();
       done();
     });
   });
@@ -94,8 +94,8 @@ describe('Basket Service', () => {
     when(apiService.patch(anything(), anything(), anything())).thenReturn(of(basketMockData));
     const payload = { invoiceToAddress: '123456' };
 
-    basketService.updateBasket(basketMockData.data.id, payload).subscribe(() => {
-      verify(apiService.patch(`baskets/${basketMockData.data.id}`, payload, anything())).once();
+    basketService.updateBasket(payload).subscribe(() => {
+      verify(apiService.patch(`baskets/current`, payload, anything())).once();
       done();
     });
   });
@@ -103,8 +103,8 @@ describe('Basket Service', () => {
   it("should validate the basket when 'validateBasket' is called", done => {
     when(apiService.post(anything(), anything(), anything())).thenReturn(of(undefined));
 
-    basketService.validateBasket(basketMockData.data.id).subscribe(() => {
-      verify(apiService.post(`baskets/${basketMockData.data.id}/validations`, anything(), anything())).once();
+    basketService.validateBasket().subscribe(() => {
+      verify(apiService.post(`baskets/current/validations`, anything(), anything())).once();
       done();
     });
   });
@@ -121,8 +121,8 @@ describe('Basket Service', () => {
   it("should post item to basket when 'addItemsToBasket' is called", done => {
     when(apiService.post(anything(), anything(), anything())).thenReturn(of({}));
 
-    basketService.addItemsToBasket(basketMockData.data.id, [itemMockData]).subscribe(() => {
-      verify(apiService.post(`baskets/${basketMockData.data.id}/items`, anything(), anything())).once();
+    basketService.addItemsToBasket([itemMockData]).subscribe(() => {
+      verify(apiService.post(`baskets/current/items`, anything(), anything())).once();
       done();
     });
   });
@@ -167,10 +167,8 @@ describe('Basket Service', () => {
     when(apiService.patch(anyString(), anything(), anything())).thenReturn(of({}));
 
     const payload = { quantity: { value: 2 } } as BasketItemUpdateType;
-    basketService.updateBasketItem(basketMockData.data.id, lineItemData.id, payload).subscribe(() => {
-      verify(
-        apiService.patch(`baskets/${basketMockData.data.id}/items/${lineItemData.id}`, payload, anything())
-      ).once();
+    basketService.updateBasketItem(lineItemData.id, payload).subscribe(() => {
+      verify(apiService.patch(`baskets/current/items/${lineItemData.id}`, payload, anything())).once();
       done();
     });
   });
@@ -178,8 +176,8 @@ describe('Basket Service', () => {
   it("should remove line item from specific basket when 'deleteBasketItem' is called", done => {
     when(apiService.delete(anyString(), anything())).thenReturn(of({}));
 
-    basketService.deleteBasketItem(basketMockData.data.id, lineItemData.id).subscribe(() => {
-      verify(apiService.delete(`baskets/${basketMockData.data.id}/items/${lineItemData.id}`, anything())).once();
+    basketService.deleteBasketItem(lineItemData.id).subscribe(() => {
+      verify(apiService.delete(`baskets/current/items/${lineItemData.id}`, anything())).once();
       done();
     });
   });
@@ -187,8 +185,8 @@ describe('Basket Service', () => {
   it("should add promotion code to specific basket when 'addPromotionCodeToBasket' is called", done => {
     when(apiService.post(anything(), anything(), anything())).thenReturn(of({}));
 
-    basketService.addPromotionCodeToBasket(basketMockData.data.id, 'code').subscribe(() => {
-      verify(apiService.post(`baskets/${basketMockData.data.id}/promotioncodes`, anything(), anything())).once();
+    basketService.addPromotionCodeToBasket('code').subscribe(() => {
+      verify(apiService.post(`baskets/current/promotioncodes`, anything(), anything())).once();
       done();
     });
   });
@@ -196,8 +194,8 @@ describe('Basket Service', () => {
   it("should remove a promotion code from a specific basket when 'removePromotionCodeFromBasket' is called", done => {
     when(apiService.delete(anyString(), anything())).thenReturn(of({}));
 
-    basketService.removePromotionCodeFromBasket(basketMockData.data.id, 'promoCode').subscribe(() => {
-      verify(apiService.delete(`baskets/${basketMockData.data.id}/promotioncodes/promoCode`, anything())).once();
+    basketService.removePromotionCodeFromBasket('promoCode').subscribe(() => {
+      verify(apiService.delete(`baskets/current/promotioncodes/promoCode`, anything())).once();
       done();
     });
   });
@@ -205,8 +203,8 @@ describe('Basket Service', () => {
   it("should create a basket address when 'createBasketAddress' is called", done => {
     when(apiService.post(anyString(), anything(), anything())).thenReturn(of({ data: {} as Address }));
 
-    basketService.createBasketAddress(basketMockData.data.id, BasketMockData.getAddress()).subscribe(() => {
-      verify(apiService.post(`baskets/${basketMockData.data.id}/addresses`, anything(), anything())).once();
+    basketService.createBasketAddress(BasketMockData.getAddress()).subscribe(() => {
+      verify(apiService.post(`baskets/current/addresses`, anything(), anything())).once();
       done();
     });
   });
@@ -216,10 +214,8 @@ describe('Basket Service', () => {
 
     const address = BasketMockData.getAddress();
 
-    basketService.updateBasketAddress(basketMockData.data.id, address).subscribe(() => {
-      verify(
-        apiService.patch(`baskets/${basketMockData.data.id}/addresses/${address.id}`, anything(), anything())
-      ).once();
+    basketService.updateBasketAddress(address).subscribe(() => {
+      verify(apiService.patch(`baskets/current/addresses/${address.id}`, anything(), anything())).once();
       done();
     });
   });
@@ -227,8 +223,8 @@ describe('Basket Service', () => {
   it("should get eligible shipping methods for a basket when 'getBasketEligibleShippingMethods' is called", done => {
     when(apiService.get(anything(), anything())).thenReturn(of({ data: [] }));
 
-    basketService.getBasketEligibleShippingMethods(basketMockData.data.id).subscribe(() => {
-      verify(apiService.get(`baskets/${basketMockData.data.id}/eligible-shipping-methods`, anything())).once();
+    basketService.getBasketEligibleShippingMethods().subscribe(() => {
+      verify(apiService.get(`baskets/current/eligible-shipping-methods`, anything())).once();
       done();
     });
   });

--- a/src/app/core/services/payment/payment.service.spec.ts
+++ b/src/app/core/services/payment/payment.service.spec.ts
@@ -109,28 +109,20 @@ describe('Payment Service', () => {
     it("should get basket eligible payment methods for a basket when 'getBasketEligiblePaymentMethods' is called", done => {
       when(apiService.get(anything(), anything())).thenReturn(of({ data: [] }));
 
-      paymentService.getBasketEligiblePaymentMethods(basketMock.data.id).subscribe(() => {
-        verify(apiService.get(`baskets/${basketMock.data.id}/eligible-payment-methods`, anything())).once();
+      paymentService.getBasketEligiblePaymentMethods().subscribe(() => {
+        verify(apiService.get(`baskets/current/eligible-payment-methods`, anything())).once();
         done();
       });
     });
 
     it("should set a payment to the basket when 'setBasketPayment' is called", done => {
       when(
-        apiService.put(
-          `baskets/${basketMock.data.id}/payments/open-tender?include=paymentMethod`,
-          anything(),
-          anything()
-        )
+        apiService.put(`baskets/current/payments/open-tender?include=paymentMethod`, anything(), anything())
       ).thenReturn(of([]));
 
-      paymentService.setBasketPayment(basketMock.data.id, basketMock.data.payment.name).subscribe(() => {
+      paymentService.setBasketPayment(basketMock.data.payment.name).subscribe(() => {
         verify(
-          apiService.put(
-            `baskets/${basketMock.data.id}/payments/open-tender?include=paymentMethod`,
-            anything(),
-            anything()
-          )
+          apiService.put(`baskets/current/payments/open-tender?include=paymentMethod`, anything(), anything())
         ).once();
         done();
       });
@@ -138,29 +130,19 @@ describe('Payment Service', () => {
 
     it("should create a payment instrument for the basket when 'createBasketPayment' is called", done => {
       when(
-        apiService.post(
-          `baskets/${basketMock.data.id}/payment-instruments?include=paymentMethod`,
-          anything(),
-          anything()
-        )
+        apiService.post(`baskets/current/payment-instruments?include=paymentMethod`, anything(), anything())
       ).thenReturn(of([]));
 
-      paymentService.createBasketPayment(basketMock.data.id, newPaymentInstrument).subscribe(() => {
+      paymentService.createBasketPayment(newPaymentInstrument).subscribe(() => {
         verify(
-          apiService.post(
-            `baskets/${basketMock.data.id}/payment-instruments?include=paymentMethod`,
-            anything(),
-            anything()
-          )
+          apiService.post(`baskets/current/payment-instruments?include=paymentMethod`, anything(), anything())
         ).once();
         done();
       });
     });
 
     it("should update a basket payment when 'updateBasketPayment' is called", done => {
-      when(apiService.patch(`baskets/${basketMock.data.id}/payments/open-tender`, anything(), anything())).thenReturn(
-        of({})
-      );
+      when(apiService.patch(`baskets/current/payments/open-tender`, anything(), anything())).thenReturn(of({}));
 
       const params = {
         redirect: 'success',
@@ -168,8 +150,8 @@ describe('Payment Service', () => {
         param2: '456',
       };
 
-      paymentService.updateBasketPayment(basketMock.data.id, params).subscribe(() => {
-        verify(apiService.patch(`baskets/${basketMock.data.id}/payments/open-tender`, anything(), anything())).once();
+      paymentService.updateBasketPayment(params).subscribe(() => {
+        verify(apiService.patch(`baskets/current/payments/open-tender`, anything(), anything())).once();
         done();
       });
     });
@@ -216,18 +198,16 @@ describe('Payment Service', () => {
 
     it("should update payment instrument from basket when 'updateBasketPaymentInstrument' is called", done => {
       when(apiService.patch(anyString(), anything(), anything())).thenReturn(of({}));
-      paymentService
-        .updateConcardisCvcLastUpdated(BasketMockData.getBasket(), creditCardPaymentInstrument)
-        .subscribe(() => {
-          verify(
-            apiService.patch(
-              `baskets/${BasketMockData.getBasket().id}/payment-instruments/${creditCardPaymentInstrument.id}`,
-              anything(),
-              anything()
-            )
-          ).once();
-          done();
-        });
+      paymentService.updateConcardisCvcLastUpdated(creditCardPaymentInstrument).subscribe(() => {
+        verify(
+          apiService.patch(
+            `baskets/current/payment-instruments/${creditCardPaymentInstrument.id}`,
+            anything(),
+            anything()
+          )
+        ).once();
+        done();
+      });
     });
   });
 
@@ -295,12 +275,10 @@ describe('Payment Service', () => {
       };
 
       when(apiService.put(anyString(), anything())).thenReturn(of({}));
-      paymentService
-        .updateConcardisCvcLastUpdated(BasketMockData.getBasket(), userCreditCardPaymentInstrument)
-        .subscribe(() => {
-          verify(apiService.put(`customers/-/payments/${userCreditCardPaymentInstrument.id}`, anything())).once();
-          done();
-        });
+      paymentService.updateConcardisCvcLastUpdated(userCreditCardPaymentInstrument).subscribe(() => {
+        verify(apiService.put(`customers/-/payments/${userCreditCardPaymentInstrument.id}`, anything())).once();
+        done();
+      });
     });
   });
 });

--- a/src/app/core/services/payment/payment.service.ts
+++ b/src/app/core/services/payment/payment.service.ts
@@ -34,18 +34,13 @@ export class PaymentService {
 
   /**
    * Get eligible payment methods for selected basket.
-   * @param basketId  The basket id.
    * @returns         The eligible payment methods.
    */
-  getBasketEligiblePaymentMethods(basketId: string): Observable<PaymentMethod[]> {
-    if (!basketId) {
-      return throwError('getBasketEligiblePaymentMethods() called without basketId');
-    }
-
+  getBasketEligiblePaymentMethods(): Observable<PaymentMethod[]> {
     const params = new HttpParams().set('include', 'paymentInstruments');
 
     return this.apiService
-      .get(`baskets/${basketId}/eligible-payment-methods`, {
+      .get(`baskets/current/eligible-payment-methods`, {
         headers: this.basketHeaders,
         params,
       })
@@ -54,21 +49,17 @@ export class PaymentService {
 
   /**
    * Adds a payment at the selected basket. If redirect is required the redirect urls are saved at basket in dependence of the payment instrument capabilities (redirectBeforeCheckout/RedirectAfterCheckout).
-   * @param basketId          The basket id.
    * @param paymentInstrument The unique name of the payment method, e.g. ISH_INVOICE
    * @returns                 The payment instrument.
    */
-  setBasketPayment(basketId: string, paymentInstrument: string): Observable<string> {
-    if (!basketId) {
-      return throwError('setBasketPayment() called without basketId');
-    }
+  setBasketPayment(paymentInstrument: string): Observable<string> {
     if (!paymentInstrument) {
       return throwError('setBasketPayment() called without paymentInstrument');
     }
 
     return this.apiService
       .put<{ data: PaymentInstrument; included: { paymentMethod: { [id: string]: PaymentMethodBaseData } } }>(
-        `baskets/${basketId}/payments/open-tender?include=paymentMethod`,
+        `baskets/current/payments/open-tender?include=paymentMethod`,
         { paymentInstrument },
         {
           headers: this.basketHeaders,
@@ -80,7 +71,7 @@ export class PaymentService {
         ),
         withLatestFrom(this.store.pipe(select(getCurrentLocale))),
         concatMap(([pm, currentLocale]) =>
-          this.sendRedirectUrlsIfRequired(pm, paymentInstrument, basketId, currentLocale && currentLocale.lang)
+          this.sendRedirectUrlsIfRequired(pm, paymentInstrument, currentLocale && currentLocale.lang)
         )
       );
   }
@@ -89,14 +80,12 @@ export class PaymentService {
    *  Checks, if RedirectUrls are requested by the server and sends them if it is necessary.
    * @param pm                The payment method to determine if redirect is required.
    * @param paymentInstrument The payment instrument id.
-   * @param basketId          The basket id.
    * @param lang              The language code of the current locale, e.g. en_US
    * @returns                 The payment instrument id.
    */
   private sendRedirectUrlsIfRequired(
     pm: PaymentMethodBaseData,
     paymentInstrument: string,
-    basketId: string,
     lang: string
   ): Observable<string> {
     const loc = location.origin;
@@ -123,7 +112,7 @@ export class PaymentService {
       };
 
       return this.apiService
-        .put(`baskets/${basketId}/payments/open-tender`, body, {
+        .put(`baskets/current/payments/open-tender`, body, {
           headers: this.basketHeaders,
         })
         .pipe(mapTo(paymentInstrument));
@@ -131,14 +120,10 @@ export class PaymentService {
   }
   /**
    * Creates a payment instrument for the selected basket.
-   * @param basketId          The basket id.
    * @param paymentInstrument The payment instrument with parameters, id=undefined, paymentMethod= required.
    * @returns                 The created payment instrument.
    */
-  createBasketPayment(basketId: string, paymentInstrument: PaymentInstrument): Observable<PaymentInstrument> {
-    if (!basketId) {
-      return throwError('createBasketPayment() called without basketId');
-    }
+  createBasketPayment(paymentInstrument: PaymentInstrument): Observable<PaymentInstrument> {
     if (!paymentInstrument) {
       return throwError('createBasketPayment() called without paymentInstrument');
     }
@@ -147,7 +132,7 @@ export class PaymentService {
     }
 
     return this.apiService
-      .post(`baskets/${basketId}/payment-instruments?include=paymentMethod`, paymentInstrument, {
+      .post(`baskets/current/payment-instruments?include=paymentMethod`, paymentInstrument, {
         headers: this.basketHeaders,
       })
       .pipe(map(({ data }) => data));
@@ -155,15 +140,10 @@ export class PaymentService {
 
   /**
    * Updates a payment for the selected basket. Used to set redirect query parameters and status after redirect.
-   * @param basketId          The basket id.
    * @param redirect          The payment redirect information (parameters and status).
    * @returns                 The updated payment.
    */
-  updateBasketPayment(basketId: string, params: { [key: string]: string }): Observable<Payment> {
-    if (!basketId) {
-      return throwError('createBasketPayment() called without basketId');
-    }
-
+  updateBasketPayment(params: { [key: string]: string }): Observable<Payment> {
     if (!params) {
       return throwError('updateBasketPayment() called without parameter data');
     }
@@ -181,7 +161,7 @@ export class PaymentService {
 
     return this.apiService
       .patch(
-        `baskets/${basketId}/payments/open-tender`,
+        `baskets/current/payments/open-tender`,
         { redirect },
         {
           headers: this.basketHeaders,
@@ -328,13 +308,9 @@ export class PaymentService {
 
   /**
    * Update CvcLastUpdated in concardis credit card (user/basket) payment instrument.
-   * @param basket            The basket.
    * @param paymentInstrument The payment instrument, that is to be updated
    */
-  updateConcardisCvcLastUpdated(basket: Basket, paymentInstrument: PaymentInstrument): Observable<PaymentInstrument> {
-    if (!basket) {
-      return throwError('updateConcardisCvcLastUpdated() called without basket');
-    }
+  updateConcardisCvcLastUpdated(paymentInstrument: PaymentInstrument): Observable<PaymentInstrument> {
     if (!paymentInstrument) {
       return throwError('updateConcardisCvcLastUpdated() called without paymentInstrument');
     }
@@ -353,7 +329,7 @@ export class PaymentService {
       };
 
       return this.apiService
-        .patch(`baskets/${basket.id}/payment-instruments/${paymentInstrument.id}`, body, {
+        .patch(`baskets/current/payment-instruments/${paymentInstrument.id}`, body, {
           headers: this.basketHeaders,
         })
         .pipe(map(({ data }) => data));

--- a/src/app/core/store/customer/basket/basket-addresses.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-addresses.effects.spec.ts
@@ -97,7 +97,7 @@ describe('Basket Addresses Effects', () => {
 
   describe('createAddressForBasket$ for an anonymous user', () => {
     beforeEach(() => {
-      when(basketServiceMock.createBasketAddress('current', anything())).thenReturn(of(BasketMockData.getAddress()));
+      when(basketServiceMock.createBasketAddress(anything())).thenReturn(of(BasketMockData.getAddress()));
     });
     it('should call the basketService if user is not logged in', done => {
       const address = BasketMockData.getAddress();
@@ -105,7 +105,7 @@ describe('Basket Addresses Effects', () => {
       actions$ = of(action);
 
       effects.createAddressForBasket$.subscribe(() => {
-        verify(basketServiceMock.createBasketAddress('current', anything())).once();
+        verify(basketServiceMock.createBasketAddress(anything())).once();
         done();
       });
     });
@@ -240,7 +240,7 @@ describe('Basket Addresses Effects', () => {
 
   describe('updateBasketAddress$ for anonymous user', () => {
     beforeEach(() => {
-      when(basketServiceMock.updateBasketAddress(anyString(), anything())).thenReturn(of(BasketMockData.getAddress()));
+      when(basketServiceMock.updateBasketAddress(anything())).thenReturn(of(BasketMockData.getAddress()));
     });
 
     it('should call the basketService for updateBasketAddress', done => {
@@ -249,7 +249,7 @@ describe('Basket Addresses Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketAddress$.subscribe(() => {
-        verify(basketServiceMock.updateBasketAddress('current', anything())).once();
+        verify(basketServiceMock.updateBasketAddress(anything())).once();
         done();
       });
     });
@@ -268,7 +268,7 @@ describe('Basket Addresses Effects', () => {
 
     it('should map invalid request to action of type UpdateCustomerAddressFail', () => {
       const address = BasketMockData.getAddress();
-      when(basketServiceMock.updateBasketAddress(anyString(), anything())).thenReturn(
+      when(basketServiceMock.updateBasketAddress(anything())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
 

--- a/src/app/core/store/customer/basket/basket-addresses.effects.ts
+++ b/src/app/core/store/customer/basket/basket-addresses.effects.ts
@@ -53,7 +53,7 @@ export class BasketAddressesEffects {
           );
           // create address at basket for anonymous user
         } else {
-          return this.basketService.createBasketAddress('current', action.payload.address).pipe(
+          return this.basketService.createBasketAddress(action.payload.address).pipe(
             map(newAddress => createBasketAddressSuccess({ address: newAddress, scope: action.payload.scope })),
             mapErrorToAction(createCustomerAddressFail)
           );
@@ -127,7 +127,7 @@ export class BasketAddressesEffects {
           // create address at basket for anonymous user
         } else {
           return this.basketService
-            .updateBasketAddress('current', address)
+            .updateBasketAddress(address)
             .pipe(
               concatMapTo([updateCustomerAddressSuccess({ address }), loadBasket(), resetBasketErrors()]),
               mapErrorToAction(updateCustomerAddressFail)

--- a/src/app/core/store/customer/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, Store } from '@ngrx/store';
@@ -113,48 +113,16 @@ describe('Basket Items Effects', () => {
       });
     });
 
-    it('should call the basketService for addItemsToBasket with specific basketId when basketId set', done => {
-      store$.dispatch(
-        loadBasketSuccess({
-          basket: {
-            id: 'BID',
-            lineItems: [],
-          } as Basket,
-        })
-      );
-
-      const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
-      const basketId = 'BID';
-      const action = addItemsToBasket({ items, basketId });
-      actions$ = of(action);
-
-      effects.addItemsToBasket$.subscribe(() => {
-        verify(basketServiceMock.addItemsToBasket('BID', items)).once();
-        done();
-      });
-    });
-
-    it('should not call the basketService for addItemsToBasket if no basket in store', fakeAsync(() => {
-      const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
-      const action = addItemsToBasket({ items });
-      actions$ = of(action);
-
-      effects.addItemsToBasket$.subscribe(fail, fail);
-
-      tick(5000);
-
-      verify(basketServiceMock.addItemsToBasket('BID', anything())).never();
-    }));
-
-    it('should call the basketService for createBasket when no basket is present', done => {
+    it('should call the basketService for createBasket and addItemsToBasket when no basket is present', done => {
       when(basketServiceMock.createBasket()).thenReturn(of({} as Basket));
 
       const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
       const action = addItemsToBasket({ items });
       actions$ = of(action);
 
-      effects.createBasketBeforeAddItemsToBasket$.subscribe(() => {
+      effects.addItemsToBasket$.subscribe(() => {
         verify(basketServiceMock.createBasket()).once();
+        verify(basketServiceMock.addItemsToBasket(items)).once();
         done();
       });
     });

--- a/src/app/core/store/customer/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.spec.ts
@@ -90,7 +90,7 @@ describe('Basket Items Effects', () => {
 
   describe('addItemsToBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.addItemsToBasket(anyString(), anything())).thenReturn(of(undefined));
+      when(basketServiceMock.addItemsToBasket(anything())).thenReturn(of(undefined));
     });
 
     it('should call the basketService for addItemsToBasket', done => {
@@ -108,7 +108,7 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.addItemsToBasket$.subscribe(() => {
-        verify(basketServiceMock.addItemsToBasket('BID', items)).once();
+        verify(basketServiceMock.addItemsToBasket(items)).once();
         done();
       });
     });
@@ -147,7 +147,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should map invalid request to action of type AddItemsToBasketFail', () => {
-      when(basketServiceMock.addItemsToBasket(anyString(), anything())).thenReturn(
+      when(basketServiceMock.addItemsToBasket(anything())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
 
@@ -172,7 +172,7 @@ describe('Basket Items Effects', () => {
 
   describe('loadProductsForAddItemsToBasket$', () => {
     it('should trigger product loading actions for line items if AddItemsToBasket action is triggered', () => {
-      when(basketServiceMock.getBasket(anything())).thenReturn(of());
+      when(basketServiceMock.getBasket()).thenReturn(of());
 
       const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
       const action = addItemsToBasket({ items });
@@ -198,7 +198,7 @@ describe('Basket Items Effects', () => {
 
   describe('updateBasketItems$', () => {
     beforeEach(() => {
-      when(basketServiceMock.updateBasketItem(anyString(), anyString(), anything())).thenReturn(of([{} as BasketInfo]));
+      when(basketServiceMock.updateBasketItem(anyString(), anything())).thenReturn(of([{} as BasketInfo]));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -238,10 +238,9 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketItems$.subscribe(() => {
-        verify(basketServiceMock.updateBasketItem('BID', payload.lineItemUpdates[1].itemId, anything())).thrice();
+        verify(basketServiceMock.updateBasketItem(payload.lineItemUpdates[1].itemId, anything())).thrice();
         expect(capture(basketServiceMock.updateBasketItem).first()).toMatchInlineSnapshot(`
           Array [
-            "BID",
             "BIID",
             Object {
               "product": undefined,
@@ -254,7 +253,6 @@ describe('Basket Items Effects', () => {
         `);
         expect(capture(basketServiceMock.updateBasketItem).second()).toMatchInlineSnapshot(`
           Array [
-            "BID",
             "BIID",
             Object {
               "product": undefined,
@@ -267,7 +265,6 @@ describe('Basket Items Effects', () => {
         `);
         expect(capture(basketServiceMock.updateBasketItem).third()).toMatchInlineSnapshot(`
           Array [
-            "BID",
             "BIID",
             Object {
               "product": undefined,
@@ -283,7 +280,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should call the basketService for deleteBasketItem if quantity = 0', done => {
-      when(basketServiceMock.deleteBasketItem(anyString(), anyString())).thenReturn(of());
+      when(basketServiceMock.deleteBasketItem(anyString())).thenReturn(of());
 
       const payload = {
         lineItemUpdates: [
@@ -297,7 +294,7 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketItems$.subscribe(() => {
-        verify(basketServiceMock.deleteBasketItem('BID', payload.lineItemUpdates[0].itemId)).once();
+        verify(basketServiceMock.deleteBasketItem(payload.lineItemUpdates[0].itemId)).once();
         done();
       });
     });
@@ -321,7 +318,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should map invalid request to action of type UpdateBasketItemsFail', () => {
-      when(basketServiceMock.updateBasketItem(anyString(), anyString(), anything())).thenReturn(
+      when(basketServiceMock.updateBasketItem(anyString(), anything())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
 
@@ -366,7 +363,7 @@ describe('Basket Items Effects', () => {
 
   describe('deleteBasketItem$', () => {
     beforeEach(() => {
-      when(basketServiceMock.deleteBasketItem(anyString(), anyString())).thenReturn(of(undefined));
+      when(basketServiceMock.deleteBasketItem(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -384,7 +381,7 @@ describe('Basket Items Effects', () => {
       actions$ = of(action);
 
       effects.deleteBasketItem$.subscribe(() => {
-        verify(basketServiceMock.deleteBasketItem('BID', 'BIID')).once();
+        verify(basketServiceMock.deleteBasketItem('BIID')).once();
         done();
       });
     });
@@ -400,7 +397,7 @@ describe('Basket Items Effects', () => {
     });
 
     it('should map invalid request to action of type DeleteBasketItemFail', () => {
-      when(basketServiceMock.deleteBasketItem(anyString(), anyString())).thenReturn(
+      when(basketServiceMock.deleteBasketItem(anyString())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
 

--- a/src/app/core/store/customer/basket/basket-items.effects.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.ts
@@ -130,15 +130,13 @@ export class BasketItemsEffects {
       map(([{ lineItemUpdates }, { lineItems }]) =>
         LineItemUpdateHelper.filterUpdatesByItems(lineItemUpdates, lineItems as LineItemUpdateHelperItem[])
       ),
-
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([updates, basketId]) =>
+      concatMap(updates =>
         concat(
           ...updates.map(update => {
             if (update.quantity === 0) {
-              return this.basketService.deleteBasketItem(basketId, update.itemId);
+              return this.basketService.deleteBasketItem(update.itemId);
             } else {
-              return this.basketService.updateBasketItem(basketId, update.itemId, {
+              return this.basketService.updateBasketItem(update.itemId, {
                 quantity: update.quantity > 0 ? { value: update.quantity, unit: update.unit } : undefined,
                 product: update.sku,
               });
@@ -173,9 +171,8 @@ export class BasketItemsEffects {
     this.actions$.pipe(
       ofType(deleteBasketItem),
       mapToPayloadProperty('itemId'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([itemId, basketId]) =>
-        this.basketService.deleteBasketItem(basketId, itemId).pipe(
+      concatMap(itemId =>
+        this.basketService.deleteBasketItem(itemId).pipe(
           map(info => deleteBasketItemSuccess({ info })),
           mapErrorToAction(deleteBasketItemFail)
         )

--- a/src/app/core/store/customer/basket/basket-payment.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-payment.effects.spec.ts
@@ -77,9 +77,7 @@ describe('Basket Payment Effects', () => {
 
   describe('loadBasketEligiblePaymentMethods$', () => {
     beforeEach(() => {
-      when(paymentServiceMock.getBasketEligiblePaymentMethods(anyString())).thenReturn(
-        of([BasketMockData.getPaymentMethod()])
-      );
+      when(paymentServiceMock.getBasketEligiblePaymentMethods()).thenReturn(of([BasketMockData.getPaymentMethod()]));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -96,7 +94,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.loadBasketEligiblePaymentMethods$.subscribe(() => {
-        verify(paymentServiceMock.getBasketEligiblePaymentMethods('BID')).once();
+        verify(paymentServiceMock.getBasketEligiblePaymentMethods()).once();
         done();
       });
     });
@@ -113,7 +111,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketEligiblePaymentMethodsFail', () => {
-      when(paymentServiceMock.getBasketEligiblePaymentMethods(anyString())).thenReturn(
+      when(paymentServiceMock.getBasketEligiblePaymentMethods()).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
       const action = loadBasketEligiblePaymentMethods();
@@ -129,7 +127,7 @@ describe('Basket Payment Effects', () => {
 
   describe('setPaymentAtBasket$ - set payment at basket for the first time', () => {
     beforeEach(() => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(of(undefined));
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -148,7 +146,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.setPaymentAtBasket$.subscribe(() => {
-        verify(paymentServiceMock.setBasketPayment('BID', id)).once();
+        verify(paymentServiceMock.setBasketPayment(id)).once();
         done();
       });
     });
@@ -164,7 +162,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type SetPaymentFail', () => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
       const action = setBasketPayment({ id: 'newPayment' });
@@ -178,7 +176,7 @@ describe('Basket Payment Effects', () => {
 
   describe('setPaymentAtBasket$ - change payment method at basket', () => {
     beforeEach(() => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(of(undefined));
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(loadBasketSuccess({ basket: BasketMockData.getBasket() }));
     });
@@ -189,7 +187,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.setPaymentAtBasket$.subscribe(() => {
-        verify(paymentServiceMock.setBasketPayment('4711', id)).once();
+        verify(paymentServiceMock.setBasketPayment(id)).once();
         done();
       });
     });
@@ -205,7 +203,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid addBasketPayment request to action of type SetPaymentFail', () => {
-      when(paymentServiceMock.setBasketPayment(anyString(), anyString())).thenReturn(
+      when(paymentServiceMock.setBasketPayment(anyString())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
       const action = setBasketPayment({ id: 'newPayment' });
@@ -235,7 +233,7 @@ describe('Basket Payment Effects', () => {
     const customer = { customerNo: 'patricia' } as Customer;
 
     beforeEach(() => {
-      when(paymentServiceMock.createBasketPayment(anyString(), anything())).thenReturn(
+      when(paymentServiceMock.createBasketPayment(anything())).thenReturn(
         of({ id: 'newPaymentInstrumentId' } as PaymentInstrument)
       );
       when(paymentServiceMock.createUserPayment(anyString(), anything())).thenReturn(
@@ -259,7 +257,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.createBasketPaymentInstrument$.subscribe(() => {
-        verify(paymentServiceMock.createBasketPayment('BID', anything())).once();
+        verify(paymentServiceMock.createBasketPayment(anything())).once();
         done();
       });
     });
@@ -284,7 +282,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type CreateBasketPaymentFail', () => {
-      when(paymentServiceMock.createBasketPayment(anyString(), anything())).thenReturn(
+      when(paymentServiceMock.createBasketPayment(anything())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
       const action = createBasketPayment({ paymentInstrument, saveForLater: false });
@@ -360,7 +358,7 @@ describe('Basket Payment Effects', () => {
     };
 
     beforeEach(() => {
-      when(paymentServiceMock.updateBasketPayment(anyString(), anything())).thenReturn(of(payment));
+      when(paymentServiceMock.updateBasketPayment(anything())).thenReturn(of(payment));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -378,7 +376,7 @@ describe('Basket Payment Effects', () => {
       actions$ = of(action);
 
       effects.updateBasketPayment$.subscribe(() => {
-        verify(paymentServiceMock.updateBasketPayment('BID', anything())).once();
+        verify(paymentServiceMock.updateBasketPayment(anything())).once();
         done();
       });
     });
@@ -394,7 +392,7 @@ describe('Basket Payment Effects', () => {
     });
 
     it('should map invalid request to action of type UpdateBasketPaymentFail', () => {
-      when(paymentServiceMock.updateBasketPayment(anyString(), anything())).thenReturn(
+      when(paymentServiceMock.updateBasketPayment(anything())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
       const action = updateBasketPayment({ params });

--- a/src/app/core/store/customer/basket/basket-payment.effects.ts
+++ b/src/app/core/store/customer/basket/basket-payment.effects.ts
@@ -41,9 +41,8 @@ export class BasketPaymentEffects {
   loadBasketEligiblePaymentMethods$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadBasketEligiblePaymentMethods),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([, basketid]) =>
-        this.paymentService.getBasketEligiblePaymentMethods(basketid).pipe(
+      concatMap(() =>
+        this.paymentService.getBasketEligiblePaymentMethods().pipe(
           map(result => loadBasketEligiblePaymentMethodsSuccess({ paymentMethods: result })),
           mapErrorToAction(loadBasketEligiblePaymentMethodsFail)
         )
@@ -58,10 +57,9 @@ export class BasketPaymentEffects {
     this.actions$.pipe(
       ofType(setBasketPayment),
       mapToPayloadProperty('id'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([paymentInstrumentId, basketid]) =>
+      concatMap(paymentInstrumentId =>
         this.paymentService
-          .setBasketPayment(basketid, paymentInstrumentId)
+          .setBasketPayment(paymentInstrumentId)
           .pipe(mapTo(setBasketPaymentSuccess()), mapErrorToAction(setBasketPaymentFail))
       )
     )
@@ -80,12 +78,11 @@ export class BasketPaymentEffects {
         paymentInstrument: payload.paymentInstrument,
         customerNo: customer && customer.customerNo,
       })),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([payload, basketid]) => {
+      concatMap(payload => {
         const createPayment$ =
           payload.customerNo && payload.saveForLater
             ? this.paymentService.createUserPayment(payload.customerNo, payload.paymentInstrument)
-            : this.paymentService.createBasketPayment(basketid, payload.paymentInstrument);
+            : this.paymentService.createBasketPayment(payload.paymentInstrument);
 
         return createPayment$.pipe(
           concatMap(pi => [setBasketPayment({ id: pi.id }), createBasketPaymentSuccess()]),
@@ -122,10 +119,9 @@ export class BasketPaymentEffects {
     this.actions$.pipe(
       ofType(updateBasketPayment),
       mapToPayloadProperty('params'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([params, basketid]) =>
+      concatMap(params =>
         this.paymentService
-          .updateBasketPayment(basketid, params)
+          .updateBasketPayment(params)
           .pipe(mapTo(updateBasketPaymentSuccess()), mapErrorToAction(updateBasketPaymentFail))
       )
     )
@@ -173,9 +169,8 @@ export class BasketPaymentEffects {
     this.actions$.pipe(
       ofType(updateConcardisCvcLastUpdated),
       mapToPayloadProperty('paymentInstrument'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasket))),
-      concatMap(([paymentInstrument, basket]) =>
-        this.paymentService.updateConcardisCvcLastUpdated(basket, paymentInstrument).pipe(
+      concatMap(paymentInstrument =>
+        this.paymentService.updateConcardisCvcLastUpdated(paymentInstrument).pipe(
           map(pi => updateConcardisCvcLastUpdatedSuccess({ paymentInstrument: pi })),
           mapErrorToAction(updateConcardisCvcLastUpdatedFail)
         )

--- a/src/app/core/store/customer/basket/basket-promotion-code.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-promotion-code.effects.spec.ts
@@ -62,7 +62,7 @@ describe('Basket Promotion Code Effects', () => {
 
   describe('addPromotionCodeToBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.addPromotionCodeToBasket(anyString(), anyString())).thenReturn(of(undefined));
+      when(basketServiceMock.addPromotionCodeToBasket(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -80,7 +80,7 @@ describe('Basket Promotion Code Effects', () => {
       actions$ = of(action);
 
       effects.addPromotionCodeToBasket$.subscribe(() => {
-        verify(basketServiceMock.addPromotionCodeToBasket('BID', 'CODE')).once();
+        verify(basketServiceMock.addPromotionCodeToBasket('CODE')).once();
         done();
       });
     });
@@ -96,7 +96,7 @@ describe('Basket Promotion Code Effects', () => {
     });
 
     it('should map invalid request to action of type AddPromotionCodeToBasketFail', () => {
-      when(basketServiceMock.addPromotionCodeToBasket(anyString(), anyString())).thenReturn(
+      when(basketServiceMock.addPromotionCodeToBasket(anyString())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
 
@@ -112,7 +112,7 @@ describe('Basket Promotion Code Effects', () => {
 
   describe('removePromotionCodeFromBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.removePromotionCodeFromBasket(anyString(), anyString())).thenReturn(of(undefined));
+      when(basketServiceMock.removePromotionCodeFromBasket(anyString())).thenReturn(of(undefined));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -130,7 +130,7 @@ describe('Basket Promotion Code Effects', () => {
       actions$ = of(action);
 
       effects.removePromotionCodeFromBasket$.subscribe(() => {
-        verify(basketServiceMock.removePromotionCodeFromBasket('BID', 'CODE')).once();
+        verify(basketServiceMock.removePromotionCodeFromBasket('CODE')).once();
         done();
       });
     });
@@ -146,7 +146,7 @@ describe('Basket Promotion Code Effects', () => {
     });
 
     it('should map invalid request to action of type RemovePromotionCodeFromBasketFail', () => {
-      when(basketServiceMock.removePromotionCodeFromBasket(anyString(), anyString())).thenReturn(
+      when(basketServiceMock.removePromotionCodeFromBasket(anyString())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
 

--- a/src/app/core/store/customer/basket/basket-promotion-code.effects.ts
+++ b/src/app/core/store/customer/basket/basket-promotion-code.effects.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { Store, select } from '@ngrx/store';
-import { concatMap, mapTo, withLatestFrom } from 'rxjs/operators';
+import { concatMap, mapTo } from 'rxjs/operators';
 
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
@@ -15,11 +14,10 @@ import {
   removePromotionCodeFromBasketFail,
   removePromotionCodeFromBasketSuccess,
 } from './basket.actions';
-import { getCurrentBasketId } from './basket.selectors';
 
 @Injectable()
 export class BasketPromotionCodeEffects {
-  constructor(private actions$: Actions, private store: Store, private basketService: BasketService) {}
+  constructor(private actions$: Actions, private basketService: BasketService) {}
 
   /**
    * Add promotion code to the current basket.
@@ -28,10 +26,9 @@ export class BasketPromotionCodeEffects {
     this.actions$.pipe(
       ofType(addPromotionCodeToBasket),
       mapToPayloadProperty('code'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([code, basketId]) =>
+      concatMap(code =>
         this.basketService
-          .addPromotionCodeToBasket(basketId, code)
+          .addPromotionCodeToBasket(code)
           .pipe(mapTo(addPromotionCodeToBasketSuccess()), mapErrorToAction(addPromotionCodeToBasketFail))
       )
     )
@@ -51,10 +48,9 @@ export class BasketPromotionCodeEffects {
     this.actions$.pipe(
       ofType(removePromotionCodeFromBasket),
       mapToPayloadProperty('code'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([code, basketId]) =>
+      concatMap(code =>
         this.basketService
-          .removePromotionCodeFromBasket(basketId, code)
+          .removePromotionCodeFromBasket(code)
           .pipe(mapTo(removePromotionCodeFromBasketSuccess()), mapErrorToAction(removePromotionCodeFromBasketFail))
       )
     )

--- a/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
@@ -6,7 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, Store } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { Observable, noop, of, throwError } from 'rxjs';
-import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { BasketValidation } from 'ish-core/models/basket-validation/basket-validation.model';
 import { Product } from 'ish-core/models/product/product.model';
@@ -76,7 +76,7 @@ describe('Basket Validation Effects', () => {
     };
 
     beforeEach(() => {
-      when(basketServiceMock.validateBasket(anything(), anything())).thenReturn(of(basketValidation));
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidation));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -91,7 +91,7 @@ describe('Basket Validation Effects', () => {
       actions$ = of(action);
 
       effects.validateBasket$.subscribe(() => {
-        verify(basketServiceMock.validateBasket(BasketMockData.getBasket().id, anything())).once();
+        verify(basketServiceMock.validateBasket(anything())).once();
         done();
       });
     });
@@ -109,9 +109,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map invalid request to action of type ContinueCheckoutFail', () => {
-      when(basketServiceMock.validateBasket(anyString(), anything())).thenReturn(
-        throwError(makeHttpError({ message: 'invalid' }))
-      );
+      when(basketServiceMock.validateBasket(anything())).thenReturn(throwError(makeHttpError({ message: 'invalid' })));
 
       const action = validateBasket({ scopes: ['Products'] });
       const completion = continueCheckoutFail({ error: makeHttpError({ message: 'invalid' }) });
@@ -145,7 +143,7 @@ describe('Basket Validation Effects', () => {
     };
 
     beforeEach(() => {
-      when(basketServiceMock.validateBasket(anything(), anything())).thenReturn(of(basketValidation));
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidation));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -160,7 +158,7 @@ describe('Basket Validation Effects', () => {
       actions$ = of(action);
 
       effects.validateBasketAndContinueCheckout$.subscribe(() => {
-        verify(basketServiceMock.validateBasket(BasketMockData.getBasket().id, anything())).once();
+        verify(basketServiceMock.validateBasket(anything())).once();
         done();
       });
     });
@@ -179,7 +177,7 @@ describe('Basket Validation Effects', () => {
 
     it('should map to action of type CreateOrder if targetStep is 5 (order creation)', () => {
       const action = continueCheckout({ targetStep: 5 });
-      const completion1 = createOrder({ basketId: BasketMockData.getBasket().id });
+      const completion1 = createOrder();
       const completion2 = continueCheckoutSuccess({ targetRoute: undefined, basketValidation });
       actions$ = hot('-a----a----a', { a: action });
       const expected$ = cold('-(cd)-(cd)-(cd)', { c: completion1, d: completion2 });
@@ -188,9 +186,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map invalid request to action of type ContinueCheckoutFail', () => {
-      when(basketServiceMock.validateBasket(anyString(), anything())).thenReturn(
-        throwError(makeHttpError({ message: 'invalid' }))
-      );
+      when(basketServiceMock.validateBasket(anything())).thenReturn(throwError(makeHttpError({ message: 'invalid' })));
 
       const action = continueCheckout({ targetStep: 1 });
       const completion = continueCheckoutFail({ error: makeHttpError({ message: 'invalid' }) });

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -61,7 +61,7 @@ export const addProductToBasket = createAction('[Basket] Add Product', payload<{
 
 export const addItemsToBasket = createAction(
   '[Basket Internal] Add Items To Basket',
-  payload<{ items: { sku: string; quantity: number; unit: string }[]; basketId?: string }>()
+  payload<{ items: { sku: string; quantity: number; unit: string }[] }>()
 );
 
 export const addItemsToBasketFail = createAction('[Basket API] Add Items To Basket Fail', httpError());

--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -6,7 +6,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, Store } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { EMPTY, Observable, of, throwError } from 'rxjs';
-import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { BasketService } from 'ish-core/services/basket/basket.service';
@@ -127,7 +127,7 @@ describe('Basket Effects', () => {
 
   describe('loadBasketEligibleShippingMethods$', () => {
     beforeEach(() => {
-      when(basketServiceMock.getBasketEligibleShippingMethods(anyString(), anything())).thenReturn(
+      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
         of([BasketMockData.getShippingMethod()])
       );
 
@@ -146,7 +146,7 @@ describe('Basket Effects', () => {
       actions$ = of(action);
 
       effects.loadBasketEligibleShippingMethods$.subscribe(() => {
-        verify(basketServiceMock.getBasketEligibleShippingMethods('BID', undefined)).once();
+        verify(basketServiceMock.getBasketEligibleShippingMethods(undefined)).once();
         done();
       });
     });
@@ -163,7 +163,7 @@ describe('Basket Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketEligibleShippingMethodsFail', () => {
-      when(basketServiceMock.getBasketEligibleShippingMethods(anyString(), anything())).thenReturn(
+      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
         throwError(makeHttpError({ message: 'invalid' }))
       );
       const action = loadBasketEligibleShippingMethods();
@@ -179,7 +179,7 @@ describe('Basket Effects', () => {
 
   describe('updateBasket$', () => {
     beforeEach(() => {
-      when(basketServiceMock.updateBasket(anyString(), anything())).thenReturn(of(BasketMockData.getBasket()));
+      when(basketServiceMock.updateBasket(anything())).thenReturn(of(BasketMockData.getBasket()));
 
       store$.dispatch(
         loadBasketSuccess({
@@ -192,13 +192,12 @@ describe('Basket Effects', () => {
     });
 
     it('should call the basketService for updateBasket', done => {
-      const basketId = 'BID';
       const update = { invoiceToAddress: '7654' };
       const action = updateBasket({ update });
       actions$ = of(action);
 
       effects.updateBasket$.subscribe(() => {
-        verify(basketServiceMock.updateBasket(basketId, update)).once();
+        verify(basketServiceMock.updateBasket(update)).once();
         done();
       });
     });
@@ -216,9 +215,7 @@ describe('Basket Effects', () => {
 
     it('should map invalid request to action of type UpdateBasketFail', () => {
       const update = { commonShippingMethod: 'shippingId' };
-      when(basketServiceMock.updateBasket(anyString(), anything())).thenReturn(
-        throwError(makeHttpError({ message: 'invalid' }))
-      );
+      when(basketServiceMock.updateBasket(anything())).thenReturn(throwError(makeHttpError({ message: 'invalid' })));
 
       const action = updateBasket({ update });
       const completion = updateBasketFail({ error: makeHttpError({ message: 'invalid' }) });

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -63,7 +63,7 @@ export class BasketEffects {
       ofType(loadBasketEligibleShippingMethods),
       withLatestFrom(this.store.pipe(select(getCurrentBasket))),
       concatMap(([, basket]) =>
-        this.basketService.getBasketEligibleShippingMethods(basket.id, basket.bucketId).pipe(
+        this.basketService.getBasketEligibleShippingMethods(basket.bucketId).pipe(
           map(result => loadBasketEligibleShippingMethodsSuccess({ shippingMethods: result })),
           mapErrorToAction(loadBasketEligibleShippingMethodsFail)
         )
@@ -78,9 +78,8 @@ export class BasketEffects {
     this.actions$.pipe(
       ofType(updateBasket),
       mapToPayloadProperty('update'),
-      withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([update, currentBasketId]) =>
-        this.basketService.updateBasket(currentBasketId, update).pipe(
+      concatMap(update =>
+        this.basketService.updateBasket(update).pipe(
           concatMap(basket => [loadBasketSuccess({ basket }), resetBasketErrors()]),
           mapErrorToAction(updateBasketFail)
         )

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -223,13 +223,6 @@ describe('Customer Store', () => {
               quantity: 1
             [Basket Internal] Add Items To Basket:
               items: [{"sku":"test","quantity":1,"unit":"pcs."}]
-            [Products Internal] Load Product:
-              sku: "test"
-            [Basket Internal] Add Items To Basket:
-              items: [{"sku":"test","quantity":1,"unit":"pcs."}]
-              basketId: "test"
-            [Products API] Load Product Success:
-              product: {"name":"test","shortDescription":"test","longDescription":"...
             [Basket API] Add Items To Basket Success:
               info: undefined
             [Products Internal] Load Product:

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -131,13 +131,11 @@ describe('Customer Store', () => {
     when(countryServiceMock.getCountries()).thenReturn(of([{ countryCode: 'DE', name: 'Germany' }]));
 
     const basketServiceMock = mock(BasketService);
-    when(basketServiceMock.getBasket(anything())).thenReturn(of(basket));
     when(basketServiceMock.getBasket()).thenReturn(of(basket));
-    when(basketServiceMock.getBasket(anything())).thenReturn(of(basket));
     when(basketServiceMock.createBasket()).thenReturn(of(basket));
     when(basketServiceMock.getBaskets()).thenReturn(of([]));
     when(basketServiceMock.mergeBasket(anything(), anything(), anything())).thenReturn(of(basket));
-    when(basketServiceMock.addItemsToBasket(anything(), anything())).thenReturn(of(undefined));
+    when(basketServiceMock.addItemsToBasket(anything())).thenReturn(of(undefined));
 
     const productsServiceMock = mock(ProductsService);
     when(productsServiceMock.getProduct(anything())).thenReturn(of(product));

--- a/src/app/core/store/customer/orders/orders.actions.ts
+++ b/src/app/core/store/customer/orders/orders.actions.ts
@@ -4,7 +4,7 @@ import { createAction } from '@ngrx/store';
 import { Order } from 'ish-core/models/order/order.model';
 import { httpError, payload } from 'ish-core/utils/ngrx-creators';
 
-export const createOrder = createAction('[Orders] Create Order', payload<{ basketId: string }>());
+export const createOrder = createAction('[Orders] Create Order');
 
 export const createOrderFail = createAction('[Orders API] Create Order Fail', httpError());
 

--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -20,7 +20,7 @@ import {
 import { OrderService } from 'ish-core/services/order/order.service';
 import { ofUrl, selectQueryParams, selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
-import { continueCheckoutWithIssues, loadBasket } from 'ish-core/store/customer/basket';
+import { continueCheckoutWithIssues, getCurrentBasketId, loadBasket } from 'ish-core/store/customer/basket';
 import { getLoggedInUser } from 'ish-core/store/customer/user';
 import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
@@ -57,8 +57,8 @@ export class OrdersEffects {
   createOrder$ = createEffect(() =>
     this.actions$.pipe(
       ofType(createOrder),
-      mapToPayloadProperty('basketId'),
-      mergeMap(basketId =>
+      withLatestFrom(this.store.select(getCurrentBasketId)),
+      mergeMap(([, basketId]) =>
         this.orderService.createOrder(basketId, true).pipe(
           map(order => createOrderSuccess({ order })),
           mapErrorToAction(createOrderFail)

--- a/src/app/core/store/customer/orders/orders.reducer.spec.ts
+++ b/src/app/core/store/customer/orders/orders.reducer.spec.ts
@@ -1,6 +1,5 @@
 import { Order } from 'ish-core/models/order/order.model';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
-import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 
 import {
   createOrder,
@@ -46,7 +45,7 @@ describe('Orders Reducer', () => {
   describe('CreateOrder actions', () => {
     describe('CreateOrder action', () => {
       it('should set loading to true', () => {
-        const action = createOrder({ basketId: BasketMockData.getBasket().id });
+        const action = createOrder();
         const state = ordersReducer(initialState, action);
 
         expect(state.loading).toBeTrue();

--- a/src/app/extensions/quoting/services/quoting/quoting.service.spec.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.spec.ts
@@ -154,11 +154,11 @@ describe('Quoting Service', () => {
     });
 
     it('should use basket API for adding quotes to basket', done => {
-      quotingService.addQuoteToBasket('quoteID', 'basketID').subscribe(
+      quotingService.addQuoteToBasket('quoteID').subscribe(
         () => {
           verify(apiService.post(anything(), anything())).once();
           const args = capture(apiService.post).last();
-          expect(args?.[0]).toMatchInlineSnapshot(`"baskets/basketID/items"`);
+          expect(args?.[0]).toMatchInlineSnapshot(`"baskets/current/items"`);
           expect(args?.[1]).toMatchInlineSnapshot(`
             Object {
               "quoteID": "quoteID",

--- a/src/app/extensions/quoting/services/quoting/quoting.service.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.ts
@@ -96,8 +96,8 @@ export class QuotingService {
       .pipe(map(data => this.quoteMapper.fromData(data, 'Quote')));
   }
 
-  addQuoteToBasket(quoteID: string, basketId: string) {
-    return this.apiService.post(`baskets/${basketId}/items`, { quoteID }).pipe(mapTo(quoteID));
+  addQuoteToBasket(quoteID: string) {
+    return this.apiService.post(`baskets/current/items`, { quoteID }).pipe(mapTo(quoteID));
   }
 
   createQuoteRequestFromQuote(quoteID: string) {

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
@@ -105,7 +105,7 @@ describe('Quoting Effects', () => {
 
   describe('addQuoteToBasket$', () => {
     beforeEach(() => {
-      when(quotingService.addQuoteToBasket(anything(), anything())).thenReturn(of(''));
+      when(quotingService.addQuoteToBasket(anything())).thenReturn(of(''));
     });
 
     describe('with basket', () => {
@@ -117,7 +117,7 @@ describe('Quoting Effects', () => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
         effects.addQuoteToBasket$.subscribe(() => {
-          verify(quotingService.addQuoteToBasket('quoteID', 'basketID')).once();
+          verify(quotingService.addQuoteToBasket('quoteID')).once();
           verify(basketService.createBasket()).never();
           done();
         });
@@ -134,7 +134,7 @@ describe('Quoting Effects', () => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
         effects.addQuoteToBasket$.subscribe(() => {
-          verify(quotingService.addQuoteToBasket('quoteID', 'basketID')).once();
+          verify(quotingService.addQuoteToBasket('quoteID')).once();
           verify(basketService.createBasket()).once();
           done();
         });

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.ts
@@ -133,7 +133,7 @@ export class QuotingEffects {
           switchMap(basketId =>
             !basketId ? this.basketService.createBasket().pipe(map(basket => basket.id)) : of(basketId)
           ),
-          concatMap(basketId => this.quotingService.addQuoteToBasket(id, basketId)),
+          concatMap(() => this.quotingService.addQuoteToBasket(id)),
           mergeMapTo([updateBasket({ update: { calculated: true } }), addQuoteToBasketSuccess({ id })]),
           mapErrorToAction(loadQuotingFail)
         )


### PR DESCRIPTION
## PR Type

 [x] Refactoring (no functional changes, no API changes)

## Changes

The basket service is able to access the current basket via the "baskets/current" route and thus does not need a valid **basketId** in its calls.
This pull request removes the **basketId** parameter from all unnecessary service and effect calls. 
In addition, the addItemsToBasket and createBasketBeforeAddItemsToBasket effects are combined for more straightforward behaviour.