### PR TITLE
fix: set breadcrumb from routing only if none was set previously

### DIFF
--- a/e2e/cypress/integration/pages/account/order-templates-details.page.ts
+++ b/e2e/cypress/integration/pages/account/order-templates-details.page.ts
@@ -1,10 +1,12 @@
 import { waitLoadingEnd } from '../../framework';
+import { BreadcrumbModule } from '../breadcrumb.module';
 import { HeaderModule } from '../header.module';
 
 export class OrderTemplatesDetailsPage {
   readonly tag = 'ish-account-order-template-detail-page';
 
   readonly header = new HeaderModule();
+  readonly breadcrumb = new BreadcrumbModule();
 
   static navigateToOverviewPage() {
     cy.get('[href="/account/order-templates"]').first().click();

--- a/e2e/cypress/integration/pages/account/order-templates-overview.page.ts
+++ b/e2e/cypress/integration/pages/account/order-templates-overview.page.ts
@@ -1,9 +1,11 @@
+import { BreadcrumbModule } from '../breadcrumb.module';
 import { HeaderModule } from '../header.module';
 
 export class OrderTemplatesOverviewPage {
   readonly tag = 'ish-account-order-template-page';
 
   readonly header = new HeaderModule();
+  readonly breadcrumb = new BreadcrumbModule();
 
   addOrderTemplate(name: string) {
     cy.get('a[data-testing-id="add-order-template"').click();

--- a/e2e/cypress/integration/pages/account/quote-detail.page.ts
+++ b/e2e/cypress/integration/pages/account/quote-detail.page.ts
@@ -1,9 +1,11 @@
+import { BreadcrumbModule } from '../breadcrumb.module';
 import { HeaderModule } from '../header.module';
 
 export class QuoteDetailPage {
   readonly tag = 'ish-quote-page';
 
   readonly header = new HeaderModule();
+  readonly breadcrumb = new BreadcrumbModule();
 
   private copyQuoteRequestButton = () => cy.get('[data-testing-id="copy-quote-request"]');
 

--- a/e2e/cypress/integration/pages/account/quote-list.page.ts
+++ b/e2e/cypress/integration/pages/account/quote-list.page.ts
@@ -1,9 +1,11 @@
+import { BreadcrumbModule } from '../breadcrumb.module';
 import { HeaderModule } from '../header.module';
 
 export class QuoteListPage {
   readonly tag = 'ish-quote-list';
 
   readonly header = new HeaderModule();
+  readonly breadcrumb = new BreadcrumbModule();
 
   static navigateTo() {
     cy.visit('/account/quotes');

--- a/e2e/cypress/integration/pages/account/wishlists-details.page.ts
+++ b/e2e/cypress/integration/pages/account/wishlists-details.page.ts
@@ -1,9 +1,11 @@
+import { BreadcrumbModule } from '../breadcrumb.module';
 import { HeaderModule } from '../header.module';
 
 export class WishlistsDetailsPage {
   readonly tag = 'ish-account-wishlist-detail-page';
 
   readonly header = new HeaderModule();
+  readonly breadcrumb = new BreadcrumbModule();
 
   static navigateToOverviewPage() {
     cy.get('[href="/account/wishlists"]').first().click();
@@ -37,6 +39,7 @@ export class WishlistsDetailsPage {
       cy.get('[data-testing-id="preferred"]').check();
     }
     cy.get('[data-testing-id="wishlist-dialog-submit"]').click();
+    cy.wait(500);
   }
 
   deleteWishlist(id: string) {

--- a/e2e/cypress/integration/pages/account/wishlists-overview.page.ts
+++ b/e2e/cypress/integration/pages/account/wishlists-overview.page.ts
@@ -1,9 +1,11 @@
+import { BreadcrumbModule } from '../breadcrumb.module';
 import { HeaderModule } from '../header.module';
 
 export class WishlistsOverviewPage {
   readonly tag = 'ish-account-wishlist-page';
 
   readonly header = new HeaderModule();
+  readonly breadcrumb = new BreadcrumbModule();
 
   addWishlist(name: string, preferred: boolean) {
     cy.get('a[data-testing-id="add-wishlist"').click();

--- a/e2e/cypress/integration/specs/extras/order-templates-management.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/extras/order-templates-management.b2b.e2e-spec.ts
@@ -34,9 +34,10 @@ describe('Order Template MyAccount Functionality', () => {
     at(OrderTemplatesOverviewPage);
   });
 
-  it('user creates order template', () => {
+  it('user creates an order template', () => {
     at(OrderTemplatesOverviewPage, page => {
       page.addOrderTemplate(orderTemplate);
+      page.breadcrumb.items.should('have.length', 3);
       page.orderTemplatesArray.should('have.length', 1);
       page.orderTemplatesTitlesArray.should('contain', orderTemplate);
     });
@@ -76,6 +77,8 @@ describe('Order Template MyAccount Functionality', () => {
       page.addToOrderTemplate.addProductToOrderTemplateFromPage(orderTemplate, true);
     });
     at(OrderTemplatesDetailsPage, page => {
+      page.breadcrumb.items.should('have.length', 4);
+      page.breadcrumb.items.eq(3).should('contain', orderTemplate);
       page.listItemLink.invoke('attr', 'href').should('contain', _.product2);
       page.header.gotoCategoryPage(_.category);
     });
@@ -107,6 +110,7 @@ describe('Order Template MyAccount Functionality', () => {
     at(OrderTemplatesDetailsPage, page => {
       page.moveProductToOrderTemplate(_.product1, anotherOrderTemplate);
       waitLoadingEnd(1000);
+      page.breadcrumb.items.eq(3).should('contain', anotherOrderTemplate);
       page.OrderTemplateTitle.should('contain', anotherOrderTemplate);
       page.getOrderTemplateItemById(_.product1).should('exist');
       OrderTemplatesDetailsPage.navigateToOverviewPage();

--- a/e2e/cypress/integration/specs/extras/wishlists-management.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/extras/wishlists-management.b2c.e2e-spec.ts
@@ -41,6 +41,7 @@ describe('Wishlist MyAccount Functionality', () => {
       page.addWishlist(unpreferredWishlist, false);
       page.wishlistsArray.should('have.length', 1);
       page.wishlistsTitlesArray.should('contain', unpreferredWishlist);
+      page.breadcrumb.items.should('have.length', 3);
     });
   });
 
@@ -78,6 +79,8 @@ describe('Wishlist MyAccount Functionality', () => {
       page.addToWishlist.addProductToWishlistFromPage();
     });
     at(WishlistsDetailsPage, page => {
+      page.breadcrumb.items.should('have.length', 4);
+      page.breadcrumb.items.eq(3).should('contain', preferredWishlist);
       page.listItemLinks.invoke('attr', 'href').should('contain', _.product2);
       page.header.gotoCategoryPage(_.category);
     });
@@ -96,6 +99,8 @@ describe('Wishlist MyAccount Functionality', () => {
   it('user renames a wishlist and sets it to unpreferred', () => {
     at(WishlistsDetailsPage, page => {
       page.editWishlistDetails(editedWishlist, false);
+      page.breadcrumb.items.should('have.length', 4);
+      page.breadcrumb.items.eq(3).should('contain', editedWishlist);
       page.wishlistTitle.should('equal', editedWishlist);
       page.wishlistPreferredTextElement.should('not.exist');
     });
@@ -119,6 +124,7 @@ describe('Wishlist MyAccount Functionality', () => {
       page.header.gotoWishlists();
     });
     at(WishlistsOverviewPage, page => {
+      page.breadcrumb.items.should('have.length', 3);
       page.goToWishlistDetailLink(editedWishlist);
     });
 

--- a/e2e/cypress/integration/specs/quoting/quote-handling.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/quoting/quote-handling.b2b.e2e-spec.ts
@@ -96,10 +96,14 @@ describe('Quote Handling', () => {
         dialog.hide();
         at(FamilyPage, page => page.header.goToMyAccount());
         at(MyAccountPage, page => page.navigateToQuoting());
-        at(QuoteListPage, page => page.goToQuoteDetailLink(quoteId));
+        at(QuoteListPage, page => {
+          page.breadcrumb.items.should('have.length', 3);
+          page.goToQuoteDetailLink(quoteId);
+        });
       });
     });
     at(QuoteDetailPage, page => {
+      page.breadcrumb.items.should('have.length', 4);
       page.quoteState.should('have.text', 'Submitted');
     });
   });

--- a/src/app/core/store/core/viewconf/viewconf.effects.ts
+++ b/src/app/core/store/core/viewconf/viewconf.effects.ts
@@ -1,16 +1,16 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { routerNavigatedAction } from '@ngrx/router-store';
+import { routerNavigatedAction, routerRequestAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { defer, fromEvent, iif } from 'rxjs';
-import { distinctUntilChanged, map, sample } from 'rxjs/operators';
+import { bufferToggle, concatMap, delay, distinctUntilChanged, filter, first, map } from 'rxjs/operators';
 
+import { BreadcrumbItem } from 'ish-core/models/breadcrumb-item/breadcrumb-item.interface';
 import { selectRouteData } from 'ish-core/store/core/router';
-import { distinctCompareWith } from 'ish-core/utils/operators';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 import { setBreadcrumbData, setStickyHeader } from './viewconf.actions';
-import { getBreadcrumbData } from './viewconf.selectors';
 
 @Injectable()
 export class ViewconfEffects {
@@ -30,11 +30,23 @@ export class ViewconfEffects {
   );
 
   retrieveBreadcrumbDataFromRouting$ = createEffect(() =>
-    this.store.pipe(
-      select(selectRouteData('breadcrumbData')),
-      sample(this.actions$.pipe(ofType(routerNavigatedAction))),
-      distinctCompareWith(this.store.pipe(select(getBreadcrumbData))),
-      map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+    this.actions$.pipe(
+      ofType(setBreadcrumbData),
+      // collect all breadcrumb actions during routing
+      bufferToggle(this.actions$.pipe(ofType(routerRequestAction)), () =>
+        this.actions$.pipe(ofType(routerNavigatedAction), delay(100))
+      ),
+      // if no breadcrumb was set with effects
+      filter(actions => !actions.length),
+      concatMap(() =>
+        // set the current one from the routing (if available)
+        this.store.pipe(
+          select(selectRouteData<BreadcrumbItem[]>('breadcrumbData')),
+          first(),
+          whenTruthy(),
+          map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+        )
+      )
     )
   );
 }

--- a/src/app/core/store/customer/orders/orders.effects.spec.ts
+++ b/src/app/core/store/customer/orders/orders.effects.spec.ts
@@ -22,6 +22,7 @@ import { loginUserSuccess } from 'ish-core/store/customer/user';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
+import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
 import {
   createOrder,
@@ -452,12 +453,17 @@ describe('Orders Effects', () => {
   });
 
   describe('setOrderBreadcrumb$', () => {
-    beforeEach(() => {
+    beforeEach(fakeAsync(() => {
       store$.dispatch(loadOrdersSuccess({ orders }));
+      router.navigateByUrl('/account/orders/' + orders[0].id);
+      tick(500);
       store$.dispatch(selectOrder({ orderId: orders[0].id }));
-    });
+    }));
 
     it('should set the breadcrumb of the selected order', done => {
+      // tslint:disable-next-line: no-any
+      actions$ = of(routerTestNavigatedAction({}));
+
       effects.setOrderBreadcrumb$.subscribe(action => {
         expect(action.payload).toMatchInlineSnapshot(`
           Object {

--- a/src/app/extensions/order-templates/store/order-template/order-template.effects.spec.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.effects.spec.ts
@@ -15,6 +15,7 @@ import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { loginUserSuccess } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
+import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
 import { OrderTemplate } from '../../models/order-template/order-template.model';
 import { OrderTemplateService } from '../../services/order-template/order-template.service';
@@ -511,6 +512,7 @@ describe('Order Template Effects', () => {
 
     it('should set the breadcrumb of the selected Order Template when on account url', done => {
       router.navigateByUrl('/account/order-templates/' + orderTemplates[0].id);
+      actions$ = of(routerTestNavigatedAction({}));
 
       effects.setOrderTemplateBreadcrumb$.subscribe(action => {
         expect(action.payload).toMatchInlineSnapshot(`

--- a/src/app/extensions/order-templates/store/order-template/order-template.effects.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.effects.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { concat } from 'rxjs';
-import { concatMap, filter, last, map, mapTo, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
+import { concatMap, filter, last, map, mapTo, mergeMap, switchMap, switchMapTo, withLatestFrom } from 'rxjs/operators';
 
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { ofUrl, selectRouteParam } from 'ish-core/store/core/router';
@@ -273,17 +274,22 @@ export class OrderTemplateEffects {
   );
 
   setOrderTemplateBreadcrumb$ = createEffect(() =>
-    this.store.pipe(
-      ofUrl(/^\/account\/.*/),
-      select(getSelectedOrderTemplateDetails),
-      whenTruthy(),
-      map(orderTemplate =>
-        setBreadcrumbData({
-          breadcrumbData: [
-            { key: 'account.ordertemplates.link', link: '/account/order-templates' },
-            { text: orderTemplate.title },
-          ],
-        })
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      switchMapTo(
+        this.store.pipe(
+          ofUrl(/^\/account\/order-templates\/.*/),
+          select(getSelectedOrderTemplateDetails),
+          whenTruthy(),
+          map(orderTemplate =>
+            setBreadcrumbData({
+              breadcrumbData: [
+                { key: 'account.ordertemplates.link', link: '/account/order-templates' },
+                { text: orderTemplate.title },
+              ],
+            })
+          )
+        )
       )
     )
   );

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.ts
@@ -3,18 +3,7 @@ import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { iif, of } from 'rxjs';
-import {
-  concatMap,
-  delay,
-  filter,
-  first,
-  map,
-  mergeMap,
-  mergeMapTo,
-  switchMap,
-  tap,
-  withLatestFrom,
-} from 'rxjs/operators';
+import { concatMap, filter, first, map, mergeMap, mergeMapTo, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
@@ -257,8 +246,6 @@ export class QuotingEffects {
                     state === 'New' ? 'quote.edit.unsubmitted.quote_request_details.text' : 'quote.quote_details.link',
                 },
               ]),
-              // short delay to override parent breadcrumb
-              delay(100),
               map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
             )
           )

--- a/src/app/extensions/wishlists/store/wishlist/wishlist.effects.spec.ts
+++ b/src/app/extensions/wishlists/store/wishlist/wishlist.effects.spec.ts
@@ -15,6 +15,7 @@ import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { loginUserSuccess } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
+import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
 import { Wishlist } from '../../models/wishlist/wishlist.model';
 import { WishlistService } from '../../services/wishlist/wishlist.service';
@@ -528,6 +529,7 @@ describe('Wishlist Effects', () => {
 
     it('should set the breadcrumb of the selected wishlist in my account area', done => {
       router.navigateByUrl('/account/wishlists/' + wishlists[0].id);
+      actions$ = of(routerTestNavigatedAction({}));
 
       effects.setWishlistBreadcrumb$.subscribe(action => {
         expect(action.payload).toMatchInlineSnapshot(`

--- a/src/app/extensions/wishlists/store/wishlist/wishlist.effects.ts
+++ b/src/app/extensions/wishlists/store/wishlist/wishlist.effects.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { debounceTime, filter, map, mapTo, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, filter, map, mapTo, mergeMap, switchMap, switchMapTo, withLatestFrom } from 'rxjs/operators';
 
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { ofUrl, selectRouteParam } from 'ish-core/store/core/router';
@@ -218,17 +219,22 @@ export class WishlistEffects {
   );
 
   setWishlistBreadcrumb$ = createEffect(() =>
-    this.store.pipe(
-      ofUrl(/^\/account\/.*/),
-      select(getSelectedWishlistDetails),
-      whenTruthy(),
-      map(wishlist =>
-        setBreadcrumbData({
-          breadcrumbData: [
-            { key: 'account.wishlists.breadcrumb_link', link: '/account/wishlists' },
-            { text: wishlist.title },
-          ],
-        })
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      switchMapTo(
+        this.store.pipe(
+          ofUrl(/^\/account\/wishlists\/.*/),
+          select(getSelectedWishlistDetails),
+          whenTruthy(),
+          map(wishlist =>
+            setBreadcrumbData({
+              breadcrumbData: [
+                { key: 'account.wishlists.breadcrumb_link', link: '/account/wishlists' },
+                { text: wishlist.title },
+              ],
+            })
+          )
+        )
       )
     )
   );


### PR DESCRIPTION
Closes  #399

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

introduced by 3e55b635da47e1843f791b2e7574f95e8f15b4b4

## What Is the New Behavior?

Fixed.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## TODO:

- [x] extend e2e tests for quoting, order-templates, wishlists and orders to check breadcrumb for list vs. detail pages.
