### PR TITLE
fix: display error messages on the b2b user edit profile page

### DIFF
--- a/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.html
+++ b/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="profileForm">
   <h1>{{ 'account.user.update_profile.heading' | translate }} - {{ user.firstName }} {{ user.lastName }}</h1>
   <form [formGroup]="profileForm" (ngSubmit)="submitForm()" class="form-horizontal" novalidate="novalidate">
-    <ish-user-profile-form [form]="profileForm"></ish-user-profile-form>
+    <ish-user-profile-form [form]="profileForm" [error]="userError$ | async"></ish-user-profile-form>
     <div class="row">
       <div class="offset-md-4 col-md-8">
         <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="edit-user-submit">


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:


[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/master/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If a b2b administrator edits a b2b user profiles and an error occurs after submitting changes this error won't be displayed.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
Errors are displayed on the b2b user edit profile page

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
