### PR TITLE
fix: provide configuration meta reducer only on SSR side

### DIFF
--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -61,7 +61,7 @@ server {
 
         rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang=$LANG';
 
-        set $default_rewrite_params ';channel=$CHANNEL;application=$APPLICATION;features=$FEATURES;theme=$THEME;device=$ua_device';
+        set $default_rewrite_params ';icmHost=default;channel=$CHANNEL;application=$APPLICATION;features=$FEATURES;theme=$THEME;device=$ua_device';
 
         rewrite '^(?!.*;device=.*)(.*)$' '$1$default_rewrite_params' break;
 

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -2,12 +2,14 @@ import { HTTP_INTERCEPTORS, HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler, NgModule } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 import { ServerModule, ServerTransferStateModule } from '@angular/platform-server';
+import { META_REDUCERS } from '@ngrx/store';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { existsSync, readFileSync } from 'fs';
 import { ServerCookiesModule } from 'ngx-utils-cookies-port';
 import { join } from 'path';
 import { Observable, Observer } from 'rxjs';
 
+import { configurationMeta } from 'ish-core/configurations/configuration.meta';
 import { DISPLAY_VERSION } from 'ish-core/configurations/state-keys';
 import { UniversalLogInterceptor } from 'ish-core/interceptors/universal-log.interceptor';
 import { UniversalMockInterceptor } from 'ish-core/interceptors/universal-mock.interceptor';
@@ -67,6 +69,7 @@ export class UniversalErrorHandler implements ErrorHandler {
     { provide: HTTP_INTERCEPTORS, useClass: UniversalMockInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UniversalLogInterceptor, multi: true },
     { provide: ErrorHandler, useClass: UniversalErrorHandler },
+    { provide: META_REDUCERS, useValue: configurationMeta, multi: true },
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/core/configurations/configuration.meta.ts
+++ b/src/app/core/configurations/configuration.meta.ts
@@ -25,7 +25,7 @@ function extractConfigurationParameters(state: ConfigurationState, paramMap: Sim
     .map(key => ({ [key]: paramMap.get(key) }))
     .reduce((acc, val) => ({ ...acc, ...val }), {});
 
-  if (paramMap.has('icmHost')) {
+  if (paramMap.has('icmHost') && paramMap.get('icmHost') !== 'default') {
     properties.baseURL = `${paramMap.get('icmScheme') || 'https'}://${paramMap.get('icmHost')}`;
   }
 

--- a/src/app/core/store/core/core-store.module.ts
+++ b/src/app/core/store/core/core-store.module.ts
@@ -5,7 +5,6 @@ import { StoreRouterConnectingModule, routerReducer } from '@ngrx/router-store';
 import { ActionReducerMap, MetaReducer, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
-import { configurationMeta } from 'ish-core/configurations/configuration.meta';
 import { ngrxStateTransferMeta } from 'ish-core/configurations/ngrx-state-transfer';
 import { ConfigurationGuard } from 'ish-core/guards/configuration.guard';
 import { addGlobalGuard } from 'ish-core/utils/routing';
@@ -31,7 +30,7 @@ const coreReducers: ActionReducerMap<CoreState> = {
 
 const coreEffects = [ErrorEffects, ViewconfEffects, ConfigurationEffects, MessagesEffects];
 
-const coreMetaReducers: MetaReducer<CoreState>[] = [ngrxStateTransferMeta, configurationMeta];
+const coreMetaReducers: MetaReducer<CoreState>[] = [ngrxStateTransferMeta];
 
 @NgModule({
   imports: [


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

URL configuration parameters can be provided on storefront. -> security issue

## What Is the New Behavior?

The metaReducer for reading configuration parameters works only for the SSR container. The nginx running in front prevents setting of incoming configuration parameters.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
