### PR TITLE
refactor: Bootstrap Modal HTML unification and cleanup

### DIFF
--- a/e2e/cypress/integration/pages/account/add-to-order-template.module.ts
+++ b/e2e/cypress/integration/pages/account/add-to-order-template.module.ts
@@ -3,14 +3,14 @@ export class AddToOrderTemplateModule {
 
   addNewOrderTemplate(name: string) {
     cy.wait(500);
-    cy.get('[class="modal-body"] input').type(name);
-    cy.get('[class="modal-footer"] button.btn-primary').click();
+    cy.get('.modal-body input').type(name);
+    cy.get('.modal-footer button.btn-primary').click();
   }
 
   addProductToOrderTemplateFromPage(title: string = '', modal: boolean = false) {
     if (modal) {
       cy.get(`[data-testing-id="${title}"]`).click();
-      cy.get('[class="modal-footer"] button.btn-primary').click();
+      cy.get('.modal-footer button.btn-primary').click();
     }
     this.closeAddProductToOrderTemplateModal('link');
   }
@@ -23,7 +23,7 @@ export class AddToOrderTemplateModule {
       if (title) {
         cy.get(`[data-testing-id="${title}"]`).click();
       }
-      cy.get('[class="modal-footer"] button.btn-primary').click();
+      cy.get('.modal-footer button.btn-primary').click();
       this.closeAddProductToOrderTemplateModal('link');
     } else {
       cy.get(this.contextSelector)
@@ -37,6 +37,6 @@ export class AddToOrderTemplateModule {
     cy.wait(500);
     mode === 'link'
       ? cy.get('[data-testing-id="order-template-success-link"] a').click()
-      : cy.get('[class="modal-header"] button').click();
+      : cy.get('.modal-header button').click();
   }
 }

--- a/e2e/cypress/integration/pages/account/add-to-wishlist.module.ts
+++ b/e2e/cypress/integration/pages/account/add-to-wishlist.module.ts
@@ -4,7 +4,7 @@ export class AddToWishlistModule {
   addProductToWishlistFromPage(title: string = '', modal: boolean = false) {
     if (modal) {
       cy.get(`[data-testing-id="${title}"]`).click();
-      cy.get('[class="modal-footer"] button.btn-primary').click();
+      cy.get('.modal-footer button.btn-primary').click();
     }
     this.closeAddProductToWishlistModal('link');
   }
@@ -15,7 +15,7 @@ export class AddToWishlistModule {
         .find(`ish-product-item div[data-testing-sku="${product}"] button.add-to-wishlist`)
         .click();
       cy.get(`[data-testing-id="${title}"]`).click();
-      cy.get('[class="modal-footer"] button.btn-primary').click();
+      cy.get('.modal-footer button.btn-primary').click();
       this.closeAddProductToWishlistModal('link');
     } else {
       cy.get(this.contextSelector)
@@ -29,6 +29,6 @@ export class AddToWishlistModule {
     cy.wait(500);
     mode === 'link'
       ? cy.get('[data-testing-id="wishlist-success-link"] a').click()
-      : cy.get('[class="modal-header"] button').click();
+      : cy.get('.modal-header button').click();
   }
 }

--- a/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.html
+++ b/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.html
@@ -61,5 +61,6 @@
     confirmText: 'account.order_template.delete.button.text' | translate,
     rejectText: 'account.cancel.button.label' | translate
   }"
-  >{{ 'account.order_template.delete.do_you_really.text' | translate }}</ish-modal-dialog
 >
+  {{ 'account.order_template.delete.do_you_really.text' | translate }}
+</ish-modal-dialog>

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
@@ -1,42 +1,47 @@
 <ng-template #modal let-addModal>
-  <div class="modal-content">
-    <div class="modal-header">
-      <h2 class="modal-title">{{ modalHeader | translate }}</h2>
-      <button class="close" (click)="hide()" [title]="'application.overlay.close.text' | translate" aria-label="Close">
-        <span aria-hidden="true">×</span>
-      </button>
-    </div>
+  <div class="modal-header">
+    <h2 class="modal-title">{{ modalHeader | translate }}</h2>
+    <button
+      type="button"
+      class="close"
+      [title]="'dialog.close.text' | translate"
+      [attr.aria-label]="'dialog.close.text' | translate"
+      (click)="hide()"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
+  <div class="modal-body">
     <form [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm(); addModal.close('')">
-      <div class="modal-body">
-        <!-- TODO: Show server error -->
-        <ish-input
-          [form]="orderTemplateForm"
-          controlName="title"
-          label="account.order_template.form.name.label"
-          markRequiredLabel="off"
-          maxlength="35"
-          [errorMessages]="{
-            required: 'account.order_template.form.name.error.required',
-            maxlength: 'account.order_template.form.name.error.maxlength'
-          }"
-          data-testing-id="order-template-dialog-name"
-        ></ish-input>
-      </div>
+      <!-- TODO: Show server error -->
+      <ish-input
+        [form]="orderTemplateForm"
+        controlName="title"
+        label="account.order_template.form.name.label"
+        markRequiredLabel="off"
+        maxlength="35"
+        [errorMessages]="{
+          required: 'account.order_template.form.name.error.required',
+          maxlength: 'account.order_template.form.name.error.maxlength'
+        }"
+        data-testing-id="order-template-dialog-name"
+      ></ish-input>
     </form>
-    <div class="modal-footer">
-      <button
-        class="btn btn-primary"
-        type="submit"
-        [disabled]="formDisabled"
-        (click)="submitOrderTemplateForm()"
-        data-testing-id="order-template-dialog-submit"
-      >
-        {{ primaryButton | translate }}
-      </button>
-      <button class="btn btn-secondary" type="button" (click)="addModal.close('')">
-        {{ 'account.cancel.button.label' | translate }}
-      </button>
-    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button
+      type="submit"
+      class="btn btn-primary"
+      [disabled]="formDisabled"
+      (click)="submitOrderTemplateForm()"
+      data-testing-id="order-template-dialog-submit"
+    >
+      {{ primaryButton | translate }}
+    </button>
+    <button type="button" class="btn btn-secondary" (click)="addModal.close('')">
+      {{ 'account.cancel.button.label' | translate }}
+    </button>
   </div>
 </ng-template>

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -1,94 +1,96 @@
 <ng-template #modal let-selectModal>
-  <div class="modal-content">
-    <div class="modal-header">
-      <h2 class="modal-title">{{ headerTranslationKey | translate }}</h2>
-      <button
-        type="button"
-        class="close close-modal"
-        [attr.aria-label]="'dialog.close.text' | translate"
-        (click)="hide()"
-        [title]="'application.overlay.close.text' | translate"
-      >
-        <span aria-hidden="true">&times;</span>
+  <div class="modal-header">
+    <h2 class="modal-title">{{ headerTranslationKey | translate }}</h2>
+    <button
+      type="button"
+      class="close"
+      [title]="'dialog.close.text' | translate"
+      [attr.aria-label]="'dialog.close.text' | translate"
+      (click)="hide()"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <ng-container *ngIf="showForm; else showSuccess">
+    <div class="modal-body">
+      <form [formGroup]="updateOrderTemplateForm" (ngSubmit)="submitForm()">
+        <ng-container
+          *ngIf="orderTemplateOptions === undefined || orderTemplateOptions.length === 0; else radioButtonForm"
+        >
+          <ish-input
+            controlName="newOrderTemplate"
+            [errorMessages]="{ required: 'account.order_template.name.error.required' }"
+            [form]="updateOrderTemplateForm"
+          ></ish-input>
+        </ng-container>
+
+        <ng-template #radioButtonForm>
+          <div class="form-group">
+            <div class="radio" *ngFor="let option of orderTemplateOptions; let i = index">
+              <label>
+                <input
+                  type="radio"
+                  name="orderTemplate"
+                  formControlName="orderTemplate"
+                  [value]="option.value"
+                  id="orderTemplate_{{ i }}"
+                  [attr.data-testing-id]="option.label"
+                />
+                {{ option.label }}
+              </label>
+            </div>
+            <div class="radio">
+              <label class="d-flex align-items-center">
+                <input
+                  type="radio"
+                  name="orderTemplate"
+                  formControlName="orderTemplate"
+                  value="newTemplate"
+                  class="mb-3"
+                  id="orderTemplate"
+                />
+                <ish-input
+                  class="w-75"
+                  controlName="newOrderTemplate"
+                  [disabled]="newOrderTemplateDisabled ? 'true' : null"
+                  [errorMessages]="{ required: 'account.order_template.name.error.required' }"
+                  [form]="updateOrderTemplateForm"
+                  inputClass="col-md-12"
+                ></ish-input>
+              </label>
+            </div>
+          </div>
+        </ng-template>
+      </form>
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-primary" (click)="submitForm()">
+        {{ submitButtonTranslationKey | translate }}
+      </button>
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'account.cancel.button.label' | translate }}
       </button>
     </div>
-    <ng-container *ngIf="showForm; else showSuccess">
-      <form [formGroup]="updateOrderTemplateForm" (ngSubmit)="submitForm()">
-        <div class="modal-body">
-          <ng-container
-            *ngIf="orderTemplateOptions === undefined || orderTemplateOptions.length === 0; else radioButtonForm"
-          >
-            <ish-input
-              controlName="newOrderTemplate"
-              [errorMessages]="{ required: 'account.order_template.name.error.required' }"
-              [form]="updateOrderTemplateForm"
-            ></ish-input>
-          </ng-container>
+  </ng-container>
 
-          <ng-template #radioButtonForm>
-            <div class="form-group">
-              <div class="radio" *ngFor="let option of orderTemplateOptions; let i = index">
-                <label>
-                  <input
-                    type="radio"
-                    name="orderTemplate"
-                    formControlName="orderTemplate"
-                    [value]="option.value"
-                    id="orderTemplate_{{ i }}"
-                    [attr.data-testing-id]="option.label"
-                  />
-                  {{ option.label }}
-                </label>
-              </div>
-              <div class="radio">
-                <label class="d-flex align-items-center">
-                  <input
-                    type="radio"
-                    name="orderTemplate"
-                    formControlName="orderTemplate"
-                    value="newTemplate"
-                    class="mb-3"
-                    id="orderTemplate"
-                  />
-                  <ish-input
-                    class="w-75"
-                    controlName="newOrderTemplate"
-                    [disabled]="newOrderTemplateDisabled ? 'true' : null"
-                    [errorMessages]="{ required: 'account.order_template.name.error.required' }"
-                    [form]="updateOrderTemplateForm"
-                    inputClass="col-md-12"
-                  ></ish-input>
-                </label>
-              </div>
-            </div>
-          </ng-template>
-        </div>
-        <div class="modal-footer">
-          <button class="btn btn-primary" type="submit">
-            {{ submitButtonTranslationKey | translate }}
-          </button>
-          <button class="btn btn-secondary" type="button" (click)="hide()">
-            {{ 'account.cancel.button.label' | translate }}
-          </button>
-        </div>
-      </form>
-    </ng-container>
-    <ng-template #showSuccess>
-      <div class="modal-body">
-        <span
-          [ishServerHtml]="
-            successTranslationKey
-              | translate: { '0': product.name, '1': selectedOrderTemplateTitle, '2': selectedOrderTemplateRoute }
-          "
-          [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
-          data-testing-id="order-template-success-link"
-        ></span>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" (click)="hide()">
-          {{ 'store.dialog.button.ok' | translate }}
-        </button>
-      </div>
-    </ng-template>
-  </div>
+  <ng-template #showSuccess>
+    <div class="modal-body">
+      <span
+        [ishServerHtml]="
+          successTranslationKey
+            | translate: { '0': product.name, '1': selectedOrderTemplateTitle, '2': selectedOrderTemplateRoute }
+        "
+        [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
+        data-testing-id="order-template-success-link"
+      ></span>
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'store.dialog.button.ok' | translate }}
+      </button>
+    </div>
+  </ng-template>
 </ng-template>

--- a/src/app/extensions/quoting/shared/product-add-to-quote-dialog/product-add-to-quote-dialog.component.html
+++ b/src/app/extensions/quoting/shared/product-add-to-quote-dialog/product-add-to-quote-dialog.component.html
@@ -2,7 +2,6 @@
   <ng-container *ngIf="state$ | async as state">
     <div class="modal-header">
       <h2 class="modal-title">
-        <!-- Titel and Description -->
         <ng-container *ngIf="state === 'Submitted'; else quoteTitle">
           {{ 'quote.edit.submitted.heading' | translate }}
         </ng-container>
@@ -11,7 +10,13 @@
           {{ quote.displayName || quote.number }}
         </ng-template>
       </h2>
-      <button type="button" class="close" [attr.aria-label]="'dialog.close.text' | translate" (click)="hide()">
+      <button
+        type="button"
+        class="close"
+        [title]="'dialog.close.text' | translate"
+        [attr.aria-label]="'dialog.close.text' | translate"
+        (click)="hide()"
+      >
         <span aria-hidden="true">&times;</span>
       </button>
     </div>

--- a/src/app/extensions/wishlists/pages/account-wishlist/account-wishlist-list/account-wishlist-list.component.html
+++ b/src/app/extensions/wishlists/pages/account-wishlist/account-wishlist-list/account-wishlist-list.component.html
@@ -41,5 +41,6 @@
     confirmText: 'account.wishlists.delete_wishlist_dialog.delete_button.text' | translate,
     rejectText: 'account.wishlists.delete_wishlist_dialog.cancel_button.text' | translate
   }"
-  >{{ 'account.wishlists.delete_wishlist_dialog.are_you_sure_paragraph' | translate }}</ish-modal-dialog
 >
+  {{ 'account.wishlists.delete_wishlist_dialog.are_you_sure_paragraph' | translate }}
+</ish-modal-dialog>

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
@@ -1,96 +1,93 @@
 <ng-template #modal let-selectModal>
-  <div class="modal-content">
-    <div class="modal-header">
-      <h2 class="modal-title">{{ headerTranslationKey | translate }}</h2>
-      <button
-        type="button"
-        class="close close-modal"
-        [attr.aria-label]="'dialog.close.text' | translate"
-        (click)="hide()"
-        [title]="'application.overlay.close.text' | translate"
-      >
-        <span aria-hidden="true">&times;</span>
+  <div class="modal-header">
+    <h2 class="modal-title">{{ headerTranslationKey | translate }}</h2>
+    <button
+      type="button"
+      class="close"
+      [title]="'dialog.close.text' | translate"
+      [attr.aria-label]="'dialog.close.text' | translate"
+      (click)="hide()"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <ng-container *ngIf="showForm; else showSuccess">
+    <div class="modal-body">
+      <form [formGroup]="updateWishlistForm" (ngSubmit)="submitForm()">
+        <ng-container *ngIf="wishlistOptions === undefined || wishlistOptions.length === 0; else radioButtonForm">
+          <ish-input
+            controlName="newWishlist"
+            [errorMessages]="{ required: 'account.wishlist.name.error.required' }"
+            [form]="updateWishlistForm"
+          ></ish-input>
+        </ng-container>
+
+        <ng-template #radioButtonForm>
+          <div class="form-group">
+            <div class="radio" *ngFor="let option of wishlistOptions; let i = index">
+              <label>
+                <input
+                  type="radio"
+                  name="wishlist"
+                  formControlName="wishlist"
+                  [value]="option.value"
+                  id="wishlist_{{ i }}"
+                  [attr.data-testing-id]="option.label"
+                />
+                {{ option.label }}
+              </label>
+            </div>
+            <div class="radio">
+              <label class="d-flex align-items-center">
+                <input
+                  type="radio"
+                  name="wishlist"
+                  formControlName="wishlist"
+                  value="newList"
+                  class="mb-3"
+                  id="wishlist"
+                />
+                <ish-input
+                  controlName="newWishlist"
+                  [disabled]="newWishlistDisabled ? 'true' : null"
+                  [errorMessages]="{ required: 'account.wishlist.name.error.required' }"
+                  [form]="updateWishlistForm"
+                  inputClass="col-md-12"
+                ></ish-input>
+              </label>
+            </div>
+          </div>
+        </ng-template>
+      </form>
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-primary" (click)="submitForm()">
+        {{ submitButtonTranslationKey | translate }}
+      </button>
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'account.wishlists.add_to_wishlist.cancel_button.text' | translate }}
       </button>
     </div>
-    <ng-container *ngIf="showForm; else showSuccess">
-      <form [formGroup]="updateWishlistForm" (ngSubmit)="submitForm()">
-        <div class="modal-body">
-          <ng-container *ngIf="wishlistOptions === undefined || wishlistOptions.length === 0; else radioButtonForm">
-            <ish-input
-              controlName="newWishlist"
-              [errorMessages]="{ required: 'account.wishlist.name.error.required' }"
-              [form]="updateWishlistForm"
-            ></ish-input>
-          </ng-container>
+  </ng-container>
 
-          <ng-template #radioButtonForm>
-            <div class="form-group">
-              <div class="radio" *ngFor="let option of wishlistOptions; let i = index">
-                <label>
-                  <input
-                    type="radio"
-                    name="wishlist"
-                    formControlName="wishlist"
-                    [value]="option.value"
-                    id="wishlist_{{ i }}"
-                    [attr.data-testing-id]="option.label"
-                  />
-                  {{ option.label }}
-                </label>
-              </div>
-              <div class="radio">
-                <label class="d-flex align-items-center">
-                  <input
-                    type="radio"
-                    name="wishlist"
-                    formControlName="wishlist"
-                    value="newList"
-                    class="mb-3"
-                    id="wishlist"
-                  />
-                  <ish-input
-                    controlName="newWishlist"
-                    [disabled]="newWishlistDisabled ? 'true' : null"
-                    [errorMessages]="{ required: 'account.wishlist.name.error.required' }"
-                    [form]="updateWishlistForm"
-                    inputClass="col-md-12"
-                  ></ish-input>
-                </label>
-              </div>
-            </div>
-          </ng-template>
-        </div>
-        <div class="modal-footer">
-          <button class="btn btn-primary" type="submit">
-            {{ submitButtonTranslationKey | translate }}
-          </button>
-          <button
-            class="btn btn-secondary"
-            type="button"
-            [name]="'account.wishlists.wishlist_form.cancel_button.text' | translate"
-            (click)="hide()"
-          >
-            {{ 'account.wishlists.add_to_wishlist.cancel_button.text' | translate }}
-          </button>
-        </div>
-      </form>
-    </ng-container>
-    <ng-template #showSuccess>
-      <div class="modal-body">
-        <span
-          [ishServerHtml]="
-            successTranslationKey
-              | translate: { '0': product.name, '1': selectedWishlistRoute, '2': selectedWishlistTitle }
-          "
-          [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
-          data-testing-id="wishlist-success-link"
-        ></span>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" (click)="hide()">
-          {{ 'account.wishlists.add_to_wishlist.confirmation.ok_button.text' | translate }}
-        </button>
-      </div>
-    </ng-template>
-  </div>
+  <ng-template #showSuccess>
+    <div class="modal-body">
+      <span
+        [ishServerHtml]="
+          successTranslationKey
+            | translate: { '0': product.name, '1': selectedWishlistRoute, '2': selectedWishlistTitle }
+        "
+        [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
+        data-testing-id="wishlist-success-link"
+      ></span>
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'account.wishlists.add_to_wishlist.confirmation.ok_button.text' | translate }}
+      </button>
+    </div>
+  </ng-template>
 </ng-template>

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
@@ -1,69 +1,69 @@
 <ng-template #modal let-addModal>
-  <div class="modal-content">
-    <div class="modal-header">
-      <h2 class="modal-title">{{ modalHeader | translate }}</h2>
-      <button class="close" (click)="hide()" [title]="'application.overlay.close.text' | translate" aria-label="Close">
-        <span aria-hidden="true">×</span>
-      </button>
-    </div>
+  <div class="modal-header">
+    <h2 class="modal-title">{{ modalHeader | translate }}</h2>
+    <button
+      type="button"
+      class="close"
+      [title]="'dialog.close.text' | translate"
+      [attr.aria-label]="'dialog.close.text' | translate"
+      (click)="hide()"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
+  <div class="modal-body">
     <form [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm(); addModal.close('')">
-      <div class="modal-body">
-        <!-- TODO: Show server error -->
-        <ish-input
-          [form]="wishListForm"
-          controlName="title"
-          label="account.wishlists.wishlist_form.name.label"
-          markRequiredLabel="off"
-          maxlength="35"
-          [errorMessages]="{
-            required: 'account.wishlists.wishlist_form.name.error.required',
-            maxlength: 'account.wishlists.wishlist_form.name.error.maxlength'
-          }"
-          data-testing-id="wishlist-dialog-name"
-        ></ish-input>
-        <div class="offset-md-4 col row">
-          <div class="d-flex align-items-center">
-            <ish-checkbox
-              [form]="wishListForm"
-              controlName="preferred"
-              label="account.wishlists.wishlist_form.preferred.label"
-              data-testing-id="wishlist-dialog-preferred"
-            ></ish-checkbox>
-            <ng-template #preferredDetails>
-              <span innerHTML="{{ 'account.wishlists.wishlist_form.preferred.tooltip.content' | translate }}"></span>
-            </ng-template>
+      <!-- TODO: Show server error -->
+      <ish-input
+        [form]="wishListForm"
+        controlName="title"
+        label="account.wishlists.wishlist_form.name.label"
+        markRequiredLabel="off"
+        maxlength="35"
+        [errorMessages]="{
+          required: 'account.wishlists.wishlist_form.name.error.required',
+          maxlength: 'account.wishlists.wishlist_form.name.error.maxlength'
+        }"
+        data-testing-id="wishlist-dialog-name"
+      ></ish-input>
+      <div class="offset-md-4 col row">
+        <div class="d-flex align-items-center">
+          <ish-checkbox
+            [form]="wishListForm"
+            controlName="preferred"
+            label="account.wishlists.wishlist_form.preferred.label"
+            data-testing-id="wishlist-dialog-preferred"
+          ></ish-checkbox>
+          <ng-template #preferredDetails>
+            <span innerHTML="{{ 'account.wishlists.wishlist_form.preferred.tooltip.content' | translate }}"></span>
+          </ng-template>
 
-            <a
-              [ngbPopover]="preferredDetails"
-              class="details-tooltip"
-              placement="top"
-              popoverTitle="{{ 'account.wishlists.wishlist_form.preferred.tooltip.headline' | translate }}"
-              >{{ 'account.wishlists.wishlist_form.preferred.tooltip.linktext' | translate }}
-              <fa-icon [icon]="['fas', 'info-circle']"></fa-icon
-            ></a>
-          </div>
+          <a
+            [ngbPopover]="preferredDetails"
+            class="details-tooltip"
+            placement="top"
+            popoverTitle="{{ 'account.wishlists.wishlist_form.preferred.tooltip.headline' | translate }}"
+            >{{ 'account.wishlists.wishlist_form.preferred.tooltip.linktext' | translate }}
+            <fa-icon [icon]="['fas', 'info-circle']"></fa-icon
+          ></a>
         </div>
       </div>
     </form>
-    <div class="modal-footer">
-      <button
-        class="btn btn-primary"
-        type="submit"
-        [disabled]="formDisabled"
-        (click)="submitWishlistForm()"
-        data-testing-id="wishlist-dialog-submit"
-      >
-        {{ primaryButton | translate }}
-      </button>
-      <button
-        class="btn btn-secondary"
-        type="button"
-        [name]="'account.wishlists.wishlist_form.cancel_button.text' | translate"
-        (click)="addModal.close('')"
-      >
-        {{ 'account.wishlists.wishlist_form.cancel_button.text' | translate }}
-      </button>
-    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button
+      type="button"
+      class="btn btn-primary"
+      [disabled]="formDisabled"
+      (click)="submitWishlistForm()"
+      data-testing-id="wishlist-dialog-submit"
+    >
+      {{ primaryButton | translate }}
+    </button>
+    <button type="button" class="btn btn-secondary" (click)="addModal.close('')">
+      {{ 'account.wishlists.wishlist_form.cancel_button.text' | translate }}
+    </button>
   </div>
 </ng-template>

--- a/src/app/shared/components/common/modal-dialog/modal-dialog.component.html
+++ b/src/app/shared/components/common/modal-dialog/modal-dialog.component.html
@@ -1,8 +1,14 @@
 <ng-template #template>
   <div class="modal-header">
-    <h2 *ngIf="options" class="modal-title pull-left">{{ options.titleText }}</h2>
-    <button type="button" class="close" [attr.aria-label]="'dialog.close.text' | translate" (click)="hide()">
-      <span aria-hidden="true" [attr.title]="'dialog.close.text' | translate">&times;</span>
+    <h2 *ngIf="options?.titleText" class="modal-title">{{ options.titleText }}</h2>
+    <button
+      type="button"
+      class="close"
+      [title]="'dialog.close.text' | translate"
+      [attr.aria-label]="'dialog.close.text' | translate"
+      (click)="hide()"
+    >
+      <span aria-hidden="true">&times;</span>
     </button>
   </div>
 
@@ -11,14 +17,21 @@
   <div *ngIf="options.confirmText || options.rejectText" class="modal-footer">
     <button
       *ngIf="options.confirmText"
-      data-testing-id="confirm"
+      type="button"
       class="btn btn-primary"
       [disabled]="options.confirmDisabled"
       (click)="confirm()"
+      data-testing-id="confirm"
     >
       {{ options.confirmText }}
     </button>
-    <button *ngIf="options.rejectText" data-testing-id="reject" class="btn btn-secondary" (click)="hide()">
+    <button
+      *ngIf="options.rejectText"
+      type="button"
+      class="btn btn-secondary"
+      (click)="hide()"
+      data-testing-id="reject"
+    >
       {{ options.rejectText }}
     </button>
   </div>

--- a/src/app/shared/components/login/login-modal/login-modal.component.html
+++ b/src/app/shared/components/login/login-modal/login-modal.component.html
@@ -1,15 +1,17 @@
 <div class="login-modal">
   <div class="modal-header">
-    <h2>{{ 'account.login.signin.heading' | translate }}</h2>
+    <h2 class="modal-title">{{ 'account.login.signin.heading' | translate }}</h2>
     <button
       type="button"
-      class="close close-modal"
+      class="close"
+      [title]="'dialog.close.text' | translate"
       [attr.aria-label]="'dialog.close.text' | translate"
       (click)="hide()"
     >
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
+
   <div class="modal-body">
     <div data-testing-id="account-login-page">
       <p *ngIf="loginMessageKey" class="alert alert-info">

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -518,7 +518,6 @@
   "account.wishlists.wishlist_form.preferred.tooltip.content": "Die Auswahl markiert die Wunschliste als bevorzugte Liste und setzt alle anderen (wenn vorhanden) zurück auf Standard. Alle hinzugefügten Produkte werden standardmäßig zu dieser Liste hinzugefügt.",
   "account.wishlists.wishlist_form.preferred.tooltip.headline": "Als bevorzugt markieren",
   "account.wishlists.wishlist_form.preferred.tooltip.linktext": "Details",
-  "application.overlay.close.text": "Schließen",
   "application.recentlyViewed.breadcrumb.label": "Ihre Browsing-Historie",
   "application.recentlyViewed.clear": "Historie löschen",
   "application.recentlyViewed.empty": "Ihre Browsing-Historie ist leer",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -520,7 +520,6 @@
   "account.wishlists.wishlist_form.preferred.tooltip.content": "Selection will make the wish list your preferred wish list and sets all other (if any) back to normal. All added products will be added by default to this wish list.",
   "account.wishlists.wishlist_form.preferred.tooltip.headline": "Set as Preferred",
   "account.wishlists.wishlist_form.preferred.tooltip.linktext": "Details",
-  "application.overlay.close.text": "Close",
   "application.recentlyViewed.breadcrumb.label": "Your Browsing History",
   "application.recentlyViewed.clear": "Clear My History",
   "application.recentlyViewed.empty": "Your browsing history is empty",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -520,7 +520,6 @@
   "account.wishlists.wishlist_form.preferred.tooltip.content": "La sélection fera de la liste de souhaits votre liste de souhaits préférée et remettra tous les autres (s’il y en a) à l’état normal. Tous les produits ajoutés seront ajoutés par défaut à cette liste de souhaits.",
   "account.wishlists.wishlist_form.preferred.tooltip.headline": "Définir comme préférence",
   "account.wishlists.wishlist_form.preferred.tooltip.linktext": "Détails",
-  "application.overlay.close.text": "Fermer",
   "application.recentlyViewed.breadcrumb.label": "Votre historique de navigation",
   "application.recentlyViewed.clear": "Effacer mon historique de navigation",
   "application.recentlyViewed.empty": "Votre historique de navigation est vide",

--- a/src/styles/global/modals.scss
+++ b/src/styles/global/modals.scss
@@ -3,10 +3,6 @@
 // --------------------------------------------------
 
 .modal-dialog {
-  .close-modal {
-    padding: 1rem 1rem;
-  }
-
   .close {
     opacity: 1;
   }


### PR DESCRIPTION
- used the same 'modal-header' HTML in all places
- changed to cleaner modal-header / modal-body / modal-footer structure
- removed unneccessary 'modal-content' (duplicated in rendered HTML)
- removed unneccessary CSS classes (close-modal) and obsolete localization keys

## PR Type

[x] Refactoring (no functional changes, no API changes)

## Does this PR Introduce a Breaking Change?

[x] No
