### PR TITLE
i18n: renamed line items table column (ISREST-1111)

### DIFF
--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -205,9 +205,9 @@
   "account.order_template.form.name.error.required": "Geben Sie einen Namen für die Bestellvorlage an.",
   "account.order_template.form.name.label": "Name der Bestellvorlage",
   "account.order_template.items": {
-    "=0": "0 Artikel",
-    "=1": "1 Artikel",
-    "other": "# Artikel"
+    "=0": "0",
+    "=1": "1",
+    "other": "#"
   },
   "account.order_template.list.button.add_template.label": "Bestellvorlage hinzufügen",
   "account.order_template.list.link.back": "Zurück zu Bestellvorlagen",

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -214,7 +214,7 @@
   "account.order_template.list.link.remove": "Löschen",
   "account.order_template.list.no_templates.text": "Derzeit haben Sie keine Bestellvorlagen.",
   "account.order_template.list.table.created": "Angelegt",
-  "account.order_template.list.table.item": "Artikelanzahl",
+  "account.order_template.list.table.item": "Bestellpositionen",
   "account.order_template.list.table.template": "Name der Vorlage",
   "account.order_template.move.added.text": "{{0}} wurde zu Bestellvorlage <a callback=\"callbackHideDialogModal\" href=\"{{2}}\">{{1}}</a> hinzugefügt.",
   "account.order_template.name.error.required": "Zum Erstellen einer neuen Bestellvorlage geben Sie bitte einen Namen ein.",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -214,7 +214,7 @@
   "account.order_template.list.link.remove": "Delete",
   "account.order_template.list.no_templates.text": "Currently you don't have any order templates.",
   "account.order_template.list.table.created": "Created",
-  "account.order_template.list.table.item": "No. of Items",
+  "account.order_template.list.table.item": "Line Items",
   "account.order_template.list.table.template": "Template Name",
   "account.order_template.move.added.text": "{{0}} has been added to <a callback=\"callbackHideDialogModal\" href=\"{{2}}\">{{1}}</a>.",
   "account.order_template.name.error.required": "If you want to create a new order template, please enter a name.",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -205,9 +205,9 @@
   "account.order_template.form.name.error.required": "Please enter an order template name.",
   "account.order_template.form.name.label": "Order Template Name",
   "account.order_template.items": {
-    "=0": "0 Items",
-    "=1": "1 Item",
-    "other": "# Items"
+    "=0": "0",
+    "=1": "1",
+    "other": "#"
   },
   "account.order_template.list.button.add_template.label": "Add Order Template",
   "account.order_template.list.link.back": "Back to Order Templates",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -214,7 +214,7 @@
   "account.order_template.list.link.remove": "Supprimer",
   "account.order_template.list.no_templates.text": "Actuellement, vous n’avez pas de modèles de commande.",
   "account.order_template.list.table.created": "Créé",
-  "account.order_template.list.table.item": "Nombre d’articles",
+  "account.order_template.list.table.item": "Articles",
   "account.order_template.list.table.template": "Nom du modèle",
   "account.order_template.move.added.text": "{{0}} a été ajouté au modèle de <a callback=\"callbackHideDialogModal\" href=\"{{2}}\">{{1}}</a>.",
   "account.order_template.name.error.required": "Si vous souhaitez créer un nouveau modèle de commande, veuillez entrer un nom.",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -205,9 +205,9 @@
   "account.order_template.form.name.error.required": "Veuillez entrer un nom pour le modèle de commande.",
   "account.order_template.form.name.label": "Nom du modèle de commande",
   "account.order_template.items": {
-    "=0": "0 Articles",
-    "=1": "1 Article",
-    "other": "# Articles"
+    "=0": "0",
+    "=1": "1",
+    "other": "#"
   },
   "account.order_template.list.button.add_template.label": "Ajouter un modèle de commande",
   "account.order_template.list.link.back": "Retour aux modèles de commande",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ x] Other: Changes in the localization files

## What Is the Current Behavior?

A table column has an incorrect naming, see ISREST-1111.

Issue Number: Closes #ISREST-1111

## What Is the New Behavior?

The table column has been renamed to "line items" and the German and French translations have been adapted.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x ] No

## Other Information
