### PR TITLE
chore: replace jasmine-data-provider with jest.each

### DIFF
--- a/3rd-party-licenses.txt
+++ b/3rd-party-licenses.txt
@@ -1015,7 +1015,6 @@
 "istanbul-lib-report@3.0.0","BSD-3-Clause","Copyright 2012-2015 Yahoo! Inc.. All rights reserved.","https://github.com/istanbuljs/istanbuljs"
 "istanbul-lib-source-maps@4.0.0","BSD-3-Clause","Copyright 2015 Yahoo! Inc.. All rights reserved.","https://github.com/istanbuljs/istanbuljs"
 "istanbul-reports@3.0.2","BSD-3-Clause","Copyright 2012-2015 Yahoo! Inc.. All rights reserved.","https://github.com/istanbuljs/istanbuljs"
-"jasmine-data-provider@2.2.0","MIT","","https://github.com/MortalFlesh/jasmine-data-provider"
 "jest-changed-files@26.3.0","MIT","Copyright (c) Facebook, Inc. and its affiliates.","https://github.com/facebook/jest"
 "jest-cli@26.4.2","MIT","Copyright (c) Facebook, Inc. and its affiliates.","https://github.com/facebook/jest"
 "jest-config@26.4.2","MIT","Copyright (c) Facebook, Inc. and its affiliates.","https://github.com/facebook/jest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15486,12 +15486,6 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
-    "jasmine-data-provider": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-data-provider/-/jasmine-data-provider-2.2.0.tgz",
-      "integrity": "sha1-XwKbLF+82q+/pbkQymJ+rEjNu2Y=",
-      "dev": true
-    },
     "jest": {
       "version": "26.4.2",
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "cz-customizable": "^6.3.0",
     "husky": "^4.3.0",
     "intershop-schematics": "file:schematics/src",
-    "jasmine-data-provider": "^2.2.0",
     "jest": "^26.4.2",
     "jest-extended": "^0.11.5",
     "jest-marbles": "^2.5.1",

--- a/schematics/src/model/files/__name@dasherize__/__name@dasherize__.helper.spec.ts.template
+++ b/schematics/src/model/files/__name@dasherize__/__name@dasherize__.helper.spec.ts.template
@@ -1,23 +1,18 @@
-import * as using from 'jasmine-data-provider';
-
 import { <%= classify(name) %>Helper } from './<%= dasherize(name) %>.helper';
 import { <%= classify(name) %> } from './<%= dasherize(name) %>.model';
 
 describe('<%= classify(name) %> Helper', () => {
   describe('equal', () => {
-    using(
-      [
-        { o1: undefined, o2: undefined, expected: false },
-        { o1: { id: 'test' } as <%= classify(name) %>, o2: undefined, expected: false },
-        { o1: undefined, o2: { id: 'test' } as <%= classify(name) %>, expected: false },
-        { o1: { id: 'test' } as <%= classify(name) %>, o2: { id: 'other' } as <%= classify(name) %>, expected: false },
-        { o1: { id: 'test' } as <%= classify(name) %>, o2: { id: 'test' } as <%= classify(name) %>, expected: true },
-      ],
-      slice => {
-        it(`should return ${slice.expected} when comparing ${JSON.stringify(slice.o1)} and ${JSON.stringify(slice.o2)}`, () => {
-          expect(<%= classify(name) %>Helper.equal(slice.o1, slice.o2)).toEqual(slice.expected);
-        });
-      }
-    );
+    it.each([
+        [false, undefined,  undefined],
+        [false, { id: 'test' } as <%= classify(name) %>,  undefined],
+        [false, undefined,  { id: 'test' } as <%= classify(name) %>],
+        [false, { id: 'test' } as <%= classify(name) %>,  { id: 'other' } as <%= classify(name) %>],
+        [true, { id: 'test' } as <%= classify(name) %>,  { id: 'test' } as <%= classify(name) %>],
+      ])
+      (`should return %s when comparing %j and %j`,
+      (expected, o1, o2) => {
+        expect(<%= classify(name) %>Helper.equal(o1, o2)).toEqual(expected);
+      });
   });
 });

--- a/src/app/core/models/address/address.helper.spec.ts
+++ b/src/app/core/models/address/address.helper.spec.ts
@@ -1,30 +1,21 @@
-import * as using from 'jasmine-data-provider';
-
 import { AddressHelper } from './address.helper';
 import { Address } from './address.model';
 
 describe('Address Helper', () => {
   describe('equal', () => {
-    using(
-      [
-        { add1: undefined, add2: undefined, expected: false },
-        { add1: { urn: '1' } as Address, add2: undefined, expected: false },
-        { add1: undefined, add2: { urn: '1' } as Address, expected: false },
-        { add1: { urn: '1' } as Address, add2: { urn: '2' } as Address, expected: false },
-        { add1: { urn: '1' } as Address, add2: { urn: '1' } as Address, expected: true },
-        { add1: { id: '1' } as Address, add2: { id: '2' } as Address, expected: false },
-        { add1: { id: '1' } as Address, add2: { id: '1' } as Address, expected: true },
-        { add1: { urn: '1', id: '1' } as Address, add2: { urn: '2', id: '1' } as Address, expected: false },
-        { add1: { urn: '1', id: '1' } as Address, add2: { urn: '1', id: '1' } as Address, expected: true },
-        { add1: { urn: '1', id: '1' } as Address, add2: { urn: '1', id: '2' } as Address, expected: true },
-      ],
-      slice => {
-        it(`should yield ${slice.expected} when comparing ${JSON.stringify(slice.add1)} and ${JSON.stringify(
-          slice.add2
-        )}`, () => {
-          expect(AddressHelper.equal(slice.add1, slice.add2)).toBe(slice.expected);
-        });
-      }
-    );
+    it.each([
+      [false, undefined, undefined],
+      [false, { urn: '1' }, undefined],
+      [false, undefined, { urn: '1' }],
+      [false, { urn: '1' }, { urn: '2' }],
+      [true, { urn: '1' }, { urn: '1' }],
+      [false, { id: '1' }, { id: '2' }],
+      [true, { id: '1' }, { id: '1' }],
+      [false, { urn: '1', id: '1' }, { urn: '2', id: '1' }],
+      [true, { urn: '1', id: '1' }, { urn: '1', id: '1' }],
+      [true, { urn: '1', id: '1' }, { urn: '1', id: '2' }],
+    ])('should yield %s when comparing %j and %j', (expected, add1: Address, add2: Address) => {
+      expect(AddressHelper.equal(add1, add2)).toBe(expected);
+    });
   });
 });

--- a/src/app/core/models/attribute/attribute.pipe.spec.ts
+++ b/src/app/core/models/attribute/attribute.pipe.spec.ts
@@ -2,7 +2,6 @@ import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import * as using from 'jasmine-data-provider';
 
 import { AttributeToStringPipe } from './attribute.pipe';
 
@@ -24,181 +23,35 @@ describe('Attribute Pipe', () => {
     translateService.setDefaultLang('en');
   });
 
-  function dataProvider() {
-    return [
-      {
-        attribute: {
-          name: 'StringAttribute',
-          type: 'String',
-          value: '1920 x 1080, 1600 x 1200, 640 x 480',
-        },
-        en_US: '1920 x 1080, 1600 x 1200, 640 x 480',
-        de_DE: '1920 x 1080, 1600 x 1200, 640 x 480',
-      },
-      {
-        attribute: {
-          name: 'DateAttribute',
-          type: 'Date',
-          value: 1521457386000,
-        },
-        en_US: '3/19/18',
-        de_DE: '19.03.18',
-      },
-      {
-        attribute: {
-          name: 'IntegerAttribute',
-          type: 'Integer',
-          value: 1234,
-        },
-        en_US: '1,234',
-        de_DE: '1.234',
-      },
-      {
-        attribute: {
-          name: 'DoubleAttribute',
-          type: 'Double',
-          value: 123.12,
-        },
-        en_US: '123.12',
-        de_DE: '123,12',
-      },
-      {
-        attribute: {
-          name: 'LongAttribute',
-          type: 'Long',
-          value: 123456789,
-        },
-        en_US: '123,456,789',
-        de_DE: '123.456.789',
-      },
-      {
-        attribute: {
-          name: 'BigDecimalAttribute',
-          type: 'BigDecimal',
-          value: 12345.6789,
-        },
-        en_US: '12,345.679',
-        de_DE: '12.345,679',
-      },
-      {
-        attribute: {
-          name: 'BooleanAttribute',
-          type: 'Boolean',
-          value: true,
-        },
-        en_US: 'true',
-        de_DE: 'true',
-      },
-      {
-        attribute: {
-          name: 'QuantityAttribute',
-          type: 'ResourceAttribute',
-          value: {
-            type: 'Quantity',
-            value: 1234,
-            unit: 'mm',
-          },
-        },
-        en_US: '1,234\xA0mm',
-        de_DE: '1.234\xA0mm',
-      },
-      {
-        attribute: {
-          name: 'MoneyAttribute',
-          type: 'ResourceAttribute',
-          value: {
-            type: 'Money',
-            value: 391.98,
-            currency: 'USD',
-          },
-        },
-        en_US: '$391.98',
-        de_DE: '391,98\xA0$',
-      },
-      {
-        attribute: {
-          name: 'UnsupportedAttribute',
-          type: 'Unsupported',
-          value: 'SomeValue',
-        },
-        en_US: 'SomeValue',
-        de_DE: 'SomeValue',
-      },
-      {
-        attribute: {
-          name: 'MultipleStringAttribute',
-          type: 'MultipleString',
-          value: ['hallo', 'welt'],
-        },
-        en_US: `hallo${valuesSeparator}welt`,
-        de_DE: `hallo${valuesSeparator}welt`,
-      },
-      {
-        attribute: {
-          name: 'MultipleIntegerAttribute',
-          type: 'MultipleInteger',
-          value: [12345, 2345],
-        },
-        en_US: `12,345${valuesSeparator}2,345`,
-        de_DE: `12.345${valuesSeparator}2.345`,
-      },
-      {
-        attribute: {
-          name: 'MultipleDoubleAttribute',
-          type: 'MultipleDouble',
-          value: [1234.5, 234.5],
-        },
-        en_US: `1,234.5${valuesSeparator}234.5`,
-        de_DE: `1.234,5${valuesSeparator}234,5`,
-      },
-      {
-        attribute: {
-          name: 'MultipleLongAttribute',
-          type: 'MultipleLong',
-          value: [123456789, 123456789],
-        },
-        en_US: `123,456,789${valuesSeparator}123,456,789`,
-        de_DE: `123.456.789${valuesSeparator}123.456.789`,
-      },
-      {
-        attribute: {
-          name: 'MultipleBigDecimalAttribute',
-          type: 'MultipleBigDecimal',
-          value: [12.3456789, 12345.6789],
-        },
-        en_US: `12.346${valuesSeparator}12,345.679`,
-        de_DE: `12,346${valuesSeparator}12.345,679`,
-      },
-      {
-        attribute: {
-          name: 'MultipleBooleanAttribute',
-          type: 'MultipleBoolean',
-          value: [true, false],
-        },
-        en_US: `true${valuesSeparator}false`,
-        de_DE: `true${valuesSeparator}false`,
-      },
-      {
-        attribute: {
-          name: 'MultipleDateAttribute',
-          type: 'MultipleDate',
-          value: [1355270400000, 1349827200000],
-        },
-        en_US: `12/12/12${valuesSeparator}10/10/12`,
-        de_DE: `12.12.12${valuesSeparator}10.10.12`,
-      },
-    ];
-  }
-
-  using(dataProvider, slice => {
-    it(`should translate attribute of type ${slice.attribute.type} correcly when locale en_US is set`, () => {
+  describe.each`
+    attribute                                                                                                          | en_US                                         | de_DE
+    ${{ name: 'StringAttribute', type: 'String', value: '1920 x 1080, 1600 x 1200, 640 x 480' }}                       | ${'1920 x 1080, 1600 x 1200, 640 x 480'}      | ${'1920 x 1080, 1600 x 1200, 640 x 480'}
+    ${{ name: 'DateAttribute', type: 'Date', value: 1521457386000 }}                                                   | ${'3/19/18'}                                  | ${'19.03.18'}
+    ${{ name: 'IntegerAttribute', type: 'Integer', value: 1234 }}                                                      | ${'1,234'}                                    | ${'1.234'}
+    ${{ name: 'DoubleAttribute', type: 'Double', value: 123.12 }}                                                      | ${'123.12'}                                   | ${'123,12'}
+    ${{ name: 'LongAttribute', type: 'Long', value: 123456789 }}                                                       | ${'123,456,789'}                              | ${'123.456.789'}
+    ${{ name: 'BigDecimalAttribute', type: 'BigDecimal', value: 12345.6789 }}                                          | ${'12,345.679'}                               | ${'12.345,679'}
+    ${{ name: 'BooleanAttribute', type: 'Boolean', value: true }}                                                      | ${'true'}                                     | ${'true'}
+    ${{ name: 'QuantityAttribute', type: 'ResourceAttribute', value: { type: 'Quantity', value: 1234, unit: 'mm' } }}  | ${'1,234\xA0mm'}                              | ${'1.234\xA0mm'}
+    ${{ name: 'MoneyAttribute', type: 'ResourceAttribute', value: { type: 'Money', value: 391.98, currency: 'USD' } }} | ${'$391.98'}                                  | ${'391,98\xA0$'}
+    ${{ name: 'UnsupportedAttribute', type: 'Unsupported', value: 'SomeValue' }}                                       | ${'SomeValue'}                                | ${'SomeValue'}
+    ${{ name: 'MultipleStringAttribute', type: 'MultipleString', value: ['hallo', 'welt'] }}                           | ${`hallo${valuesSeparator}welt`}              | ${`hallo${valuesSeparator}welt`}
+    ${{ name: 'MultipleIntegerAttribute', type: 'MultipleInteger', value: [12345, 2345] }}                             | ${`12,345${valuesSeparator}2,345`}            | ${`12.345${valuesSeparator}2.345`}
+    ${{ name: 'MultipleDoubleAttribute', type: 'MultipleDouble', value: [1234.5, 234.5] }}                             | ${`1,234.5${valuesSeparator}234.5`}           | ${`1.234,5${valuesSeparator}234,5`}
+    ${{ name: 'MultipleLongAttribute', type: 'MultipleLong', value: [123456789, 123456789] }}                          | ${`123,456,789${valuesSeparator}123,456,789`} | ${`123.456.789${valuesSeparator}123.456.789`}
+    ${{ name: 'MultipleBigDecimalAttribute', type: 'MultipleBigDecimal', value: [12.3456789, 12345.6789] }}            | ${`12.346${valuesSeparator}12,345.679`}       | ${`12,346${valuesSeparator}12.345,679`}
+    ${{ name: 'MultipleBooleanAttribute', type: 'MultipleBoolean', value: [true, false] }}                             | ${`true${valuesSeparator}false`}              | ${`true${valuesSeparator}false`}
+    ${{ name: 'MultipleDateAttribute', type: 'MultipleDate', value: [1355270400000, 1349827200000] }}                  | ${`12/12/12${valuesSeparator}10/10/12`}       | ${`12.12.12${valuesSeparator}10.10.12`}
+  `('should translate attribute of type $attribute.type correctly when locale ', ({ attribute, en_US, de_DE }) => {
+    // tslint:disable-next-line:meaningful-naming-in-tests
+    it(`en_US is set`, () => {
       translateService.use('en_US');
-      expect(pipe.transform(slice.attribute, valuesSeparator)).toEqual(slice.en_US);
+      expect(pipe.transform(attribute, valuesSeparator)).toEqual(en_US);
     });
-
-    it(`should translate attribute of type ${slice.attribute.type} correcly when locale de_DE is set`, () => {
+    // tslint:disable-next-line:meaningful-naming-in-tests
+    it(`de_DE is set`, () => {
       translateService.use('de_DE');
-      expect(pipe.transform(slice.attribute, valuesSeparator)).toEqual(slice.de_DE);
+      expect(pipe.transform(attribute, valuesSeparator)).toEqual(de_DE);
     });
   });
 });

--- a/src/app/core/models/category-tree/category-tree.helper.spec.ts
+++ b/src/app/core/models/category-tree/category-tree.helper.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import * as using from 'jasmine-data-provider';
 
 import { CategoryData } from 'ish-core/models/category/category.interface';
 import { CategoryMapper } from 'ish-core/models/category/category.mapper';
@@ -431,33 +430,28 @@ describe('Category Tree Helper', () => {
   });
 
   describe('updateStrategy()', () => {
-    using(
-      [
-        { category1CL: 0, category2CL: 1, expected: 'new' },
-        { category1CL: 0, category2CL: 2, expected: 'new' },
-        { category1CL: 2, category2CL: 2, expected: 'new' },
-        { category1CL: 1, category2CL: 0, expected: 'old' },
-        { category1CL: 2, category2CL: 0, expected: 'old' },
-      ],
-      slice => {
-        it(`should prefer ${slice.expected} one when having completenessLevel ${slice.category1completenessLevel} vs. ${slice.category2completenessLevel}`, () => {
-          const category1 = {
-            uniqueId: 'A',
-            name: 'old',
-            completenessLevel: slice.category1CL,
-          } as Category;
-          const category2 = {
-            uniqueId: 'A',
-            name: 'new',
-            completenessLevel: slice.category2CL,
-          } as Category;
+    it.each([
+      ['new', 0, 1],
+      ['new', 0, 2],
+      ['new', 2, 2],
+      ['old', 1, 0],
+      ['old', 2, 0],
+    ])(`should prefer %s one when having completenessLevel %i vs. %i`, (expected, category1CL, category2CL) => {
+      const category1 = {
+        uniqueId: 'A',
+        name: 'old',
+        completenessLevel: category1CL,
+      } as Category;
+      const category2 = {
+        uniqueId: 'A',
+        name: 'new',
+        completenessLevel: category2CL,
+      } as Category;
 
-          const result = CategoryTreeHelper.updateStrategy(category1, category2);
+      const result = CategoryTreeHelper.updateStrategy(category1, category2);
 
-          expect(result.name).toEqual(slice.expected);
-        });
-      }
-    );
+      expect(result.name).toEqual(expected);
+    });
   });
 
   describe('subTree', () => {

--- a/src/app/core/models/category/category.helper.spec.ts
+++ b/src/app/core/models/category/category.helper.spec.ts
@@ -1,43 +1,29 @@
-import * as using from 'jasmine-data-provider';
-
 import { CategoryCompletenessLevel, CategoryHelper } from './category.helper';
 import { Category } from './category.model';
 
 describe('Category Helper', () => {
   describe('getCategoryPath', () => {
-    function dataProvider() {
-      return [
-        { uniqueId: undefined, result: undefined },
-        { uniqueId: '', result: undefined },
-        { uniqueId: 'A', result: 'A' },
-        { uniqueId: 'A.B', result: 'A/B' },
-        { uniqueId: 'A.B.C', result: 'A/B/C' },
-      ];
-    }
-
-    using(dataProvider, slice => {
-      it(`should return '${slice.result}' when expanding '${slice.uniqueId}'`, () => {
-        expect(CategoryHelper.getCategoryPath(slice.uniqueId)).toEqual(slice.result);
-      });
+    it.each([
+      [undefined, undefined],
+      [undefined, ''],
+      ['A', 'A'],
+      ['A/B', 'A.B'],
+      ['A/B/C', 'A.B.C'],
+    ])(`should return '%s' when expanding '%s'`, (result, uniqueId) => {
+      expect(CategoryHelper.getCategoryPath(uniqueId)).toEqual(result);
     });
   });
 
-  describe('isCategoryCompletelyLoaded', () => {
-    function dataProvider() {
-      return [
-        { category: undefined, result: false },
-        { category: {} as Category, result: false },
-        { category: { completenessLevel: undefined } as Category, result: false },
-        { category: { completenessLevel: 0 } as Category, result: false },
-        { category: { completenessLevel: CategoryCompletenessLevel.Max } as Category, result: true },
-        { category: { completenessLevel: CategoryCompletenessLevel.Max + 1 } as Category, result: true },
-      ];
-    }
-
-    using(dataProvider, slice => {
-      it(`should return ${slice.result} when checking '${JSON.stringify(slice.category)}'`, () => {
-        expect(CategoryHelper.isCategoryCompletelyLoaded(slice.category)).toEqual(slice.result);
-      });
+  describe('Category Helper', () => {
+    it.each([
+      [false, undefined],
+      [false, {} as Category],
+      [false, { completenessLevel: undefined } as Category],
+      [false, { completenessLevel: 0 } as Category],
+      [true, { completenessLevel: CategoryCompletenessLevel.Max } as Category],
+      [true, { completenessLevel: CategoryCompletenessLevel.Max + 1 } as Category],
+    ])(`should return %s when checking '%j'`, (result, category) => {
+      expect(CategoryHelper.isCategoryCompletelyLoaded(category)).toEqual(result);
     });
   });
 });

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import * as using from 'jasmine-data-provider';
 
 import { Locale } from 'ish-core/models/locale/locale.model';
 import { getCurrentLocale, getICMStaticURL } from 'ish-core/store/core/configuration';
@@ -63,46 +62,25 @@ describe('Content Configuration Parameter Mapper', () => {
   });
 
   describe('postProcessFileReferences', () => {
-    using(
+    it.each([
+      ['assets/pwa/pwa_home_teaser_1.jpg', 'assets/pwa/pwa_home_teaser_1.jpg', 'Image'],
       [
-        {
-          key: 'Image',
-          input: 'assets/pwa/pwa_home_teaser_1.jpg',
-          expected: 'assets/pwa/pwa_home_teaser_1.jpg',
-        },
-        {
-          key: 'Image',
-          input: 'site:/pwa/pwa_home_teaser_1.jpg',
-          expected: 'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
-        },
-        {
-          key: 'ImageXS',
-          input: 'site:/pwa/pwa_home_teaser_1.jpg',
-          expected: 'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
-        },
-        {
-          key: 'Other',
-          input: 'site:/pwa/pwa_home_teaser_1.jpg',
-          expected: 'site:/pwa/pwa_home_teaser_1.jpg',
-        },
-        {
-          key: 'Video',
-          input: 'site:/video/video.mp4',
-          expected: 'http://www.example.org/static/channel/-/site/de_DE/video/video.mp4',
-        },
-        {
-          key: 'Video',
-          input: 'https://www.youtube.com/watch?v=ABCDEFG',
-          expected: 'https://www.youtube.com/watch?v=ABCDEFG',
-        },
+        'site:/pwa/pwa_home_teaser_1.jpg',
+        'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
+        'Image',
       ],
-      ({ key, input, expected }) => {
-        it(`should transform ${input} to ${expected} for key ${key}`, () => {
-          expect(contentConfigurationParameterMapper.postProcessFileReferences({ [key]: input })).toEqual({
-            [key]: expected,
-          });
-        });
-      }
-    );
+      [
+        'site:/pwa/pwa_home_teaser_1.jpg',
+        'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
+        'ImageXS',
+      ],
+      ['site:/pwa/pwa_home_teaser_1.jpg', 'site:/pwa/pwa_home_teaser_1.jpg', 'Other'],
+      ['site:/video/video.mp4', 'http://www.example.org/static/channel/-/site/de_DE/video/video.mp4', 'Video'],
+      ['https://www.youtube.com/watch?v=ABCDEFG', 'https://www.youtube.com/watch?v=ABCDEFG', 'Video'],
+    ])(`should transform %s to %s for key %s`, (input, expected, key) => {
+      expect(contentConfigurationParameterMapper.postProcessFileReferences({ [key]: input })).toEqual({
+        [key]: expected,
+      });
+    });
   });
 });

--- a/src/app/core/models/content-view/content-view.helper.spec.ts
+++ b/src/app/core/models/content-view/content-view.helper.spec.ts
@@ -1,58 +1,44 @@
-import * as using from 'jasmine-data-provider';
-
 import { ContentViewHelper } from './content-view.helper';
 import { createContentPageletView } from './content-view.model';
 
 describe('Content View Helper', () => {
   describe('getRouterLink', () => {
-    using(
-      [
-        { input: 'route://category/Computers', expected: '/category/Computers' },
-        { input: 'route://category/Home-Entertainment.SmartHome', expected: '/category/Home-Entertainment.SmartHome' },
-        { input: 'product://201807195@inSPIRED-inTRONICS', expected: '/sku201807195' },
-      ],
-      ({ input, expected }) => {
-        it(`should transform ${input} to ${expected}`, () => {
-          const pagelet = createContentPageletView({
-            definitionQualifiedName: 'fq',
-            id: 'id',
-            domain: 'domain',
-            displayName: 'name',
-            configurationParameters: {
-              Link: input,
-            },
-          });
-
-          expect(ContentViewHelper.getRouterLink(pagelet, 'Link')).toEqual(expected);
-        });
-      }
-    );
+    it.each([
+      ['route://category/Computers', '/category/Computers'],
+      ['route://category/Home-Entertainment.SmartHome', '/category/Home-Entertainment.SmartHome'],
+      ['product://201807195@inSPIRED-inTRONICS', '/sku201807195'],
+    ])(`should transform %s to %s`, (input, expected) => {
+      const pagelet = createContentPageletView({
+        definitionQualifiedName: 'fq',
+        id: 'id',
+        domain: 'domain',
+        displayName: 'name',
+        configurationParameters: {
+          Link: input,
+        },
+      });
+      expect(ContentViewHelper.getRouterLink(pagelet, 'Link')).toEqual(expected);
+    });
   });
 
-  describe('isRouterLink', () => {
-    using(
-      [
-        { input: 'route://category/Computers', expected: true },
-        { input: 'product://201807195@inSPIRED-inTRONICS', expected: true },
-        { input: 'page://page.aboutus', expected: true },
-        { input: 'http://example.com', expected: false },
-        { input: 'https://example.com', expected: false },
-      ],
-      ({ input, expected }) => {
-        it(`should evalute ${input} to ${expected}`, () => {
-          const pagelet = createContentPageletView({
-            definitionQualifiedName: 'fq',
-            id: 'id',
-            domain: 'domain',
-            displayName: 'name',
-            configurationParameters: {
-              Link: input,
-            },
-          });
-
-          expect(ContentViewHelper.isRouterLink(pagelet, 'Link')).toEqual(expected);
-        });
-      }
-    );
+  describe('Content View Helper', () => {
+    it.each([
+      ['route://category/Computers', true],
+      ['product://201807195@inSPIRED-inTRONICS', true],
+      ['page://page.aboutus', true],
+      ['http://example.com', false],
+      ['https://example.com', false],
+    ])(`should evalute %s to %s`, (input, expected) => {
+      const pagelet = createContentPageletView({
+        definitionQualifiedName: 'fq',
+        id: 'id',
+        domain: 'domain',
+        displayName: 'name',
+        configurationParameters: {
+          Link: input,
+        },
+      });
+      expect(ContentViewHelper.isRouterLink(pagelet, 'Link')).toEqual(expected);
+    });
   });
 });

--- a/src/app/core/models/price/price.helper.spec.ts
+++ b/src/app/core/models/price/price.helper.spec.ts
@@ -1,125 +1,117 @@
-import * as using from 'jasmine-data-provider';
-
 import { PriceItem } from 'ish-core/models/price-item/price-item.model';
 
 import { Price, PriceHelper } from './price.model';
 
 describe('Price Helper', () => {
-  function dataProviderValid() {
-    return [
-      {
-        p1: { type: 'Money', currency: 'USD', value: 10 } as Price,
-        p2: { type: 'Money', currency: 'USD', value: 9 } as Price,
-        diff: { type: 'Money', currency: 'USD', value: 1 } as Price,
-        sum: { type: 'Money', currency: 'USD', value: 19 } as Price,
-        min: { type: 'Money', currency: 'USD', value: 9 } as Price,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 10.99 } as Price,
-        p2: { type: 'Money', currency: 'USD', value: 9.45 } as Price,
-        diff: { type: 'Money', currency: 'USD', value: 1.54 } as Price,
-        sum: { type: 'Money', currency: 'USD', value: 20.44 } as Price,
-        min: { type: 'Money', currency: 'USD', value: 9.45 } as Price,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 8 } as Price,
-        p2: { type: 'Money', currency: 'USD', value: 9 } as Price,
-        diff: { type: 'Money', currency: 'USD', value: -1 } as Price,
-        sum: { type: 'Money', currency: 'USD', value: 17 } as Price,
-        min: { type: 'Money', currency: 'USD', value: 8 } as Price,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 8.88888 } as Price,
-        p2: { type: 'Money', currency: 'USD', value: 3.55555 } as Price,
-        diff: { type: 'Money', currency: 'USD', value: 5.33 } as Price,
-        sum: { type: 'Money', currency: 'USD', value: 12.44 } as Price,
-        min: { type: 'Money', currency: 'USD', value: 3.56 } as Price,
-      },
-    ];
-  }
-
-  function dataProviderInvalid() {
-    return [
-      {
-        p1: undefined,
-        p2: { type: 'Money', currency: 'USD', value: 9 } as Price,
-        error: /.*undefined.*/,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 9 } as Price,
-        p2: undefined,
-        error: /.*undefined.*/,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 9 } as Price,
-        p2: { type: 'Money', value: 9 } as Price,
-        error: /.*undefined.*/,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 9 } as Price,
-        p2: { type: 'Money', currency: 'USD' } as Price,
-        error: /.*undefined.*/,
-      },
-      {
-        p1: { type: 'Money', currency: 'USD', value: 10 } as Price,
-        p2: { type: 'Money', currency: 'EUR', value: 9 } as Price,
-        error: /.*currency.*/,
-      },
-    ];
-  }
+  const dataProviderInvalid = [
+    [/.*undefined.*/, undefined, { type: 'Money', currency: 'USD', value: 9 }],
+    [/.*undefined.*/, { type: 'Money', currency: 'USD', value: 9 }, undefined],
+    [/.*undefined.*/, { type: 'Money', currency: 'USD', value: 9 }, { type: 'Money', value: 9 }],
+    [/.*undefined.*/, { type: 'Money', currency: 'USD', value: 9 }, { type: 'Money', currency: 'USD' }],
+    [/.*currency.*/, { type: 'Money', currency: 'USD', value: 10 }, { type: 'Money', currency: 'EUR', value: 9 }],
+  ];
 
   describe('diff', () => {
-    using(dataProviderValid, slice => {
-      it(`should return ${slice.diff.value} when diff'ing '${JSON.stringify(slice.p1)}' and '${JSON.stringify(
-        slice.p2
-      )}'`, () => {
-        expect(PriceHelper.diff(slice.p1, slice.p2)).toEqual(slice.diff);
-      });
+    it.each([
+      [
+        { type: 'Money', currency: 'USD', value: 1 },
+        { type: 'Money', currency: 'USD', value: 10 },
+        { type: 'Money', currency: 'USD', value: 9 },
+      ],
+
+      [
+        { type: 'Money', currency: 'USD', value: 1.54 },
+        { type: 'Money', currency: 'USD', value: 10.99 },
+        { type: 'Money', currency: 'USD', value: 9.45 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: -1 },
+        { type: 'Money', currency: 'USD', value: 8 },
+        { type: 'Money', currency: 'USD', value: 9 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 5.33 },
+        { type: 'Money', currency: 'USD', value: 8.88888 },
+        { type: 'Money', currency: 'USD', value: 3.55555 },
+      ],
+    ])(`should return %j when diff'ing '%j' and '%j'`, (diff, p1: Price, p2: Price) => {
+      expect(PriceHelper.diff(p1, p2)).toEqual(diff);
     });
 
-    using(dataProviderInvalid, slice => {
-      it(`should throw something like ${slice.error} when diff'ing '${JSON.stringify(slice.p1)}' and '${JSON.stringify(
-        slice.p2
-      )}'`, () => {
-        expect(() => PriceHelper.diff(slice.p1, slice.p2)).toThrowError(slice.error);
-      });
-    });
+    it.each(dataProviderInvalid)(
+      `should throw something like %s when diff'ing '%j' and '%j'`,
+      (error: RegExp, p1: Price, p2: Price) => {
+        expect(() => PriceHelper.diff(p1, p2)).toThrowError(error);
+      }
+    );
   });
 
   describe('sum', () => {
-    using(dataProviderValid, slice => {
-      it(`should return ${slice.sum.value} when summing '${JSON.stringify(slice.p1)}' and '${JSON.stringify(
-        slice.p2
-      )}'`, () => {
-        expect(PriceHelper.sum(slice.p1, slice.p2)).toEqual(slice.sum);
-      });
+    it.each([
+      [
+        { type: 'Money', currency: 'USD', value: 19 },
+        { type: 'Money', currency: 'USD', value: 10 },
+        { type: 'Money', currency: 'USD', value: 9 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 20.44 },
+        { type: 'Money', currency: 'USD', value: 10.99 },
+        { type: 'Money', currency: 'USD', value: 9.45 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 17 },
+        { type: 'Money', currency: 'USD', value: 8 },
+        { type: 'Money', currency: 'USD', value: 9 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 12.44 },
+        { type: 'Money', currency: 'USD', value: 8.88888 },
+        { type: 'Money', currency: 'USD', value: 3.55555 },
+      ],
+    ])(`should return %j when summing '%j' and '%j'`, (sum, p1: Price, p2: Price) => {
+      expect(PriceHelper.sum(p1, p2)).toEqual(sum);
     });
 
-    using(dataProviderInvalid, slice => {
-      it(`should throw something like ${slice.error} when summing '${JSON.stringify(slice.p1)}' and '${JSON.stringify(
-        slice.p2
-      )}'`, () => {
-        expect(() => PriceHelper.sum(slice.p1, slice.p2)).toThrowError(slice.error);
-      });
-    });
+    it.each(dataProviderInvalid)(
+      `should throw something like %s when summing '%j' and '%j'`,
+      (error: RegExp, p1: Price, p2: Price) => {
+        expect(() => PriceHelper.sum(p1, p2)).toThrowError(error);
+      }
+    );
   });
 
   describe('min', () => {
-    using(dataProviderValid, slice => {
-      it(`should return ${slice.min.value} when finding minimum of '${JSON.stringify(slice.p1)}' and '${JSON.stringify(
-        slice.p2
-      )}'`, () => {
-        expect(PriceHelper.min(slice.p1, slice.p2)).toEqual(slice.min);
-      });
+    it.each([
+      [
+        { type: 'Money', currency: 'USD', value: 9 },
+        { type: 'Money', currency: 'USD', value: 10 },
+        { type: 'Money', currency: 'USD', value: 9 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 9.45 },
+        { type: 'Money', currency: 'USD', value: 10.99 },
+        { type: 'Money', currency: 'USD', value: 9.45 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 8 },
+        { type: 'Money', currency: 'USD', value: 8 },
+        { type: 'Money', currency: 'USD', value: 9 },
+      ],
+      [
+        { type: 'Money', currency: 'USD', value: 3.56 },
+        { type: 'Money', currency: 'USD', value: 8.88888 },
+        { type: 'Money', currency: 'USD', value: 3.55555 },
+      ],
+    ])(`should return %j when finding minimum of '%j' and '%j'`, (min, p1: Price, p2: Price) => {
+      expect(PriceHelper.min(p1, p2)).toEqual(min);
     });
 
-    using(dataProviderInvalid, slice => {
-      it(`should throw something like ${slice.error} when finding minimum '${JSON.stringify(
-        slice.p1
-      )}' and '${JSON.stringify(slice.p2)}'`, () => {
-        expect(() => PriceHelper.min(slice.p1, slice.p2)).toThrowError(slice.error);
-      });
-    });
+    it.each(dataProviderInvalid)(
+      `should throw something like %s when finding minimum '%j' and '%j'`,
+      (error: RegExp, p1: Price, p2: Price) => {
+        expect(() => PriceHelper.min(p1, p2)).toThrowError(error);
+      }
+    );
   });
 
   describe('invert', () => {

--- a/src/app/core/models/product/product.helper.spec.ts
+++ b/src/app/core/models/product/product.helper.spec.ts
@@ -1,5 +1,3 @@
-import * as using from 'jasmine-data-provider';
-
 import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.model';
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
@@ -119,18 +117,12 @@ describe('Product Helper', () => {
   });
 
   describe('isMasterProduct()', () => {
-    function dataProvider() {
-      return [
-        { product: { type: 'Product' }, expected: false },
-        { product: { type: 'VariationProduct' }, expected: false },
-        { product: { type: 'VariationProductMaster' }, expected: true },
-      ];
-    }
-
-    using(dataProvider, dataSlice => {
-      it(`should return ${dataSlice.expected} when supplying product '${JSON.stringify(dataSlice.product)}'`, () => {
-        expect(ProductHelper.isMasterProduct(dataSlice.product)).toEqual(dataSlice.expected);
-      });
+    it.each([
+      [false, { type: 'Product' }],
+      [false, { type: 'VariationProduct' }],
+      [true, { type: 'VariationProductMaster' }],
+    ])(`should return %s when supplying '%j'`, (expected, product: Product) => {
+      expect(ProductHelper.isMasterProduct(product)).toEqual(expected);
     });
   });
 
@@ -161,51 +153,36 @@ describe('Product Helper', () => {
   });
 
   describe('isFailedLoading()', () => {
-    using(
-      [
-        { product: undefined, expected: false },
-        { product: {}, expected: false },
-        { product: { failed: false }, expected: false },
-        { product: { failed: true }, expected: true },
-      ],
-      ({ product, expected }) => {
-        it(`should return ${expected} when supplying product '${JSON.stringify(product)}'`, () => {
-          expect(ProductHelper.isFailedLoading(product)).toEqual(expected);
-        });
-      }
-    );
+    it.each([
+      [false, undefined],
+      [false, {}],
+      [false, { failed: false }],
+      [true, { failed: true }],
+    ])(`should return %s when supplying product '%j'`, (expected, product: Product) => {
+      expect(ProductHelper.isFailedLoading(product)).toEqual(expected);
+    });
   });
 
   describe('isSufficientlyLoaded()', () => {
-    using(
-      [
-        { product: undefined, expected: false },
-        { product: { completenessLevel: 0 }, expected: false },
-        { product: { completenessLevel: ProductCompletenessLevel.List }, expected: true },
-        { product: { completenessLevel: ProductCompletenessLevel.Detail }, expected: true },
-      ],
-      ({ product, expected }) => {
-        it(`should return ${expected} when supplying product '${JSON.stringify(product)}'`, () => {
-          expect(ProductHelper.isSufficientlyLoaded(product, ProductCompletenessLevel.List)).toEqual(expected);
-        });
-      }
-    );
+    it.each([
+      [false, undefined],
+      [false, { completenessLevel: 0 }],
+      [true, { completenessLevel: ProductCompletenessLevel.List }],
+      [true, { completenessLevel: ProductCompletenessLevel.Detail }],
+    ])(`should return %s when supplying product '%j'`, (expected, product: Product) => {
+      expect(ProductHelper.isSufficientlyLoaded(product, ProductCompletenessLevel.List)).toEqual(expected);
+    });
   });
 
   describe('isReadyForDisplay()', () => {
-    using(
-      [
-        { product: undefined, expected: false },
-        { product: { completenessLevel: ProductCompletenessLevel.List }, expected: true },
-        { product: { completenessLevel: ProductCompletenessLevel.Detail }, expected: true },
-        { product: { failed: true }, expected: true },
-      ],
-      ({ product, expected }) => {
-        it(`should return ${expected} when supplying product '${JSON.stringify(product)}'`, () => {
-          expect(ProductHelper.isReadyForDisplay(product, ProductCompletenessLevel.List)).toEqual(expected);
-        });
-      }
-    );
+    it.each([
+      [false, undefined],
+      [true, { completenessLevel: ProductCompletenessLevel.List }],
+      [true, { completenessLevel: ProductCompletenessLevel.Detail }],
+      [true, { failed: true }],
+    ])(`should return %s when supplying product '%j'`, (expected, product: Product) => {
+      expect(ProductHelper.isReadyForDisplay(product, ProductCompletenessLevel.List)).toEqual(expected);
+    });
   });
 
   describe('calculatePriceRange()', () => {

--- a/src/app/core/models/product/product.mapper.spec.ts
+++ b/src/app/core/models/product/product.mapper.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import * as using from 'jasmine-data-provider';
 import { anything, spy, verify } from 'ts-mockito';
 
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
@@ -231,25 +230,20 @@ describe('Product Mapper', () => {
   });
 
   describe('parseSKUfromURI()', () => {
-    using(
-      [
-        'site/products/123',
-        'products/123',
-        'site/products/123?test=dummy',
-        'products/123?test=dummy',
-        'site/products;spgid=dfds/123',
-        'products;spgid=dfds/123',
-        'site/products;spgid=dfds/123?test=dummy',
-        'products;spgid=dfds/123?test=dummy',
-        'site/products;spgid=dfds/123?test=dummy&test2=dummy',
-        'products;spgid=dfds/123?test=dummy&test2=dummy',
-      ],
-      uri => {
-        it(`should parse correct sku when given '${uri}'`, () => {
-          expect(ProductMapper.parseSKUfromURI(uri)).toEqual('123');
-        });
-      }
-    );
+    it.each([
+      'site/products/123',
+      'products/123',
+      'site/products/123?test=dummy',
+      'products/123?test=dummy',
+      'site/products;spgid=dfds/123',
+      'products;spgid=dfds/123',
+      'site/products;spgid=dfds/123?test=dummy',
+      'products;spgid=dfds/123?test=dummy',
+      'site/products;spgid=dfds/123?test=dummy&test2=dummy',
+      'products;spgid=dfds/123?test=dummy&test2=dummy',
+    ])(`should parse correct sku when given '%s'`, uri => {
+      expect(ProductMapper.parseSKUfromURI(uri)).toEqual('123');
+    });
   });
 
   it('should find default variation for master product', () => {

--- a/src/app/core/pipes/date.pipe.spec.ts
+++ b/src/app/core/pipes/date.pipe.spec.ts
@@ -2,7 +2,6 @@ import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import * as using from 'jasmine-data-provider';
 
 import { DatePipe } from './date.pipe';
 
@@ -27,61 +26,23 @@ describe('Date Pipe', () => {
     expect(datePipe).toBeTruthy();
   });
 
-  using(
-    [
-      {
-        date: undefined,
-        format: undefined,
-        EN: 'undefined',
-        DE: 'undefined',
-      },
-      {
-        date: 1000,
-        format: undefined,
-        EN: 'Jan 1, 1970',
-        DE: '01.01.1970',
-      },
-      {
-        date: new Date(1000),
-        format: 'shortDate',
-        EN: '1/1/70',
-        DE: '01.01.70',
-      },
-      {
-        date: '1971-01-01T00:00:01+00:00',
-        format: 'mediumTime',
-        EN: '12:00:01 AM',
-        DE: '00:00:01',
-      },
-      {
-        date: 32452435234,
-        format: undefined,
-        EN: 'Jan 11, 1971',
-        DE: '11.01.1971',
-      },
-      {
-        date: new Date(32452435234),
-        format: 'shortDate',
-        EN: '1/11/71',
-        DE: '11.01.71',
-      },
-      {
-        date: '1971-01-11T14:33:55+00:00',
-        format: 'mediumTime',
-        EN: '2:33:55 PM',
-        DE: '14:33:55',
-      },
-    ],
-    ({ date, format, EN, DE }) => {
-      it(`should transform ${date} to ${EN} with format ${format} for english locale`, () => {
-        translateService.use('en');
-        expect(datePipe.transform(date, format)).toEqual(EN);
-      });
-
-      it(`should transform ${date} to ${DE} with format ${format} for german locale`, () => {
-        translateService.use('de');
-        expect(datePipe.transform(date, format)).toEqual(DE);
-      });
-    }
-  );
+  describe.each`
+    date                           | format          | EN                | DE
+    ${undefined}                   | ${undefined}    | ${'undefined'}    | ${'undefined'}
+    ${1000}                        | ${undefined}    | ${'Jan 1, 1970'}  | ${'01.01.1970'}
+    ${new Date(1000)}              | ${'shortDate'}  | ${'1/1/70'}       | ${'01.01.70'}
+    ${'1971-01-01T00:00:01+00:00'} | ${'mediumTime'} | ${'12:00:01 AM'}  | ${'00:00:01'}
+    ${32452435234}                 | ${undefined}    | ${'Jan 11, 1971'} | ${'11.01.1971'}
+    ${new Date(32452435234)}       | ${'shortDate'}  | ${'1/11/71'}      | ${'11.01.71'}
+    ${'1971-01-11T14:33:55+00:00'} | ${'mediumTime'} | ${'2:33:55 PM'}   | ${'14:33:55'}
+  `('should transform $date to ', ({ date, format, EN, DE }) => {
+    test(`${EN} with format ${format} for english local`, () => {
+      translateService.use('en');
+      expect(datePipe.transform(date, format)).toEqual(EN);
+    });
+    test(`${DE} with format ${format} for german locale`, () => {
+      translateService.use('de');
+      expect(datePipe.transform(date, format)).toEqual(DE);
+    });
+  });
 });

--- a/src/app/core/pipes/highlight.pipe.spec.ts
+++ b/src/app/core/pipes/highlight.pipe.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import * as using from 'jasmine-data-provider';
 
 import { HighlightPipe } from './highlight.pipe';
 
@@ -17,26 +16,16 @@ describe('Highlight Pipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  using(
+  it.each([
+    [undefined, undefined, undefined],
+    ['Lorem ipsum dolor sit amet', undefined, 'Lorem ipsum dolor sit amet'],
+    ['Lorem ipsum dolor sit amet', 'ipsum', 'Lorem <span class="searchTerm">ipsum</span> dolor sit amet'],
     [
-      { text: undefined, expected: undefined },
-      { text: 'Lorem ipsum dolor sit amet', search: undefined, expected: 'Lorem ipsum dolor sit amet' },
-      {
-        text: 'Lorem ipsum dolor sit amet',
-        search: 'ipsum',
-        expected: 'Lorem <span class="searchTerm">ipsum</span> dolor sit amet',
-      },
-      {
-        text: 'Lorem ipsum dolor sit amet',
-        search: 'Lorem ipsum dolor sit amet',
-        expected:
-          '<span class="searchTerm">Lorem</span> <span class="searchTerm">ipsum</span> <span class="searchTerm">dolor</span> <span class="searchTerm">sit</span> <span class="searchTerm">amet</span>',
-      },
+      'Lorem ipsum dolor sit amet',
+      'Lorem ipsum dolor sit amet',
+      '<span class="searchTerm">Lorem</span> <span class="searchTerm">ipsum</span> <span class="searchTerm">dolor</span> <span class="searchTerm">sit</span> <span class="searchTerm">amet</span>',
     ],
-    ({ text, search, expected }) => {
-      it(`should transform "${text}" with "${search}" to "${expected}"`, () => {
-        expect(pipe.transform(text, search)).toEqual(expected);
-      });
-    }
-  );
+  ])(`should transform '%s' with '%s' to '%s'`, (text, search, expected) => {
+    expect(pipe.transform(text, search)).toEqual(expected);
+  });
 });

--- a/src/app/core/pipes/make-href.pipe.spec.ts
+++ b/src/app/core/pipes/make-href.pipe.spec.ts
@@ -1,6 +1,5 @@
 import { Location } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
-import * as using from 'jasmine-data-provider';
 
 import { MakeHrefPipe } from './make-href.pipe';
 
@@ -18,22 +17,17 @@ describe('Make Href Pipe', () => {
     expect(makeHrefPipe).toBeTruthy();
   });
 
-  using(
-    [
-      { url: undefined, expected: 'undefined' },
-      { url: '/test', params: undefined, expected: '/test' },
-      { url: '/test', params: {}, expected: '/test' },
-      { url: '/test', params: { foo: 'bar' }, expected: '/test;foo=bar' },
-      { url: '/test', params: { foo: 'bar', marco: 'polo' }, expected: '/test;foo=bar;marco=polo' },
-      { url: '/test?query=q', params: undefined, expected: '/test?query=q' },
-      { url: '/test?query=q', params: {}, expected: '/test?query=q' },
-      { url: '/test?query=q', params: { foo: 'bar' }, expected: '/test;foo=bar?query=q' },
-      { url: '/test?query=q', params: { foo: 'bar', marco: 'polo' }, expected: '/test;foo=bar;marco=polo?query=q' },
-    ],
-    ({ url, params, expected }) => {
-      it(`should transform "${url}" with ${JSON.stringify(params)} to "${expected}"`, () => {
-        expect(makeHrefPipe.transform({ path: () => url } as Location, params)).toEqual(expected);
-      });
-    }
-  );
+  it.each([
+    [undefined, undefined, 'undefined'],
+    ['/test', undefined, '/test'],
+    ['/test', {}, '/test'],
+    ['/test', { foo: 'bar' }, '/test;foo=bar'],
+    ['/test', { foo: 'bar', marco: 'polo' }, '/test;foo=bar;marco=polo'],
+    ['/test?query=q', undefined, '/test?query=q'],
+    ['/test?query=q', {}, '/test?query=q'],
+    ['/test?query=q', { foo: 'bar' }, '/test;foo=bar?query=q'],
+    ['/test?query=q', { foo: 'bar', marco: 'polo' }, '/test;foo=bar;marco=polo?query=q'],
+  ])(`should transform "%s" with %j to "%s"`, (url, params, expected) => {
+    expect(makeHrefPipe.transform({ path: () => url } as Location, params)).toEqual(expected);
+  });
 });

--- a/src/app/core/pipes/sanitize.pipe.spec.ts
+++ b/src/app/core/pipes/sanitize.pipe.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import * as using from 'jasmine-data-provider';
 
 import { SanitizePipe } from './sanitize.pipe';
 
@@ -17,19 +16,14 @@ describe('Sanitize Pipe', () => {
     expect(sanitizePipe).toBeTruthy();
   });
 
-  using(
-    [
-      { input: '', output: '' },
-      { input: undefined, output: 'undefined' },
-      { input: '(/&%/(%(&/%/&%/(&§!!', output: '' },
-      { input: 'Red', output: 'Red' },
-      { input: '$ 25 - $ 50', output: '25_-_50' },
-      { input: '    HELLO     ', output: 'HELLO' },
-    ],
-    ({ input, output }) => {
-      it(`should transform '${input}' to '${output}'`, () => {
-        expect(sanitizePipe.transform(input)).toEqual(output);
-      });
-    }
-  );
+  it.each([
+    ['', ''],
+    [undefined, 'undefined'],
+    ['(/&%/(%(&/%/&%/(&§!!', ''],
+    ['Red', 'Red'],
+    ['$ 25 - $ 50', '25_-_50'],
+    ['    HELLO     ', 'HELLO'],
+  ])(`should transform '%s' to '%s'`, (input, output) => {
+    expect(sanitizePipe.transform(input)).toEqual(output);
+  });
 });

--- a/src/app/core/store/core/error/error.reducer.spec.ts
+++ b/src/app/core/store/core/error/error.reducer.spec.ts
@@ -1,5 +1,4 @@
 import { Action } from '@ngrx/store';
-import * as using from 'jasmine-data-provider';
 import { anything } from 'ts-mockito';
 
 import { loginUserSuccess } from 'ish-core/store/customer/user';
@@ -27,32 +26,20 @@ describe('Error Reducer', () => {
     });
   });
 
-  function dataProvider() {
-    return [
-      {
-        state: initialState,
-        action: {},
-        expected: initialState,
-      },
-      {
-        state: initialState,
-        action: communicationTimeoutError({ error: makeHttpError({}) }),
-        expected: { current: { name: 'HttpErrorResponse' }, type: communicationTimeoutError.type },
-      },
-      {
-        state: initialState,
-        action: loginUserSuccess(anything()),
-        expected: initialState,
-      },
-    ];
-  }
+  it(`should return initialState when Action undefined is reduced on initial state`, () => {
+    const newState = errorReducer(initialState, {} as Action);
+    expect(newState).toEqual(initialState);
+  });
 
-  using(dataProvider, dataSlice => {
-    it(`should return ${
-      dataSlice.expected === initialState ? ' initialState' : ` '${dataSlice.expected.type}'`
-    } when Action ${dataSlice.action.type} is reduced on state ${dataSlice.state.type}`, () => {
-      const newState = errorReducer(dataSlice.state, dataSlice.action);
-      expect(newState).toEqual(dataSlice.expected);
-    });
+  it(`should return Timeout Error when Action Timeout Error is reduced on initial state`, () => {
+    const action = communicationTimeoutError({ error: makeHttpError({}) });
+    const newState = errorReducer(initialState, action);
+    expect(newState).toEqual({ current: { name: 'HttpErrorResponse' }, type: communicationTimeoutError.type });
+  });
+
+  it(`should return initialState when Action Login User Success is reduced on initial state`, () => {
+    const action = loginUserSuccess(anything());
+    const newState = errorReducer(initialState, action);
+    expect(newState).toEqual(initialState);
   });
 });

--- a/src/app/core/utils/feature-toggle/feature-toggle.service.spec.ts
+++ b/src/app/core/utils/feature-toggle/feature-toggle.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import * as using from 'jasmine-data-provider';
 
 import { FeatureToggleModule, FeatureToggleService } from 'ish-core/feature-toggle.module';
 import { getFeatures } from 'ish-core/store/core/configuration';
@@ -33,18 +32,13 @@ describe('Feature Toggle Service', () => {
       featureToggle = TestBed.inject(FeatureToggleService);
     });
 
-    using(
-      () => [
-        { feature: 'always', expected: true },
-        { feature: 'never', expected: false },
-        { feature: 'feature1', expected: true },
-        { feature: 'feature2', expected: false },
-      ],
-      slice => {
-        it(`should have ${slice.feature} == ${slice.expected} when asked`, () => {
-          expect(featureToggle.enabled(slice.feature)).toBe(slice.expected);
-        });
-      }
-    );
+    it.each([
+      ['always', true],
+      ['never', false],
+      ['feature1', true],
+      ['feature2', false],
+    ])(`should have %s == %s when asked`, (feature, expected) => {
+      expect(featureToggle.enabled(feature)).toBe(expected);
+    });
   });
 });

--- a/src/app/core/utils/link-parser.spec.ts
+++ b/src/app/core/utils/link-parser.spec.ts
@@ -1,30 +1,21 @@
-import * as using from 'jasmine-data-provider';
 import { noop } from 'rxjs';
 
 import { LinkParser } from './link-parser';
 
 describe('Link Parser', () => {
-  using(
-    [
-      { input: 'route://category/Computers', output: '/category/Computers' },
-      {
-        input: 'route://category/Home-Entertainment.SmartHome',
-        output: '/category/Home-Entertainment.SmartHome',
-      },
-      { input: 'product://201807195@inSPIRED-inTRONICS', output: '/sku201807195' },
-      { input: 'http://google.de', output: 'http://google.de' },
-      { input: 'https://google.de', output: 'https://google.de' },
-      { input: 'page://mypage', output: '/page/mypage' },
-      { input: 'category://Computers@inSPIRED-Computers', output: '/catComputers' },
-      { input: '/product/ABC', output: '/product/ABC' },
-      { input: undefined, output: undefined },
-    ],
-    ({ input, output }) => {
-      it(`should transform ${input} to ${output}`, () => {
-        expect(LinkParser.parseLink(input)).toEqual(output);
-      });
-    }
-  );
+  it.each([
+    ['route://category/Computers', '/category/Computers'],
+    ['route://category/Home-Entertainment.SmartHome', '/category/Home-Entertainment.SmartHome'],
+    ['product://201807195@inSPIRED-inTRONICS', '/sku201807195'],
+    ['http://google.de', 'http://google.de'],
+    ['https://google.de', 'https://google.de'],
+    ['page://mypage', '/page/mypage'],
+    ['category://Computers@inSPIRED-Computers', '/catComputers'],
+    ['/product/ABC', '/product/ABC'],
+    [undefined, undefined],
+  ])(`should transform %s to %s`, (input, output) => {
+    expect(LinkParser.parseLink(input)).toEqual(output);
+  });
 
   it('should log if no mapping could be found', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementationOnce(noop);

--- a/src/app/shared/address-forms/components/address-form/address-form.component.spec.ts
+++ b/src/app/shared/address-forms/components/address-form/address-form.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import * as using from 'jasmine-data-provider';
 import { MockComponent } from 'ng-mocks';
 
 import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
@@ -73,23 +72,17 @@ describe('Address Form Component', () => {
   });
 
   describe('dataprovider', () => {
-    function dataProvider() {
-      return [
-        { countryCode: '', cmp: 'ish-address-form-default' },
-        { countryCode: 'DE', cmp: 'ish-address-form-de' },
-        { countryCode: 'FR', cmp: 'ish-address-form-fr' },
-        { countryCode: 'GB', cmp: 'ish-address-form-gb' },
-        { countryCode: 'US', cmp: 'ish-address-form-us' },
-        { countryCode: 'BG', cmp: 'ish-address-form-default' },
-      ];
-    }
-
-    using(dataProvider, dataSlice => {
-      it(`should render \'${dataSlice.cmp}\' if countryCode equals \'${dataSlice.countryCode}\'`, () => {
-        component.countryCode = dataSlice.countryCode;
-        fixture.detectChanges();
-        expect(findAllCustomElements(element)).toContain(dataSlice.cmp);
-      });
+    it.each([
+      ['ish-address-form-default', ''],
+      ['ish-address-form-de', 'DE'],
+      ['ish-address-form-fr', 'FR'],
+      ['ish-address-form-gb', 'GB'],
+      ['ish-address-form-us', 'US'],
+      ['ish-address-form-default', 'BG'],
+    ])(`should render '%s' if countryCode equals '%s'`, (cmp, countryCode) => {
+      component.countryCode = countryCode;
+      fixture.detectChanges();
+      expect(findAllCustomElements(element)).toContain(cmp);
     });
   });
 });

--- a/src/app/shared/cms/sfe-adapter/dev/sfe.mapper.spec.dom-data.ts
+++ b/src/app/shared/cms/sfe-adapter/dev/sfe.mapper.spec.dom-data.ts
@@ -236,20 +236,29 @@ export const reducedTreeComplex = {
 
 //////////////////////////////////
 
-export const domDataProvider = {
-  'text/comment nodes and nested sfe elements': {
-    html: html1,
-    tree: tree1,
-    reducedTree: reducedTree1,
-  },
-  'nested nodes containing sfe elements': {
-    html: html2,
-    tree: tree2,
-    reducedTree: reducedTree2,
-  },
-  'nested nodes containing no sfe elements': {
-    html: html3,
-    tree: tree3,
-    reducedTree: reducedTree3,
-  },
-};
+export const domDataProvider = [
+  [
+    'text/comment nodes and nested sfe elements',
+    {
+      html: html1,
+      tree: tree1,
+      reducedTree: reducedTree1,
+    },
+  ],
+  [
+    'nested nodes containing sfe elements',
+    {
+      html: html2,
+      tree: tree2,
+      reducedTree: reducedTree2,
+    },
+  ],
+  [
+    'nested nodes containing no sfe elements',
+    {
+      html: html3,
+      tree: tree3,
+      reducedTree: reducedTree3,
+    },
+  ],
+];

--- a/src/app/shared/cms/sfe-adapter/sfe.mapper.spec.ts
+++ b/src/app/shared/cms/sfe-adapter/sfe.mapper.spec.ts
@@ -1,5 +1,3 @@
-import * as using from 'jasmine-data-provider';
-
 import { ContentPageletEntryPoint } from 'ish-core/models/content-pagelet-entry-point/content-pagelet-entry-point.model';
 import {
   ContentPageletView,
@@ -13,22 +11,26 @@ import { SfeMapper } from './sfe.mapper';
 
 describe('Sfe Mapper', () => {
   describe('tree mappings with getDomTree and reduceDomTree', () => {
-    using(domDataProvider, (slice, description) => {
-      it(`should extract the tree structure for DOM with ${description}`, () => {
-        const dom = createDocumentFromHTML(slice.html).querySelector('body').firstChild;
+    it.each(domDataProvider)(
+      `should extract the tree structure for DOM with %s`,
+      // tslint:disable-next-line:no-any
+      (_, data: { html: string; tree: any; reducedTree: any }) => {
+        const dom = createDocumentFromHTML(data.html).querySelector('body').firstChild;
         const tree = SfeMapper.getDomTree(dom);
 
-        expect(tree).toEqual(slice.tree);
-      });
-    });
+        expect(tree).toEqual(data.tree);
+      }
+    );
 
-    using(domDataProvider, (slice, description) => {
-      it(`should reduce the tree structure for ${description}`, () => {
-        const reducedTree = SfeMapper.reduceDomTree(slice.tree);
+    it.each(domDataProvider)(
+      `should reduce the tree structure for %s`,
+      // tslint:disable-next-line:no-any
+      (_, data: { html: string; tree: any; reducedTree: any }) => {
+        const reducedTree = SfeMapper.reduceDomTree(data.tree);
 
-        expect(reducedTree).toEqual(slice.reducedTree);
-      });
-    });
+        expect(reducedTree).toEqual(data.reducedTree);
+      }
+    );
 
     it('should create reduced tree for complex DOM', () => {
       const dom = createDocumentFromHTML(htmlComplex).querySelector('body').firstChild;

--- a/src/app/shared/components/product/product-price/product-price.component.spec.ts
+++ b/src/app/shared/components/product/product-price/product-price.component.spec.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import * as using from 'jasmine-data-provider';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
@@ -62,40 +61,20 @@ describe('Product Price Component', () => {
   });
 
   describe('price comparison', () => {
-    function dataProvider() {
-      return [
-        {
-          listPrice: 10,
-          salePrice: 10,
-          isListPriceGreaterThanSalePrice: false,
-          isListPriceLessThanSalePrice: false,
-          description: 'list price equals sale price',
-        },
-        {
-          listPrice: 11,
-          salePrice: 10,
-          isListPriceGreaterThanSalePrice: true,
-          isListPriceLessThanSalePrice: false,
-          description: 'list price is greater than sale price',
-        },
-        {
-          listPrice: 10,
-          salePrice: 11,
-          isListPriceGreaterThanSalePrice: false,
-          isListPriceLessThanSalePrice: true,
-          description: 'list price is less than sale price',
-        },
-      ];
-    }
-    using(dataProvider, dataSlice => {
-      it(`should evaluate isListPriceGreaterThanSalePrice to "${dataSlice.isListPriceGreaterThanSalePrice}" and isListPriceLessThanSalePrice to "${dataSlice.isListPriceLessThanSalePrice}" when ${dataSlice.description}`, () => {
-        product.listPrice.value = dataSlice.listPrice;
-        product.salePrice.value = dataSlice.salePrice;
+    it.each([
+      [false, false, 'list price equals sale price', 10, 10],
+      [true, false, 'list price is greater than sale price', 11, 10],
+      [false, true, 'list price is less than sale price', 10, 11],
+    ])(
+      `should evaluate isListPriceGreaterThanSalePrice to "%s" and isListPriceLessThanSalePrice to "%s" when %s`,
+      (isListPriceGreaterThanSalePrice, isListPriceLessThanSalePrice, _, listPrice, salePrice) => {
+        product.listPrice.value = listPrice;
+        product.salePrice.value = salePrice;
         component.ngOnChanges();
-        expect(component.isListPriceGreaterThanSalePrice).toBe(dataSlice.isListPriceGreaterThanSalePrice);
-        expect(component.isListPriceLessThanSalePrice).toBe(dataSlice.isListPriceLessThanSalePrice);
-      });
-    });
+        expect(component.isListPriceGreaterThanSalePrice).toBe(isListPriceGreaterThanSalePrice);
+        expect(component.isListPriceLessThanSalePrice).toBe(isListPriceLessThanSalePrice);
+      }
+    );
   });
 
   describe('template rendering', () => {
@@ -155,36 +134,20 @@ describe('Product Price Component', () => {
         translate.set('product.price.savingsFallback.text', 'you saved {{0}}');
         component.showInformationalPrice = true;
       });
-      function dataProvider() {
-        return [
-          {
-            isListPriceGreaterThanSalePrice: false,
-            isListPriceLessThanSalePrice: false,
-            querySelector: '.current-price',
-            description: 'list price equals sale price',
-          },
-          {
-            isListPriceGreaterThanSalePrice: true,
-            isListPriceLessThanSalePrice: false,
-            querySelector: '.current-price.sale-price',
-            description: 'list price is greater than sale price',
-          },
-          {
-            isListPriceGreaterThanSalePrice: false,
-            isListPriceLessThanSalePrice: true,
-            querySelector: '.current-price.sale-price-higher',
-            description: 'list price is less than sale price',
-          },
-        ];
-      }
-      using(dataProvider, dataSlice => {
-        it(`should apply "${dataSlice.querySelector}" class when showInformationalPrice = true and ${dataSlice.description}`, () => {
-          component.isListPriceGreaterThanSalePrice = dataSlice.isListPriceGreaterThanSalePrice;
-          component.isListPriceLessThanSalePrice = dataSlice.isListPriceLessThanSalePrice;
+
+      it.each([
+        ['.current-price', 'list price equals sale price', false, false],
+        ['.current-price.sale-price', 'list price is greater than sale price', true, false],
+        ['.current-price.sale-price-higher', 'list price is less than sale price', false, true],
+      ])(
+        `should apply "%s" class when showInformationalPrice = true and %s`,
+        (querySelector, _, isListPriceGreaterThanSalePrice, isListPriceLessThanSalePrice) => {
+          component.isListPriceGreaterThanSalePrice = isListPriceGreaterThanSalePrice;
+          component.isListPriceLessThanSalePrice = isListPriceLessThanSalePrice;
           fixture.detectChanges();
-          expect(element.querySelector(dataSlice.querySelector)).toBeTruthy();
-        });
-      });
+          expect(element.querySelector(querySelector)).toBeTruthy();
+        }
+      );
     });
 
     it('should generate rich snippet meta tag when sale price is available', () => {

--- a/src/app/shared/components/product/product-shipment/product-shipment.component.spec.ts
+++ b/src/app/shared/components/product/product-shipment/product-shipment.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import * as using from 'jasmine-data-provider';
 import { MockComponent } from 'ng-mocks';
 
 import { Product } from 'ish-core/models/product/product.model';
@@ -57,40 +56,26 @@ describe('Product Shipment Component', () => {
   });
 
   describe('text rendering', () => {
-    function dataProvider() {
-      return [
-        {
-          readyForShipmentMin: 0,
-          readyForShipmentMax: 1,
-          localeKey: 'product.ready_for_shipment.within24',
-          localeValue: 'Usually ships within 24 hours',
-          expectedText: 'Usually ships within 24 hours',
-        },
-        {
-          readyForShipmentMin: 0,
-          readyForShipmentMax: 3,
-          localeKey: 'product.ready_for_shipment.within',
-          localeValue: 'Usually ships within {{0}} days.',
-          expectedText: 'Usually ships within 3 days.',
-        },
-        {
-          readyForShipmentMin: 3,
-          readyForShipmentMax: 7,
-          localeKey: 'product.ready_for_shipment.minmax',
-          localeValue: 'Usually ships in {{0}} to {{1}} days.',
-          expectedText: 'Usually ships in 3 to 7 days.',
-        },
-      ];
-    }
-    using(dataProvider, dataSlice => {
-      it(`should use "${dataSlice.localeKey}" localization text when readyForShipmentMin = ${dataSlice.readyForShipmentMin} and readyForShipmentMax = ${dataSlice.readyForShipmentMax}`, () => {
-        product.readyForShipmentMin = dataSlice.readyForShipmentMin;
-        product.readyForShipmentMax = dataSlice.readyForShipmentMax;
-        translate.set(dataSlice.localeKey, dataSlice.localeValue);
+    it.each([
+      ['product.ready_for_shipment.within24', 0, 1, 'Usually ships within 24 hours', 'Usually ships within 24 hours'],
+      ['product.ready_for_shipment.within', 0, 3, 'Usually ships within {{0}} days.', 'Usually ships within 3 days.'],
+      [
+        'product.ready_for_shipment.minmax',
+        3,
+        7,
+        'Usually ships in {{0}} to {{1}} days.',
+        'Usually ships in 3 to 7 days.',
+      ],
+    ])(
+      `should use "%s" localization text when readyForShipmentMin = %i and readyForShipmentMax = %i`,
+      (localeKey, readyForShipmentMin, readyForShipmentMax, localeValue, expectedText) => {
+        product.readyForShipmentMin = readyForShipmentMin;
+        product.readyForShipmentMax = readyForShipmentMax;
+        translate.set(localeKey, localeValue);
         component.isShipmentInformationAvailable = true;
         fixture.detectChanges();
-        expect(element.querySelector('.ready-for-shipment').textContent).toContain(dataSlice.expectedText);
-      });
-    });
+        expect(element.querySelector('.ready-for-shipment').textContent).toContain(expectedText);
+      }
+    );
   });
 });


### PR DESCRIPTION
## PR Type
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: Library Replacement 

## What Is the Current Behavior?
jasmine-data provider is used to provide multiple arguments to tests.
Issue Number: Closes #405

## What Is the New Behavior?
jest.each is natively available since jest version 23. Jasmine-data provider can be replaced.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No