### PR TITLE
fix: submit a promotion code by pressing enter

### DIFF
--- a/src/app/extensions/order-templates/shared/product-add-to-order-template/product-add-to-order-template.component.html
+++ b/src/app/extensions/order-templates/shared/product-add-to-order-template/product-add-to-order-template.component.html
@@ -1,6 +1,6 @@
 <!-- display addToOrderTemplate Icon/animated Icon or link-->
 <button
-  type="submit"
+  type="button"
   name="addProduct"
   class="btn"
   [ngClass]="class"

--- a/src/app/extensions/wishlists/shared/product-add-to-wishlist/product-add-to-wishlist.component.html
+++ b/src/app/extensions/wishlists/shared/product-add-to-wishlist/product-add-to-wishlist.component.html
@@ -1,6 +1,6 @@
 <!-- display addToCart Icon/animated Icon or link-->
 <button
-  type="submit"
+  type="button"
   name="addProduct"
   class="btn btn-link add-to-wishlist"
   (click)="openModal(modal)"

--- a/src/app/shared/components/basket/basket-promotion-code/basket-promotion-code.component.html
+++ b/src/app/shared/components/basket/basket-promotion-code/basket-promotion-code.component.html
@@ -12,12 +12,13 @@
   <div class="form-inline" [ngbCollapse]="isCollapsed">
     <input
       [formControl]="codeInput"
+      (keydown.enter)="submitPromotionCode()"
       class="form-control"
       type="text"
       [maxlength]="codeMaxLength"
       [placeholder]="'shopping_cart.promotional_code.label' | translate"
     />
-    <button type="submit" class="btn btn-secondary" [disabled]="!codeInput.valid" (click)="submitPromotionCode()">
+    <button type="button" class="btn btn-secondary" [disabled]="!codeInput.valid" (click)="submitPromotionCode()">
       {{ 'shopping_cart.promotion.apply.button.label' | translate }}
     </button>
   </div>

--- a/src/app/shared/components/basket/basket-promotion-code/basket-promotion-code.component.ts
+++ b/src/app/shared/components/basket/basket-promotion-code/basket-promotion-code.component.ts
@@ -61,6 +61,8 @@ export class BasketPromotionCodeComponent implements OnInit, OnDestroy {
       this.lastEnteredPromoCode = this.codeInput.value;
     }
     this.checkoutFacade.addPromotionCodeToBasket(this.codeInput.value);
+    // prevent further form submit
+    return false;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user presses enter in the promotion code input on the cart page the add-to-wishlist or add-to-order-template dialog opens up.

Issue Number: Closes #433 

## What Is the New Behavior?
If the user presses enter in the promotion code input on the cart page the promotion code is submitted.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
