### PR TITLE
fix: display line item quantity on checkout cart page after merging q…

### DIFF
--- a/e2e/cypress/integration/pages/checkout/cart.page.ts
+++ b/e2e/cypress/integration/pages/checkout/cart.page.ts
@@ -53,6 +53,7 @@ export class CartPage {
       quantity: {
         set: (num: number) =>
           cy.get(this.tag).find('input[data-testing-id="quantity"]').eq(idx).clear().type(num.toString()).blur(),
+        get: () => cy.get(this.tag).find('input[data-testing-id="quantity"]').eq(idx).invoke('val'),
       },
       remove: () => cy.get(this.tag).find('svg[data-icon="trash-alt"]').eq(idx).click(),
       sku: cy.get(this.tag).find('.product-id').eq(idx),

--- a/e2e/cypress/integration/specs/checkout/basket-handling.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/basket-handling.b2c.e2e-spec.ts
@@ -78,6 +78,9 @@ describe('Basket Handling', () => {
       waitLoadingEnd(1000);
       page.header.miniCart.total.should('contain', _.product.price * 3);
     });
+    at(CartPage, page => {
+      page.lineItem(0).quantity.get().should('equal', '3');
+    });
   });
 
   it('user should get info messages', () => {

--- a/src/app/shared/components/line-item/line-item-list/line-item-list.component.ts
+++ b/src/app/shared/components/line-item/line-item-list/line-item-list.component.ts
@@ -68,7 +68,7 @@ export class LineItemListComponent {
 
       return group;
     },
-    pli => pli.id
+    pli => pli.id + pli.quantity?.value
   );
 
   product$(sku: string) {
@@ -80,7 +80,9 @@ export class LineItemListComponent {
    * @param item ItemId and quantity pair that should be updated
    */
   onUpdateItem(item: LineItemUpdate) {
-    (this.createDummyForm({ id: item.itemId }).get('quantity') as FormControl).setValue(item.quantity, {
+    (this.createDummyForm({ id: item.itemId, quantity: { value: item.quantity } }).get(
+      'quantity'
+    ) as FormControl).setValue(item.quantity, {
       emitEvent: false,
     });
     this.updateItem.emit(item);


### PR DESCRIPTION
…uantities

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Shopping cart quantity field no updated when adding the same product twice or multiple times. Adding a product from the product detail page with quantity 1 and adding it again with quantity 1 will redirect us to the Shopping cart where the quantity value will be 1 instead of 2

Issue Number: Closes #440

## What Is the New Behavior?
When adding a product to an existing line item its expected to see the quantity resulting from merging the lines.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
