### PR TITLE
fix: repair setting of locales meta tags

### DIFF
--- a/src/app/core/store/core/configuration/configuration.selectors.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.ts
@@ -37,8 +37,9 @@ export const getAvailableLocales = createSelector(getConfigurationState, state =
 /**
  * selects the current locale if set. If not returns the first available locale
  */
-export const getCurrentLocale = createSelector(getConfigurationState, state =>
-  state.lang ? state.locales.find(l => l.lang === state.lang) : state.locales[0]
+export const getCurrentLocale = createSelector(
+  getConfigurationState,
+  state => state.locales.find(l => l.lang === state.lang) || state.locales[0]
 );
 
 export const getDeviceType = createSelector(getConfigurationState, state => state._deviceType);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

- meta tags `og:locale` and `og:locale:alternate` did not make it into the SSR response.
- selector `getCurrentLocale` returns falsy values when current locale (URL param `lang`) is set to invalid value.
- SSR crashes after delivering page when `og:locale:alternate` is attempted to be set, when `og:locale` isn't already set. 

## What Is the New Behavior?

Fixed.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
