### PR TITLE
Add server configuration and feature toggle pipe

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -186,6 +186,12 @@ If the feature is deactivated, the user is sent to the error page on accessing.
 <ish-product-add-to-compare *ishFeature="'compare'"> ...</ish-product-add-to-compare>
 ```
 
+**Pipe**
+
+```html
+<ish-product-add-to-compare *ngIf="'compare' | ishFeature"> ...</ish-product-add-to-compare>
+```
+
 **Service**
 
 ```typescript

--- a/src/app/core/directives/feature-toggle.directive.ts
+++ b/src/app/core/directives/feature-toggle.directive.ts
@@ -7,6 +7,7 @@ import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-togg
  * Used on an element, this element will only be rendered if the specified feature *is enabled*.
  *
  * For the negated case see {@link NotFeatureToggleDirective}.
+ * For the corresponding pipe see {@link FeatureTogglePipe}.
  *
  * @example
  * <div *ishFeature="'quoting'">

--- a/src/app/core/facades/app.facade.ts
+++ b/src/app/core/facades/app.facade.ts
@@ -15,13 +15,12 @@ import { getServerConfigParameter } from 'ish-core/store/general/server-config';
 
 @Injectable({ providedIn: 'root' })
 export class AppFacade {
-  icmBaseUrl: string;
-
   constructor(private store: Store, private router: Router) {
     this.routingInProgress$.subscribe(noop);
 
     store.pipe(select(getICMBaseURL)).subscribe(icmBaseUrl => (this.icmBaseUrl = icmBaseUrl));
   }
+  icmBaseUrl: string;
 
   headerType$ = this.store.pipe(select(getHeaderType));
   deviceType$ = this.store.pipe(select(getDeviceType));
@@ -45,8 +44,6 @@ export class AppFacade {
       map(deviceType => (deviceType === 'mobile' ? 'sticky-header' : ''))
     ),
   ]).pipe(map(classes => classes.filter(c => !!c)));
-
-  // COUNTRIES AND REGIONS
 
   countriesLoading$ = this.store.pipe(select(getCountriesLoading));
 
@@ -88,6 +85,10 @@ export class AppFacade {
     isAppTypeREST: boolean
   ): 'customers' | 'privatecustomers' {
     return isAppTypeREST && !isBusinessCustomer ? 'privatecustomers' : 'customers';
+  }
+
+  serverSetting$<T>(path: string) {
+    return this.store.pipe(select(getServerConfigParameter<T>(path)));
   }
 
   countries$() {

--- a/src/app/core/facades/app.facade.ts
+++ b/src/app/core/facades/app.facade.ts
@@ -87,6 +87,10 @@ export class AppFacade {
     return isAppTypeREST && !isBusinessCustomer ? 'privatecustomers' : 'customers';
   }
 
+  /**
+   * extracts a specific server setting from the store.
+   * @param path the path to the server setting, starting from the serverConfig/_config store.
+   */
   serverSetting$<T>(path: string) {
     return this.store.pipe(select(getServerConfigParameter<T>(path)));
   }

--- a/src/app/core/feature-toggle.module.ts
+++ b/src/app/core/feature-toggle.module.ts
@@ -2,13 +2,11 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { FeatureToggleDirective } from './directives/feature-toggle.directive';
 import { NotFeatureToggleDirective } from './directives/not-feature-toggle.directive';
-import { FeatureTogglePipe } from './pipes/feature-toggle.pipe';
 import { FeatureToggleService, checkFeature } from './utils/feature-toggle/feature-toggle.service';
 
 @NgModule({
-  declarations: [FeatureToggleDirective, FeatureTogglePipe, NotFeatureToggleDirective],
+  declarations: [FeatureToggleDirective, NotFeatureToggleDirective],
   exports: [FeatureToggleDirective, NotFeatureToggleDirective],
-  providers: [FeatureTogglePipe],
 })
 export class FeatureToggleModule {
   private static features: string[];
@@ -22,7 +20,6 @@ export class FeatureToggleModule {
           provide: FeatureToggleService,
           useValue: { enabled: (feature: string) => checkFeature(FeatureToggleModule.features, feature) },
         },
-        FeatureTogglePipe,
       ],
     };
   }

--- a/src/app/core/feature-toggle.module.ts
+++ b/src/app/core/feature-toggle.module.ts
@@ -2,11 +2,13 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { FeatureToggleDirective } from './directives/feature-toggle.directive';
 import { NotFeatureToggleDirective } from './directives/not-feature-toggle.directive';
+import { FeatureTogglePipe } from './pipes/feature-toggle.pipe';
 import { FeatureToggleService, checkFeature } from './utils/feature-toggle/feature-toggle.service';
 
 @NgModule({
-  declarations: [FeatureToggleDirective, NotFeatureToggleDirective],
+  declarations: [FeatureToggleDirective, FeatureTogglePipe, NotFeatureToggleDirective],
   exports: [FeatureToggleDirective, NotFeatureToggleDirective],
+  providers: [FeatureTogglePipe],
 })
 export class FeatureToggleModule {
   private static features: string[];
@@ -20,6 +22,7 @@ export class FeatureToggleModule {
           provide: FeatureToggleService,
           useValue: { enabled: (feature: string) => checkFeature(FeatureToggleModule.features, feature) },
         },
+        FeatureTogglePipe,
       ],
     };
   }

--- a/src/app/core/pipes.module.ts
+++ b/src/app/core/pipes.module.ts
@@ -3,6 +3,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { AttributeToStringPipe } from './models/attribute/attribute.pipe';
 import { PricePipe } from './models/price/price.pipe';
 import { DatePipe } from './pipes/date.pipe';
+import { FeatureTogglePipe } from './pipes/feature-toggle.pipe';
 import { HighlightPipe } from './pipes/highlight.pipe';
 import { MakeHrefPipe } from './pipes/make-href.pipe';
 import { SanitizePipe } from './pipes/sanitize.pipe';
@@ -14,6 +15,7 @@ const pipes = [
   AttributeToStringPipe,
   CategoryRoutePipe,
   DatePipe,
+  FeatureTogglePipe,
   HighlightPipe,
   MakeHrefPipe,
   PricePipe,

--- a/src/app/core/pipes.module.ts
+++ b/src/app/core/pipes.module.ts
@@ -6,6 +6,7 @@ import { DatePipe } from './pipes/date.pipe';
 import { HighlightPipe } from './pipes/highlight.pipe';
 import { MakeHrefPipe } from './pipes/make-href.pipe';
 import { SanitizePipe } from './pipes/sanitize.pipe';
+import { ServerSettingPipe } from './pipes/server-setting.pipe';
 import { CategoryRoutePipe } from './routing/category/category-route.pipe';
 import { ProductRoutePipe } from './routing/product/product-route.pipe';
 
@@ -18,11 +19,13 @@ const pipes = [
   PricePipe,
   ProductRoutePipe,
   SanitizePipe,
+  ServerSettingPipe,
 ];
 
 @NgModule({
   declarations: [...pipes],
   exports: [...pipes],
+  providers: [ServerSettingPipe],
 })
 export class PipesModule {
   static forRoot(): ModuleWithProviders<PipesModule> {

--- a/src/app/core/pipes.module.ts
+++ b/src/app/core/pipes.module.ts
@@ -27,7 +27,6 @@ const pipes = [
 @NgModule({
   declarations: [...pipes],
   exports: [...pipes],
-  providers: [ServerSettingPipe],
 })
 export class PipesModule {
   static forRoot(): ModuleWithProviders<PipesModule> {

--- a/src/app/core/pipes/feature-toggle.pipe.spec.ts
+++ b/src/app/core/pipes/feature-toggle.pipe.spec.ts
@@ -3,6 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 
+import { FeatureTogglePipe } from './feature-toggle.pipe';
+
 @Component({
   template: `
     <div>unrelated</div>
@@ -22,7 +24,7 @@ describe('Feature Toggle Pipe', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [FeatureToggleModule.forTesting('feature1')],
-      declarations: [TestComponent],
+      declarations: [FeatureTogglePipe, TestComponent],
     });
   });
 

--- a/src/app/core/pipes/feature-toggle.pipe.spec.ts
+++ b/src/app/core/pipes/feature-toggle.pipe.spec.ts
@@ -1,0 +1,54 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+
+@Component({
+  template: `
+    <div>unrelated</div>
+    <div *ngIf="'feature1' | ishFeature">content1</div>
+    <div *ngIf="'feature2' | ishFeature">content2</div>
+    <div *ngIf="'always' | ishFeature">contentAlways</div>
+    <div *ngIf="'never' | ishFeature">contentNever</div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestComponent {}
+
+describe('Feature Toggle Pipe', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FeatureToggleModule.forTesting('feature1')],
+      declarations: [TestComponent],
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    element = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should always render unreleated content', () => {
+    expect(element.textContent).toContain('unrelated');
+  });
+
+  it('should render content of enabled features', () => {
+    expect(element.textContent).toContain('content1');
+  });
+
+  it('should not render content of disabled features', () => {
+    expect(element.textContent).not.toContain('content2');
+  });
+
+  it("should always render content for 'always'", () => {
+    expect(element.textContent).toContain('contentAlways');
+  });
+
+  it("should never render content for 'never'", () => {
+    expect(element.textContent).not.toContain('contentNever');
+  });
+});

--- a/src/app/core/pipes/feature-toggle.pipe.ts
+++ b/src/app/core/pipes/feature-toggle.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+
+@Pipe({ name: 'ishFeature', pure: true })
+export class FeatureTogglePipe implements PipeTransform {
+  constructor(private featureToggleService: FeatureToggleService) {}
+
+  transform(feature: string): boolean {
+    return this.featureToggleService.enabled(feature);
+  }
+}

--- a/src/app/core/pipes/feature-toggle.pipe.ts
+++ b/src/app/core/pipes/feature-toggle.pipe.ts
@@ -2,6 +2,15 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
+/**
+ * Pipe
+ *
+ * Used on a string, this pipe will only return true if the specified feature *is enabled*.
+ * For the corresponding directive, see {@link FeatureToggleDirective}.
+ *
+ * @example
+ * <ish-product-add-to-compare *ngIf="'compare' | ishFeature"> ...</ish-product-add-to-compare>
+ */
 @Pipe({ name: 'ishFeature', pure: true })
 export class FeatureTogglePipe implements PipeTransform {
   constructor(private featureToggleService: FeatureToggleService) {}

--- a/src/app/core/pipes/server-setting.pipe.spec.ts
+++ b/src/app/core/pipes/server-setting.pipe.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ServerSettingPipe } from './server-setting.pipe';
+
+describe('Server Setting Pipe', () => {
+  let serverSettingPipe: ServerSettingPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ServerSettingPipe],
+    });
+    serverSettingPipe = TestBed.inject(ServerSettingPipe);
+  });
+
+  it('should be created', () => {
+    expect(serverSettingPipe).toBeTruthy();
+  });
+
+  it('should transform true to okay', () => {
+    expect(serverSettingPipe.transform(true)).toEqual('test: okay');
+  });
+
+  it('should transform false to failed', () => {
+    expect(serverSettingPipe.transform(false)).toEqual('test: failed');
+  });
+});

--- a/src/app/core/pipes/server-setting.pipe.spec.ts
+++ b/src/app/core/pipes/server-setting.pipe.spec.ts
@@ -1,26 +1,62 @@
-import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 
 import { ServerSettingPipe } from './server-setting.pipe';
 
+@Component({ template: `<ng-container *ngIf="'service.ABC.runnable' | ishServerSetting">TEST</ng-container>` })
+class TestComponent {}
+
 describe('Server Setting Pipe', () => {
-  let serverSettingPipe: ServerSettingPipe;
+  let fixture: ComponentFixture<TestComponent>;
+  let element: HTMLElement;
+  let appFacade: AppFacade;
+
+  beforeEach(async () => {
+    appFacade = mock(AppFacade);
+    TestBed.configureTestingModule({
+      declarations: [ServerSettingPipe, TestComponent],
+      providers: [
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
+        { provide: ShoppingFacade, useFactory: () => instance(mock(ShoppingFacade)) },
+      ],
+    }).compileComponents();
+  });
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ServerSettingPipe],
-    });
-    serverSettingPipe = TestBed.inject(ServerSettingPipe);
+    fixture = TestBed.createComponent(TestComponent);
+    element = fixture.nativeElement;
   });
 
-  it('should be created', () => {
-    expect(serverSettingPipe).toBeTruthy();
+  it('should render TEST when setting is set', () => {
+    when(appFacade.serverSetting$('service.ABC.runnable')).thenReturn(of(true));
+    fixture.detectChanges();
+
+    expect(element).toMatchInlineSnapshot(`TEST`);
   });
 
-  it('should transform true to okay', () => {
-    expect(serverSettingPipe.transform(true)).toEqual('test: okay');
+  it('should render TEST when setting is set to anything truthy', () => {
+    when(appFacade.serverSetting$('service.ABC.runnable')).thenReturn(of('ABC'));
+    fixture.detectChanges();
+
+    expect(element).toMatchInlineSnapshot(`TEST`);
   });
 
-  it('should transform false to failed', () => {
-    expect(serverSettingPipe.transform(false)).toEqual('test: failed');
+  it('should render nothing when setting is not set', () => {
+    when(appFacade.serverSetting$(anything())).thenReturn(of(undefined));
+    fixture.detectChanges();
+
+    expect(element).toMatchInlineSnapshot(`N/A`);
+  });
+
+  it('should render nothing when setting is set to sth falsy', () => {
+    when(appFacade.serverSetting$(anything())).thenReturn(of(''));
+    fixture.detectChanges();
+
+    expect(element).toMatchInlineSnapshot(`N/A`);
   });
 });

--- a/src/app/core/pipes/server-setting.pipe.spec.ts
+++ b/src/app/core/pipes/server-setting.pipe.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { concat, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -57,18 +57,14 @@ describe('Server Setting Pipe', () => {
     expect(element).toMatchInlineSnapshot(`N/A`);
   });
 
-  it.skip('should render TEST when setting is set', done => {
-    when(appFacade.serverSetting$('service.ABC.runnable')).thenReturn(concat(of(false), of(true).pipe(delay(2000))));
+  it('should render TEST when setting is set', fakeAsync(() => {
+    when(appFacade.serverSetting$('service.ABC.runnable')).thenReturn(concat(of(false), of(true).pipe(delay(1000))));
     fixture.detectChanges();
 
-    setTimeout(() => {
-      expect(element).toMatchInlineSnapshot(`N/A`);
-    }, 1000);
+    expect(element).toMatchInlineSnapshot(`N/A`);
+    tick(1000);
 
-    setTimeout(() => {
-      fixture.detectChanges();
-      expect(element).toMatchInlineSnapshot(`TEST`);
-      done();
-    }, 3000);
-  });
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`TEST`);
+  }));
 });

--- a/src/app/core/pipes/server-setting.pipe.spec.ts
+++ b/src/app/core/pipes/server-setting.pipe.spec.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { concat, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
-import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 
 import { ServerSettingPipe } from './server-setting.pipe';
 
@@ -20,10 +20,7 @@ describe('Server Setting Pipe', () => {
     appFacade = mock(AppFacade);
     TestBed.configureTestingModule({
       declarations: [ServerSettingPipe, TestComponent],
-      providers: [
-        { provide: AppFacade, useFactory: () => instance(appFacade) },
-        { provide: ShoppingFacade, useFactory: () => instance(mock(ShoppingFacade)) },
-      ],
+      providers: [{ provide: AppFacade, useFactory: () => instance(appFacade) }],
     }).compileComponents();
   });
 
@@ -58,5 +55,20 @@ describe('Server Setting Pipe', () => {
     fixture.detectChanges();
 
     expect(element).toMatchInlineSnapshot(`N/A`);
+  });
+
+  it.skip('should render TEST when setting is set', done => {
+    when(appFacade.serverSetting$('service.ABC.runnable')).thenReturn(concat(of(false), of(true).pipe(delay(2000))));
+    fixture.detectChanges();
+
+    setTimeout(() => {
+      expect(element).toMatchInlineSnapshot(`N/A`);
+    }, 1000);
+
+    setTimeout(() => {
+      fixture.detectChanges();
+      expect(element).toMatchInlineSnapshot(`TEST`);
+      done();
+    }, 3000);
   });
 });

--- a/src/app/core/pipes/server-setting.pipe.ts
+++ b/src/app/core/pipes/server-setting.pipe.ts
@@ -1,8 +1,31 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { ChangeDetectorRef, OnDestroy, Pipe, PipeTransform } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
-@Pipe({ name: 'serverSetting', pure: true })
-export class ServerSettingPipe implements PipeTransform {
-  transform(value: boolean): string {
-    return 'test: ' + (value ? 'okay' : 'failed');
+import { AppFacade } from 'ish-core/facades/app.facade';
+
+@Pipe({ name: 'ishServerSetting', pure: false })
+export class ServerSettingPipe implements PipeTransform, OnDestroy {
+  private returnValue: unknown;
+
+  private destroy$ = new Subject();
+
+  constructor(private appFacade: AppFacade, private cdRef: ChangeDetectorRef) {}
+
+  transform(path: string) {
+    this.appFacade
+      .serverSetting$(path)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(value => {
+        this.returnValue = value;
+        this.cdRef.markForCheck();
+      });
+
+    return this.returnValue;
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/core/pipes/server-setting.pipe.ts
+++ b/src/app/core/pipes/server-setting.pipe.ts
@@ -4,6 +4,15 @@ import { takeUntil } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 
+/**
+ * Pipe
+ *
+ * Used on a string, this pipe will return the corresponding server setting by checking the general/serverConfig store.
+ * If it is set, the Pipe will return a truthy value.
+ *
+ * @example
+ * <example *ngIf="'services.ABC.runnable' | ishServerSetting"> ...</example>
+ */
 @Pipe({ name: 'ishServerSetting', pure: false })
 export class ServerSettingPipe implements PipeTransform, OnDestroy {
   private returnValue: unknown;

--- a/src/app/core/pipes/server-setting.pipe.ts
+++ b/src/app/core/pipes/server-setting.pipe.ts
@@ -1,24 +1,33 @@
 import { ChangeDetectorRef, OnDestroy, Pipe, PipeTransform } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
+import { log } from 'ish-core/utils/dev/operators';
 
 @Pipe({ name: 'ishServerSetting', pure: false })
 export class ServerSettingPipe implements PipeTransform, OnDestroy {
   private returnValue: unknown;
 
   private destroy$ = new Subject();
+  private sub: Subscription;
 
   constructor(private appFacade: AppFacade, private cdRef: ChangeDetectorRef) {}
 
   transform(path: string) {
-    this.appFacade
+    console.log('##', path);
+
+    if (this.sub) {
+      // tslint:disable-next-line: ban
+      this.sub.unsubscribe();
+    }
+
+    this.sub = this.appFacade
       .serverSetting$(path)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(log('####'), takeUntil(this.destroy$))
       .subscribe(value => {
         this.returnValue = value;
-        this.cdRef.markForCheck();
+        this.cdRef.detectChanges();
       });
 
     return this.returnValue;

--- a/src/app/core/pipes/server-setting.pipe.ts
+++ b/src/app/core/pipes/server-setting.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'serverSetting', pure: true })
+export class ServerSettingPipe implements PipeTransform {
+  transform(value: boolean): string {
+    return 'test: ' + (value ? 'okay' : 'failed');
+  }
+}

--- a/src/app/pages/account/account-navigation/account-navigation.component.html
+++ b/src/app/pages/account/account-navigation/account-navigation.component.html
@@ -16,7 +16,7 @@
       <ul *ngIf="item.value.children" class="account-navigation list-unstyled">
         <ng-container *ngFor="let subItem of item.value.children | keyvalue: unsorted">
           <ng-container *ishIsAuthorizedTo="item.value.permission || 'always'">
-            <li *ishFeature="subItem.value.feature || 'always'">
+            <li *ngIf="subItem.value.feature || 'always' | ishFeature">
               <a [routerLink]="item.key + subItem.key" [attr.data-testing-id]="subItem.value.dataTestingId">{{
                 subItem.value.localizationKey | translate
               }}</a>

--- a/src/app/pages/account/account-navigation/account-navigation.component.spec.ts
+++ b/src/app/pages/account/account-navigation/account-navigation.component.spec.ts
@@ -1,13 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockPipe } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mock, when } from 'ts-mockito';
 
 import { AuthorizationToggleModule } from 'ish-core/authorization-toggle.module';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { FeatureTogglePipe } from 'ish-core/pipes/feature-toggle.pipe';
 
 import { AccountUserInfoComponent } from '../account-user-info/account-user-info.component';
 
@@ -22,7 +23,7 @@ describe('Account Navigation Component', () => {
   beforeEach(async () => {
     accountFacadeMock = mock(AccountFacade);
     await TestBed.configureTestingModule({
-      declarations: [AccountNavigationComponent, MockComponent(AccountUserInfoComponent)],
+      declarations: [AccountNavigationComponent, MockComponent(AccountUserInfoComponent), MockPipe(FeatureTogglePipe)],
       imports: [
         AuthorizationToggleModule.forTesting('APP_B2B_MANAGE_USERS'),
         FeatureToggleModule.forTesting('quoting', 'orderTemplates'),


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the current and new behavior?

-  Currently, there is no way to check server settings from a template.  This PR adds a ishServerSetting pipe that checks the store for relevant server settings.

- This PR adds an alternative to the feature toggle directive by introducing a feature toggle pipe. 


## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No