### PR TITLE
fix: prevent an error if language switched on order details page 

### DIFF
--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -1,11 +1,12 @@
-import { Injectable } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { isEqual } from 'lodash-es';
-import { race } from 'rxjs';
+import { iif, race } from 'rxjs';
 import {
   concatMap,
   distinctUntilChanged,
@@ -50,6 +51,7 @@ export class OrdersEffects {
     private actions$: Actions,
     private orderService: OrderService,
     private router: Router,
+    @Inject(PLATFORM_ID) private platformId: string,
     private store: Store,
     private translateService: TranslateService
   ) {}
@@ -163,11 +165,14 @@ export class OrdersEffects {
    * Selects and loads an order.
    */
   loadOrderForSelectedOrder$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(selectOrder),
-      mapToPayloadProperty('orderId'),
-      whenTruthy(),
-      map(orderId => loadOrder({ orderId }))
+    iif(
+      () => isPlatformBrowser(this.platformId),
+      this.actions$.pipe(
+        ofType(selectOrder),
+        mapToPayloadProperty('orderId'),
+        whenTruthy(),
+        map(orderId => loadOrder({ orderId }))
+      )
     )
   );
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
After the user changed the language on the order details page an error page is displayed. - This problem only occurs in case of server-side rendering with Angular Universal.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
see also IS-IS-31347

## What Is the New Behavior?
The order detail page is displayed in the requested language.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
