### PR TITLE
chore: lazy-component fix for --ci option (#437)

### DIFF
--- a/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -5,7 +5,7 @@ import {
   <% if (onChanges === 'complex') { %>SimpleChange, SimpleChanges, <% } %>
 } from '@angular/core';
 
-import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+<% if(!isProject) { %> import { FeatureToggleService } from 'ish-core/feature-toggle.module'; <% } %>
 
 <% if (imports.length) { %><%= imports.map(i => `import { ${i.types.join(', ')} } from ${i.from};`).join('\n') %><% } %>
 


### PR DESCRIPTION
Simple fix to enable correct behaviour when running the simplified --ci option of the schematic:
FeatureToggleService is now imported only when needed. 

No breaking changes.