### PR TITLE
fix: customization start script should add themes with inject false

### DIFF
--- a/schematics/customization/add/index.js
+++ b/schematics/customization/add/index.js
@@ -21,7 +21,7 @@ if (prefix != 'ish') {
   if (!styles.find(style => style.bundleName === prefix)) {
     styles.push({
       input: `src/styles/themes/${prefix}/style.scss`,
-      inject: true,
+      inject: false,
       bundleName: prefix,
     });
   }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

Script for adding customizations adds theme css to angular.json with inject = true, which causes faulty behavior.
This was a regression added with 3b8ea71cadafbe6b42093c8847f628cab8ab648b.

## What Is the New Behavior?

Fixed.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
