### PR TITLE
perf: deny SSR rendering when accept headers do not match

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -131,6 +131,13 @@ export function app() {
       console.log(`SSR ${req.originalUrl}`);
     }
 
+    if (req.originalUrl.startsWith('/assets/')) {
+      if (logging) {
+        console.log(`RES 404 ${req.originalUrl} - cannot serve static assets with Angular Universal`);
+      }
+      return res.sendStatus(404);
+    }
+
     if (req.headers.accept) {
       const accept = req.headers.accept.toLowerCase();
       if (!accept.includes('html') && ['css', 'image', 'json', 'javascript'].some(inc => accept.includes(inc))) {

--- a/server.ts
+++ b/server.ts
@@ -130,6 +130,17 @@ export function app() {
     if (logging) {
       console.log(`SSR ${req.originalUrl}`);
     }
+
+    if (req.headers.accept) {
+      const accept = req.headers.accept.toLowerCase();
+      if (!accept.includes('html') && ['css', 'image', 'json', 'javascript'].some(inc => accept.includes(inc))) {
+        if (logging) {
+          console.log(`RES 404 ${req.originalUrl} - accept header mismatch '${accept}'`);
+        }
+        return res.sendStatus(404);
+      }
+    }
+
     // find last baseHref parameter
     const regex = /baseHref=([^;\?\#]*)/g;
     let baseHref = '/';


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Other: Performance Improvement

## What Is the Current Behavior?

Requests for static resources, that don't exist, trigger an SSR rendering cycle which renders the error page.

## What Is the New Behavior?

The request accept headers are used to determine if the browser was expecting an html response. If the static resource was referenced in an img src, link or script tag, the browser doesn't explicitly request html content. This can be used to short-cut the 404 response and not trigger SSR.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Accept