### PR TITLE
chore: run jest precommit sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     ],
     "*.ts": [
       "tslint --project tsconfig.base.json --fix",
-      "jest --ci --bail --findRelatedTests"
+      "jest --ci -bi --findRelatedTests"
     ]
   },
   "commitlint": {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes

## What Is the Current Behavior?

- The pre-commit hook running jest sometimes hangs if certain TestBed declarations are not properly configured.
- Jest in pre-commit uses all available cores for the test run which can overwhelm developer machines.

## What Is the New Behavior?

Jest is run sequentially in pre-commit. This will also cause it to run significantly slower every time.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
