### PR TITLE
fix: user registration mail always sent in english

### DIFF
--- a/projects/organization-management/src/app/models/b2b-user/b2b-user.mapper.spec.ts
+++ b/projects/organization-management/src/app/models/b2b-user/b2b-user.mapper.spec.ts
@@ -14,6 +14,7 @@ describe('B2b User Mapper', () => {
         preferredInvoiceToAddress: BasketMockData.getAddress(),
         preferredShipToAddress: { urn: 'urn:1234' } as Address,
         preferredPaymentInstrument: { id: '1234' } as PaymentInstrument,
+        preferredLanguage: 'en_US',
         active: true,
       } as B2bUserData;
       const user = B2bUserMapper.fromData(userData);

--- a/projects/organization-management/src/app/pages/user-create/user-create-page.component.spec.ts
+++ b/projects/organization-management/src/app/pages/user-create/user-create-page.component.spec.ts
@@ -59,7 +59,6 @@ describe('User Create Page Component', () => {
         firstName: ['Bernhard', [Validators.required]],
         lastName: ['Boldner', [Validators.required]],
         email: ['test@gmail.com', [Validators.required, SpecialValidators.email]],
-        preferredLanguage: ['en_US', [Validators.required]],
         active: [true],
       }),
       roleIDs: ['Buyer'],
@@ -79,7 +78,6 @@ describe('User Create Page Component', () => {
           "email": "test@gmail.com",
           "firstName": "Bernhard",
           "lastName": "Boldner",
-          "preferredLanguage": "en_US",
         },
         "roleIDs": "Buyer",
         "userBudget": Object {

--- a/projects/organization-management/src/app/pages/user-create/user-create-page.component.ts
+++ b/projects/organization-management/src/app/pages/user-create/user-create-page.component.ts
@@ -28,7 +28,6 @@ export class UserCreatePageComponent implements OnInit {
       active: [true],
       phone: [''],
       birthday: [''],
-      preferredLanguage: ['en_US', [Validators.required]],
     }),
     roleIDs: this.fb.control([]),
     userBudget: this.fb.group({
@@ -73,7 +72,6 @@ export class UserCreatePageComponent implements OnInit {
       active: formValue.profile.active,
       phoneHome: formValue.profile.phone,
       birthday: formValue.profile.birthday === '' ? undefined : formValue.birthday, // TODO: see IS-22276
-      preferredLanguage: formValue.profile.preferredLanguage,
       businessPartnerNo: 'U' + UUID.UUID(),
       roleIDs: formValue.roleIDs,
       userBudget: formValue.userBudget.currency

--- a/projects/organization-management/src/app/services/users/users.service.spec.ts
+++ b/projects/organization-management/src/app/services/users/users.service.spec.ts
@@ -3,7 +3,9 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { anyString, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
+import { AppFacade } from 'ish-core/facades/app.facade';
 import { Customer } from 'ish-core/models/customer/customer.model';
+import { Locale } from 'ish-core/models/locale/locale.model';
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
@@ -16,17 +18,21 @@ import { UsersService } from './users.service';
 describe('Users Service', () => {
   let apiService: ApiService;
   let usersService: UsersService;
+  let appFacade: AppFacade;
 
   beforeEach(() => {
     apiService = mock(ApiService);
+    appFacade = mock(AppFacade);
     when(apiService.get(anything())).thenReturn(of({}));
     when(apiService.delete(anything())).thenReturn(of({}));
     when(apiService.post(anyString(), anything())).thenReturn(of({}));
     when(apiService.put(anyString(), anything())).thenReturn(of({}));
+    when(appFacade.currentLocale$).thenReturn(of({ lang: 'en_US' } as Locale));
 
     TestBed.configureTestingModule({
       providers: [
         { provide: ApiService, useFactory: () => instance(apiService) },
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
         provideMockStore({
           selectors: [
             { selector: getLoggedInCustomer, value: { customerNo: '4711', isBusinessCustomer: true } as Customer },

--- a/src/app/core/models/user/user.interface.ts
+++ b/src/app/core/models/user/user.interface.ts
@@ -17,7 +17,7 @@ export interface UserData {
   email: string;
   login: string;
 
-  preferredLanguage: string;
+  preferredLanguage?: string;
   preferredInvoiceToAddress?: Address;
   preferredShipToAddress?: Address;
   preferredPaymentInstrument?: PaymentInstrument;

--- a/src/app/core/models/user/user.mapper.ts
+++ b/src/app/core/models/user/user.mapper.ts
@@ -10,7 +10,7 @@ export class UserMapper {
           lastName: user.lastName,
           email: user.email,
           login: user.login,
-          preferredLanguage: user.preferredLanguage || 'en_US', // necessary because of #IS-26193
+          preferredLanguage: user.preferredLanguage,
           title: user.title,
           phoneHome: user.phoneHome,
           phoneBusiness: user.phoneBusiness,

--- a/src/app/core/models/user/user.model.ts
+++ b/src/app/core/models/user/user.model.ts
@@ -2,7 +2,7 @@ export interface User {
   title?: string;
   firstName: string;
   lastName: string;
-  preferredLanguage: string;
+  preferredLanguage?: string;
   birthday?: string;
 
   phoneHome?: string;

--- a/src/app/core/services/user/user.service.spec.ts
+++ b/src/app/core/services/user/user.service.spec.ts
@@ -8,6 +8,7 @@ import { Address } from 'ish-core/models/address/address.model';
 import { Credentials } from 'ish-core/models/credentials/credentials.model';
 import { CustomerData } from 'ish-core/models/customer/customer.interface';
 import { Customer, CustomerRegistrationType, CustomerUserType } from 'ish-core/models/customer/customer.model';
+import { Locale } from 'ish-core/models/locale/locale.model';
 import { User } from 'ish-core/models/user/user.model';
 import { ApiService } from 'ish-core/services/api/api.service';
 
@@ -30,6 +31,7 @@ describe('User Service', () => {
     });
     userService = TestBed.inject(UserService);
     when(appFacade.isAppTypeREST$).thenReturn(of(true));
+    when(appFacade.currentLocale$).thenReturn(of({ lang: 'en_US' } as Locale));
     when(appFacade.customerRestResource$).thenReturn(of('customers'));
   });
 

--- a/src/app/pages/registration/registration-form/registration-form.component.spec.ts
+++ b/src/app/pages/registration/registration-form/registration-form.component.spec.ts
@@ -65,7 +65,6 @@ describe('Registration Form Component', () => {
   it('should create a registration form on creation', () => {
     expect(component.form).toBeUndefined();
     fixture.detectChanges();
-    expect(component.form.get('preferredLanguage')).toBeTruthy();
     expect(component.form.get('birthday')).toBeTruthy();
     expect(component.form.get('taxationID')).toBeTruthy();
   });
@@ -85,7 +84,7 @@ describe('Registration Form Component', () => {
 
   it('should set submitted flag if submit is clicked and form is not valid', async () => {
     component.form = new FormGroup({
-      preferredLanguage: new FormControl('', Validators.required),
+      countryCodeSwitch: new FormControl('', Validators.required),
     });
     expect(component.submitted).toBeFalsy();
     component.submitForm();

--- a/src/app/pages/registration/registration-form/registration-form.component.ts
+++ b/src/app/pages/registration/registration-form/registration-form.component.ts
@@ -58,7 +58,6 @@ export class RegistrationFormComponent implements OnInit {
         }
       ),
       countryCodeSwitch: ['', [Validators.required]],
-      preferredLanguage: ['en_US', [Validators.required]],
       birthday: [''],
       termsAndConditions: [false, [Validators.required, Validators.pattern('true')]],
       captcha: [''],
@@ -102,7 +101,6 @@ export class RegistrationFormComponent implements OnInit {
       email: formValue.credentials.login,
       phoneHome: formValue.address.phoneHome,
       birthday: formValue.birthday === '' ? undefined : formValue.birthday, // TODO: see IS-22276
-      preferredLanguage: formValue.preferredLanguage,
     };
 
     const credentials: Credentials = {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix


## What Is the Current Behavior?

User registration email is always sent in english (en_US) even if the user triggers the registration from a different storefront locale and with a this different locale in the REST call too.
This results from the hardcoded 'en_US' as preferredLanguage in the registration form.

## What Is the New Behavior?

The currently selected locale is used as 'preferredLanguage' when sending the registration form. With this change the registration email is send in the locale the user triggers the registration from.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No


