### PR TITLE
fix: send PGID for CMS View Context calls

### DIFF
--- a/src/app/core/services/cms/cms.service.ts
+++ b/src/app/core/services/cms/cms.service.ts
@@ -74,6 +74,7 @@ export class CMSService {
 
     return this.apiService
       .get<ContentPageletEntryPointData>(`cms/viewcontexts/${viewContextId}/entrypoint`, {
+        sendPGID: true,
         params,
         skipApiErrorHandling: true,
       })


### PR DESCRIPTION
- enables personalized content for view contexts
- prevents error "Bad Request (Matrix parameter "pgid" is required if auth token is present)"

addition to PR "feat: render view context content" #4
