### PR TITLE
refactor: remove improper tap usage in effects

### DIFF
--- a/e2e/cypress/integration/specs/checkout/checkout-payments.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/checkout-payments.b2c.e2e-spec.ts
@@ -144,8 +144,7 @@ describe('Checkout Payment', () => {
     });
   });
 
-  // ignored until https://jira.intershop.de/browse/IS-31634 is fixed
-  xdescribe('Within the MyAccount', () => {
+  describe('Within the MyAccount', () => {
     before(() => {
       at(CheckoutPaymentPage, page => page.header.gotoHomePage());
       at(HomePage, page => page.header.goToMyAccount());

--- a/projects/requisition-management/src/app/store/requisitions/requisitions.effects.spec.ts
+++ b/projects/requisition-management/src/app/store/requisitions/requisitions.effects.spec.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -51,6 +52,7 @@ describe('Requisitions Effects', () => {
   let actions$: Observable<Action>;
   let effects: RequisitionsEffects;
   let requisitionsService: RequisitionsService;
+  let location: Location;
 
   beforeEach(() => {
     requisitionsService = mock(RequisitionsService);
@@ -71,6 +73,7 @@ describe('Requisitions Effects', () => {
     });
 
     effects = TestBed.inject(RequisitionsEffects);
+    location = TestBed.inject(Location);
   });
 
   describe('loadRequisitions$', () => {
@@ -135,11 +138,13 @@ describe('Requisitions Effects', () => {
   });
 
   describe('updateRequisitionStatus$', () => {
-    it('should call the service for updating the status of a requisition', done => {
+    beforeEach(() => {
       actions$ = of(
         updateRequisitionStatus({ requisitionId: '4711', status: 'APPROVED', approvalComment: 'test comment' })
       );
+    });
 
+    it('should call the service for updating the status of a requisition', done => {
       effects.updateRequisitionStatus$.subscribe(() => {
         verify(requisitionsService.updateRequisitionStatus('4711', 'APPROVED', 'test comment')).once();
         done();
@@ -147,15 +152,18 @@ describe('Requisitions Effects', () => {
     });
 
     it('should retrieve the requisition after updating the status', done => {
-      actions$ = of(
-        updateRequisitionStatus({ requisitionId: '4711', status: 'APPROVED', approvalComment: 'test comment' })
-      );
-
       effects.updateRequisitionStatus$.subscribe(action => {
         expect(action).toMatchInlineSnapshot(`
           [Requisitions API] Update Requisition Status Success:
             requisition: {"id":"testUUID","requisitionNo":"0001","user":{"firstName":...
         `);
+        done();
+      });
+    });
+
+    it('should redirect to listing', done => {
+      effects.updateRequisitionStatus$.subscribe(() => {
+        expect(location.path()).toMatchInlineSnapshot(`"/account/requisitions/approver/testUUID;status=PENDING"`);
         done();
       });
     });

--- a/projects/requisition-management/src/app/store/requisitions/requisitions.effects.ts
+++ b/projects/requisition-management/src/app/store/requisitions/requisitions.effects.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatMap, map, switchMap, tap } from 'rxjs/operators';
+import { from } from 'rxjs';
+import { concatMap, map, mapTo, switchMap } from 'rxjs/operators';
 
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { loadProductIfNotLoaded } from 'ish-core/store/shopping/products';
@@ -75,14 +76,15 @@ export class RequisitionsEffects {
         this.requisitionsService
           .updateRequisitionStatus(payload.requisitionId, payload.status, payload.approvalComment)
           .pipe(
-            tap(requisition =>
+            concatMap(requisition =>
               /* ToDo: use only relative routes */
-              this.router.navigate([
-                `/account/requisitions/approver/${requisition.id}`,
-                { status: requisition.approval?.statusCode },
-              ])
+              from(
+                this.router.navigate([
+                  `/account/requisitions/approver/${requisition.id}`,
+                  { status: requisition.approval?.statusCode },
+                ])
+              ).pipe(mapTo(updateRequisitionStatusSuccess({ requisition })))
             ),
-            map(requisition => updateRequisitionStatusSuccess({ requisition })),
             mapErrorToAction(updateRequisitionStatusFail)
           )
       )

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.effects.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.effects.ts.template
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { filter, tap } from 'rxjs/operators';
+import { Action } from '@ngrx/store';
+import { EMPTY, Observable } from 'rxjs';
+import { concatMap } from 'rxjs/operators';
 
 import { load<%= classify(name) %> } from './<%= dasherize(name) %>.actions';
 
@@ -11,9 +13,7 @@ export class <%= classify(name) %>Effects {
   load<%= classify(name) %>$ = createEffect(() =>
     this.actions$.pipe(
       ofType(load<%= classify(name) %>),
-      // tslint:disable-next-line:no-console
-      tap(() => console.log('got load<%= classify(name) %> in <%= classify(name) %>Effects.load<%= classify(name) %>$')),
-      filter(() => false)
+      concatMap(() => EMPTY as Observable<Action>)
     )
   );
 }

--- a/src/app/core/models/basket-feedback/basket-feedback.model.ts
+++ b/src/app/core/models/basket-feedback/basket-feedback.model.ts
@@ -7,7 +7,7 @@ export interface BasketFeedback {
     lineItemId?: string;
     productSku?: string;
     shippingRestriction?: string;
-    scopes?: string; // data type will change IS-28602
+    scopes?: string[];
   };
 }
 

--- a/src/app/core/store/core/error/error.effects.spec.ts
+++ b/src/app/core/store/core/error/error.effects.spec.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
-import { noop } from 'rxjs';
 
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
@@ -12,7 +11,6 @@ import { communicationTimeoutError } from './error.actions';
 import { ErrorEffects } from './error.effects';
 
 describe('Error Effects', () => {
-  let effects: ErrorEffects;
   let store$: Store;
   let location: Location;
 
@@ -23,26 +21,20 @@ describe('Error Effects', () => {
     TestBed.configureTestingModule({
       declarations: [DummyComponent],
       imports: [
-        CoreStoreModule.forTesting(['error']),
+        CoreStoreModule.forTesting(['error'], [ErrorEffects]),
         RouterTestingModule.withRoutes([{ path: 'error', component: DummyComponent }]),
       ],
-      providers: [ErrorEffects],
     });
 
     store$ = TestBed.inject(Store);
-    effects = TestBed.inject(ErrorEffects);
     location = TestBed.inject(Location);
   });
 
-  describe('gotoErrorPageInCaseOfError$', () => {
-    it('should call Router Navigation when Error is handled', fakeAsync(() => {
-      store$.dispatch(communicationTimeoutError({ error: makeHttpError({}) }));
+  it('should redirect to error page when general errors are encountered', fakeAsync(() => {
+    store$.dispatch(communicationTimeoutError({ error: makeHttpError({}) }));
 
-      effects.gotoErrorPageInCaseOfError$.subscribe(noop, fail, fail);
+    tick(500);
 
-      tick(500);
-
-      expect(location.path()).toEqual('/error');
-    }));
-  });
+    expect(location.path()).toEqual('/error');
+  }));
 });

--- a/src/app/core/store/core/error/error.effects.ts
+++ b/src/app/core/store/core/error/error.effects.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
-import { createEffect } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { map, tap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
@@ -11,18 +10,15 @@ import { getGeneralError } from './error.selectors';
 
 @Injectable()
 export class ErrorEffects {
-  constructor(private store: Store, private httpStatusCodeService: HttpStatusCodeService) {}
-
-  gotoErrorPageInCaseOfError$ = createEffect(
-    () =>
-      this.store.pipe(
+  constructor(store: Store, httpStatusCodeService: HttpStatusCodeService) {
+    store
+      .pipe(
         select(getGeneralError),
         whenTruthy(),
-        map(error => this.mapStatus(error)),
-        tap(status => this.httpStatusCodeService.setStatusAndRedirect(status))
-      ),
-    { dispatch: false }
-  );
+        map(error => this.mapStatus(error))
+      )
+      .subscribe(status => httpStatusCodeService.setStatusAndRedirect(status));
+  }
 
   private mapStatus(state: HttpError): number {
     if (state && typeof state.status === 'number') {

--- a/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
@@ -376,7 +376,7 @@ describe('Basket Validation Effects', () => {
         results: {
           valid: false,
           adjusted: false,
-          errors: [{ code: '1234', message: 'error', parameters: { scopes: 'Addresses' } }],
+          errors: [{ code: '1234', message: 'error', parameters: { scopes: ['Addresses'] } }],
         },
       };
       const action = continueCheckoutWithIssues({

--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -34,7 +34,6 @@ import {
   setBasketAttributeSuccess,
   submitBasket,
   submitBasketFail,
-  submitBasketSuccess,
   updateBasket,
   updateBasketFail,
   updateBasketShippingMethod,
@@ -448,15 +447,15 @@ describe('Basket Effects', () => {
       });
     });
 
-    it('should map a valid request to action of type SubmitBasketBuccess', () => {
+    it('should map a valid request to action of type SubmitBasketBuccess', done => {
       when(basketServiceMock.createRequisition(anyString())).thenReturn(of(undefined));
 
-      const action = submitBasket();
-      const completion = submitBasketSuccess();
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = of(submitBasket());
 
-      expect(effects.createRequisition$).toBeObservable(expected$);
+      effects.createRequisition$.subscribe(action => {
+        expect(action).toMatchInlineSnapshot(`[Basket API] Submit a Basket for Approval Success`);
+        done();
+      });
     });
 
     it('should map an invalid request to action of type SubmitBasketFail', () => {

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { RouterNavigatedPayload, routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { EMPTY, combineLatest, iif, of } from 'rxjs';
+import { EMPTY, combineLatest, from, iif, of } from 'rxjs';
 import {
   concatMap,
   concatMapTo,
@@ -14,7 +14,6 @@ import {
   sample,
   startWith,
   switchMap,
-  tap,
   withLatestFrom,
 } from 'rxjs/operators';
 
@@ -241,11 +240,12 @@ export class BasketEffects {
       ofType(submitBasket),
       withLatestFrom(this.store.select(getCurrentBasketId)),
       concatMap(([, basketId]) =>
-        this.basketService.createRequisition(basketId).pipe(
-          tap(() => this.router.navigate(['/checkout/receipt'])),
-          map(submitBasketSuccess),
-          mapErrorToAction(submitBasketFail)
-        )
+        this.basketService
+          .createRequisition(basketId)
+          .pipe(
+            concatMapTo(from(this.router.navigate(['/checkout/receipt'])).pipe(mapTo(submitBasketSuccess()))),
+            mapErrorToAction(submitBasketFail)
+          )
       )
     )
   );

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { EMPTY } from 'rxjs';
+import { EMPTY, from } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -17,7 +17,6 @@ import {
   sample,
   switchMap,
   takeWhile,
-  tap,
   withLatestFrom,
 } from 'rxjs/operators';
 
@@ -109,9 +108,7 @@ export class UserEffects {
         takeWhile(() => isPlatformBrowser(this.platformId)),
         whenTruthy(),
         sample(this.actions$.pipe(ofType(loginUserSuccess))),
-        tap(navigateTo => {
-          this.router.navigateByUrl(navigateTo);
-        })
+        concatMap(navigateTo => from(this.router.navigateByUrl(navigateTo)))
       ),
     { dispatch: false }
   );
@@ -180,9 +177,7 @@ export class UserEffects {
         ofType(updateUserSuccess, updateCustomerSuccess, updateUserPasswordSuccess),
         withLatestFrom(this.store$.pipe(select(selectUrl))),
         filter(([, url]) => url.includes('/account/profile')),
-        tap(() => {
-          this.router.navigateByUrl('/account/profile');
-        })
+        concatMap(() => from(this.router.navigateByUrl('/account/profile')))
       ),
     { dispatch: false }
   );

--- a/src/app/core/store/hybrid/hybrid.effects.ts
+++ b/src/app/core/store/hybrid/hybrid.effects.ts
@@ -1,28 +1,25 @@
 import { isPlatformServer } from '@angular/common';
 import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
 import { TransferState, makeStateKey } from '@angular/platform-browser';
-import { Actions, createEffect } from '@ngrx/effects';
-import { filter, take, tap } from 'rxjs/operators';
+import { Actions } from '@ngrx/effects';
+import { filter, take } from 'rxjs/operators';
 
 export const SSR_HYBRID_STATE = makeStateKey<boolean>('ssrHybrid');
 
 @Injectable()
 export class HybridEffects {
   constructor(
-    private actions: Actions,
-    @Inject(PLATFORM_ID) private platformId: string,
-    private transferState: TransferState,
-    @Optional() @Inject('SSR_HYBRID') private ssrHybridState: boolean
-  ) {}
-
-  propagateSSRHybridPropToTransferState$ = createEffect(
-    () =>
-      this.actions.pipe(
+    actions: Actions,
+    @Inject(PLATFORM_ID) platformId: string,
+    transferState: TransferState,
+    @Optional() @Inject('SSR_HYBRID') ssrHybridState: boolean
+  ) {
+    actions
+      .pipe(
         take(1),
-        filter(() => isPlatformServer(this.platformId)),
-        filter(() => !!this.ssrHybridState),
-        tap(() => this.transferState.set(SSR_HYBRID_STATE, true))
-      ),
-    { dispatch: false }
-  );
+        filter(() => isPlatformServer(platformId)),
+        filter(() => !!ssrHybridState)
+      )
+      .subscribe(() => transferState.set(SSR_HYBRID_STATE, true));
+  }
 }

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -2,7 +2,8 @@ import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { filter, map, mergeMap, switchMap, switchMapTo, tap, withLatestFrom } from 'rxjs/operators';
+import { from } from 'rxjs';
+import { concatMap, filter, map, mergeMap, switchMap, switchMapTo, withLatestFrom } from 'rxjs/operators';
 
 import { MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH } from 'ish-core/configurations/injection-keys';
 import { CategoryHelper } from 'ish-core/models/category/category.model';
@@ -109,7 +110,7 @@ export class CategoriesEffects {
     () =>
       this.actions$.pipe(
         ofType(loadCategoryFail),
-        tap(() => this.httpStatusCodeService.setStatusAndRedirect(404))
+        concatMap(() => from(this.httpStatusCodeService.setStatusAndRedirect(404)))
       ),
     { dispatch: false }
   );

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -5,7 +5,7 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Dictionary } from '@ngrx/entity';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { identity } from 'rxjs';
+import { from, identity } from 'rxjs';
 import {
   concatMap,
   distinct,
@@ -16,7 +16,6 @@ import {
   map,
   mergeMap,
   switchMapTo,
-  tap,
   throttleTime,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -325,7 +324,7 @@ export class ProductsEffects {
         whenTruthy(),
         distinctUntilKeyChanged('sku'),
         filter(ProductHelper.isFailedLoading),
-        tap(() => this.httpStatusCodeService.setStatusAndRedirect(404))
+        concatMap(() => from(this.httpStatusCodeService.setStatusAndRedirect(404)))
       ),
     { dispatch: false }
   );
@@ -334,7 +333,7 @@ export class ProductsEffects {
     () =>
       this.actions$.pipe(
         ofType(loadProductsForCategoryFail),
-        tap(() => this.httpStatusCodeService.setStatusAndRedirect(404))
+        concatMap(() => from(this.httpStatusCodeService.setStatusAndRedirect(404)))
       ),
     { dispatch: false }
   );

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -3,7 +3,7 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { EMPTY } from 'rxjs';
+import { EMPTY, from } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -13,7 +13,6 @@ import {
   sample,
   switchMap,
   switchMapTo,
-  tap,
   withLatestFrom,
 } from 'rxjs/operators';
 
@@ -104,7 +103,7 @@ export class SearchEffects {
     () =>
       this.actions$.pipe(
         ofType(searchProductsFail),
-        tap(() => this.httpStatusCodeService.setStatusAndRedirect(404))
+        concatMap(() => from(this.httpStatusCodeService.setStatusAndRedirect(404)))
       ),
     { dispatch: false }
   );

--- a/src/app/core/utils/http-status-code/http-status-code.service.ts
+++ b/src/app/core/utils/http-status-code/http-status-code.service.ts
@@ -20,6 +20,6 @@ export class HttpStatusCodeService {
 
   setStatusAndRedirect(status: number) {
     this.setStatus(status);
-    this.router.navigateByUrl('/error');
+    return this.router.navigateByUrl('/error');
   }
 }

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { iif, of } from 'rxjs';
-import { concatMap, filter, first, map, mergeMap, mergeMapTo, switchMap, tap, withLatestFrom } from 'rxjs/operators';
+import { from, iif, of } from 'rxjs';
+import { concatMap, filter, first, map, mergeMap, mergeMapTo, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
@@ -176,9 +176,7 @@ export class QuotingEffects {
         ofType(createQuoteRequestFromQuoteSuccess, createQuoteRequestFromBasketSuccess),
         mapToPayloadProperty('entity'),
         mapToProperty('id'),
-        tap(id => {
-          this.router.navigateByUrl('/account/quotes/' + id);
-        })
+        concatMap(id => from(this.router.navigateByUrl('/account/quotes/' + id)))
       ),
     { dispatch: false }
   );
@@ -191,9 +189,7 @@ export class QuotingEffects {
         mapToProperty('id'),
         withLatestFrom(this.store.pipe(select(selectUrl))),
         filter(([, url]) => url.startsWith('/account/quotes')),
-        tap(([id]) => {
-          this.router.navigateByUrl('/account/quotes/' + id);
-        })
+        concatMap(([id]) => from(this.router.navigateByUrl('/account/quotes/' + id)))
       ),
     { dispatch: false }
   );

--- a/src/app/extensions/tacton/store/product-configuration/product-configuration.effects.ts
+++ b/src/app/extensions/tacton/store/product-configuration/product-configuration.effects.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { combineLatest, of } from 'rxjs';
+import { combineLatest, from, of } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -14,7 +14,6 @@ import {
   switchMap,
   switchMapTo,
   take,
-  tap,
   throttleTime,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -107,11 +106,8 @@ export class ProductConfigurationEffects {
           this.store.pipe(select(selectRouteParam('sku'))),
           this.store.pipe(select(selectRouteParam('mainStep')))
         ),
-        tap(([step, sku, previous]) => {
-          if (step && previous !== step) {
-            this.router.navigate(['/configure', sku, step]);
-          }
-        })
+        filter(([step, , previous]) => step && previous !== step),
+        switchMap(([step, sku]) => from(this.router.navigate(['/configure', sku, step])))
       ),
     { dispatch: false }
   );
@@ -229,9 +225,7 @@ export class ProductConfigurationEffects {
       this.actions$.pipe(
         ofType(submitTactonConfigurationSuccess, submitTactonConfigurationFail),
         withLatestFrom(this.store.pipe(select(getSelectedProduct))),
-        tap(([, product]) => {
-          this.router.navigateByUrl(generateProductUrl(product));
-        })
+        switchMap(([, product]) => from(this.router.navigateByUrl(generateProductUrl(product))))
       ),
     { dispatch: false }
   );

--- a/tslint.json
+++ b/tslint.json
@@ -473,6 +473,12 @@
           "from": "@ngrx/router-store",
           "filePattern": "^.*\\.spec\\.ts*$",
           "message": "We customized the serialization of the router state. Use router actions from 'ish-core/utils/dev/routing' in tests."
+        },
+        {
+          "import": "tap",
+          "from": "rxjs/operators",
+          "filePattern": "^(?!.*/store/(sentry-config/sentry-config|seo/seo|core/messages/messages)\\.effects\\.ts$).*\\.effects\\.ts*$",
+          "message": "The usage of 'tap' in effects, if not related to 3rd party integrations, can usually be transformed properly into RxJS stream code."
         }
       ]
     },


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

RxJS `tap` in effects usually points to improper usage.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
