### PR TITLE
fix: use localStorage as storage for oauth

### DIFF
--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -1,5 +1,6 @@
-import { NgModule } from '@angular/core';
-import { OAuthModule } from 'angular-oauth2-oidc';
+import { isPlatformBrowser } from '@angular/common';
+import { NgModule, PLATFORM_ID } from '@angular/core';
+import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { NgModuleWithProviders } from 'ng-mocks';
 import { noop } from 'rxjs';
 
@@ -8,9 +9,20 @@ import { ICMIdentityProvider } from './identity-provider/icm.identity-provider';
 import { IDENTITY_PROVIDER_IMPLEMENTOR, IdentityProviderFactory } from './identity-provider/identity-provider.factory';
 import { IdentityProviderCapabilities } from './identity-provider/identity-provider.interface';
 
+/**
+ * provider factory for storage
+ * We need a factory, since localStorage is not available during AOT build time.
+ */
+export function storageFactory(platformId: string): OAuthStorage {
+  if (isPlatformBrowser(platformId)) {
+    return localStorage;
+  }
+}
+
 @NgModule({
   imports: [OAuthModule.forRoot({ resourceServer: { sendAccessToken: false } })],
   providers: [
+    { provide: OAuthStorage, useFactory: storageFactory, deps: [PLATFORM_ID] },
     {
       provide: IDENTITY_PROVIDER_IMPLEMENTOR,
       multi: true,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #512


## What Is the New Behavior?

`localStorage` is used for OAuth library to persist state across sessions.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/configure-custom-oauthstorage.html

fix deployed to #483 for testing: http://pwa-gh-review-483-universal-b2c.azurewebsites.net/