### PR TITLE
perf: tune webpack chunk settings

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -58,12 +58,26 @@
               "sourceMap": false,
               "namedChunks": false,
               "extractLicenses": true,
-              "vendorChunk": false,
+              "vendorChunk": true,
               "buildOptimizer": true,
               "budgets": [
                 {
+                  "type": "bundle",
+                  "name": "main",
+                  "baseline": "750kb",
+                  "warning": "200kb",
+                  "error": "500kb"
+                },
+                {
+                  "type": "bundle",
+                  "name": "vendor",
+                  "baseline": "1mb",
+                  "warning": "200kb",
+                  "error": "500kb"
+                },
+                {
                   "type": "initial",
-                  "maximumWarning": "2mb",
+                  "maximumWarning": "3mb",
                   "maximumError": "5mb"
                 },
                 {

--- a/templates/production/webpack.production.js
+++ b/templates/production/webpack.production.js
@@ -1,6 +1,14 @@
 var path = require('path');
 
 module.exports = config => {
+  // splitChunks not available for SSR build
+  if (config.optimization.splitChunks) {
+    const cacheGroups = config.optimization.splitChunks.cacheGroups;
+    cacheGroups.default.minChunks = 10;
+    cacheGroups.common.minChunks = 1;
+    cacheGroups.common.priority = 20;
+  }
+
   const angularPluginIndex = config.plugins.findIndex(
     p => typeof p && p.constructor && p.constructor.name === 'AngularCompilerPlugin'
   );


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes

## What Is the Current Behavior?

Multiple small bundles produced by webpack. 3rd party imports all over the place.

## What Is the New Behavior?

- main bundle
- vendor bundle (should be the same as long as we don't upgrade dependencies)
- common bundle for all lazy loaded code
- budgets adapted

-> fewer files should lead to an overall performance improvement
initial load size still stays the same, though

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

https://medium.com/dailyjs/how-did-angular-cli-budgets-save-my-day-and-how-they-can-save-yours-300d534aae7a
https://webpack.js.org/plugins/split-chunks-plugin/
