### PR TITLE
fix: remove specific mapper method for root nodes

### DIFF
--- a/src/app/extensions/organization-hierarchies/models/organization-group/organization-group.mapper.spec.ts
+++ b/src/app/extensions/organization-hierarchies/models/organization-group/organization-group.mapper.spec.ts
@@ -45,21 +45,5 @@ describe('Organization Group Mapper', () => {
       expect(mapped).toHaveProperty('name', 'Some Child');
       expect(mapped).toHaveProperty('parentid', 'test');
     });
-
-    it('should map customer name to mapped data', () => {
-      const mapped = organizationGroupMapper.fromData(ROOT);
-      const handled = organizationGroupMapper.handleRoot(mapped, 'OilCorp');
-      expect(handled).toHaveProperty('id', 'test');
-      expect(handled).toHaveProperty('name', 'OilCorp');
-      expect(handled).toHaveProperty('parentid', undefined);
-    });
-
-    it('should NOT map customer name to mapped data', () => {
-      const mapped = organizationGroupMapper.fromData(CHILD);
-      const handled = organizationGroupMapper.handleRoot(mapped, 'OilCorp');
-      expect(handled).toHaveProperty('id', 'Child');
-      expect(handled).toHaveProperty('name', 'Some Child');
-      expect(handled).toHaveProperty('parentid', 'test');
-    });
   });
 });

--- a/src/app/extensions/organization-hierarchies/models/organization-group/organization-group.mapper.ts
+++ b/src/app/extensions/organization-hierarchies/models/organization-group/organization-group.mapper.ts
@@ -16,11 +16,4 @@ export class OrganizationGroupMapper {
       throw new Error(`organizationGroupData is required`);
     }
   }
-
-  handleRoot(organizationGroup: OrganizationGroup, companyName: string): OrganizationGroup {
-    return {
-      ...organizationGroup,
-      name: organizationGroup.parentid ? organizationGroup.name : companyName,
-    };
-  }
 }

--- a/src/app/extensions/organization-hierarchies/services/organization-hierarchies/organization-hierarchies.service.ts
+++ b/src/app/extensions/organization-hierarchies/services/organization-hierarchies/organization-hierarchies.service.ts
@@ -30,11 +30,7 @@ export class OrganizationHierarchiesService {
             `${baseURL}/organizations/${customer.customerNo}/groups`,
             this.contentTypeHeader
           )
-          .pipe(
-            map(list =>
-              list.data.map(this.mapper.fromData).map(item => this.mapper.handleRoot(item, customer.companyName))
-            )
-          )
+          .pipe(map(list => list.data.map(this.mapper.fromData)))
       )
     );
   }


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

If a customer creates a root group in the PWA company structure page, then this group will not displayed with the correct group name in the group selectbox of the header component.
During the loading of the organization group into the PWA store, each root node name will mapped to the organization name. This solution works if only one root group exists. If more than one root group exist than several groups with the same name will displayed in the selectbox.

Issue Number: ISREST-1151

## What Is the New Behavior?

Remove mapping name to organization name.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x ] No
