### PR TITLE
fix: crossed prices in checkout items widget

### DIFF
--- a/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.html
+++ b/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.html
@@ -12,7 +12,7 @@
         <span> {{ 'checkout.pli.qty.label' | translate }} {{ pli.quantity.value }} </span>
       </div>
       <div class="col-4 text-right">
-        <div *ngIf="pli.totals.valueRebatesTotal" class="old-price">{{ pli.price | ishPrice }}</div>
+        <div *ngIf="pli.totals.valueRebatesTotal" class="old-price">{{ pli.totals.undiscountedTotal | ishPrice }}</div>
         <div *ngIf="pli.isFreeGift" class="list-item-promo">{{ 'checkout.pli.freegift.text' | translate }}</div>
       </div>
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If a user has added products with reduced prices to his cart the crossed out prices are the same as the current product price on the checkout items widget.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


Issue Number: Closes #ISREST-898

## What Is the New Behavior?
The correct crossed out prices are displayed on the checkout items widget.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
