### PR TITLE
feat: reload orders after group selection

### DIFF
--- a/src/app/extensions/organization-hierarchies/facades/organization-hierarchies.facade.ts
+++ b/src/app/extensions/organization-hierarchies/facades/organization-hierarchies.facade.ts
@@ -3,6 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { switchMap, take, tap } from 'rxjs/operators';
 
+import { loadOrders } from 'ish-core/store/customer/orders';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { whenTruthy } from 'ish-core/utils/operators';
 
@@ -37,6 +38,7 @@ export class OrganizationHierarchiesFacade {
 
   selectGroup(id: string): void {
     this.store.dispatch(selectGroup({ id }));
+    this.store.dispatch(loadOrders());
   }
 
   getDetailsOfGroup$(id: string): Observable<OrganizationGroup> {


### PR DESCRIPTION
<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

If the order history is opened and an new organization group is selected the order history page is not adapted regarding the new group.

Issue Number: ISREST-1131

## What Is the New Behavior?

If a new group is selected than the order history page should reload content.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[ x] No
