### PR TITLE
build: consistently set service-worker activation with custom webpack…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -234,7 +234,11 @@
             "aot": false,
             "styles": ["src/styles/themes/default/style.scss"],
             "assets": [
-              { "glob": "**/*", "input": "src/assets/", "output": "/assets/" }
+              {
+                "glob": "**/*",
+                "input": "src/assets/",
+                "output": "/assets/"
+              }
             ],
             "scripts": [],
             "fileReplacements": [

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -97,8 +97,7 @@ This provides the most flexible way of configuring the application at runtime.
 
 ### Build Settings
 
-One example for a build time configuration is the property `serviceWorker`, which is managed in the _environment.ts_ and used to activate the `ServiceWorker` module.
-Another example of such a build setting is the property `production` as multiple debug modules are only compiled into the application when running in development mode.
+One example for a build time configuration is the property `serviceWorker`, which is managed in the _angular.json_ configurations and used to activate the [service worker](./progressive-web-app.md#service-worker).
 
 In general, properties available at build time can only be supplied by Angular CLI environments (see above).
 

--- a/e2e/test-schematics.sh
+++ b/e2e/test-schematics.sh
@@ -129,7 +129,6 @@ node scripts/init-local-environment -f
 
 node schematics/customization/service-worker false
 grep '"serviceWorker": false' angular.json
-grep 'serviceWorker: false' src/environments/environment.local.ts
 
 git add -A
 npm run clean

--- a/schematics/customization/service-worker/index.js
+++ b/schematics/customization/service-worker/index.js
@@ -29,26 +29,3 @@ Object.keys(build.configurations).forEach(key => {
 
 fs.writeFileSync('./angular.json', stringify(angularJson, null, 2));
 execSync('npx prettier --write angular.json');
-
-// replace in environments
-const tsMorphProject = new Project();
-tsMorphProject.addSourceFilesAtPaths('src/environments/environment*.ts');
-
-tsMorphProject
-  .getSourceFiles()
-  .filter(file => !file.getBaseName().endsWith('.model.ts') && file.getBaseName() !== 'environment.ts')
-  .forEach(file => {
-    file
-      .forEachDescendantAsArray()
-      .filter(stm => stm.getKind() == ts.SyntaxKind.VariableDeclaration && stm.getName() === 'environment')
-      .map(stm => stm.getInitializer())
-      .forEach(objectLiteralExpression => {
-        const property = objectLiteralExpression.getProperty('serviceWorker');
-        if (property) {
-          property.setInitializer(`${enable}`);
-        }
-      });
-  });
-
-tsMorphProject.saveSync();
-execSync('npx prettier --write src/environments/*.*');

--- a/scripts/init-local-environment.js
+++ b/scripts/init-local-environment.js
@@ -38,7 +38,6 @@ const extraFeatures: typeof environment.features =
 export const environment: Environment = {
   ...ENVIRONMENT_DEFAULTS,
 
-  serviceWorker: false,
   defaultDeviceType: 'desktop',
 
   icmBaseURL: 'https://pwa-ish-demo.test.intershop.com',

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -5,8 +5,6 @@ import { ServiceWorkerModule } from '@angular/service-worker';
 import { TranslateModule } from '@ngx-translate/core';
 import { BrowserCookiesModule } from 'ngx-utils-cookies-port';
 
-import { environment } from '../../environments/environment';
-
 import { AppearanceModule } from './appearance.module';
 import { ConfigurationModule } from './configuration.module';
 import { ExtrasModule } from './extras.module';
@@ -30,7 +28,7 @@ import { ModuleLoaderService } from './utils/module-loader/module-loader.service
     HttpClientModule,
     IdentityProviderModule,
     InternationalizationModule,
-    ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.serviceWorker }),
+    ServiceWorkerModule.register('ngsw-worker.js', { enabled: SERVICE_WORKER }),
     StateManagementModule,
   ],
   providers: [

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -73,9 +73,6 @@ export interface Environment {
   // default device type used for initial page responses
   defaultDeviceType: DeviceType;
 
-  // enable or disable service worker
-  serviceWorker: boolean;
-
   // configuration of the available locales - hard coded for now
   locales: Locale[];
 
@@ -111,7 +108,6 @@ export const ENVIRONMENT_DEFAULTS: Environment = {
   features: ['compare', 'recently', 'rating', 'wishlists'],
 
   /* PROGRESSIVE WEB APP CONFIGURATIONS */
-  serviceWorker: false,
   smallBreakpointWidth: 576,
   mediumBreakpointWidth: 768,
   largeBreakpointWidth: 992,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,4 +7,6 @@ interface NodeModule {
 
 declare var PRODUCTION_MODE: boolean;
 
+declare var SERVICE_WORKER: boolean;
+
 declare var PWA_VERSION: string;

--- a/tslint.json
+++ b/tslint.json
@@ -377,7 +377,7 @@
         {
           "import": ".*",
           "from": ".*environments/environment.*",
-          "filePattern": "^.*/app/((?!(module|core/store/core/configuration/configuration\\.reducer|core/utils/state-transfer/state-properties\\.service|injection-keys)\\.ts).)*$",
+          "filePattern": "^.*/app/((?!(app(.server)?.module|core/store/core/configuration/configuration\\.reducer|core/utils/state-transfer/state-properties\\.service|injection-keys)\\.ts).)*$",
           "message": "Importing environment is not allowed. Inject needed properties instead."
         },
         {


### PR DESCRIPTION
… build

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes

## What Is the Current Behavior?

- `serviceWorker` activation has to be done in [angular.json](https://github.com/intershop/intershop-pwa/blob/101e3a3bfa061629f07376cc06415bc954c009c5/angular.json#L84) and [environment.ts](https://github.com/intershop/intershop-pwa/blob/101e3a3bfa061629f07376cc06415bc954c009c5/src/environments/environment.model.ts#L77) files synchronously, which could lead to unsynchronized and inconsistent settings.

## What Is the New Behavior?

- `serviceWorker` property is done in webpack custom build and set consistently depending on the current configuration in angular.json

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Relates to b15a471501888b174be420879bb6af3d44289ce3 where this was previously done for `production`