### PR TITLE
perf: restructure chunk splitting for features

### DIFF
--- a/schematics/src/extension/files/__name@dasherize__/exports/__name@dasherize__-exports.module.ts.template
+++ b/schematics/src/extension/files/__name@dasherize__/exports/__name@dasherize__-exports.module.ts.template
@@ -8,7 +8,7 @@ import { LAZY_FEATURE_MODULE } from 'ish-core/utils/module-loader/module-loader.
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: '<%= camelize(name) %>', location: import('../store/<%= dasherize(name) %>-store.module') },
+      useValue: { feature: '<%= camelize(name) %>', location: () => import('../store/<%= dasherize(name) %>-store.module') },
       multi: true,
     },
   ],

--- a/src/app/core/utils/module-loader/module-loader.service.ts
+++ b/src/app/core/utils/module-loader/module-loader.service.ts
@@ -7,7 +7,7 @@ import { whenTruthy } from 'ish-core/utils/operators';
 
 declare interface LazyModuleType {
   feature: string;
-  location: unknown;
+  location(): unknown;
 }
 
 export const LAZY_FEATURE_MODULE = new InjectionToken<LazyModuleType>('lazyModule');
@@ -25,7 +25,7 @@ export class ModuleLoaderService {
         .filter(mod => !this.loadedModules.includes(mod.feature))
         .filter(mod => this.featureToggleService.enabled(mod.feature))
         .forEach(async mod => {
-          await this.loadModule(mod.location, injector);
+          await this.loadModule(mod.location(), injector);
           this.loadedModules.push(mod.feature);
         });
     });

--- a/src/app/extensions/order-templates/exports/order-templates-exports.module.ts
+++ b/src/app/extensions/order-templates/exports/order-templates-exports.module.ts
@@ -12,7 +12,7 @@ import { LazyProductAddToOrderTemplateComponent } from './lazy-product-add-to-or
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'orderTemplates', location: import('../store/order-templates-store.module') },
+      useValue: { feature: 'orderTemplates', location: () => import('../store/order-templates-store.module') },
       multi: true,
     },
   ],

--- a/src/app/extensions/punchout/exports/punchout-exports.module.ts
+++ b/src/app/extensions/punchout/exports/punchout-exports.module.ts
@@ -13,7 +13,7 @@ import { LazyPunchoutTransferBasketComponent } from './lazy-punchout-transfer-ba
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'punchout', location: import('../store/punchout-store.module') },
+      useValue: { feature: 'punchout', location: () => import('../store/punchout-store.module') },
       multi: true,
     },
     {

--- a/src/app/extensions/quoting/exports/quoting-exports.module.ts
+++ b/src/app/extensions/quoting/exports/quoting-exports.module.ts
@@ -12,7 +12,7 @@ import { LazyQuoteWidgetComponent } from './lazy-quote-widget/lazy-quote-widget.
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'quoting', location: import('../store/quoting-store.module') },
+      useValue: { feature: 'quoting', location: () => import('../store/quoting-store.module') },
       multi: true,
     },
   ],

--- a/src/app/extensions/sentry/exports/sentry-exports.module.ts
+++ b/src/app/extensions/sentry/exports/sentry-exports.module.ts
@@ -6,7 +6,7 @@ import { LAZY_FEATURE_MODULE } from 'ish-core/utils/module-loader/module-loader.
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'sentry', location: import('../store/sentry-store.module') },
+      useValue: { feature: 'sentry', location: () => import('../store/sentry-store.module') },
       multi: true,
     },
   ],

--- a/src/app/extensions/tacton/exports/tacton-exports.module.ts
+++ b/src/app/extensions/tacton/exports/tacton-exports.module.ts
@@ -13,7 +13,7 @@ import { LazyTactonConfigureProductComponent } from './lazy-tacton-configure-pro
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'tacton', location: import('../store/tacton-store.module') },
+      useValue: { feature: 'tacton', location: () => import('../store/tacton-store.module') },
       multi: true,
     },
     {

--- a/src/app/extensions/tracking/exports/tracking-exports.module.ts
+++ b/src/app/extensions/tracking/exports/tracking-exports.module.ts
@@ -8,7 +8,7 @@ import { LAZY_FEATURE_MODULE } from 'ish-core/utils/module-loader/module-loader.
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'tracking', location: import('../store/tracking-store.module') },
+      useValue: { feature: 'tracking', location: () => import('../store/tracking-store.module') },
       multi: true,
     },
   ],

--- a/src/app/extensions/wishlists/exports/wishlists-exports.module.ts
+++ b/src/app/extensions/wishlists/exports/wishlists-exports.module.ts
@@ -12,7 +12,7 @@ import { LazyWishlistsLinkComponent } from './lazy-wishlists-link/lazy-wishlists
   providers: [
     {
       provide: LAZY_FEATURE_MODULE,
-      useValue: { feature: 'wishlists', location: import('../store/wishlists-store.module') },
+      useValue: { feature: 'wishlists', location: () => import('../store/wishlists-store.module') },
       multi: true,
     },
   ],


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes

## What Is the Current Behavior?

- one common bundle for all lazy loaded code
- if features are deactivated, the corresponding code will still be loaded
- previous bundling with many bundles had also issues, as it was closely associated with actual features

Current Bundles:
![image](https://user-images.githubusercontent.com/23452927/109007508-7be52780-76ac-11eb-8608-d4682f9fcbf3.png)


## What Is the New Behavior?

- features are split into bundles
  - not every feature deserves a bundle (i.e. quickorder, tracking) - automatically managed by webpack
  - feature specific libraries (like sentry) can be pushed into the chunk, that is lazy loaded when the feature is used
- one bundle for customer specific account functionality, that is not used while browsing
- common bundle for all remaining stuff

Proposed Bundles:
![image](https://user-images.githubusercontent.com/23452927/109007586-94554200-76ac-11eb-8e58-bae4c0f2dafe.png)


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
