### PR TITLE
fix: prevent calling forkJoin with empty array for wishlists and order templates

### DIFF
--- a/src/app/extensions/order-templates/services/order-template/order-template.service.ts
+++ b/src/app/extensions/order-templates/services/order-template/order-template.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, throwError } from 'rxjs';
-import { concatMap, defaultIfEmpty, map, switchMap } from 'rxjs/operators';
+import { Observable, forkJoin, of, throwError } from 'rxjs';
+import { concatMap, map, switchMap } from 'rxjs/operators';
 
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
 
@@ -21,9 +21,7 @@ export class OrderTemplateService {
       unpackEnvelope(),
       map(orderTemplateData => orderTemplateData.map(this.orderTemplateMapper.fromDataToIds)),
       map(orderTemplateData => orderTemplateData.map(orderTemplate => this.getOrderTemplate(orderTemplate.id))),
-      // tslint:disable-next-line:no-unnecessary-callback-wrapper
-      switchMap(obsArray => forkJoin(obsArray)),
-      defaultIfEmpty([])
+      switchMap(obsArray => (obsArray.length ? forkJoin(obsArray) : of([])))
     );
   }
 

--- a/src/app/extensions/wishlists/services/wishlist/wishlist.service.ts
+++ b/src/app/extensions/wishlists/services/wishlist/wishlist.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, throwError } from 'rxjs';
-import { concatMap, defaultIfEmpty, first, map, switchMap } from 'rxjs/operators';
+import { Observable, forkJoin, of, throwError } from 'rxjs';
+import { concatMap, first, map, switchMap } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
@@ -25,9 +25,7 @@ export class WishlistService {
           unpackEnvelope(),
           map(wishlistData => wishlistData.map(this.wishlistMapper.fromDataToIds)),
           map(wishlistData => wishlistData.map(wishlist => this.getWishlist(wishlist.id))),
-          // tslint:disable-next-line:no-unnecessary-callback-wrapper
-          switchMap(obsArray => forkJoin(obsArray)),
-          defaultIfEmpty([])
+          switchMap(obsArray => (obsArray.length ? forkJoin(obsArray) : of([])))
         )
       )
     );


### PR DESCRIPTION


<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

If a user doesn't have order templates or wishlists and navigates to the corresponding my-account list view, the loading animation doesn't stop.

## What Is the New Behavior?

It works!

Calling `forkJoin` with an empty array will immediately complete, but somehow the `defaultIfEmpty` does not trigger anymore. I tried reproducing this behaviour on StackBlitz, but everything seems to work just fine (maybe a newer RxJS version? idk).

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
