### PR TITLE
build: make it possible to test and review in production mode

### DIFF
--- a/.github/workflows/demo-server.yml
+++ b/.github/workflows/demo-server.yml
@@ -33,14 +33,15 @@ jobs:
         uses: elgohr/Publish-Docker-Github-Action@master
         env:
           serviceWorker: false
-          configuration: local
+          configuration: production
           displayVersion: ${{ github.event.after }}
+          testing: true
         with:
           name: universal
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY }}
-          buildargs: serviceWorker,configuration,displayVersion
+          buildargs: serviceWorker,configuration,displayVersion,testing
 
       # - name: Publish Nginx Image to Registry
       #   id: nginx

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,8 @@ jobs:
   Build:
     needs: [CancelPrevious]
     runs-on: ubuntu-latest
+    env:
+      TESTING: true
 
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +48,7 @@ jobs:
       - name: Build SSR
         run: |
           node scripts/init-local-environment -f
-          npm run build --configuration=local
+          npm run build
 
       - name: Upload Build Output
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Set Environment
         run: |
           echo "LOGGING=true" >> $GITHUB_ENV
-          echo "PROXY_ICM=true" >> $GITHUB_ENV
 
       - name: Set B2B Environment
         if: matrix.test == 'b2b'
@@ -123,7 +122,6 @@ jobs:
         run: |
           echo "PWA_BASE_URL=http://localhost:4200" >> $GITHUB_ENV
           echo "LOGGING=true" >> $GITHUB_ENV
-          echo "PROXY_ICM=true" >> $GITHUB_ENV
           echo "BROWSER=chrome" >> $GITHUB_ENV
 
       - name: Set B2B Environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN test "${configuration}" = 'local' && node scripts/init-local-environment.js 
 ARG serviceWorker
 RUN node schematics/customization/service-worker ${serviceWorker} || true
 COPY templates/webpack/* /workspace/templates/webpack/
+ARG testing=false
+ENV TESTING=${testing}
 RUN npm run ng -- build -c ${configuration}
 # synchronize-marker:pwa-docker-build:end
 

--- a/Dockerfile_noSSR
+++ b/Dockerfile_noSSR
@@ -15,6 +15,8 @@ RUN test "${configuration}" = 'local' && node scripts/init-local-environment.js 
 ARG serviceWorker
 RUN node schematics/customization/service-worker ${serviceWorker} || true
 COPY templates/webpack/* /workspace/templates/webpack/
+ARG testing=false
+ENV TESTING=${testing}
 RUN npm run ng -- build -c ${configuration}
 # synchronize-marker:pwa-docker-build:end
 

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -2,4 +2,5 @@ module.exports = on => {
   on('task', {
     failed: require('cypress-failed-log/src/failed')(),
   });
+  require('cypress-log-to-output').install(on);
 };

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "cypress": "^6.0.0",
     "cypress-failed-log": "^2.0.0",
+    "cypress-log-to-output": "^1.1.2",
     "typescript": "*"
   }
 }

--- a/src/app/core/services/user/user.service.spec.ts
+++ b/src/app/core/services/user/user.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpHeaders } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { of, throwError } from 'rxjs';
 import { anyString, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
@@ -11,6 +12,7 @@ import { Customer, CustomerRegistrationType, CustomerUserType } from 'ish-core/m
 import { Locale } from 'ish-core/models/locale/locale.model';
 import { User } from 'ish-core/models/user/user.model';
 import { ApiService } from 'ish-core/services/api/api.service';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
 import { UserService } from './user.service';
 
@@ -27,6 +29,7 @@ describe('User Service', () => {
       providers: [
         { provide: ApiService, useFactory: () => instance(apiServiceMock) },
         { provide: AppFacade, useFactory: () => instance(appFacade) },
+        provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: undefined }] }),
       ],
     });
     userService = TestBed.inject(UserService);

--- a/src/app/core/store/core/core-store.module.ts
+++ b/src/app/core/store/core/core-store.module.ts
@@ -40,10 +40,11 @@ const coreMetaReducers: MetaReducer<CoreState>[] = [
     StoreModule.forRoot<CoreState>(coreReducers, {
       metaReducers: coreMetaReducers,
       runtimeChecks: {
-        strictActionImmutability: !PRODUCTION_MODE,
-        strictActionSerializability: !PRODUCTION_MODE,
-        strictStateImmutability: !PRODUCTION_MODE,
-        strictStateSerializability: !PRODUCTION_MODE,
+        strictActionImmutability: NGRX_RUNTIME_CHECKS,
+        strictActionSerializability: NGRX_RUNTIME_CHECKS,
+        strictStateImmutability: NGRX_RUNTIME_CHECKS,
+        strictStateSerializability: NGRX_RUNTIME_CHECKS,
+        strictActionTypeUniqueness: NGRX_RUNTIME_CHECKS,
       },
     }),
     StoreRouterConnectingModule.forRoot({ serializer: CustomRouterSerializer }),

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -37,6 +37,10 @@ Object.defineProperty(global, 'PRODUCTION_MODE', {
   value: () => false,
 });
 
+Object.defineProperty(global, 'NGRX_RUNTIME_CHECKS', {
+  value: () => true,
+});
+
 Object.defineProperty(document.body.style, 'transform', {
   value: () => ({
     enumerable: true,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -9,4 +9,6 @@ declare var PRODUCTION_MODE: boolean;
 
 declare var SERVICE_WORKER: boolean;
 
+declare var NGRX_RUNTIME_CHECKS: boolean;
+
 declare var PWA_VERSION: string;


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes
[x] CI-related changes

## What Is the Current Behavior?

With the webpack custom build we introduced a couple of minifications for production, but neither the cypress tests nor the demo servers are deployed with production settings to review and automatically test, if everything also works in production mode.

## What Is the New Behavior?

The GitHub review PWAs are deployed with production settings which also includes CSS minification for visual review.
See here for example:
- http://pwa-gh-review-572-universal-b2c.azurewebsites.net/page/page.helpdesk.pagelet2-Page
- https://intershoppwa.azurewebsites.net/page/page.helpdesk.pagelet2-Page
-> orange boxes are missing because this class is purged for production (thanks to @shauke for this example)

Now also cypress testing is run with production mode (and still ngrx runtime checks and data-testing-ids).

One test (e2e/cypress/integration/specs/checkout/shopping-prices.b2b.e2e-spec.ts) was always failing because fetching the company user returned an empty response from the ICM when it is done in the form `/customers/-/users/-`. When using the customer number in that request everything works. This is supposed to be the new standard, not to ask with `-` anymore, right? 🤔 

While debugging this, because I couldn't reconstruct this problem locally, I also added [cypress-log-to-output](https://www.npmjs.com/package/cypress-log-to-output) plugin to cypress, which now also prints browser logs (in a very verbose fashion) to the CI log output for debugging.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
