### PR TITLE
feat: add order template detail links on order template widget

### DIFF
--- a/src/app/extensions/order-templates/shared/order-template-widget/order-template-widget.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-widget/order-template-widget.component.html
@@ -8,7 +8,9 @@
       <ng-container *ngIf="orderTemplates$ | async as orderTemplates; else emptyList">
         <ng-container *ngIf="orderTemplates.length; else emptyList">
           <div *ngFor="let orderTemplate of orderTemplates" class="mb-2">
-            {{ orderTemplate.title }}
+            <a [routerLink]="['/account/order-templates/', orderTemplate.id]" class="text-decoration-none">{{
+              orderTemplate.title
+            }}</a>
             <a *ngIf="orderTemplate.items?.length" class="align-top float-right">
               <ish-product-add-to-basket
                 ishProductContext

--- a/src/app/extensions/order-templates/shared/order-template-widget/order-template-widget.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/order-template-widget/order-template-widget.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
@@ -30,7 +31,7 @@ describe('Order Template Widget Component', () => {
     when(orderTemplatesFacade.orderTemplates$).thenReturn(of(orderTemplates));
 
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
       declarations: [
         MockComponent(InfoBoxComponent),
         MockComponent(LoadingComponent),
@@ -62,8 +63,8 @@ describe('Order Template Widget Component', () => {
 
   it('should render order template list after creation', () => {
     fixture.detectChanges();
-    expect(element.querySelector('.loading-container').textContent.trim()).toMatchInlineSnapshot(
-      `"order template  order template 2"`
+    expect(element.querySelector('.loading-container').textContent).toMatchInlineSnapshot(
+      `"order templateorder template 2"`
     );
   });
 });


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the New Behavior?
On the order template widget the names of the order templates are linked to the corresponding order template detail pages now.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
