### PR TITLE
refactor: use swiper for product-images component

### DIFF
--- a/src/app/core/models/product/product.helper.spec.ts
+++ b/src/app/core/models/product/product.helper.spec.ts
@@ -95,23 +95,23 @@ describe('Product Helper', () => {
       });
     });
 
-    describe('getImageViewIDsExcludePrimary()', () => {
-      it('should return list of image viewIDs  excluding primary image viewID when called with image type as L(Large size)', () => {
-        expect(ProductHelper.getImageViewIDsExcludePrimary(product, 'L').length).toBeGreaterThan(0);
+    describe('getImageViewIDs()', () => {
+      it('should return list of image viewIDs when called with image type as L(Large size)', () => {
+        expect(ProductHelper.getImageViewIDs(product, 'L').length).toBeGreaterThan(0);
       });
 
       it('should return empty list when called with invalid image type', () => {
-        expect(ProductHelper.getImageViewIDsExcludePrimary(product, 'W')).toBeEmpty();
+        expect(ProductHelper.getImageViewIDs(product, 'W')).toBeEmpty();
       });
 
       it('should return empty list when images are not available', () => {
         product.images = [];
-        expect(ProductHelper.getImageViewIDsExcludePrimary(product, 'L')).toBeEmpty();
+        expect(ProductHelper.getImageViewIDs(product, 'L')).toBeEmpty();
       });
 
       it('should return empty list when images is not defined', () => {
         product = { sku: 'sku' } as Product;
-        expect(ProductHelper.getImageViewIDsExcludePrimary(product, 'L')).toBeEmpty();
+        expect(ProductHelper.getImageViewIDs(product, 'L')).toBeEmpty();
       });
     });
   });

--- a/src/app/core/models/product/product.helper.ts
+++ b/src/app/core/models/product/product.helper.ts
@@ -65,16 +65,19 @@ export class ProductHelper {
   }
 
   /**
-   * Get all product ImageView ids excluding the primary product image
+   * Get all product ImageView ids matching image type
    * @param product   The Product for which to get the image types
    * @param imageType The wanted ImageType
    * @returns         Array of available ImageView ids
    */
-  static getImageViewIDsExcludePrimary(product: Product, imageType: string): string[] {
+  static getImageViewIDs(product: Product, imageType: string): string[] {
     if (!(product && product.images)) {
       return [];
     }
-    return product.images.filter(image => image.typeID === imageType && !image.primaryImage).map(image => image.viewID);
+    return product.images
+      .filter(image => image.typeID === imageType)
+      .sort((a, b) => (a.primaryImage ? -1 : b.primaryImage ? 1 : 0))
+      .map(image => image.viewID);
   }
 
   /**

--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -1,39 +1,25 @@
 <div *ngIf="product$ | async" class="row">
   <div class="col-lg-3 d-none d-lg-block">
     <div class="product-img-thumbs" data-type="S">
-      <div class="product-thumb-set" [ngClass]="{ active: isActiveSlide(0) }" (click)="setActiveSlide(0)">
-        <ish-product-image imageType="S"></ish-product-image>
-      </div>
       <div
-        *ngFor="let imageView of getImageViewIDsExcludePrimary$('S') | async; index as i"
+        *ngFor="let imageView of getImageViewIDs$('S') | async; index as i"
         class="product-thumb-set"
-        [ngClass]="{ active: isActiveSlide(i + 1) }"
-        (click)="setActiveSlide(i + 1)"
+        [ngClass]="{ active: isActiveSlide(i) }"
+        (click)="setActiveSlide(i)"
       >
         <ish-product-image imageType="S" [imageView]="imageView"></ish-product-image>
       </div>
     </div>
   </div>
-  <div
-    *ngIf="getImageViewIDsExcludePrimary$('L') | async as largeImages"
-    class="col-12 col-lg-9 product-detail-img clearfix"
-  >
+  <div *ngIf="getImageViewIDs$('L') | async as largeImages" class="col-12 col-lg-9 product-detail-img clearfix">
     <div class="product-image-container">
-      <ngb-carousel
-        #carousel
-        [activeId]="activeSlide"
-        (slide)="setActiveSlide($event.current)"
-        [showNavigationArrows]="largeImages.length > 0"
-        [showNavigationIndicators]="false"
-        [interval]="0"
-      >
-        <ng-template ngbSlide id="0">
-          <ish-product-image imageType="L"></ish-product-image>
-        </ng-template>
-        <ng-template ngbSlide *ngFor="let imageView of largeImages; index as i" id="{{ i + 1 }}">
-          <ish-product-image imageType="L" [imageView]="imageView"></ish-product-image>
-        </ng-template>
-      </ngb-carousel>
+      <swiper #carousel [navigation]="true" [(index)]="activeSlide">
+        <ng-container *ngFor="let imageView of largeImages">
+          <ng-template swiperSlide>
+            <ish-product-image imageType="L" [imageView]="imageView"></ish-product-image>
+          </ng-template>
+        </ng-container>
+      </swiper>
       <ish-product-label></ish-product-label>
     </div>
   </div>

--- a/src/app/pages/product/product-images/product-images.component.spec.ts
+++ b/src/app/pages/product/product-images/product-images.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NgbCarouselModule } from '@ng-bootstrap/ng-bootstrap';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
+import { SwiperModule } from 'swiper/angular';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
@@ -68,7 +68,7 @@ describe('Product Images Component', () => {
       } as ProductView)
     );
     await TestBed.configureTestingModule({
-      imports: [NgbCarouselModule],
+      imports: [SwiperModule],
       declarations: [
         MockComponent(ProductImageComponent),
         MockComponent(ProductLabelComponent),
@@ -82,7 +82,7 @@ describe('Product Images Component', () => {
     fixture = TestBed.createComponent(ProductImagesComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
-    component.activeSlide = '0';
+    component.activeSlide = 0;
   });
 
   it('should be created', () => {
@@ -93,7 +93,7 @@ describe('Product Images Component', () => {
 
   it('should render carousel on component', () => {
     fixture.detectChanges();
-    expect(element.getElementsByClassName('carousel-item')).toHaveLength(2);
+    expect(element.getElementsByClassName('swiper-slide')).toHaveLength(2);
   });
 
   it('should render thumbnails on component', () => {
@@ -110,7 +110,7 @@ describe('Product Images Component', () => {
     (element.getElementsByClassName('product-thumb-set')[1] as HTMLElement).click();
     fixture.detectChanges();
     expect(element.getElementsByClassName('product-thumb-set')[1].getAttribute('class')).toContain('active');
-    expect(component.activeSlide).toEqual('1');
+    expect(component.activeSlide).toEqual(1);
   });
 
   it('should render product image component on component', () => {

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -1,10 +1,13 @@
 import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
-import { NgbCarousel } from '@ng-bootstrap/ng-bootstrap';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { SwiperComponent } from 'swiper/angular';
+import SwiperCore, { Navigation } from 'swiper/core';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { AnyProductViewType, ProductHelper } from 'ish-core/models/product/product.model';
+
+SwiperCore.use([Navigation]);
 
 /**
  * The Product Images Component
@@ -21,9 +24,9 @@ import { AnyProductViewType, ProductHelper } from 'ish-core/models/product/produ
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProductImagesComponent implements OnInit {
-  @ViewChild('carousel') carousel: NgbCarousel;
+  @ViewChild('carousel') carousel: SwiperComponent;
 
-  activeSlide = '0';
+  activeSlide = 0;
 
   product$: Observable<AnyProductViewType>;
 
@@ -33,18 +36,16 @@ export class ProductImagesComponent implements OnInit {
     this.product$ = this.context.select('product');
   }
 
-  getImageViewIDsExcludePrimary$(imageType: string) {
-    return this.product$.pipe(map(p => ProductHelper.getImageViewIDsExcludePrimary(p, imageType)));
+  getImageViewIDs$(imageType: string) {
+    return this.product$.pipe(map(p => ProductHelper.getImageViewIDs(p, imageType)));
   }
 
   /**
    * Set the active slide via index (used by the thumbnail indicator)
    * @param slideIndex The slide index to set the active slide
    */
-  setActiveSlide(slideIndex: number | string) {
-    this.activeSlide = slideIndex?.toString();
-
-    this.carousel.select(this.activeSlide);
+  setActiveSlide(slideIndex: number) {
+    this.carousel.setIndex(slideIndex);
   }
 
   /**
@@ -53,6 +54,6 @@ export class ProductImagesComponent implements OnInit {
    * @returns True if the given slide index is the active slide, false otherwise
    */
   isActiveSlide(slideIndex: number): boolean {
-    return this.activeSlide === slideIndex?.toString();
+    return this.activeSlide === slideIndex;
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

`ish-product-images` uses NgbCarousel

## What Is the New Behavior?

`ish-product-images` uses Swiper

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
