### PR TITLE
feat: detect browser language

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       # PROMETHEUS: 1
       # COMPRESSION: 0
       # DEVICE_DETECTION: 0
+      LOCALE_DETECTION: 1
       # MULTI_CHANNEL_SOURCE: env:///ASDF?type=application/yaml
       MULTI_CHANNEL: |
         .+\.net:

--- a/docs/concepts/pwa-building-blocks.md
+++ b/docs/concepts/pwa-building-blocks.md
@@ -37,7 +37,8 @@ Nginx enables the following features to be used in an Intershop PWA deployment:
 - Integration of the [PageSpeed Module](https://www.modpagespeed.com/) for access to different browser optimizations.
 - Handling of multiple channels via URL parameters in conjunction with SSR (see [Multi-Site Handling](multi-site-handling.md)).
 - Customizable compression for downstream services
-- Device type detection to ensure a correct pre-render, adapted to the incoming user agent.
+- Device type detection to ensure a correct pre-render, adapted to the incoming [User-Agent](https://developer.mozilla.org/de/docs/Web/HTTP/Headers/User-Agent) header.
+- Browser language detection to ensure a localized pre-render, depending on the [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) headers.
 
 For an overview of the ever-growing list of third party integrations relating to nginx and deployment in general, see [Third-party Integrations](../README.md#third-party-integrations).
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -48,7 +48,7 @@ All other properties are optional:
 - **application**: The ICM application
 - **identityProvider**: The active identity provider for this site
 - **features**: Comma-separated list of activated features
-- **lang**: The default language as defined in the Angular CLI environment
+- **lang**: Override the default language defined in the ICM (also overrides browser language detection).
 - **theme**: The theme used for the channel (format: `<theme-name>(|<icon-color>)?`)
 
 Dynamically directing the PWA to different ICM installations can by done by using:
@@ -96,6 +96,7 @@ Built-in features can be enabled and disabled:
 - `COMPRESSION=off` disables compression (default `on`)
 - `DEVICE_DETECTION=off` disables user-agent detection (default `on`)
 - `PROMETHEUS=on` enables [Prometheus](https://prometheus.io) metrics exports on port `9113` (default `off`)
+- `LOCALE_DETECTION=on` enables browser language detection (default `off`)
 
 ## Features
 

--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -4,7 +4,7 @@
         {{- $channel := .channel }}
         {{- $application := "" }}{{ if (has . "application") }}{{ $application = join ( slice ";application" .application ) "=" }}{{ end }}
         {{- $identityProvider := "" }}{{ if (has . "identityProvider") }}{{ $identityProvider = join ( slice ";identityProvider" .identityProvider ) "=" }}{{ end }}
-        {{- $lang := "default" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
+        {{- $lang := "$detected_locale" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
         {{- $features := "" }}{{ if (has . "features") }}{{ $features = join ( slice ";features" .features ) "=" }}{{ end }}
         {{- $theme := "" }}{{ if (has . "theme") }}{{ $theme = join ( slice ";theme" .theme ) "=" }}{{ end }}
         {{- $baseHref := "/" }}{{ if (has . "baseHref") }}{{ $baseHref = .baseHref }}{{ end }}
@@ -22,18 +22,19 @@
         proxy_cache_valid 404      1m;
 
         add_header X-icm-channel {{ $channel }} always;
-        add_header X-icm-default-lang {{ $lang }} always;
+        add_header X-icm-locale {{ $lang }} always;
         add_header X-ua-device $ua_device always;
+        add_header X-ua-detected-locale $detected_locale always;
 
         rewrite ^.*/index.html$ {{ $baseHref }}/loading;
 
         rewrite ^{{ $baseHref }}/?$ {{ $baseHref }}/home;
 
-        rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang={{ $lang }}';
+        rewrite '^(?!.*;lang=.*)(?<old>.*)$' '$old;lang={{ $lang }}';
 
         set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $identityProvider }}{{ $features }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
 
-        rewrite '^(.*)$' '$1$default_rewrite_params' break;
+        rewrite '^(?<old>.*)$' '$old$default_rewrite_params' break;
 
         proxy_pass {{ getenv "UPSTREAM_PWA" }};
         proxy_buffer_size 128k;

--- a/nginx/features/locale_detection-off.conf
+++ b/nginx/features/locale_detection-off.conf
@@ -1,0 +1,3 @@
+map $host $detected_locale {
+  default default;
+}

--- a/nginx/features/locale_detection.conf
+++ b/nginx/features/locale_detection.conf
@@ -1,0 +1,5 @@
+map $http_accept_language $detected_locale {
+    default default;
+    ~(?P<lang>[a-z][a-z]-[A-Z][A-Z][A-Z]?) $lang;
+    ~(?P<lang>[a-z][a-z]) $lang;
+}

--- a/src/app/core/store/core/configuration/configuration.selectors.spec.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.spec.ts
@@ -140,7 +140,16 @@ describe('Configuration Selectors', () => {
         ${'no_NO'} | ${'no_NO'}
         ${'nl_BE'} | ${'nl_BE'}
         ${'zh_CN'} | ${'zh_CN'}
-        ${'nl_NL'} | ${'de_DE'}
+        ${'nl_NL'} | ${'nl_BE'}
+        ${'de'}    | ${'de_DE'}
+        ${'de-DE'} | ${'de_DE'}
+        ${'no'}    | ${'no_NO'}
+        ${'zh'}    | ${'zh_CN'}
+        ${'fr'}    | ${'fr_BE'}
+        ${'en'}    | ${'en_US'}
+        ${'nl'}    | ${'nl_BE'}
+        ${'nl-BE'} | ${'nl_BE'}
+        ${'nl-NL'} | ${'nl_BE'}
       `('should choose $chosen when $requested is requested', ({ requested, chosen }) => {
         store$.dispatch(applyConfiguration({ lang: requested }));
         expect(getCurrentLocale(store$.state)?.lang).toEqual(chosen);
@@ -186,7 +195,16 @@ describe('Configuration Selectors', () => {
         ${'no_NO'} | ${'en_US'}
         ${'nl_BE'} | ${'nl_BE'}
         ${'zh_CN'} | ${'en_US'}
-        ${'nl_NL'} | ${'en_US'}
+        ${'nl_NL'} | ${'nl_BE'}
+        ${'de'}    | ${'de_DE'}
+        ${'de-DE'} | ${'de_DE'}
+        ${'no'}    | ${'en_US'}
+        ${'zh'}    | ${'en_US'}
+        ${'fr'}    | ${'fr_BE'}
+        ${'en'}    | ${'en_US'}
+        ${'nl'}    | ${'nl_BE'}
+        ${'nl-BE'} | ${'nl_BE'}
+        ${'nl-NL'} | ${'nl_BE'}
       `('should choose $chosen when $requested is requested', ({ requested, chosen }) => {
         store$.dispatch(applyConfiguration({ lang: requested }));
         expect(getCurrentLocale(store$.state)?.lang).toEqual(chosen);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature
[x] Refactoring (no functional changes, no API changes)

## What Is the New Behaviour?

- Closes #104
- nginx implements simple browser language detection (extracts the first locale from Accept-Language headers) and passes to SSR

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

- Language detection has to be implemented in nginx, to assure the correct responses are also cached there.


## Scenarios

- Scenarios, that are handled by this:
  - Europe-wide Shop (shop.com) with all possible languages configured
  - Shop-Channel in Belgium or Switzerland, where multiple languages apply (fr-BE, nl-BE, ...)
- Scenarios not handled:
  - Europe-wide shop with different channels per country. For this a pop-up when reaching the page should suggest switching to the specific shop of the country -> #588
