### PR TITLE
refactor: use formly for my account profile forms

### DIFF
--- a/e2e/cypress/integration/specs/checkout/shopping-prices.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/shopping-prices.b2b.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { at } from '../../framework';
+import { at, waitLoadingEnd } from '../../framework';
 import { createB2BUserViaREST } from '../../framework/b2b-user';
 import { LoginPage } from '../../pages/account/login.page';
 import { MyAccountPage } from '../../pages/account/my-account.page';
@@ -51,6 +51,7 @@ describe('Price Display B2B', () => {
       page.fillForm(_.user.login, _.user.password);
       page.submit().its('response.statusCode').should('equal', 200);
     });
+    waitLoadingEnd();
   });
 
   it('should see the same prices', () => {

--- a/e2e/cypress/integration/specs/extras/order-templates-shopping.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/extras/order-templates-shopping.b2b.e2e-spec.ts
@@ -32,6 +32,7 @@ describe('Order Template Shopping Experience Functionality', () => {
     at(LoginPage, page => {
       page.fillForm(_.user.login, _.user.password);
       page.submit().its('response.statusCode').should('equal', 200);
+      waitLoadingEnd();
     });
     at(OrderTemplatesOverviewPage, page => {
       page.addOrderTemplate(accountOrderTemplate);

--- a/src/app/pages/account-profile-company/account-profile-company/account-profile-company.component.html
+++ b/src/app/pages/account-profile-company/account-profile-company/account-profile-company.component.html
@@ -1,6 +1,5 @@
 <h1>{{ 'account.company_profile.heading' | translate }}</h1>
 
-<!-- Error message -->
 <ish-error-message [error]="error"></ish-error-message>
 
 <p>{{ 'account.company_profile.heading.text' | translate }}</p>
@@ -11,20 +10,8 @@
       <p class="indicates-required">
         <span class="required">*</span>{{ 'account.required_field.message' | translate }}
       </p>
-      <form [formGroup]="form" (ngSubmit)="submit()" class="form-horizontal" novalidate="novalidate">
-        <ish-input
-          [form]="form"
-          controlName="companyName"
-          label="account.address.company_name.label"
-          [errorMessages]="{
-            required: 'account.address.company_name.error.required'
-          }"
-        ></ish-input>
-
-        <ish-input [form]="form" controlName="companyName2" label="account.address.company_name_2.label"></ish-input>
-
-        <ish-input [form]="form" controlName="taxationID" label="account.companyprofile.taxationid.label"></ish-input>
-
+      <form class="form-horizontal" [formGroup]="accountProfileCompanyForm" (ngSubmit)="submit()">
+        <formly-form [form]="accountProfileCompanyForm" [fields]="fields" [model]="model"></formly-form>
         <div class="row">
           <div class="offset-md-4 col-md-8">
             <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">

--- a/src/app/pages/account-profile-company/account-profile-company/account-profile-company.component.spec.ts
+++ b/src/app/pages/account-profile-company/account-profile-company/account-profile-company.component.spec.ts
@@ -1,12 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 import { anything, spy, verify } from 'ts-mockito';
 
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { AccountProfileCompanyComponent } from './account-profile-company.component';
 
@@ -17,12 +16,8 @@ describe('Account Profile Company Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
-      declarations: [
-        AccountProfileCompanyComponent,
-        MockComponent(ErrorMessageComponent),
-        MockComponent(InputComponent),
-      ],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
+      declarations: [AccountProfileCompanyComponent, MockComponent(ErrorMessageComponent)],
     }).compileComponents();
   });
 
@@ -40,7 +35,7 @@ describe('Account Profile Company Component', () => {
 
   it('should display 3 input fields for companyName, companyName2 and taxationID', () => {
     fixture.detectChanges();
-    expect(element.querySelectorAll('ish-input')).toHaveLength(3);
+    expect(element.querySelectorAll('formly-field')).toHaveLength(3);
   });
 
   it('should emit updateCompanyProfile event if form is valid', () => {

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.html
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.html
@@ -6,49 +6,13 @@
 <div class="row">
   <div class="col-md-10 col-xl-8">
     <div class="section">
-      <form [formGroup]="form" (ngSubmit)="submit()" class="form-horizontal" novalidate="novalidate">
-        <ish-input
-          [form]="form"
-          controlName="currentPassword"
-          type="password"
-          label="account.password.label"
-          markRequiredLabel="off"
-          [errorMessages]="{
-            required: 'account.update_password.old_password.error.required',
-            incorrect: 'account.update_password.old_password.error.incorrect'
-          }"
-        >
-        </ish-input>
-
-        <ish-input
-          [form]="form"
-          controlName="password"
-          type="password"
-          label="account.update_password.newpassword.label"
-          markRequiredLabel="off"
-          [errorMessages]="{
-            required: 'account.update_password.new_password.error.required',
-            minLength: 'account.update_password.new_password.error.length',
-            password: 'account.update_password.new_password.error.regexp'
-          }"
-          ><small class="input-help">{{
-            'account.register.password.extrainfo.message' | translate: { '0': '7' }
-          }}</small>
-        </ish-input>
-
-        <ish-input
-          [form]="form"
-          controlName="passwordConfirmation"
-          type="password"
-          markRequiredLabel="on"
-          label="account.update_password.newpassword_confirmation.label"
-          markRequiredLabel="off"
-          [errorMessages]="{
-            required: 'account.register.password_confirmation.error.default',
-            password: 'account.update_password.new_password.error.regexp',
-            equalTo: 'account.update_password.confirm_password.error.stringcompare'
-          }"
-        ></ish-input>
+      <form
+        [formGroup]="accountProfilePasswordForm"
+        class="form-horizontal"
+        novalidate="novalidate"
+        (ngSubmit)="submit()"
+      >
+        <formly-form [form]="accountProfilePasswordForm" [fields]="fields"></formly-form>
 
         <div class="row">
           <div class="offset-md-4 col-md-8">

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.spec.ts
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.spec.ts
@@ -1,11 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 import { anything, spy, verify } from 'ts-mockito';
 
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { AccountProfilePasswordComponent } from './account-profile-password.component';
 
@@ -16,12 +15,8 @@ describe('Account Profile Password Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        AccountProfilePasswordComponent,
-        MockComponent(ErrorMessageComponent),
-        MockComponent(InputComponent),
-      ],
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [AccountProfilePasswordComponent, MockComponent(ErrorMessageComponent)],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 
@@ -39,16 +34,16 @@ describe('Account Profile Password Component', () => {
 
   it('should display 3 input fields for oldPassword, password and passwordConfirmation', () => {
     fixture.detectChanges();
-    expect(element.querySelectorAll('ish-input')).toHaveLength(3);
+    expect(element.querySelectorAll('formly-field')).toHaveLength(3);
   });
 
   it('should emit updatePassword event if form is valid', () => {
     const eventEmitter$ = spy(component.updatePassword);
     fixture.detectChanges();
 
-    component.form.get('currentPassword').setValue('!Password01!');
-    component.form.get('password').setValue('!Password01!');
-    component.form.get('passwordConfirmation').setValue('!Password01!');
+    component.accountProfilePasswordForm.get('currentPassword').setValue('!Password01!');
+    component.accountProfilePasswordForm.get('password').setValue('!Password01!');
+    component.accountProfilePasswordForm.get('passwordConfirmation').setValue('!Password01!');
     component.submit();
 
     verify(eventEmitter$.emit(anything())).once();

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.html
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.html
@@ -11,31 +11,8 @@
       <p class="indicates-required">
         <span class="required">*</span>{{ 'account.required_field.message' | translate }}
       </p>
-      <form [formGroup]="form" (ngSubmit)="submit()" class="form-horizontal" novalidate="novalidate">
-        <ish-select-title [form]="form" [titles]="titles"></ish-select-title>
-
-        <ish-input
-          [form]="form"
-          controlName="firstName"
-          label="account.update_profile.firstname.label"
-          [errorMessages]="{
-            required: 'account.firstname.error.required',
-            noSpecialChars: 'account.name.error.forbidden.chars'
-          }"
-        ></ish-input>
-
-        <ish-input
-          [form]="form"
-          controlName="lastName"
-          label="account.update_profile.lastname.label"
-          [errorMessages]="{
-            required: 'account.lastname.error.required',
-            noSpecialChars: 'account.name.error.forbidden.chars'
-          }"
-        ></ish-input>
-
-        <ish-input [form]="form" controlName="phoneHome" label="account.update_profile.phone.label"></ish-input>
-
+      <form [formGroup]="accountProfileUserForm" (ngSubmit)="submit()" class="form-horizontal" novalidate="novalidate">
+        <formly-form [form]="accountProfileUserForm" [fields]="fields" [model]="model"></formly-form>
         <div class="row">
           <div class="offset-md-4 col-md-8">
             <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
@@ -1,13 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
-import { anything, spy, verify } from 'ts-mockito';
+import { of } from 'rxjs';
+import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
 
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { Locale } from 'ish-core/models/locale/locale.model';
 import { User } from 'ish-core/models/user/user.model';
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
-import { SelectTitleComponent } from 'ish-shared/forms/components/select-title/select-title.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { AccountProfileUserComponent } from './account-profile-user.component';
 
@@ -15,16 +16,15 @@ describe('Account Profile User Component', () => {
   let component: AccountProfileUserComponent;
   let fixture: ComponentFixture<AccountProfileUserComponent>;
   let element: HTMLElement;
+  let appFacade: AppFacade;
 
   beforeEach(async () => {
+    appFacade = mock(AppFacade);
+
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
-      declarations: [
-        AccountProfileUserComponent,
-        MockComponent(ErrorMessageComponent),
-        MockComponent(InputComponent),
-        MockComponent(SelectTitleComponent),
-      ],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
+      declarations: [AccountProfileUserComponent, MockComponent(ErrorMessageComponent)],
+      providers: [{ provide: AppFacade, useFactory: () => instance(appFacade) }],
     }).compileComponents();
   });
 
@@ -32,6 +32,7 @@ describe('Account Profile User Component', () => {
     fixture = TestBed.createComponent(AccountProfileUserComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
+    when(appFacade.currentLocale$).thenReturn(of({ lang: 'en_US' } as Locale));
   });
 
   it('should be created', () => {
@@ -42,12 +43,19 @@ describe('Account Profile User Component', () => {
 
   it('should display 3 input fields for firstName, lastName and phone', () => {
     fixture.detectChanges();
-    expect(element.querySelectorAll('ish-input')).toHaveLength(3);
+
+    expect(element.innerHTML.match(/ish-text-input-field/g)).toHaveLength(3);
+
+    expect(element.innerHTML).toContain('firstName');
+    expect(element.innerHTML).toContain('lastName');
+    expect(element.innerHTML).toContain('phone');
   });
 
   it('should display select box for title', () => {
     fixture.detectChanges();
-    expect(element.querySelectorAll('ish-select-title')).toHaveLength(1);
+
+    expect(element.innerHTML.match('ish-select-field')).toHaveLength(1);
+    expect(element.innerHTML).toContain('title');
   });
 
   it('should emit updateUserProfile event if form is valid', () => {

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.ts
@@ -1,18 +1,17 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { TranslateService } from '@ngx-translate/core';
+import { pick } from 'lodash-es';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
+import { AppFacade } from 'ish-core/facades/app.facade';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
+import { whenTruthy } from 'ish-core/utils/operators';
+import { SelectOption } from 'ish-shared/forms/components/select/select.component';
+import { determineSalutations, markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 /**
@@ -24,7 +23,7 @@ import { SpecialValidators } from 'ish-shared/forms/validators/special-validator
   templateUrl: './account-profile-user.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AccountProfileUserComponent implements OnInit, OnChanges {
+export class AccountProfileUserComponent implements OnInit {
   @Input() currentUser: User;
   @Input() titles: string[];
   @Input() countryCode: string;
@@ -32,62 +31,103 @@ export class AccountProfileUserComponent implements OnInit, OnChanges {
 
   @Output() updateUserProfile = new EventEmitter<User>();
 
-  form: FormGroup;
   submitted = false;
 
+  accountProfileUserForm = new FormGroup({});
+  model: Partial<User>;
+  fields: FormlyFieldConfig[];
+
+  titleOptions$: Observable<SelectOption[]>;
+
+  constructor(private appFacade: AppFacade, private translate: TranslateService) {}
+
   ngOnInit() {
-    // create form
-    this.form = new FormGroup({
-      title: new FormControl(''),
-      firstName: new FormControl('', [Validators.required, SpecialValidators.noSpecialChars]),
-      lastName: new FormControl('', [Validators.required, SpecialValidators.noSpecialChars]),
-      phoneHome: new FormControl(''),
-    });
+    // get localized option values for title select box
+    this.titleOptions$ = this.appFacade.currentLocale$.pipe(
+      whenTruthy(),
+      map(locale =>
+        determineSalutations(locale.lang?.slice(3)).map(title => ({
+          value: this.translate.instant(title),
+          label: title,
+        }))
+      )
+    );
 
-    // initialize form values in case currentUser is available
-    this.initFormValues();
-  }
+    this.model = pick(this.currentUser, 'title', 'firstName', 'lastName', 'phoneHome');
 
-  ngOnChanges(c: SimpleChanges) {
-    // initialize form values in case currentUser changes (current user is later than form creation)
-    if (c.currentUser) {
-      this.initFormValues();
-    }
-  }
-
-  /**
-   * fills form values with data of the logged in user
-   */
-  initFormValues() {
-    if (this.form && this.currentUser) {
-      if (this.currentUser.title) {
-        this.form.get('title').setValue(this.currentUser.title ? this.currentUser.title : '');
-      }
-      this.form.get('firstName').setValue(this.currentUser.firstName);
-      this.form.get('lastName').setValue(this.currentUser.lastName);
-      this.form.get('phoneHome').setValue(this.currentUser.phoneHome);
-    }
+    this.fields = [
+      {
+        key: 'title',
+        type: 'ish-select-field',
+        templateOptions: {
+          label: 'account.default_address.title.label',
+          placeholder: 'account.option.select.text',
+          options: this.titleOptions$,
+        },
+      },
+      {
+        key: 'firstName',
+        type: 'ish-text-input-field',
+        templateOptions: {
+          required: true,
+          label: 'account.update_profile.firstname.label',
+        },
+        validators: {
+          validation: [SpecialValidators.noSpecialChars],
+        },
+        validation: {
+          messages: {
+            required: 'account.firstname.error.required',
+            noSpecialChars: 'account.name.error.forbidden.chars',
+          },
+        },
+      },
+      {
+        key: 'lastName',
+        type: 'ish-text-input-field',
+        templateOptions: {
+          required: true,
+          label: 'account.update_profile.lastname.label',
+        },
+        validators: {
+          validation: [SpecialValidators.noSpecialChars],
+        },
+        validation: {
+          messages: {
+            required: 'account.lastname.error.required',
+            noSpecialChars: 'account.name.error.forbidden.chars',
+          },
+        },
+      },
+      {
+        key: 'phoneHome',
+        type: 'ish-text-input-field',
+        templateOptions: {
+          label: 'account.update_profile.phone.label',
+        },
+      },
+    ];
   }
 
   /**
    * Submits form and throws update event when form is valid
    */
   submit() {
-    if (this.form.invalid) {
+    if (this.accountProfileUserForm.invalid) {
       this.submitted = true;
-      markAsDirtyRecursive(this.form);
+      markAsDirtyRecursive(this.accountProfileUserForm);
       return;
     }
 
-    const title = this.form.get('title').value;
-    const firstName = this.form.get('firstName').value;
-    const lastName = this.form.get('lastName').value;
-    const phoneHome = this.form.get('phoneHome').value;
+    const title = this.accountProfileUserForm.get('title').value;
+    const firstName = this.accountProfileUserForm.get('firstName').value;
+    const lastName = this.accountProfileUserForm.get('lastName').value;
+    const phoneHome = this.accountProfileUserForm.get('phoneHome').value;
 
     this.updateUserProfile.emit({ ...this.currentUser, title, firstName, lastName, phoneHome });
   }
 
   get buttonDisabled() {
-    return this.form.invalid && this.submitted;
+    return this.accountProfileUserForm.invalid && this.submitted;
   }
 }

--- a/src/app/shared/formly/dev/testing/formly-testing.module.ts
+++ b/src/app/shared/formly/dev/testing/formly-testing.module.ts
@@ -22,19 +22,19 @@ class CheckboxFieldComponent extends FieldType {}
 })
 class FieldsetFieldComponent extends FieldType {}
 
-@Component({ template: 'TextInputFieldComponent: {{ field.key }} {{ to | json }}' })
+@Component({ template: 'TextInputFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class TextInputFieldComponent extends FieldType {}
 
-@Component({ template: 'EmailFieldComponent: {{ field.key }} {{ to | json }}' })
+@Component({ template: 'EmailFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class EmailFieldComponent extends FieldType {}
 
-@Component({ template: 'PasswordFieldComponent: {{ field.key }} {{ to | json }}' })
+@Component({ template: 'PasswordFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class PasswordFieldComponent extends FieldType {}
 
-@Component({ template: 'SelectFieldComponent: {{ field.key }} {{ to | json }}' })
+@Component({ template: 'SelectFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class SelectFieldComponent extends FieldType {}
 
-@Component({ template: 'TextareaFieldComponent: {{ field.key }} {{ to | json }}' })
+@Component({ template: 'TextareaFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class TextareaFieldComponent extends FieldType {}
 
 @Component({ template: `<ng-template #fieldComponent> </ng-template>` })

--- a/src/styles/global/forms/formly.scss
+++ b/src/styles/global/forms/formly.scss
@@ -21,6 +21,9 @@
       text-decoration: underline;
     }
   }
+  .validation-message small {
+    display: block;
+  }
 }
 
 .formly-validation-icon {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Some parts of profile settings in my account area uses the reactive form implementation.

## What Is the New Behavior?

All parts of profile settings in my account area uses formly for the forms.
- [x] account-profile-company.component
- [x] account-profile-password.component
- [x] account-profile-user.component

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No
