### PR TITLE
refactor: remove ngx utils cookies port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14848,11 +14848,6 @@
         "tslib": "^2.0.0"
       }
     },
-    "ngx-utils-cookies-port": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ngx-utils-cookies-port/-/ngx-utils-cookies-port-1.0.1.tgz",
-      "integrity": "sha512-mot8LuTJGnwhrEKlG2vXfhGgIoyKbe5ASntjZt9cTK3vQ75/CHkKbk0De0LN4wDawnTrsT+t2sptpmJeqLu1lA=="
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "ng-recaptcha": "^7.0.1",
     "ngx-infinite-scroll": "^10.0.1",
     "ngx-toastr": "^13.2.0",
-    "ngx-utils-cookies-port": "^1.0.1",
     "prom-client": "^13.1.0",
     "rxjs": "~6.6.6",
     "swiper": "^6.4.15",

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -5,7 +5,6 @@ import { ServerModule, ServerTransferStateModule } from '@angular/platform-serve
 import { META_REDUCERS } from '@ngrx/store';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { existsSync, readFileSync } from 'fs';
-import { ServerCookiesModule } from 'ngx-utils-cookies-port';
 import { join } from 'path';
 import { Observable, Observer } from 'rxjs';
 
@@ -57,7 +56,6 @@ export class UniversalErrorHandler implements ErrorHandler {
 @NgModule({
   imports: [
     AppModule,
-    ServerCookiesModule,
     ServerModule,
     ServerTransferStateModule,
     TranslateModule.forRoot({

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -3,7 +3,6 @@ import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { ErrorHandler, NgModule, Optional, SkipSelf } from '@angular/core';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { TranslateModule } from '@ngx-translate/core';
-import { BrowserCookiesModule } from 'ngx-utils-cookies-port';
 
 import { AppearanceModule } from './appearance.module';
 import { ConfigurationModule } from './configuration.module';
@@ -20,7 +19,6 @@ import { DefaultErrorhandler } from './utils/default-error-handler';
 @NgModule({
   imports: [
     AppearanceModule,
-    BrowserCookiesModule.forRoot(),
     ConfigurationModule,
     ExtrasModule,
     FeatureToggleModule,

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -86,6 +86,7 @@ export class ApiTokenService {
             cookiesService.put('apiToken', cookieContent, {
               expires: new Date(Date.now() + 3600000),
               secure: (isPlatformBrowser(platformId) && location.protocol === 'https:') || false,
+              sameSite: 'Strict',
             });
           } else {
             cookiesService.remove('apiToken');

--- a/src/app/core/utils/cookies/cookies.service.spec.ts
+++ b/src/app/core/utils/cookies/cookies.service.spec.ts
@@ -1,21 +1,30 @@
+import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { BrowserTransferStateModule } from '@angular/platform-browser';
-import { CookiesService as ForeignCookiesService } from 'ngx-utils-cookies-port';
-import { anything, instance, mock, verify } from 'ts-mockito';
+import { noop } from 'rxjs';
 
 import { CookiesService } from './cookies.service';
 
+const mockDocument = () => ({
+  cookie: undefined,
+  getElementById: noop,
+});
+
 describe('Cookies Service', () => {
   let cookiesService: CookiesService;
-  let foreignCookiesServiceMock: ForeignCookiesService;
+  let document: Document;
 
   beforeEach(() => {
-    foreignCookiesServiceMock = mock(ForeignCookiesService);
     TestBed.configureTestingModule({
       imports: [BrowserTransferStateModule],
-      providers: [{ provide: ForeignCookiesService, useFactory: () => instance(foreignCookiesServiceMock) }],
+      providers: [
+        { provide: APP_BASE_HREF, useValue: '/de' },
+        { provide: DOCUMENT, useFactory: mockDocument },
+      ],
     });
+
     cookiesService = TestBed.inject(CookiesService);
+    document = TestBed.inject(DOCUMENT);
   });
 
   it('should be created', () => {
@@ -23,17 +32,20 @@ describe('Cookies Service', () => {
   });
 
   it('should call get of underlying implementation', () => {
-    cookiesService.get('dummy');
-    verify(foreignCookiesServiceMock.get('dummy')).once();
+    cookiesService.put('foo', 'bar');
+    expect(document.cookie).toMatchInlineSnapshot(`"foo=bar;path=/de"`);
+    expect(cookiesService.get('foo')).toMatchInlineSnapshot(`"bar;path=/de"`);
   });
 
   it('should call remove of underlying implementation', () => {
-    cookiesService.remove('dummy');
-    verify(foreignCookiesServiceMock.remove('dummy')).once();
+    cookiesService.put('foo', 'bar');
+    expect(document.cookie).toMatchInlineSnapshot(`"foo=bar;path=/de"`);
+    cookiesService.remove('foo');
+    expect(document.cookie).toMatchInlineSnapshot(`"foo=;path=/de;expires=Thu, 01 Jan 1970 00:00:00 GMT"`);
   });
 
   it('should call put of underlying implementation', () => {
-    cookiesService.put('dummy', 'value');
-    verify(foreignCookiesServiceMock.put('dummy', anything(), anything())).once();
+    cookiesService.put('foo', 'bar');
+    expect(document.cookie).toMatchInlineSnapshot(`"foo=bar;path=/de"`);
   });
 });

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -12,6 +12,7 @@ interface CookiesOptions {
   expires?: string | Date;
   secure?: boolean;
   httpOnly?: boolean;
+  sameSite?: 'Lax' | 'Strict' | 'None';
 }
 
 /**
@@ -55,6 +56,7 @@ export class CookiesService {
     this.deleteAllCookies();
     this.put('cookieConsent', JSON.stringify({ enabledOptions: options, version: cookieConsentVersion }), {
       expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
+      sameSite: 'Strict',
     });
     window.location.reload();
   }
@@ -143,6 +145,7 @@ export class CookiesService {
     str += ';path=' + path;
     str += opts.domain ? ';domain=' + opts.domain : '';
     str += expires ? ';expires=' + expires.toUTCString() : '';
+    str += opts.sameSite ? ';SameSite=' + opts.sameSite : '';
     str += opts.secure ? ';secure' : '';
     const cookiesLength = str.length + 1;
     if (cookiesLength > 4096) {

--- a/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
+++ b/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
@@ -56,7 +56,7 @@ export class PunchoutPageGuard implements CanActivate {
         switchMap(() => {
           // save HOOK_URL to 'hookURL' cookie
           if (route.queryParamMap.get('HOOK_URL')) {
-            this.cookiesService.put('hookURL', route.queryParamMap.get('HOOK_URL'));
+            this.cookiesService.put('hookURL', route.queryParamMap.get('HOOK_URL'), { sameSite: 'Strict' });
           }
 
           // Product Details


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature
[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

- library ngx-utils-cookies-port (and also original library ngx-utils/cookies) are no longer maintained
- SameSite issue

## What Is the New Behavior?

- implementation integrated into PWA
- Closes #276

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
