### PR TITLE
fix: map server-config value for null correctly

### DIFF
--- a/src/app/core/models/product-variation/product-variation.helper.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.ts
@@ -1,7 +1,8 @@
-import { flatten, groupBy, omit } from 'lodash-es';
+import { flatten, groupBy } from 'lodash-es';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { VariationProductMasterView, VariationProductView } from 'ish-core/models/product-view/product-view.model';
+import { omit } from 'ish-core/utils/functions';
 
 import { VariationAttribute } from './variation-attribute.model';
 import { VariationOptionGroup } from './variation-option-group.model';

--- a/src/app/core/models/server-config/server-config.mapper.spec.ts
+++ b/src/app/core/models/server-config/server-config.mapper.spec.ts
@@ -6,7 +6,13 @@ describe('Server Config Mapper', () => {
     it(`should return the ServerConfig when getting ServerConfigData`, () => {
       const config = ServerConfigMapper.fromData({
         data: {
-          application: { applicationType: 'intershop.B2CResponsive', id: 'application', urlIdentifier: '-' },
+          application: {
+            applicationType: 'intershop.B2CResponsive',
+            id: 'application',
+            urlIdentifier: '-',
+            // tslint:disable-next-line: no-null-keyword
+            displayName: null,
+          },
           basket: { acceleration: true, id: 'basket' },
           general: { id: 'general', locales: ['en_US', 'de_DE'] },
           services: {
@@ -22,6 +28,7 @@ describe('Server Config Mapper', () => {
         Object {
           "application": Object {
             "applicationType": "intershop.B2CResponsive",
+            "displayName": null,
             "urlIdentifier": "-",
           },
           "basket": Object {

--- a/src/app/core/models/server-config/server-config.mapper.ts
+++ b/src/app/core/models/server-config/server-config.mapper.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash-es';
+import { omit } from 'ish-core/utils/functions';
 
 import { ServerConfigData, ServerConfigDataEntry } from './server-config.interface';
 import { ServerConfig } from './server-config.model';

--- a/src/app/core/models/server-config/server-config.mapper.ts
+++ b/src/app/core/models/server-config/server-config.mapper.ts
@@ -22,7 +22,7 @@ export class ServerConfigMapper {
       (acc, entry) => ({
         ...acc,
         [entry[0]]:
-          typeof entry[1] === 'object' && !Array.isArray(entry[1])
+          entry[1] !== null && typeof entry[1] === 'object' && !Array.isArray(entry[1])
             ? // do recursion if we find an object
               ServerConfigMapper.mapEntries(
                 // get rid of id

--- a/src/app/core/services/filter/filter.service.ts
+++ b/src/app/core/services/filter/filter.service.ts
@@ -1,7 +1,6 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { omit } from 'lodash-es';
 import { Observable, identity } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -18,6 +17,7 @@ import { ApiService } from 'ish-core/services/api/api.service';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { getProductListingItemsPerPage } from 'ish-core/store/shopping/product-listing';
 import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { omit } from 'ish-core/utils/functions';
 import { URLFormParams, appendFormParamsToHttpParams } from 'ish-core/utils/url-form-params';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/core/utils/functions.spec.ts
+++ b/src/app/core/utils/functions.spec.ts
@@ -1,4 +1,4 @@
-import { arraySlices, mergeDeep } from './functions';
+import { arraySlices, mergeDeep, omit } from './functions';
 
 describe('Functions', () => {
   describe('arraySlices', () => {
@@ -69,6 +69,53 @@ describe('Functions', () => {
           },
           "d": 11,
         }
+      `);
+    });
+  });
+
+  describe('omit', () => {
+    let input;
+
+    beforeEach(() => {
+      input = {
+        a: 1,
+        b: '2',
+        c: true,
+        d: false,
+      };
+    });
+
+    it('should remove keys from object on input', () => {
+      expect(omit(input, 'a', 'c')).toMatchInlineSnapshot(`
+        Object {
+          "b": "2",
+          "d": false,
+        }
+      `);
+    });
+
+    it('should not modify original input when used', () => {
+      omit(input, 'a', 'c');
+
+      expect(input).toMatchInlineSnapshot(`
+        Object {
+          "a": 1,
+          "b": "2",
+          "c": true,
+          "d": false,
+        }
+      `);
+    });
+
+    it('should return original object if input was falsy', () => {
+      expect(omit(undefined, 'a')).toBeUndefined();
+    });
+
+    it('should return original object if input was array', () => {
+      expect(omit(['a'], 'a')).toMatchInlineSnapshot(`
+        Array [
+          "a",
+        ]
       `);
     });
   });

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -39,3 +39,14 @@ export function mergeDeep(target, source) {
   }
   return output;
 }
+
+/**
+ * Returns a copy of the object composed of the own and inherited enumerable property paths of the object that are not omitted.
+ */
+export function omit<T>(from: T, ...keys: (keyof T | string)[]) {
+  return !!from && !Array.isArray(from)
+    ? Object.entries(from)
+        .filter(([key]) => !keys.includes(key))
+        .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {})
+    : from;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -329,8 +329,9 @@
           "from": "lodash.*"
         },
         {
-          "import": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|omit|pick)$).*",
-          "from": "lodash.*"
+          "import": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|pick)$).*",
+          "from": "lodash.*",
+          "filePattern": "^(?!.*.spec.ts$).*.ts$"
         },
         {
           "import": "CookiesService",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

Server config settings with value `null` are mapped to an empty object `{ }`.
see:
![image](https://user-images.githubusercontent.com/23452927/109714156-596a7700-7ba2-11eb-90e8-be7a395ef962.png)
![image](https://user-images.githubusercontent.com/23452927/109714207-6a1aed00-7ba2-11eb-8491-442f580a3cd0.png)

## What Is the New Behavior?

`null` is correctly mapped.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

This happens because `typeof null === 'object'` and no special check was in place.