### PR TITLE
perf: forbid omit from lodash-es as it is not used to its full potential

### DIFF
--- a/src/app/core/models/product-variation/product-variation.helper.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.ts
@@ -1,7 +1,8 @@
-import { flatten, groupBy, omit } from 'lodash-es';
+import { flatten, groupBy } from 'lodash-es';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { VariationProductMasterView, VariationProductView } from 'ish-core/models/product-view/product-view.model';
+import { omit } from 'ish-core/utils/functions';
 
 import { VariationAttribute } from './variation-attribute.model';
 import { VariationOptionGroup } from './variation-option-group.model';

--- a/src/app/core/models/server-config/server-config.mapper.ts
+++ b/src/app/core/models/server-config/server-config.mapper.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash-es';
+import { omit } from 'ish-core/utils/functions';
 
 import { ServerConfigData, ServerConfigDataEntry } from './server-config.interface';
 import { ServerConfig } from './server-config.model';

--- a/src/app/core/services/filter/filter.service.ts
+++ b/src/app/core/services/filter/filter.service.ts
@@ -1,7 +1,6 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { omit } from 'lodash-es';
 import { Observable, identity } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -18,6 +17,7 @@ import { ApiService } from 'ish-core/services/api/api.service';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { getProductListingItemsPerPage } from 'ish-core/store/shopping/product-listing';
 import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { omit } from 'ish-core/utils/functions';
 import { URLFormParams, appendFormParamsToHttpParams } from 'ish-core/utils/url-form-params';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/core/utils/functions.spec.ts
+++ b/src/app/core/utils/functions.spec.ts
@@ -1,4 +1,4 @@
-import { arraySlices, mergeDeep } from './functions';
+import { arraySlices, mergeDeep, omit } from './functions';
 
 describe('Functions', () => {
   describe('arraySlices', () => {
@@ -69,6 +69,53 @@ describe('Functions', () => {
           },
           "d": 11,
         }
+      `);
+    });
+  });
+
+  describe('omit', () => {
+    let input;
+
+    beforeEach(() => {
+      input = {
+        a: 1,
+        b: '2',
+        c: true,
+        d: false,
+      };
+    });
+
+    it('should remove keys from object on input', () => {
+      expect(omit(input, 'a', 'c')).toMatchInlineSnapshot(`
+        Object {
+          "b": "2",
+          "d": false,
+        }
+      `);
+    });
+
+    it('should not modify original input when used', () => {
+      omit(input, 'a', 'c');
+
+      expect(input).toMatchInlineSnapshot(`
+        Object {
+          "a": 1,
+          "b": "2",
+          "c": true,
+          "d": false,
+        }
+      `);
+    });
+
+    it('should return original object if input was falsy', () => {
+      expect(omit(undefined, 'a')).toBeUndefined();
+    });
+
+    it('should return original object if input was array', () => {
+      expect(omit(['a'], 'a')).toMatchInlineSnapshot(`
+        Array [
+          "a",
+        ]
       `);
     });
   });

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -40,6 +40,9 @@ export function mergeDeep(target, source) {
   return output;
 }
 
+/**
+ * Returns a copy of the object composed of the own and inherited enumerable property paths of the object that are not omitted.
+ */
 export function omit<T>(from: T, ...keys: (keyof T | string)[]) {
   return !!from && !Array.isArray(from)
     ? Object.entries(from)

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -39,3 +39,11 @@ export function mergeDeep(target, source) {
   }
   return output;
 }
+
+export function omit<T>(from: T, ...keys: (keyof T | string)[]) {
+  return !!from && !Array.isArray(from)
+    ? Object.entries(from)
+        .filter(([key]) => !keys.includes(key))
+        .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {})
+    : from;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -329,8 +329,9 @@
           "from": "lodash.*"
         },
         {
-          "import": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|omit|pick)$).*",
-          "from": "lodash.*"
+          "import": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|pick)$).*",
+          "from": "lodash.*",
+          "filePattern": "^(?!.*.spec.ts$).*.ts$"
         },
         {
           "import": "CookiesService",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

- `lodash-es/omit` in the codebase is not used to its full potential and it's a rather large helper (2 kB in the vendor bundle)

## What Is the New Behavior?

- replaced `omit` with simplified custom implementation

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

needs fix in PR #594 
