### PR TITLE
test: add wrappers to formly-testing-module

### DIFF
--- a/docs/guides/formly.md
+++ b/docs/guides/formly.md
@@ -187,8 +187,8 @@ To facilitate this, the `formly/dev/testing` folder contains a `FormlyTestingCom
 - `FormlyTestingExampleComponent` is a type that contains an empty input field and can be used as an example field type.
 - `FormlyTestingFieldgroupExampleComponent` is a type that renders all configs in the `fieldGroup` attribute of the field.
 
-In addition, to test components or pages that use Formly, use the `FormlyTestingModule`.
-It defines a FormlyModule with preconfigured sample field types.
+In addition, to test components or pages that use Formly, import the `FormlyTestingModule`.
+It defines and exports a FormlyModule with preconfigured dummy field types and wrappers that match the `FormlyModule`.
 
 ### Testing Custom Types
 

--- a/src/app/shared/formly/dev/testing/formly-testing.module.ts
+++ b/src/app/shared/formly/dev/testing/formly-testing.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { FieldType, FormlyForm, FormlyModule } from '@ngx-formly/core';
+import { FieldType, FieldWrapper, FormlyForm, FormlyModule } from '@ngx-formly/core';
 import { FormlySelectModule } from '@ngx-formly/core/select';
 
 // tslint:disable: project-structure
@@ -35,6 +35,9 @@ class SelectFieldComponent extends FieldType {}
 
 @Component({ template: 'TextareaFieldComponent: {{ to | json }}' })
 class TextareaFieldComponent extends FieldType {}
+
+@Component({ template: `<ng-template #fieldComponent> </ng-template>` })
+class DummyWrapperComponent extends FieldWrapper {}
 
 // tslint:enable: project-structure
 
@@ -82,6 +85,14 @@ class TextareaFieldComponent extends FieldType {}
           component: TextareaFieldComponent,
         },
         { name: 'ish-captcha-field', component: CaptchaFieldComponent },
+      ],
+      wrappers: [
+        { name: 'form-field-horizontal', component: DummyWrapperComponent },
+        { name: 'form-field-checkbox-horizontal', component: DummyWrapperComponent },
+        { name: 'textarea-description', component: DummyWrapperComponent },
+        { name: 'tooltip', component: DummyWrapperComponent },
+        { name: 'validation', component: DummyWrapperComponent },
+        { name: 'description', component: DummyWrapperComponent },
       ],
     }),
     FormlySelectModule,

--- a/src/app/shared/formly/dev/testing/formly-testing.module.ts
+++ b/src/app/shared/formly/dev/testing/formly-testing.module.ts
@@ -45,6 +45,7 @@ class DummyWrapperComponent extends FieldWrapper {}
   declarations: [
     CaptchaFieldComponent,
     CheckboxFieldComponent,
+    DummyWrapperComponent,
     EmailFieldComponent,
     FieldsetFieldComponent,
     PasswordFieldComponent,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: Test-related changes

## What Is the Current Behavior?

FormlyTestingModule exports only FieldTypes

## What Is the New Behavior?

FormlyTestingModule exports FieldTypes and FieldWrappers to be used throughout the PWA

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
