### PR TITLE
fix: allow parentheses in urls

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule, TransferState } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { UrlSerializer } from '@angular/router';
 
 import { COOKIE_CONSENT_VERSION } from 'ish-core/configurations/state-keys';
 import { CoreModule } from 'ish-core/core.module';
+import { CustomUrlSerializer } from 'ish-core/utils/custom-url-serializer';
 
 import { environment } from '../environments/environment';
 
@@ -31,6 +33,7 @@ import { ShellModule } from './shell/shell.module';
     AppLastRoutingModule,
   ],
   bootstrap: [AppComponent],
+  providers: [{ provide: UrlSerializer, useClass: CustomUrlSerializer }],
 })
 export class AppModule {
   constructor(transferState: TransferState) {

--- a/src/app/core/utils/custom-url-serializer.spec.ts
+++ b/src/app/core/utils/custom-url-serializer.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { UrlSerializer } from '@angular/router';
+
+import { CustomUrlSerializer } from './custom-url-serializer';
+
+describe('Custom Url Serializer', () => {
+  let urlSerializer: UrlSerializer;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [{ provide: UrlSerializer, useClass: CustomUrlSerializer }] });
+    urlSerializer = TestBed.inject(UrlSerializer);
+  });
+
+  it('should deal with parenthesis in parameter names', () => {
+    const tree = urlSerializer.parse('/path/a/b/c?param=(value)');
+    const result = urlSerializer.serialize(tree);
+    expect(result).toBe('/path/a/b/c?param=(value)');
+  });
+
+  it('should deal with parenthesis in path segment names', () => {
+    const tree = urlSerializer.parse('/path/a/(segmentname)');
+    const result = urlSerializer.serialize(tree);
+    expect(result).toBe('/path/a/(segmentname)');
+  });
+
+  it('should deal with parenthesis in matrix parameters', () => {
+    const tree = urlSerializer.parse('/path/a/b/c;(matrix-param)=value');
+    const result = urlSerializer.serialize(tree);
+    expect(result).toBe('/path/a/b/c;(matrix-param)=value');
+  });
+});

--- a/src/app/core/utils/custom-url-serializer.ts
+++ b/src/app/core/utils/custom-url-serializer.ts
@@ -1,0 +1,19 @@
+import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+
+/**
+ * custom serializer for allowing parentheses in URLs
+ *
+ * taken from: https://github.com/angular/angular/issues/10280#issuecomment-309129784
+ */
+export class CustomUrlSerializer implements UrlSerializer {
+  private defaultUrlSerializer: DefaultUrlSerializer = new DefaultUrlSerializer();
+
+  parse(url: string): UrlTree {
+    const newUrl = url.replace(/\(/g, '%28').replace(/\)/g, '%29');
+    return this.defaultUrlSerializer.parse(newUrl);
+  }
+
+  serialize(tree: UrlTree): string {
+    return this.defaultUrlSerializer.serialize(tree).replace(/%28/g, '(').replace(/%29/g, ')');
+  }
+}

--- a/src/app/core/utils/custom-url-serializer.ts
+++ b/src/app/core/utils/custom-url-serializer.ts
@@ -1,7 +1,7 @@
 import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
 
 /**
- * custom serializer for allowing parentheses in URLs
+ * Custom serializer for allowing parenthesis in URLs
  *
  * taken from: https://github.com/angular/angular/issues/10280#issuecomment-309129784
  */


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

Issue Number: Closes #610 

## What Is the New Behavior?

- custom URL serializer added, that encodes parentheses while processing URLs

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Sadly, the custom serializer has to be provided in `AppModule`. I did not get it working, when providing it in `CoreModule`, where such stuff usually belongs to...
