### PR TITLE
chore: run ngcc after build for docker images and dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
     "yzhang.markdown-all-in-one"
   ],
   "forwardPorts": [4200],
-  "postStartCommand": "sudo chown node node_modules && npm install",
+  "postStartCommand": "sudo chown node node_modules && npm install && npm run ngcc",
   // Comment out the next line to run as root instead.
   "remoteUser": "node"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine as buildstep
 WORKDIR /workspace
 COPY schematics /workspace/schematics/
 COPY package.json package-lock.json /workspace/
-RUN npm i --ignore-scripts
+RUN npm i --ignore-scripts && npm run ngcc
 COPY projects/organization-management/src/app /workspace/projects/organization-management/src/app/
 COPY projects/requisition-management/src/app /workspace/projects/requisition-management/src/app/
 COPY src /workspace/src/

--- a/Dockerfile_noSSR
+++ b/Dockerfile_noSSR
@@ -3,7 +3,7 @@ FROM node:14-alpine as buildstep
 WORKDIR /workspace
 COPY schematics /workspace/schematics/
 COPY package.json package-lock.json /workspace/
-RUN npm i --ignore-scripts
+RUN npm i --ignore-scripts && npm run ngcc
 COPY projects/organization-management/src/app /workspace/projects/organization-management/src/app/
 COPY projects/requisition-management/src/app /workspace/projects/requisition-management/src/app/
 COPY src /workspace/src/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:tslint-rules": "cd tslint-rules && npm run build",
     "build:schematics": "cd schematics && npm run build",
     "ng": "ng",
+    "ngcc": "ngcc",
     "test": "jest --ci",
     "test:watch": "jest --watch -i",
     "e2e": "cd e2e && npm install && node open-cypress",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes

## What Is the Current Behavior?

- dependencies are ivy compiled when invoking build commands in docker images

## What Is the New Behavior?

- dependencies are ivy compiled directly after install for docker images (faster)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

https://angular.io/guide/ivy#ivy-and-universalapp-shell
