### PR TITLE
chore: remove deprecated camel case parameters from ng calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run ng -- build -c ${configuration}
 # ^ this part above is copied to Dockerfile_noSSR and should be kept in sync
 
 COPY tsconfig.server.json server.ts /workspace/
-RUN npm run ng -- run intershop-pwa:server -c ${configuration} --bundleDependencies
+RUN npm run ng -- run intershop-pwa:server -c ${configuration}
 # remove cache check for resources (especially index.html)
 # https://github.com/angular/angular/issues/23613#issuecomment-415886919
 RUN test "${serviceWorker}" = "true" && sed -i 's/canonicalHash !== cacheBustedHash/false/g' /workspace/dist/browser/ngsw-worker.js || true

--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -80,7 +80,7 @@ When using `ng generate` with PWA custom schematics, you can apply all those cha
 For example, the following code block creates a new Angular component named `cms-inventory` and registers it with the `CMSModule`.
 
 ```bash
-$ ng generate cms inventory --definitionQualifiedName app_sf_customer_cm:component.custom.inventory.pagelet2-Component
+$ ng generate cms inventory --definition-qualified-name app_sf_customer_cm:component.custom.inventory.pagelet2-Component
 CREATE src/app/cms/components/cms-inventory/cms-inventory.component.ts (386 bytes)
 CREATE src/app/cms/components/cms-inventory/cms-inventory.component.html (32 bytes)
 CREATE src/app/cms/components/cms-inventory/cms-inventory.component.spec.ts (795 bytes)

--- a/e2e/test-schematics.sh
+++ b/e2e/test-schematics.sh
@@ -80,12 +80,12 @@ stat src/app/extensions/awesome/store/super/super.reducer.ts
 stat src/app/extensions/awesome/store/super/super.selectors.ts
 grep "SuperState" src/app/extensions/awesome/store/awesome-store.ts
 
-npx ng g cms --definitionQualifiedName app:component.custom.inventory.pagelet2-Component inventory
+npx ng g cms --definition-qualified-name app:component.custom.inventory.pagelet2-Component inventory
 stat src/app/shared/cms/components/cms-inventory/cms-inventory.component.ts
 grep "CMSInventoryComponent" src/app/shared/cms/cms.module.ts
 grep "CMSInventoryComponent" src/app/shared/shared.module.ts
 
-npx ng g cms --definitionQualifiedName app:component.custom.audio.pagelet2-Component --noCMSPrefixing audio
+npx ng g cms --definition-qualified-name app:component.custom.audio.pagelet2-Component --noCMSPrefixing audio
 stat src/app/shared/cms/components/audio/audio.component.ts
 grep "AudioComponent" src/app/shared/cms/cms.module.ts
 grep "AudioComponent" src/app/shared/shared.module.ts

--- a/scripts/build-pwa.js
+++ b/scripts/build-pwa.js
@@ -16,4 +16,4 @@ if (!configuration) {
 }
 
 execSync('npm run ng -- build -c ' + configuration, { stdio: [0, 1, 2] });
-execSync('npm run ng -- run intershop-pwa:server --bundleDependencies -c ' + configuration, { stdio: [0, 1, 2] });
+execSync('npm run ng -- run intershop-pwa:server -c ' + configuration, { stdio: [0, 1, 2] });

--- a/templates/Dockerfile_dev
+++ b/templates/Dockerfile_dev
@@ -6,4 +6,4 @@ RUN ./node_modules/.bin/ngcc
 RUN npm run build:schematics
 RUN npm run synchronize-lazy-components -- --ci
 EXPOSE 8080
-CMD npx ng serve --host 0.0.0.0 --disableHostCheck true --aot --port 8080
+CMD npx ng serve --port 8080


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Build-related changes

## What Is the Current Behavior?

- deprecation warnings when using camel case parameters with ng commands
![image](https://user-images.githubusercontent.com/23452927/110596700-e6ec2f00-817f-11eb-81d0-647abbc82186.png)

## What Is the New Behavior?

- removed unnecessary parameters
- transformed camel case parameters to kebab case

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

https://blog.ninja-squad.com/2021/01/21/angular-cli-11.1/#camel-case-arguments-are-deprecated