### PR TITLE
refactor: use setLoadingOn and unsetLoadingAndErrorOn where possible

### DIFF
--- a/projects/organization-management/src/app/store/users/users.reducer.ts
+++ b/projects/organization-management/src/app/store/users/users.reducer.ts
@@ -49,7 +49,14 @@ const initialState: UsersState = usersAdapter.getInitialState({
 export const usersReducer = createReducer(
   initialState,
   setLoadingOn(loadUsers, addUser, updateUser, deleteUser, setUserBudget),
-  unsetLoadingAndErrorOn(loadUsersSuccess, addUserSuccess, updateUserSuccess, deleteUserSuccess, setUserBudgetSuccess),
+  unsetLoadingAndErrorOn(
+    loadUsersSuccess,
+    loadUserSuccess,
+    addUserSuccess,
+    updateUserSuccess,
+    deleteUserSuccess,
+    setUserBudgetSuccess
+  ),
   setErrorOn(
     loadUsersFail,
     loadUserFail,
@@ -73,8 +80,6 @@ export const usersReducer = createReducer(
 
     return {
       ...usersAdapter.upsertOne(user, state),
-      loading: false,
-      error: undefined,
     };
   }),
   on(addUserSuccess, (state, action) => {

--- a/src/app/core/store/content/includes/includes.reducer.ts
+++ b/src/app/core/store/content/includes/includes.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { ContentPageletEntryPoint } from 'ish-core/models/content-pagelet-entry-point/content-pagelet-entry-point.model';
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { loadContentInclude, loadContentIncludeFail, loadContentIncludeSuccess } from './includes.actions';
 
@@ -21,16 +21,12 @@ export const initialState: IncludesState = includesAdapter.getInitialState({
 export const includesReducer = createReducer(
   initialState,
   setLoadingOn(loadContentInclude),
-  on(loadContentIncludeFail, state => ({
-    ...state,
-    loading: false,
-  })),
+  unsetLoadingOn(loadContentIncludeFail, loadContentIncludeSuccess),
   on(loadContentIncludeSuccess, (state, action) => {
     const { include } = action.payload;
 
     return {
       ...includesAdapter.upsertOne(include, state),
-      loading: false,
     };
   })
 );

--- a/src/app/core/store/content/pages/pages.reducer.ts
+++ b/src/app/core/store/content/pages/pages.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { ContentPageletEntryPoint } from 'ish-core/models/content-pagelet-entry-point/content-pagelet-entry-point.model';
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { loadContentPage, loadContentPageFail, loadContentPageSuccess } from './pages.actions';
 
@@ -21,16 +21,12 @@ const initialState: PagesState = pagesAdapter.getInitialState({
 export const pagesReducer = createReducer(
   initialState,
   setLoadingOn(loadContentPage),
-  on(loadContentPageFail, state => ({
-    ...state,
-    loading: false,
-  })),
+  unsetLoadingOn(loadContentPageFail, loadContentPageSuccess),
   on(loadContentPageSuccess, (state, action) => {
     const { page } = action.payload;
 
     return {
       ...pagesAdapter.upsertOne(page, state),
-      loading: false,
     };
   })
 );

--- a/src/app/core/store/customer/basket/basket.reducer.ts
+++ b/src/app/core/store/customer/basket/basket.reducer.ts
@@ -7,7 +7,7 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { PaymentMethod } from 'ish-core/models/payment-method/payment-method.model';
 import { ShippingMethod } from 'ish-core/models/shipping-method/shipping-method.model';
 import { createOrderSuccess } from 'ish-core/store/customer/orders';
-import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import {
   addItemsToBasket,
@@ -133,6 +133,7 @@ export const basketReducer = createReducer(
     updateConcardisCvcLastUpdated,
     startCheckout
   ),
+  unsetLoadingOn(addPromotionCodeToBasketSuccess, addPromotionCodeToBasketFail),
   unsetLoadingAndErrorOn(
     loadBasketSuccess,
     mergeBasketSuccess,
@@ -241,7 +242,6 @@ export const basketReducer = createReducer(
   })),
   on(addPromotionCodeToBasketSuccess, state => ({
     ...state,
-    loading: false,
     promotionError: undefined,
   })),
 
@@ -251,7 +251,6 @@ export const basketReducer = createReducer(
     return {
       ...state,
       promotionError: error,
-      loading: false,
     };
   }),
 

--- a/src/app/core/store/customer/user/user.reducer.ts
+++ b/src/app/core/store/customer/user/user.reducer.ts
@@ -5,7 +5,7 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { PaymentMethod } from 'ish-core/models/payment-method/payment-method.model';
 import { User } from 'ish-core/models/user/user.model';
 import { loadRolesAndPermissionsFail } from 'ish-core/store/customer/authorization';
-import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import {
   createUser,
@@ -80,6 +80,20 @@ export const userReducer = createReducer(
     loadUserPaymentMethods,
     deleteUserPaymentInstrument
   ),
+  unsetLoadingOn(
+    updateUserPasswordByPasswordReminderSuccess,
+    requestPasswordReminderSuccess,
+    updateUserPasswordByPasswordReminderFail,
+    requestPasswordReminderFail
+  ),
+  setErrorOn(
+    updateUserFail,
+    updateUserPasswordFail,
+    updateCustomerFail,
+    loadUserPaymentMethodsFail,
+    deleteUserPaymentInstrumentFail,
+    loadRolesAndPermissionsFail
+  ),
   on(loginUserFail, loadCompanyUserFail, createUserFail, (_, action) => {
     const error = action.payload.error;
 
@@ -89,14 +103,6 @@ export const userReducer = createReducer(
       error,
     };
   }),
-  setErrorOn(
-    updateUserFail,
-    updateUserPasswordFail,
-    updateCustomerFail,
-    loadUserPaymentMethodsFail,
-    deleteUserPaymentInstrumentFail,
-    loadRolesAndPermissionsFail
-  ),
   unsetLoadingAndErrorOn(
     loginUserSuccess,
     loadCompanyUserSuccess,
@@ -163,13 +169,11 @@ export const userReducer = createReducer(
   })),
   on(updateUserPasswordByPasswordReminderSuccess, requestPasswordReminderSuccess, state => ({
     ...state,
-    loading: false,
     passwordReminderSuccess: true,
     passwordReminderError: undefined,
   })),
   on(updateUserPasswordByPasswordReminderFail, requestPasswordReminderFail, (state, action) => ({
     ...state,
-    loading: false,
     passwordReminderSuccess: false,
     passwordReminderError: action.payload.error,
   })),

--- a/src/app/core/store/customer/user/user.reducer.ts
+++ b/src/app/core/store/customer/user/user.reducer.ts
@@ -5,7 +5,7 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { PaymentMethod } from 'ish-core/models/payment-method/payment-method.model';
 import { User } from 'ish-core/models/user/user.model';
 import { loadRolesAndPermissionsFail } from 'ish-core/store/customer/authorization';
-import { setErrorOn, setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
 
 import {
   createUser,
@@ -97,7 +97,16 @@ export const userReducer = createReducer(
     deleteUserPaymentInstrumentFail,
     loadRolesAndPermissionsFail
   ),
-  on(loginUserSuccess, (state, action) => {
+  unsetLoadingAndErrorOn(
+    loginUserSuccess,
+    loadCompanyUserSuccess,
+    updateUserSuccess,
+    updateUserPasswordSuccess,
+    updateCustomerSuccess,
+    loadUserPaymentMethodsSuccess,
+    deleteUserPaymentInstrumentSuccess
+  ),
+  on(loginUserSuccess, (state: UserState, action) => {
     const customer = action.payload.customer;
     const user = action.payload.user;
 
@@ -106,8 +115,6 @@ export const userReducer = createReducer(
       authorized: true,
       customer,
       user,
-      loading: false,
-      error: undefined,
     };
   }),
   on(loadCompanyUserSuccess, (state, action) => {
@@ -116,8 +123,6 @@ export const userReducer = createReducer(
     return {
       ...state,
       user,
-      loading: false,
-      error: undefined,
     };
   }),
   on(updateUserSuccess, (state, action) => {
@@ -126,14 +131,10 @@ export const userReducer = createReducer(
     return {
       ...state,
       user,
-      loading: false,
-      error: undefined,
     };
   }),
   on(updateUserPasswordSuccess, state => ({
     ...state,
-    loading: false,
-    error: undefined,
   })),
   on(updateCustomerSuccess, (state, action) => {
     const customer = action.payload.customer;
@@ -141,8 +142,6 @@ export const userReducer = createReducer(
     return {
       ...state,
       customer,
-      loading: false,
-      error: undefined,
     };
   }),
   on(setPGID, (state, action) => ({
@@ -152,13 +151,9 @@ export const userReducer = createReducer(
   on(loadUserPaymentMethodsSuccess, (state, action) => ({
     ...state,
     paymentMethods: action.payload.paymentMethods,
-    loading: false,
-    error: undefined,
   })),
   on(deleteUserPaymentInstrumentSuccess, state => ({
     ...state,
-    loading: false,
-    error: undefined,
   })),
   on(updateUserPasswordByPasswordReminder, requestPasswordReminder, state => ({
     ...state,

--- a/src/app/core/store/customer/user/user.reducer.ts
+++ b/src/app/core/store/customer/user/user.reducer.ts
@@ -78,7 +78,9 @@ export const userReducer = createReducer(
     updateUserPassword,
     updateCustomer,
     loadUserPaymentMethods,
-    deleteUserPaymentInstrument
+    deleteUserPaymentInstrument,
+    updateUserPasswordByPasswordReminder,
+    requestPasswordReminder
   ),
   unsetLoadingOn(
     updateUserPasswordByPasswordReminderSuccess,
@@ -163,7 +165,6 @@ export const userReducer = createReducer(
   })),
   on(updateUserPasswordByPasswordReminder, requestPasswordReminder, state => ({
     ...state,
-    loading: true,
     passwordReminderSuccess: undefined,
     passwordReminderError: undefined,
   })),

--- a/src/app/core/store/general/contact/contact.reducer.ts
+++ b/src/app/core/store/general/contact/contact.reducer.ts
@@ -1,5 +1,7 @@
 import { createReducer, on } from '@ngrx/store';
 
+import { setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
+
 import {
   createContact,
   createContactFail,
@@ -23,14 +25,14 @@ const initialState: ContactState = {
 
 export const contactReducer = createReducer(
   initialState,
+  setLoadingOn(loadContact, createContact),
+  unsetLoadingOn(loadContactFail, loadContactSuccess, createContactFail, createContactSuccess),
   on(loadContact, state => ({
     ...state,
-    loading: true,
     success: undefined,
   })),
   on(loadContactFail, state => ({
     ...state,
-    loading: false,
     success: undefined,
   })),
   on(loadContactSuccess, (state, action) => {
@@ -38,23 +40,19 @@ export const contactReducer = createReducer(
     return {
       ...state,
       subjects,
-      loading: false,
       success: undefined,
     };
   }),
   on(createContact, state => ({
     ...state,
-    loading: true,
     success: undefined,
   })),
   on(createContactFail, state => ({
     ...state,
-    loading: false,
     success: false,
   })),
   on(createContactSuccess, state => ({
     ...state,
-    loading: false,
     success: true,
   }))
 );

--- a/src/app/core/store/general/regions/regions.reducer.ts
+++ b/src/app/core/store/general/regions/regions.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { Region } from 'ish-core/models/region/region.model';
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { loadRegions, loadRegionsFail, loadRegionsSuccess } from './regions.actions';
 
@@ -21,16 +21,12 @@ export const initialState: RegionsState = regionAdapter.getInitialState({
 export const regionsReducer = createReducer(
   initialState,
   setLoadingOn(loadRegions),
-  on(loadRegionsFail, state => ({
-    ...state,
-    loading: false,
-  })),
+  unsetLoadingOn(loadRegionsFail, loadRegionsSuccess),
   on(loadRegionsSuccess, (state, action) => {
     const { regions } = action.payload;
 
     return {
       ...regionAdapter.upsertMany(regions, state),
-      loading: false,
     };
   })
 );

--- a/src/app/core/store/shopping/product-listing/product-listing.reducer.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.reducer.ts
@@ -11,7 +11,7 @@ import {
   loadProductsForMasterFail,
 } from 'ish-core/store/shopping/products';
 import { searchProducts, searchProductsFail } from 'ish-core/store/shopping/search';
-import { setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
+import { setLoadingOn, unsetLoadingAndErrorOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 import { formParamsToString } from 'ish-core/utils/url-form-params';
 
 import { setProductListingPageSize, setProductListingPages, setViewType } from './product-listing.actions';
@@ -84,6 +84,7 @@ export const productListingReducer = createReducer(
   })),
   on(setViewType, (state, action) => ({ ...state, viewType: action.payload.viewType })),
   setLoadingOn(searchProducts, loadProductsForCategory, loadProductsForFilter, loadProductsForMaster),
+  unsetLoadingOn(setProductListingPages),
   unsetLoadingAndErrorOn(searchProductsFail, loadProductsForCategoryFail, loadProductsForMasterFail),
   on(setProductListingPages, (state, action) => {
     const pages =
@@ -95,6 +96,6 @@ export const productListingReducer = createReducer(
       filters: action.payload.id.filters,
     });
 
-    return adapter.upsertOne({ ...action.payload, pages }, { ...state, loading: false, currentSettings });
+    return adapter.upsertOne({ ...action.payload, pages }, { ...state, currentSettings });
   })
 );

--- a/src/app/core/utils/ngrx-creators.ts
+++ b/src/app/core/utils/ngrx-creators.ts
@@ -20,6 +20,14 @@ export function setLoadingOn<S extends { loading: boolean | number }>(...actionC
   return on<S, any>(...actionCreators, stateFnc);
 }
 
+export function unsetLoadingOn<S extends { loading: boolean | number }>(...actionCreators: any) {
+  const stateFnc = (state: S) => ({
+    ...state,
+    loading: typeof state.loading === 'boolean' ? false : state.loading - 1,
+  });
+  return on<S, any>(...actionCreators, stateFnc);
+}
+
 function calculateLoading<T extends boolean | number, S extends { loading: T }>(state: S): T {
   if (typeof state.loading === 'number' && state.loading - 1 < 0) {
     console.warn('State loading would be decreased below 0.');

--- a/src/app/extensions/order-templates/store/order-template/order-template.reducer.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { OrderTemplate } from '../../models/order-template/order-template.model';
 
@@ -52,21 +52,23 @@ export const orderTemplateReducer = createReducer(
     deleteOrderTemplate,
     updateOrderTemplate
   ),
+  setErrorOn(
+    loadOrderTemplatesFail,
+    deleteOrderTemplateFail,
+    createOrderTemplateFail,
+    addBasketToNewOrderTemplateFail,
+    updateOrderTemplateFail
+  ),
   on(
     loadOrderTemplatesFail,
     deleteOrderTemplateFail,
     createOrderTemplateFail,
     addBasketToNewOrderTemplateFail,
     updateOrderTemplateFail,
-    (state, action) => {
-      const { error } = action.payload;
-      return {
-        ...state,
-        loading: false,
-        error,
-        selected: undefined,
-      };
-    }
+    (state: OrderTemplateState) => ({
+      ...state,
+      selected: undefined as string,
+    })
   ),
   on(loadOrderTemplatesSuccess, (state, action) => {
     const { orderTemplates } = action.payload;

--- a/src/app/extensions/order-templates/store/order-template/order-template.reducer.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { setErrorOn, setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { OrderTemplate } from '../../models/order-template/order-template.model';
 
@@ -52,6 +52,15 @@ export const orderTemplateReducer = createReducer(
     deleteOrderTemplate,
     updateOrderTemplate
   ),
+  unsetLoadingOn(
+    loadOrderTemplatesSuccess,
+    addBasketToNewOrderTemplateSuccess,
+    createOrderTemplateSuccess,
+    updateOrderTemplateSuccess,
+    addProductToOrderTemplateSuccess,
+    removeItemFromOrderTemplateSuccess,
+    deleteOrderTemplateSuccess
+  ),
   setErrorOn(
     loadOrderTemplatesFail,
     deleteOrderTemplateFail,
@@ -72,10 +81,7 @@ export const orderTemplateReducer = createReducer(
   ),
   on(loadOrderTemplatesSuccess, (state, action) => {
     const { orderTemplates } = action.payload;
-    return orderTemplateAdapter.setAll(orderTemplates, {
-      ...state,
-      loading: false,
-    });
+    return orderTemplateAdapter.setAll(orderTemplates, state);
   }),
   on(
     addBasketToNewOrderTemplateSuccess,
@@ -86,18 +92,12 @@ export const orderTemplateReducer = createReducer(
     (state, action) => {
       const { orderTemplate } = action.payload;
 
-      return orderTemplateAdapter.upsertOne(orderTemplate, {
-        ...state,
-        loading: false,
-      });
+      return orderTemplateAdapter.upsertOne(orderTemplate, state);
     }
   ),
   on(deleteOrderTemplateSuccess, (state, action) => {
     const { orderTemplateId } = action.payload;
-    return orderTemplateAdapter.removeOne(orderTemplateId, {
-      ...state,
-      loading: false,
-    });
+    return orderTemplateAdapter.removeOne(orderTemplateId, state);
   }),
   on(selectOrderTemplate, (state, action) => {
     const { id } = action.payload;

--- a/src/app/extensions/tacton/store/product-configuration/product-configuration.reducer.ts
+++ b/src/app/extensions/tacton/store/product-configuration/product-configuration.reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer, on } from '@ngrx/store';
 
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
 
 import { TactonProductConfiguration } from '../../models/tacton-product-configuration/tacton-product-configuration.model';
 
@@ -36,9 +36,9 @@ export const productConfigurationReducer = createReducer(
     changeTactonConfigurationStep,
     submitTactonConfiguration
   ),
+  unsetLoadingOn(setCurrentConfiguration),
   on(setCurrentConfiguration, (state, action) => ({
     ...state,
-    loading: false,
     current: action.payload.configuration,
   })),
   on(clearTactonConfiguration, submitTactonConfigurationSuccess, () => initialState)

--- a/src/app/extensions/wishlists/store/wishlist/wishlist.reducer.ts
+++ b/src/app/extensions/wishlists/store/wishlist/wishlist.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { setLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
 
 import { Wishlist } from '../../models/wishlist/wishlist.model';
 
@@ -52,21 +52,22 @@ export const wishlistReducer = createReducer(
     removeItemFromWishlist,
     moveItemToWishlist
   ),
-  on(loadWishlistsFail, deleteWishlistFail, createWishlistFail, updateWishlistFail, (state, action) => {
-    const { error } = action.payload;
-    return {
-      ...state,
-      loading: false,
-      error,
-      selected: undefined,
-    };
-  }),
-  on(loadWishlistsSuccess, (state, action) => {
+  setErrorOn(loadWishlistsFail, deleteWishlistFail, createWishlistFail, updateWishlistFail),
+  unsetLoadingAndErrorOn(
+    updateWishlistSuccess,
+    addProductToWishlistSuccess,
+    removeItemFromWishlistSuccess,
+    createWishlistSuccess,
+    loadWishlistsSuccess,
+    deleteWishlistSuccess
+  ),
+  on(loadWishlistsFail, deleteWishlistFail, createWishlistFail, updateWishlistFail, (state: WishlistState) => ({
+    ...state,
+    selected: undefined as string,
+  })),
+  on(loadWishlistsSuccess, (state: WishlistState, action) => {
     const { wishlists } = action.payload;
-    return wishlistsAdapter.setAll(wishlists, {
-      ...state,
-      loading: false,
-    });
+    return wishlistsAdapter.setAll(wishlists, state);
   }),
   on(
     updateWishlistSuccess,
@@ -76,18 +77,12 @@ export const wishlistReducer = createReducer(
     (state, action) => {
       const { wishlist } = action.payload;
 
-      return wishlistsAdapter.upsertOne(wishlist, {
-        ...state,
-        loading: false,
-      });
+      return wishlistsAdapter.upsertOne(wishlist, state);
     }
   ),
   on(deleteWishlistSuccess, (state, action) => {
     const { wishlistId } = action.payload;
-    return wishlistsAdapter.removeOne(wishlistId, {
-      ...state,
-      loading: false,
-    });
+    return wishlistsAdapter.removeOne(wishlistId, state);
   }),
   on(selectWishlist, (state, action) => {
     const { id } = action.payload;


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Some reducers set their loading and error states manually when they don't have to.

## What Is the New Behavior?
Wherever possible and sensible, reducers now use setLoadingOn and unsetLoadingAndErrorOn for repetitive logic.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
