### PR TITLE
fix: hide scrollbar from navigation tabs

### DIFF
--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -123,7 +123,6 @@ img {
 .nav-tabs {
   display: block;
   margin-bottom: $space-default;
-  overflow-x: auto;
   white-space: nowrap;
 
   .nav-item {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
On the requisition page a scrollbar is shown next to the navigation bar.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What Is the New Behavior?
There is no scrollbar any more.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x No

## Other Information
