### PR TITLE
feat: replace any typescript file by configuration

### DIFF
--- a/docs/guides/customizations.md
+++ b/docs/guides/customizations.md
@@ -81,9 +81,11 @@ Typical hot-spots where copying is a good idea are header-related or product-det
 
 #### Environment Specific Copies
 
-The [customized webpack build](./optimizations.md) supports replacing HTML templates and component SCSS files with an environment suffix before the file extension.
+The [customized webpack build](./optimizations.md) supports replacing any file with an environment suffix in front of the file extension.
 If you for example want to customize the template `product-detail.component.html`, put your customized content in the parallel file `product-detail.component.brand.html` and run a build with `--configuration=brand`.
 Then this overridden component template will be swapped in.
+
+This also works for multiple configurations: `product-detail.component.foo.bar.baz.html` will be active for configurations `foo`, `bar` and `baz`, but not for `foobar`.
 
 #### Deep Copies with Replacements
 

--- a/e2e/test-schematics.sh
+++ b/e2e/test-schematics.sh
@@ -142,12 +142,15 @@ npx tsc --project tsconfig.all.json
 npx ng g add-destroy src/app/extensions/awesome/shared/dummy/dummy.component.ts
 grep destroy src/app/extensions/awesome/shared/dummy/dummy.component.ts
 
-npm run build
+echo '<p>COMPONENT_OVERRIDES</p>' > src/app/pages/home/home-page.component.local.html
+
+npm run build --configuration=local
 
 nohup bash -c "npm run serve &"
 wget -q --wait 10 --tries 10 --retry-connrefused http://localhost:4200
 
 wget -O - -q "http://localhost:4200/warehouses" | grep -q "warehouses-page works"
+wget -O - -q "http://localhost:4200/home" | grep -q "COMPONENT_OVERRIDES"
 
 npx ng g kubernetes-deployment
 find charts

--- a/package-lock.json
+++ b/package-lock.json
@@ -8893,16 +8893,6 @@
         }
       }
     },
-    "file-replace-loader": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/file-replace-loader/-/file-replace-loader-1.3.2.tgz",
-      "integrity": "sha512-nwdsqCLiMH/fyA/9Qaun9be/FOVpvat/QjLY4OQ+phL3Irv5Tgjf1QXxUc0yWX6ke7N6TXVqK4lTFux0YCSYfg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^2.7.1"
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "commitlint-config-cz": "^0.13.2",
     "conventional-changelog-cli": "2.1.1",
     "cz-customizable": "^6.3.0",
-    "file-replace-loader": "^1.3.2",
     "husky": "^4.3.8",
     "intershop-schematics": "file:schematics/src",
     "jest": "^26.6.3",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

Environment specific overrides (#537) can only override HTML templates and component styles

## What Is the New Behavior?

Any typescript file can be overridden by having the extension "<key>.ts".

File overrides can be active for multiple configurations. For example `custom.service.brand1.brand2.ts` will activate for `ng build -c brand1` and also for `ng build -c brand2`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information

This is useful for projects for overriding functionality without introducing changes in ISH sources.
