### PR TITLE
perf: use lazy properties on product context

### DIFF
--- a/src/app/core/facades/product-context.facade.spec.ts
+++ b/src/app/core/facades/product-context.facade.spec.ts
@@ -439,19 +439,22 @@ describe('Product Context Facade', () => {
       context.set('sku', () => '123');
     });
 
-    it('should set parts property for retail set', () => {
-      expect(context.get('parts')).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "quantity": 1,
-            "sku": "p1",
-          },
-          Object {
-            "quantity": 1,
-            "sku": "p2",
-          },
-        ]
-      `);
+    it('should set parts property for retail set', done => {
+      context.select('parts').subscribe(parts => {
+        expect(parts).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "quantity": 1,
+              "sku": "p1",
+            },
+            Object {
+              "quantity": 1,
+              "sku": "p2",
+            },
+          ]
+        `);
+        done();
+      });
     });
 
     it('should set correct display properties for retail set', () => {
@@ -506,19 +509,22 @@ describe('Product Context Facade', () => {
       context.set('sku', () => '123');
     });
 
-    it('should set parts property for bundle', () => {
-      expect(context.get('parts')).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "quantity": 1,
-            "sku": "p1",
-          },
-          Object {
-            "quantity": 2,
-            "sku": "p2",
-          },
-        ]
-      `);
+    it('should set parts property for bundle', done => {
+      context.select('parts').subscribe(parts => {
+        expect(parts).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "quantity": 1,
+              "sku": "p1",
+            },
+            Object {
+              "quantity": 2,
+              "sku": "p2",
+            },
+          ]
+        `);
+        done();
+      });
     });
 
     it('should set correct display properties for bundle', () => {

--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -7,9 +7,11 @@ import { debounceTime, distinctUntilChanged, filter, first, map, skip, startWith
 
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { Image } from 'ish-core/models/image/image.model';
+import { ProductLinksDictionary } from 'ish-core/models/product-links/product-links.model';
 import { ProductVariationHelper } from 'ish-core/models/product-variation/product-variation.helper';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductCompletenessLevel, ProductHelper, SkuQuantityType } from 'ish-core/models/product/product.model';
+import { Promotion } from 'ish-core/models/promotion/promotion.model';
 import { generateProductUrl } from 'ish-core/routing/product/product.route';
 import { whenTruthy } from 'ish-core/utils/operators';
 
@@ -80,8 +82,11 @@ export interface ProductContext {
   loading: boolean;
   label: string;
   categoryId: string;
-
   displayProperties: Partial<ProductContextDisplayProperties>;
+
+  // lazy
+  links: ProductLinksDictionary;
+  promotions: Promotion[];
 
   // variation handling
   variationCount: number;
@@ -108,6 +113,7 @@ export interface ProductContext {
 export class ProductContextFacade extends RxState<ProductContext> {
   private privateConfig$ = new BehaviorSubject<Partial<ProductContextDisplayProperties>>({});
   private loggingActive = false;
+  private lazyFieldsInitialized: string[] = [];
 
   set config(config: Partial<ProductContextDisplayProperties>) {
     this.privateConfig$.next(config);
@@ -275,6 +281,40 @@ export class ProductContextFacade extends RxState<ProductContext> {
     }
   }
 
+  select(): Observable<ProductContext>;
+  select<K1 extends keyof ProductContext>(k1: K1): Observable<ProductContext[K1]>;
+  select<K1 extends keyof ProductContext, K2 extends keyof ProductContext[K1]>(
+    k1: K1,
+    k2: K2
+  ): Observable<ProductContext[K1][K2]>;
+
+  select<K1 extends keyof ProductContext, K2 extends keyof ProductContext[K1]>(k1?: K1, k2?: K2) {
+    switch (k1) {
+      case 'links':
+        if (!this.lazyFieldsInitialized.includes('links')) {
+          this.connect('links', this.shoppingFacade.productLinks$(this.select('sku')));
+          this.lazyFieldsInitialized.push('links');
+        }
+        break;
+      case 'promotions':
+        if (!this.lazyFieldsInitialized.includes('promotions')) {
+          this.connect(
+            'promotions',
+            combineLatest([
+              this.select('displayProperties', 'promotions'),
+              this.select('product', 'promotionIds'),
+            ]).pipe(
+              filter(([visible]) => !!visible),
+              switchMap(([, ids]) => this.shoppingFacade.promotions$(ids))
+            )
+          );
+          this.lazyFieldsInitialized.push('promotions');
+        }
+        break;
+    }
+    return k2 ? super.select(k1, k2) : k1 ? super.select(k1) : super.select();
+  }
+
   log(val: boolean) {
     if (!this.loggingActive) {
       this.hold(this.select().pipe(filter(() => !!val)), ctx => {
@@ -340,13 +380,5 @@ export class ProductContextFacade extends RxState<ProductContext> {
           : ProductHelper.getPrimaryImage(product, imageType)
       )
     );
-  }
-
-  productLinks$() {
-    return this.shoppingFacade.productLinks$(this.select('sku'));
-  }
-
-  productPromotions$() {
-    return this.select('product', 'promotionIds').pipe(switchMap(ids => this.shoppingFacade.promotions$(ids)));
   }
 }

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -36,6 +36,7 @@ import {
   loadProduct,
   loadProductIfNotLoaded,
   loadProductLinks,
+  loadProductParts,
 } from 'ish-core/store/shopping/products';
 import { getPromotion, getPromotions, loadPromotion } from 'ish-core/store/shopping/promotions';
 import {
@@ -119,6 +120,7 @@ export class ShoppingFacade {
 
   productLinks$(sku: string | Observable<string>) {
     return toObservable(sku).pipe(
+      whenTruthy(),
       tap(plainSKU => {
         this.store.dispatch(loadProductLinks({ sku: plainSKU }));
       }),
@@ -126,10 +128,16 @@ export class ShoppingFacade {
     );
   }
 
-  // PRODUCT RETAILSET / BUNDLES
+  // PRODUCT RETAIL SET / BUNDLES
 
-  productParts$(sku: string) {
-    return this.store.pipe(select(getProductParts(sku)));
+  productParts$(sku: string | Observable<string>) {
+    return toObservable(sku).pipe(
+      whenTruthy(),
+      tap(plainSKU => {
+        this.store.dispatch(loadProductParts({ sku: plainSKU }));
+      }),
+      switchMap(plainSKU => this.store.pipe(select(getProductParts(plainSKU))))
+    );
   }
 
   // SEARCH

--- a/src/app/core/store/shopping/products/products.actions.ts
+++ b/src/app/core/store/shopping/products/products.actions.ts
@@ -53,14 +53,11 @@ export const loadProductVariationsSuccess = createAction(
   payload<{ sku: string; variations: string[]; defaultVariation: string }>()
 );
 
-export const loadProductBundlesSuccess = createAction(
-  '[Products API] Load Product Bundles Success',
-  payload<{ sku: string; bundledProducts: SkuQuantityType[] }>()
-);
+export const loadProductParts = createAction('[Products API] Load Product Parts', payload<{ sku: string }>());
 
-export const loadRetailSetSuccess = createAction(
-  '[Products API] Load Retail Set Success',
-  payload<{ sku: string; parts: string[] }>()
+export const loadProductPartsSuccess = createAction(
+  '[Products API] Load Product Parts Success',
+  payload<{ sku: string; parts: SkuQuantityType[] }>()
 );
 
 export const loadProductLinks = createAction('[Products Internal] Load Product Links', payload<{ sku: string }>());

--- a/src/app/core/store/shopping/products/products.reducer.ts
+++ b/src/app/core/store/shopping/products/products.reducer.ts
@@ -5,13 +5,12 @@ import { ProductLinksDictionary } from 'ish-core/models/product-links/product-li
 import { AllProductTypes, SkuQuantityType } from 'ish-core/models/product/product.model';
 
 import {
-  loadProductBundlesSuccess,
   loadProductFail,
   loadProductLinksSuccess,
+  loadProductPartsSuccess,
   loadProductSuccess,
   loadProductVariationsFail,
   loadProductVariationsSuccess,
-  loadRetailSetSuccess,
   productSpecialUpdate,
 } from './products.actions';
 
@@ -68,13 +67,9 @@ export const productsReducer = createReducer(
     variations: { ...state.variations, [action.payload.sku]: action.payload.variations },
     defaultVariation: { ...state.defaultVariation, [action.payload.sku]: action.payload.defaultVariation },
   })),
-  on(loadProductBundlesSuccess, (state, action) => ({
+  on(loadProductPartsSuccess, (state, action) => ({
     ...state,
-    parts: { ...state.parts, [action.payload.sku]: action.payload.bundledProducts },
-  })),
-  on(loadRetailSetSuccess, (state, action) => ({
-    ...state,
-    parts: { ...state.parts, [action.payload.sku]: action.payload.parts.map(sku => ({ sku, quantity: 1 })) },
+    parts: { ...state.parts, [action.payload.sku]: action.payload.parts },
   })),
   on(loadProductLinksSuccess, (state, action) => ({
     ...state,

--- a/src/app/core/store/shopping/products/products.selectors.spec.ts
+++ b/src/app/core/store/shopping/products/products.selectors.spec.ts
@@ -14,14 +14,13 @@ import { categoryTree } from 'ish-core/utils/dev/test-data-utils';
 
 import {
   loadProduct,
-  loadProductBundlesSuccess,
   loadProductFail,
   loadProductLinksSuccess,
+  loadProductPartsSuccess,
   loadProductSuccess,
   loadProductVariationsFail,
   loadProductVariationsIfNotLoaded,
   loadProductVariationsSuccess,
-  loadRetailSetSuccess,
 } from './products.actions';
 import {
   getBreadcrumbForProductPage,
@@ -235,9 +234,9 @@ describe('Products Selectors', () => {
     it('should contain information for the product bundle', () => {
       store$.dispatch(loadProductSuccess({ product: { sku: 'ABC' } as Product }));
       store$.dispatch(
-        loadProductBundlesSuccess({
+        loadProductPartsSuccess({
           sku: 'ABC',
-          bundledProducts: [
+          parts: [
             { sku: 'A', quantity: 1 },
             { sku: 'B', quantity: 2 },
           ],
@@ -263,9 +262,12 @@ describe('Products Selectors', () => {
     it('should contain information for the product retail set', () => {
       store$.dispatch(loadProductSuccess({ product: { sku: 'ABC' } as Product }));
       store$.dispatch(
-        loadRetailSetSuccess({
+        loadProductPartsSuccess({
           sku: 'ABC',
-          parts: ['A', 'B'],
+          parts: [
+            { sku: 'A', quantity: 1 },
+            { sku: 'B', quantity: 1 },
+          ],
         })
       );
 

--- a/src/app/pages/product/product-links/product-links.component.ts
+++ b/src/app/pages/product/product-links/product-links.component.ts
@@ -25,6 +25,6 @@ export class ProductLinksComponent implements OnInit {
   constructor(private context: ProductContextFacade) {}
 
   ngOnInit() {
-    this.links$ = this.context.productLinks$();
+    this.links$ = this.context.select('links');
   }
 }

--- a/src/app/shared/components/product/product-promotion/product-promotion.component.spec.ts
+++ b/src/app/shared/components/product/product-promotion/product-promotion.component.spec.ts
@@ -19,7 +19,7 @@ describe('Product Promotion Component', () => {
   beforeEach(async () => {
     context = mock(ProductContextFacade);
     when(context.select('displayProperties', 'promotions')).thenReturn(of(true));
-    when(context.productPromotions$()).thenReturn(EMPTY);
+    when(context.select('promotions')).thenReturn(EMPTY);
 
     await TestBed.configureTestingModule({
       declarations: [
@@ -44,7 +44,7 @@ describe('Product Promotion Component', () => {
   });
 
   it('should display the promotion when supplied', () => {
-    when(context.productPromotions$()).thenReturn(
+    when(context.select('promotions')).thenReturn(
       of([
         {
           id: 'PROMO_UUID',

--- a/src/app/shared/components/product/product-promotion/product-promotion.component.ts
+++ b/src/app/shared/components/product/product-promotion/product-promotion.component.ts
@@ -19,6 +19,6 @@ export class ProductPromotionComponent implements OnInit {
 
   ngOnInit() {
     this.visible$ = this.context.select('displayProperties', 'promotions');
-    this.promotions$ = this.context.productPromotions$();
+    this.promotions$ = this.context.select('promotions');
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

- helper methods on product context for getting promotions and links lazy
- bundle and retail set parts are always fetched

## What Is the New Behavior?

- lazy Observable properties in the ProductContext type

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Not fetching bundle and retail set information for product tiles should decrease the home page rendering time.