### PR TITLE
refactor: make display properties overridable

### DIFF
--- a/src/app/core/facades/product-context.facade.spec.ts
+++ b/src/app/core/facades/product-context.facade.spec.ts
@@ -127,7 +127,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": true,
           "quantity": false,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": false,
           "shipment": false,
           "sku": true,
@@ -303,28 +303,59 @@ describe('Product Context Facade', () => {
       });
     });
 
-    it('should set correct display properties for product', () => {
-      expect(context.get('displayProperties')).toMatchInlineSnapshot(`
-        Object {
-          "addToBasket": true,
-          "addToCompare": true,
-          "addToOrderTemplate": true,
-          "addToQuote": true,
-          "addToWishlist": true,
-          "bundleParts": false,
-          "description": true,
-          "inventory": true,
-          "name": true,
-          "price": true,
-          "promotions": true,
-          "quantity": true,
-          "readOnly": false,
-          "retailSetParts": false,
-          "shipment": true,
-          "sku": true,
-          "variations": false,
-        }
-      `);
+    describe('display properties', () => {
+      it('should set correct display properties for product', () => {
+        expect(context.get('displayProperties')).toMatchInlineSnapshot(`
+          Object {
+            "addToBasket": true,
+            "addToCompare": true,
+            "addToOrderTemplate": true,
+            "addToQuote": true,
+            "addToWishlist": true,
+            "bundleParts": false,
+            "description": true,
+            "inventory": true,
+            "name": true,
+            "price": true,
+            "promotions": true,
+            "quantity": true,
+            "readOnly": undefined,
+            "retailSetParts": false,
+            "shipment": true,
+            "sku": true,
+            "variations": false,
+          }
+        `);
+      });
+
+      it('should include external displayProperty overrides when calculating', () => {
+        context.config = {
+          readOnly: true,
+          name: false,
+        };
+
+        expect(context.get('displayProperties')).toMatchInlineSnapshot(`
+          Object {
+            "addToBasket": true,
+            "addToCompare": true,
+            "addToOrderTemplate": true,
+            "addToQuote": true,
+            "addToWishlist": true,
+            "bundleParts": false,
+            "description": true,
+            "inventory": true,
+            "name": false,
+            "price": true,
+            "promotions": true,
+            "quantity": true,
+            "readOnly": true,
+            "retailSetParts": false,
+            "shipment": true,
+            "sku": true,
+            "variations": false,
+          }
+        `);
+      });
     });
   });
 
@@ -472,7 +503,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": true,
           "quantity": false,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": true,
           "shipment": false,
           "sku": true,
@@ -542,7 +573,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": true,
           "quantity": true,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": false,
           "shipment": true,
           "sku": true,
@@ -586,7 +617,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": true,
           "quantity": true,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": false,
           "shipment": true,
           "sku": true,
@@ -628,7 +659,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": true,
           "quantity": false,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": false,
           "shipment": false,
           "sku": true,
@@ -734,7 +765,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": false,
           "quantity": true,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": false,
           "shipment": false,
           "sku": true,
@@ -764,7 +795,7 @@ describe('Product Context Facade', () => {
           "price": true,
           "promotions": false,
           "quantity": true,
-          "readOnly": false,
+          "readOnly": undefined,
           "retailSetParts": false,
           "shipment": false,
           "sku": true,
@@ -775,6 +806,37 @@ describe('Product Context Facade', () => {
       someOther$.next(true);
 
       expect(context.get('displayProperties', 'price')).toMatchInlineSnapshot(`false`);
+    });
+
+    it('should include external displayProperty overrides when calculating', () => {
+      context.set('sku', () => '456');
+
+      context.config = {
+        readOnly: true,
+        name: false,
+      };
+
+      expect(context.get('displayProperties')).toMatchInlineSnapshot(`
+        Object {
+          "addToBasket": false,
+          "addToCompare": false,
+          "addToOrderTemplate": false,
+          "addToQuote": false,
+          "addToWishlist": false,
+          "bundleParts": false,
+          "description": true,
+          "inventory": true,
+          "name": false,
+          "price": true,
+          "promotions": false,
+          "quantity": true,
+          "readOnly": true,
+          "retailSetParts": false,
+          "shipment": false,
+          "sku": true,
+          "variations": false,
+        }
+      `);
     });
   });
 });

--- a/src/app/core/utils/product-context-display-properties/product-context-display-properties.service.ts
+++ b/src/app/core/utils/product-context-display-properties/product-context-display-properties.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  ExternalDisplayPropertiesProvider,
+  ProductContextDisplayProperties,
+} from 'ish-core/facades/product-context.facade';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { ProductHelper } from 'ish-core/models/product/product.helper';
+
+@Injectable({ providedIn: 'root' })
+export class ProductContextDisplayPropertiesService implements ExternalDisplayPropertiesProvider {
+  setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
+    return product$.pipe(
+      map(product => {
+        const canBeOrdered = !ProductHelper.isMasterProduct(product) && product.available;
+
+        const canBeOrderedNotRetail = canBeOrdered && !ProductHelper.isRetailSet(product);
+
+        const calc = {
+          inventory: !ProductHelper.isRetailSet(product) && !ProductHelper.isMasterProduct(product),
+          quantity: canBeOrderedNotRetail,
+          variations: ProductHelper.isVariationProduct(product),
+          bundleParts: ProductHelper.isProductBundle(product),
+          retailSetParts: ProductHelper.isRetailSet(product),
+          shipment:
+            canBeOrderedNotRetail &&
+            Number.isInteger(product.readyForShipmentMin) &&
+            Number.isInteger(product.readyForShipmentMax),
+          addToBasket: canBeOrdered,
+          addToWishlist: !ProductHelper.isMasterProduct(product),
+          addToOrderTemplate: canBeOrdered,
+          addToCompare: !ProductHelper.isMasterProduct(product),
+          addToQuote: canBeOrdered,
+        };
+
+        return (
+          Object.entries(calc)
+            // tslint:disable-next-line: no-boolean-literal-compare
+            .filter(([, v]) => v === false)
+            .reduce((acc, [k, v]) => ({ ...acc, [k]: v as false }), {})
+        );
+      })
+    );
+  }
+}


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

it is hard to override default product context display property configuration without touching the `product-context.facade.ts` file

## What Is the New Behavior?

externalized calculation for easy overriding in projects.
see also #616 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
