### PR TITLE
feat: display only available products in product links carousels and lists

### DIFF
--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
@@ -1,9 +1,9 @@
-<div *ngIf="links.products.length" class="product-list-container">
+<div *ngIf="productSKUs.length" class="product-list-container">
   <h2>{{ productLinkTitle }}</h2>
 
   <div class="product-list">
     <swiper [config]="swiperConfig">
-      <div *ngFor="let sku of links.products" class="swiper-slide">
+      <div *ngFor="let sku of productSKUs" class="swiper-slide">
         <ng-template swiperSlide>
           <ish-product-item ishProductContext [sku]="sku"></ish-product-item>
         </ng-template>

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
@@ -1,14 +1,16 @@
-<div *ngIf="productSKUs.length" class="product-list-container">
-  <h2>{{ productLinkTitle }}</h2>
+<ng-container *ngIf="productSKUs$ | async as productSKUs">
+  <div *ngIf="productSKUs.length" class="product-list-container">
+    <h2>{{ productLinkTitle }}</h2>
 
-  <div class="product-list">
-    <swiper [config]="swiperConfig">
-      <div *ngFor="let sku of productSKUs" class="swiper-slide">
-        <ng-template swiperSlide>
-          <ish-product-item ishProductContext [sku]="sku"></ish-product-item>
-        </ng-template>
-      </div>
-    </swiper>
-    <div class="swiper-pagination"></div>
+    <div class="product-list">
+      <swiper [config]="swiperConfig">
+        <div *ngFor="let sku of productSKUs" class="swiper-slide">
+          <ng-template swiperSlide>
+            <ish-product-item ishProductContext [sku]="sku"></ish-product-item>
+          </ng-template>
+        </div>
+      </swiper>
+      <div class="swiper-pagination"></div>
+    </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockDirective } from 'ng-mocks';
+import { of } from 'rxjs';
 import { SwiperComponent } from 'swiper/angular';
-import { instance, mock } from 'ts-mockito';
+import { anything, instance, mock, when } from 'ts-mockito';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductLinksCarouselComponent } from './product-links-carousel.component';
@@ -18,6 +20,7 @@ describe('Product Links Carousel Component', () => {
 
   beforeEach(async () => {
     shoppingFacade = mock(ShoppingFacade);
+
     await TestBed.configureTestingModule({
       declarations: [
         MockComponent(ProductItemComponent),
@@ -30,7 +33,7 @@ describe('Product Links Carousel Component', () => {
   });
 
   beforeEach(() => {
-    const productLink = { products: ['sku'], categories: ['catID'] } as ProductLinks;
+    const productLink = { products: ['sku1', 'sku2', 'sku3'], categories: ['catID'] } as ProductLinks;
 
     fixture = TestBed.createComponent(ProductLinksCarouselComponent);
     component = fixture.componentInstance;
@@ -41,7 +44,28 @@ describe('Product Links Carousel Component', () => {
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
+    expect(() => component.ngOnChanges()).not.toThrow();
     expect(() => fixture.detectChanges()).not.toThrow();
     expect(element.querySelector('swiper')).toBeTruthy();
+  });
+
+  it('should render all product slides if stocks filtering is off', () => {
+    component.filterInStock = false;
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(element.querySelectorAll('.swiper-slide')).toHaveLength(3);
+  });
+
+  it('should render only available product slides if stocks filtering is on', () => {
+    when(shoppingFacade.product$(anything(), anything())).thenCall(sku =>
+      of({ sku, available: sku !== 'sku2' } as ProductView)
+    );
+
+    component.filterInStock = true;
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(element.querySelectorAll('.swiper-slide')).toHaveLength(2);
   });
 });

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
@@ -50,7 +50,7 @@ describe('Product Links Carousel Component', () => {
   });
 
   it('should render all product slides if stocks filtering is off', () => {
-    component.filterInStock = false;
+    component.displayOnlyAvailableProducts = false;
     component.ngOnChanges();
     fixture.detectChanges();
 
@@ -62,7 +62,7 @@ describe('Product Links Carousel Component', () => {
       of({ sku, available: sku !== 'sku2' } as ProductView)
     );
 
-    component.filterInStock = true;
+    component.displayOnlyAvailableProducts = true;
     component.ngOnChanges();
     fixture.detectChanges();
 

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { SwiperComponent } from 'swiper/angular';
+import { instance, mock } from 'ts-mockito';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
@@ -12,8 +14,10 @@ describe('Product Links Carousel Component', () => {
   let component: ProductLinksCarouselComponent;
   let fixture: ComponentFixture<ProductLinksCarouselComponent>;
   let element: HTMLElement;
+  let shoppingFacade: ShoppingFacade;
 
   beforeEach(async () => {
+    shoppingFacade = mock(ShoppingFacade);
     await TestBed.configureTestingModule({
       declarations: [
         MockComponent(ProductItemComponent),
@@ -21,6 +25,7 @@ describe('Product Links Carousel Component', () => {
         MockDirective(ProductContextDirective),
         ProductLinksCarouselComponent,
       ],
+      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
     }).compileComponents();
   });
 

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -34,11 +34,10 @@ export class ProductLinksCarouselComponent implements OnChanges {
    * title that should displayed for the specific product link type
    */
   @Input() productLinkTitle: string;
-
   /**
-   * if true only in-stock products are displayed
+   * display only available products if set to 'true'
    */
-  @Input() filterInStock = false;
+  @Input() displayOnlyAvailableProducts = false;
 
   productSKUs$: Observable<string[]>;
 
@@ -82,7 +81,7 @@ export class ProductLinksCarouselComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    this.productSKUs$ = this.filterInStock
+    this.productSKUs$ = this.displayOnlyAvailableProducts
       ? combineLatest(
           this.links.products.map(sku => this.shoppingFacade.product$(sku, ProductCompletenessLevel.List))
         ).pipe(map(products => products.filter(p => p.available).map(p => p.sku)))

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -36,7 +36,7 @@ export class ProductLinksCarouselComponent implements OnChanges {
   @Input() productLinkTitle: string;
 
   /**
-   * configuration to filter products which are not inStock
+   * if true only in-stock products are displayed
    */
   @Input() filterInStock = false;
 

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -1,9 +1,14 @@
-import { ChangeDetectionStrategy, Component, Inject, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { SwiperOptions } from 'swiper';
 import SwiperCore, { Navigation, Pagination } from 'swiper/core';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 
 SwiperCore.use([Navigation, Pagination]);
 
@@ -21,7 +26,7 @@ SwiperCore.use([Navigation, Pagination]);
   templateUrl: './product-links-carousel.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProductLinksCarouselComponent {
+export class ProductLinksCarouselComponent implements OnInit, OnDestroy {
   /**
    * list of products which are assigned to the specific product link type
    */
@@ -32,6 +37,14 @@ export class ProductLinksCarouselComponent {
   @Input() productLinkTitle: string;
 
   /**
+   * configuration to filter products which are not inStock
+   */
+  @Input() filterInStock = false;
+
+  productSKUs: Array<string> = [];
+  private destroy$ = new Subject();
+  private products: Array<ProductView> = [];
+  /**
    * configuration of swiper carousel
    * find possible parameters here: http://idangero.us/swiper/api/#parameters
    */
@@ -39,7 +52,9 @@ export class ProductLinksCarouselComponent {
 
   constructor(
     @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: number,
-    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: number
+    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: number,
+    private ref: ChangeDetectorRef,
+    private shoppingFacade: ShoppingFacade
   ) {
     this.swiperConfig = {
       direction: 'horizontal',
@@ -67,5 +82,31 @@ export class ProductLinksCarouselComponent {
         clickableClass: 'swiper-pagination-clickable',
       },
     };
+  }
+
+  ngOnInit() {
+    if (!this.filterInStock) {
+      this.productSKUs = this.links.products;
+    } else {
+      this.links.products.forEach(sku =>
+        this.shoppingFacade
+          .product$(sku, ProductCompletenessLevel.List)
+          .pipe(takeUntil(this.destroy$))
+          .subscribe(p => this.collectSKUs(p))
+      );
+    }
+  }
+
+  collectSKUs(product: ProductView) {
+    this.products.push(product);
+    if (this.products.length === this.links.products.length) {
+      this.productSKUs = this.products.filter(p => p.available).map(p => p.sku);
+      this.ref.detectChanges();
+    }
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/pages/product/product-links-list/product-links-list.component.html
+++ b/src/app/pages/product/product-links-list/product-links-list.component.html
@@ -1,8 +1,10 @@
-<div *ngIf="links.products.length" class="product-list-container">
-  <h2>{{ productLinkTitle }}</h2>
-  <div class="product-list">
-    <div *ngFor="let sku of links.products" class="product-list-item list-view">
-      <ish-product-item ishProductContext [sku]="sku" displayType="row"></ish-product-item>
+<ng-container *ngIf="productSKUs$ | async as productSKUs">
+  <div *ngIf="productSKUs.length" class="product-list-container">
+    <h2>{{ productLinkTitle }}</h2>
+    <div class="product-list">
+      <div *ngFor="let sku of productSKUs" class="product-list-item list-view">
+        <ish-product-item ishProductContext [sku]="sku" displayType="row"></ish-product-item>
+      </div>
     </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/pages/product/product-links-list/product-links-list.component.spec.ts
+++ b/src/app/pages/product/product-links-list/product-links-list.component.spec.ts
@@ -48,7 +48,7 @@ describe('Product Links List Component', () => {
   });
 
   it('should render all product slides if stocks filtering is off', () => {
-    component.filterInStock = false;
+    component.displayOnlyAvailableProducts = false;
     component.ngOnChanges();
     fixture.detectChanges();
 
@@ -60,7 +60,7 @@ describe('Product Links List Component', () => {
       of({ sku, available: sku !== 'sku2' } as ProductView)
     );
 
-    component.filterInStock = true;
+    component.displayOnlyAvailableProducts = true;
     component.ngOnChanges();
     fixture.detectChanges();
 

--- a/src/app/pages/product/product-links-list/product-links-list.component.spec.ts
+++ b/src/app/pages/product/product-links-list/product-links-list.component.spec.ts
@@ -1,8 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockDirective } from 'ng-mocks';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductLinksListComponent } from './product-links-list.component';
@@ -11,19 +15,23 @@ describe('Product Links List Component', () => {
   let component: ProductLinksListComponent;
   let fixture: ComponentFixture<ProductLinksListComponent>;
   let element: HTMLElement;
+  let shoppingFacade: ShoppingFacade;
 
   beforeEach(async () => {
+    shoppingFacade = mock(ShoppingFacade);
+
     await TestBed.configureTestingModule({
       declarations: [
         MockComponent(ProductItemComponent),
         MockDirective(ProductContextDirective),
         ProductLinksListComponent,
       ],
+      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    const productLink = { products: ['sku'], categories: ['catID'] } as ProductLinks;
+    const productLink = { products: ['sku1', 'sku2', 'sku3'], categories: ['catID'] } as ProductLinks;
 
     fixture = TestBed.createComponent(ProductLinksListComponent);
     component = fixture.componentInstance;
@@ -34,21 +42,28 @@ describe('Product Links List Component', () => {
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
+    expect(() => component.ngOnChanges()).not.toThrow();
     expect(() => fixture.detectChanges()).not.toThrow();
-    expect(element).toMatchInlineSnapshot(`
-      <div class="product-list-container">
-        <h2></h2>
-        <div class="product-list">
-          <div class="product-list-item list-view">
-            <ish-product-item
-              displaytype="row"
-              ishproductcontext=""
-              ng-reflect-display-type="row"
-              ng-reflect-sku="sku"
-            ></ish-product-item>
-          </div>
-        </div>
-      </div>
-    `);
+    expect(element.querySelector('.product-list')).toBeTruthy();
+  });
+
+  it('should render all product slides if stocks filtering is off', () => {
+    component.filterInStock = false;
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(element.querySelectorAll('ish-product-item')).toHaveLength(3);
+  });
+
+  it('should render only available products  if stocks filtering is on', () => {
+    when(shoppingFacade.product$(anything(), anything())).thenCall(sku =>
+      of({ sku, available: sku !== 'sku2' } as ProductView)
+    );
+
+    component.filterInStock = true;
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(element.querySelectorAll('ish-product-item')).toHaveLength(2);
   });
 });

--- a/src/app/pages/product/product-links-list/product-links-list.component.ts
+++ b/src/app/pages/product/product-links-list/product-links-list.component.ts
@@ -30,16 +30,16 @@ export class ProductLinksListComponent implements OnChanges {
    */
   @Input() productLinkTitle: string;
   /**
-   * if true only in-stock products are displayed
+   * display only available products if set to 'true'
    */
-  @Input() filterInStock = false;
+  @Input() displayOnlyAvailableProducts = false;
 
   productSKUs$: Observable<string[]>;
 
   constructor(private shoppingFacade: ShoppingFacade) {}
 
   ngOnChanges() {
-    this.productSKUs$ = this.filterInStock
+    this.productSKUs$ = this.displayOnlyAvailableProducts
       ? combineLatest(
           this.links.products.map(sku => this.shoppingFacade.product$(sku, ProductCompletenessLevel.List))
         ).pipe(map(products => products.filter(p => p.available).map(p => p.sku)))

--- a/src/app/pages/product/product-links/product-links.component.html
+++ b/src/app/pages/product/product-links/product-links.component.html
@@ -2,6 +2,7 @@
   <ng-container *ngIf="links.upselling?.products?.length">
     <ish-product-links-list
       [links]="links.upselling"
+      [filterInStock]="true"
       [productLinkTitle]="'product.product_links.upselling.title' | translate"
     ></ish-product-links-list>
   </ng-container>

--- a/src/app/pages/product/product-links/product-links.component.html
+++ b/src/app/pages/product/product-links/product-links.component.html
@@ -2,8 +2,8 @@
   <ng-container *ngIf="links.upselling?.products?.length">
     <ish-product-links-list
       [links]="links.upselling"
-      [filterInStock]="true"
       [productLinkTitle]="'product.product_links.upselling.title' | translate"
+      [displayOnlyAvailableProducts]="true"
     ></ish-product-links-list>
   </ng-container>
   <ng-container *ngIf="links.spareparts?.products?.length">
@@ -16,7 +16,7 @@
     <ish-product-links-carousel
       [links]="links.crossselling"
       [productLinkTitle]="'product.product_links.crossselling.title' | translate"
-      [filterInStock]="true"
+      [displayOnlyAvailableProducts]="true"
     ></ish-product-links-carousel>
   </ng-container>
   <ng-container *ngIf="links.accessory?.products?.length">

--- a/src/app/pages/product/product-links/product-links.component.html
+++ b/src/app/pages/product/product-links/product-links.component.html
@@ -15,6 +15,7 @@
     <ish-product-links-carousel
       [links]="links.crossselling"
       [productLinkTitle]="'product.product_links.crossselling.title' | translate"
+      [filterInStock]="true"
     ></ish-product-links-carousel>
   </ng-container>
   <ng-container *ngIf="links.accessory?.products?.length">


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

The product links carousels/lists (cross-sellings, up-sellings. accessories, replacements, etc.) have no option to filter products out that are not available.

## What Is the New Behavior?

The product links carousel and product links list now have an input parameter `displayOnlyAvailableProducts` to configure if you want to display only available products. Via the parameter it can be controlled which lists should only present sell-able products (e.g. up-selling, cross-selling) and which lists should list products even if they are not available right now (e.g. spare parts).

## Does this PR Introduce a Breaking Change?

[x] No
