### PR TITLE
refactor: use formly for update password form

### DIFF
--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.html
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.html
@@ -1,32 +1,10 @@
-<form [formGroup]="form" (ngSubmit)="submitPasswordForm()" class="form-horizontal" novalidate="novalidate">
-  <ish-input
-    [form]="form"
-    controlName="password"
-    type="password"
-    label="account.register.password.label"
-    markRequiredLabel="off"
-    [errorMessages]="{
-      required: 'account.update_password.new_password.error.required',
-      minLength: 'account.update_password.new_password.error.length',
-      password: 'account.update_password.new_password.error.regexp'
-    }"
-    ><small class="input-help">{{ 'account.register.password.extrainfo.message' | translate: { '0': '7' } }}</small>
-  </ish-input>
-
-  <ish-input
-    [form]="form"
-    controlName="passwordConfirmation"
-    type="password"
-    markRequiredLabel="on"
-    label="account.register.password_confirmation.label"
-    markRequiredLabel="off"
-    [errorMessages]="{
-      required: 'account.register.password_confirmation.error.default',
-      password: 'account.update_password.new_password.error.regexp',
-      equalTo: 'account.update_password.confirm_password.error.stringcompare'
-    }"
-  ></ish-input>
-
+<form
+  [formGroup]="updatePasswordForm"
+  (ngSubmit)="submitPasswordForm()"
+  class="form-horizontal"
+  novalidate="novalidate"
+>
+  <formly-form [form]="updatePasswordForm" [fields]="fields"></formly-form>
   <div class="row">
     <div class="offset-md-4 col-md-8">
       <button

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.spec.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { anything, spy, verify } from 'ts-mockito';
 
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { UpdatePasswordFormComponent } from './update-password-form.component';
 
@@ -14,8 +13,8 @@ describe('Update Password Form Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MockComponent(InputComponent), UpdatePasswordFormComponent],
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [UpdatePasswordFormComponent],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 
@@ -33,8 +32,30 @@ describe('Update Password Form Component', () => {
 
   it('should render forgot password form step 2 for password reminder', () => {
     fixture.detectChanges();
-    expect(element.querySelector('ish-input[controlname=password]')).toBeTruthy();
-    expect(element.querySelector('ish-input[controlname=passwordConfirmation]')).toBeTruthy();
+
+    expect(element.innerHTML.match(/ish-password-field/g)).toHaveLength(2);
+    expect(element.innerHTML).toContain('password');
+    expect(element.innerHTML).toContain('passwordConfirmation');
+
     expect(element.querySelector('[name="SubmitButton"]')).toBeTruthy();
+  });
+
+  it('should emit updatePassword event if form is valid', () => {
+    const eventEmitter$ = spy(component.submitPassword);
+    fixture.detectChanges();
+
+    component.updatePasswordForm.get('password').setValue('!Password01!');
+    component.updatePasswordForm.get('passwordConfirmation').setValue('!Password01!');
+    component.submitPasswordForm();
+
+    verify(eventEmitter$.emit(anything())).once();
+  });
+
+  it('should disable submit button when the user submits an invalid form', () => {
+    fixture.detectChanges();
+
+    expect(component.buttonDisabled).toBeFalse();
+    component.submitPasswordForm();
+    expect(component.buttonDisabled).toBeTrue();
   });
 });

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
 
 import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
@@ -23,34 +24,67 @@ export class UpdatePasswordFormComponent implements OnInit {
    */
   @Output() submitPassword = new EventEmitter<{ password: string }>();
 
-  password: string;
-
-  form: FormGroup;
+  updatePasswordForm = new FormGroup({});
+  fields: FormlyFieldConfig[];
   submitted = false;
 
   ngOnInit() {
-    this.form = new FormGroup(
+    this.fields = [
       {
-        password: new FormControl('', [Validators.required, SpecialValidators.password]),
-        passwordConfirmation: new FormControl('', [Validators.required, SpecialValidators.password]),
+        key: 'password',
+        type: 'ish-password-field',
+        templateOptions: {
+          postWrappers: ['description'],
+          required: true,
+          hideRequiredMarker: true,
+          label: 'account.register.password.label',
+          customDescription: {
+            class: 'input-help',
+            key: 'account.register.password.extrainfo.message',
+            args: { 0: '7' },
+          },
+        },
+        validation: {
+          messages: {
+            required: 'account.update_password.new_password.error.required',
+            minLength: 'account.update_password.new_password.error.length',
+          },
+        },
       },
-      SpecialValidators.equalTo('passwordConfirmation', 'password')
-    );
+      {
+        key: 'passwordConfirmation',
+        type: 'ish-password-field',
+        templateOptions: {
+          required: true,
+          hideRequiredMarker: true,
+          label: 'account.register.password_confirmation.label',
+        },
+        validators: {
+          validation: [SpecialValidators.equalToControl('password')],
+        },
+        validation: {
+          messages: {
+            required: 'account.register.password_confirmation.error.default',
+            equalTo: 'account.update_password.confirm_password.error.stringcompare',
+          },
+        },
+      },
+    ];
   }
 
   submitPasswordForm() {
-    if (this.form.invalid) {
+    if (this.updatePasswordForm.invalid) {
       this.submitted = true;
-      markAsDirtyRecursive(this.form);
+      markAsDirtyRecursive(this.updatePasswordForm);
       return;
     }
 
     this.submitPassword.emit({
-      password: this.form.get('password').value,
+      password: this.updatePasswordForm.get('password').value,
     });
   }
 
   get buttonDisabled() {
-    return this.form.invalid && this.submitted;
+    return this.updatePasswordForm.invalid && this.submitted;
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Update password form uses the reactive form implementation.

## What Is the New Behavior?

Update password form uses formly for the forms.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No
