### PR TITLE
fix: use absolute root for all static resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN node schematics/customization/service-worker ${serviceWorker} || true
 COPY templates/webpack/* /workspace/templates/webpack/
 ARG testing=false
 ENV TESTING=${testing}
-RUN npm run ng -- build -c ${configuration}
+RUN npm run ng -- build -c ${configuration} --deploy-url=/
 # synchronize-marker:pwa-docker-build:end
 
 # ^ this part above is copied to Dockerfile_noSSR and should be kept in sync

--- a/Dockerfile_noSSR
+++ b/Dockerfile_noSSR
@@ -17,7 +17,7 @@ RUN node schematics/customization/service-worker ${serviceWorker} || true
 COPY templates/webpack/* /workspace/templates/webpack/
 ARG testing=false
 ENV TESTING=${testing}
-RUN npm run ng -- build -c ${configuration}
+RUN npm run ng -- build -c ${configuration} --deploy-url=/
 # synchronize-marker:pwa-docker-build:end
 
 # ^ this part above is copied from the standard Dockerfile and should be kept in sync

--- a/src/app/core/internationalization.module.ts
+++ b/src/app/core/internationalization.module.ts
@@ -7,7 +7,7 @@ import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-transla
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 export function translateFactory(http: HttpClient) {
-  return new TranslateHttpLoader(http, 'assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, '/assets/i18n/', '.json');
 }
 
 @NgModule({

--- a/src/app/core/utils/theme/theme.service.ts
+++ b/src/app/core/utils/theme/theme.service.ts
@@ -44,31 +44,31 @@ export class ThemeService {
         const themeName = themeData[0];
         const themeColor = themeData[1];
 
-        this.trySetAttribute('link[rel="icon"]', 'href', `assets/themes/${themeName}/img/favicon.ico`);
-        this.trySetAttribute('link[rel="manifest"]', 'href', `assets/themes/${themeName}/manifest.webmanifest`);
+        this.trySetAttribute('link[rel="icon"]', 'href', `/assets/themes/${themeName}/img/favicon.ico`);
+        this.trySetAttribute('link[rel="manifest"]', 'href', `/assets/themes/${themeName}/manifest.webmanifest`);
         this.trySetAttribute(
           'link[rel="apple-touch-icon"]:not([sizes])',
           'href',
-          `assets/themes/${themeName}/img/logo_apple_120x120.png`
+          `/assets/themes/${themeName}/img/logo_apple_120x120.png`
         );
         this.trySetAttribute(
           'link[rel="apple-touch-icon"][sizes="152x152"]',
           'href',
-          `assets/themes/${themeName}/img/logo_apple_152x152.png`
+          `/assets/themes/${themeName}/img/logo_apple_152x152.png`
         );
         this.trySetAttribute(
           'link[rel="apple-touch-icon"][sizes="167x167"]',
           'href',
-          `assets/themes/${themeName}/img/logo_apple_167x167.png`
+          `/assets/themes/${themeName}/img/logo_apple_167x167.png`
         );
         this.trySetAttribute(
           'link[rel="apple-touch-icon"][sizes="180x180"]',
           'href',
-          `assets/themes/${themeName}/img/logo_apple_180x180.png`
+          `/assets/themes/${themeName}/img/logo_apple_180x180.png`
         );
         this.trySetAttribute('meta[name="theme-color"]', 'content', `#${themeColor}`);
 
-        await this.loadCss(`${themeName}.css`);
+        await this.loadCss(`/${themeName}.css`);
       });
     }
   }

--- a/src/app/pages/basket/shopping-basket-empty/shopping-basket-empty.component.html
+++ b/src/app/pages/basket/shopping-basket-empty/shopping-basket-empty.component.html
@@ -8,7 +8,11 @@
 <ish-basket-validation-results></ish-basket-validation-results>
 
 <div class="empty-cart">
-  <img class="empty-cart-icon" src="assets/img/empty-cart.png" alt="{{ 'shopping_cart.empty.alt.text' | translate }}" />
+  <img
+    class="empty-cart-icon"
+    src="/assets/img/empty-cart.png"
+    alt="{{ 'shopping_cart.empty.alt.text' | translate }}"
+  />
 
   <h2>{{ 'shopping_cart.empty.text' | translate }}</h2>
 

--- a/src/index.html
+++ b/src/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8" />
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="assets/themes/default/img/favicon.ico" />
-    <link rel="apple-touch-icon" href="assets/themes/default/img/logo_apple_120x120.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="assets/themes/default/img/logo_apple_152x152.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="assets/themes/default/img/logo_apple_180x180.png" />
-    <link rel="apple-touch-icon" sizes="167x167" href="assets/themes/default/img/logo_apple_167x167.png" />
-    <link rel="manifest" href="assets/themes/default/manifest.webmanifest" />
+    <link rel="icon" type="image/x-icon" href="/assets/themes/default/img/favicon.ico" />
+    <link rel="apple-touch-icon" href="/assets/themes/default/img/logo_apple_120x120.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="/assets/themes/default/img/logo_apple_152x152.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/themes/default/img/logo_apple_180x180.png" />
+    <link rel="apple-touch-icon" sizes="167x167" href="/assets/themes/default/img/logo_apple_167x167.png" />
+    <link rel="manifest" href="/assets/themes/default/manifest.webmanifest" />
     <meta name="theme-color" content="#ff6d00" />
     <style>
       .svg-inline--fa {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

Workaround for Issue Number: Closes #624 

## What Is the New Behavior?

All static resources explicitly use absolute URLs from root.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

This is just a workaround to fix the issue. I'd like to propose a feature for setting the deploy URL at runtime later, that will also fix this issue (by falling back to / for all URLs if the feature is not used).