### PR TITLE
fix: adapt nginx Dockerfile to nginx-prometheus-exporter changes (#632)

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
   apt-get clean && \
   rm -r /var/cache/apt /var/lib/apt/lists
 COPY --from=buildstep /usr/local/nginx /usr/local/nginx
-COPY --from=nginx/nginx-prometheus-exporter /usr/bin/exporter /nginx-prometheus-exporter
+COPY --from=nginx/nginx-prometheus-exporter:0.9.0 /usr/bin/nginx-prometheus-exporter /nginx-prometheus-exporter
 COPY --from=configstep / /
 RUN chmod 777 /gomplate
 ENV NPSC_ENABLE_FILTERS=in_place_optimize_for_browser,prioritize_critical_css,inline_preview_images,lazyload_images,rewrite_images,rewrite_css,remove_comments,move_css_to_head,move_css_above_scripts,collapse_whitespace,combine_javascript,extend_cache NPSC_JsPreserveURLs=off NPSC_ImagePreserveURLs=on NPSC_ForceCaching=off CACHE=on COMPRESSION=on PAGESPEED=on DEVICE_DETECTION=on


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Running `docker build -t nginx nginx` currently results in an error for the `nginx/nginx-prometheus-exporter` step.

Issue Number: Closes #632

## What Is the New Behavior?

`nginx` docker build is working again.

## Does this PR Introduce a Breaking Change?

[x] No


