### PR TITLE
chore: adjust tslint rule for express/router

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-// tslint:disable: no-console ish-ordered-imports force-jsdoc-comments
+// tslint:disable: no-console ish-ordered-imports force-jsdoc-comments ban-specific-imports
 import 'zone.js/dist/zone-node';
 
 import * as express from 'express';

--- a/tslint-rules/src/banSpecificImportsRule.ts
+++ b/tslint-rules/src/banSpecificImportsRule.ts
@@ -62,14 +62,27 @@ export class Rule extends Lint.Rules.AbstractRule {
         }
 
         if (pattern.import) {
-          importList
-            .filter(token => new RegExp(pattern.import).test(token.getText()))
-            .forEach(token =>
-              ctx.addFailureAtNode(
-                token,
-                pattern.message || `Using '${token.getText()}' from '${fromStringText}' is banned.`
-              )
+          if (pattern.fix && importList.every(token => new RegExp(pattern.import).test(token.getText()))) {
+            const fix = new Lint.Replacement(
+              fromStringToken.getStart(),
+              fromStringToken.getWidth(),
+              `'${fromStringText.replace(new RegExp(pattern.from), pattern.fix)}'`
             );
+            ctx.addFailureAtNode(
+              fromStringToken,
+              pattern.message || `Using '${fromStringToken.getText()}' from '${fromStringText}' is banned.`,
+              fix
+            );
+          } else {
+            importList
+              .filter(token => new RegExp(pattern.import).test(token.getText()))
+              .forEach(token =>
+                ctx.addFailureAtNode(
+                  token,
+                  pattern.message || `Using '${token.getText()}' from '${fromStringText}' is banned.`
+                )
+              );
+          }
         } else {
           let fix;
           if (pattern.fix) {

--- a/tslint.json
+++ b/tslint.json
@@ -264,7 +264,8 @@
         {
           "import": "^Router$",
           "from": "^express$",
-          "message": "Most likely you would've wanted to import the angular router instead."
+          "message": "Most likely you would've wanted to import the angular router instead.",
+          "fix": "@angular/router"
         },
         {
           "from": "^[\\./]*/core/(.*)$",

--- a/tslint.json
+++ b/tslint.json
@@ -262,6 +262,11 @@
           "message": "Most likely you would've wanted to import the model instead."
         },
         {
+          "import": "^Router$",
+          "from": "^express$",
+          "message": "Most likely you would've wanted to import the angular router instead."
+        },
+        {
           "from": "^[\\./]*/core/(.*)$",
           "message": "Use import alias ish-core",
           "fix": "ish-core/$1"


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: tslint rule change

## What Is the Current Behavior?

I often import the express router instead of @angular/router on accident.

## What Is the New Behavior?

You now get a tslint rule warning when importing the wrong router.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
