### PR TITLE
refactor: use formly for forgot password form (request reminder form)

### DIFF
--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.html
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.html
@@ -1,17 +1,5 @@
-<form name="LoginUserForm" [formGroup]="form" class="form-horizontal" (ngSubmit)="submitForm()">
-  <ish-input
-    [form]="form"
-    controlName="email"
-    type="email"
-    label="account.forgotdata.email.label"
-    markRequiredLabel="off"
-    [errorMessages]="{
-      required: 'account.email.error.required',
-      email: 'account.email.error.email'
-    }"
-  ></ish-input>
-
-  <ish-lazy-captcha topic="forgotPassword" [form]="form" cssClass="offset-md-4 col-md-8"></ish-lazy-captcha>
+<form name="LoginUserForm" [formGroup]="requestReminderForm" class="form-horizontal" (ngSubmit)="submitForm()">
+  <formly-form [form]="requestReminderForm" [fields]="fields"></formly-form>
 
   <div class="row form-group">
     <div class="offset-md-4 col-md-8">

--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.spec.ts
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.spec.ts
@@ -1,11 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
 
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
-
-import { LazyCaptchaComponent } from '../../../extensions/captcha/exports/lazy-captcha/lazy-captcha.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { RequestReminderFormComponent } from './request-reminder-form.component';
 
@@ -16,8 +12,8 @@ describe('Request Reminder Form Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MockComponent(InputComponent), MockComponent(LazyCaptchaComponent), RequestReminderFormComponent],
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [RequestReminderFormComponent],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 
@@ -36,8 +32,8 @@ describe('Request Reminder Form Component', () => {
   it('should render forgot password form for password reminder', () => {
     fixture.detectChanges();
 
-    expect(element.querySelector('ish-input[controlname=email]')).toBeTruthy();
-    expect(element.querySelector('[name="passwordReminder"]')).toBeTruthy();
+    expect(element.innerHTML.match(/ish-email-field/g)).toHaveLength(1);
+    expect(element.innerHTML).toContain('passwordReminder');
   });
 
   describe('email format', () => {
@@ -46,13 +42,13 @@ describe('Request Reminder Form Component', () => {
     });
 
     it('should not detect error if email is well formed', () => {
-      component.form.controls.email.setValue('test@test.com');
-      expect(component.form.controls.email.valid).toBeTruthy();
+      component.requestReminderForm.controls.email.setValue('test@test.com');
+      expect(component.requestReminderForm.controls.email.valid).toBeTruthy();
     });
 
     it('should detect error if email is malformed', () => {
-      component.form.controls.email.setValue('testtest.com');
-      expect(component.form.controls.email.valid).toBeFalsy();
+      component.requestReminderForm.controls.email.setValue('testtest.com');
+      expect(component.requestReminderForm.controls.email.invalid).toBeFalsy();
     });
   });
 });

--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
 
 import { PasswordReminder } from 'ish-core/models/password-reminder/password-reminder.model';
 import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
-import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 /**
  * The Request Reminder Form Component displays a Forgot Password Request Reminder form and triggers the submit.
@@ -24,28 +24,47 @@ export class RequestReminderFormComponent implements OnInit {
    */
   @Output() submitPasswordReminder = new EventEmitter<PasswordReminder>();
 
-  form: FormGroup;
   submitted = false;
 
+  requestReminderForm = new FormGroup({});
+  fields: FormlyFieldConfig[];
+
   ngOnInit() {
-    this.form = new FormGroup({
-      email: new FormControl('', [Validators.required, SpecialValidators.email]),
-      captcha: new FormControl(''),
-      captchaAction: new FormControl('forgotPassword'),
-    });
+    this.fields = [
+      {
+        key: 'email',
+        type: 'ish-email-field',
+        templateOptions: {
+          label: 'account.forgotdata.email.label',
+          hideRequiredMarker: true,
+          required: true,
+        },
+        validation: {
+          messages: {
+            required: 'account.email.error.required',
+          },
+        },
+      },
+      {
+        type: 'ish-captcha-field',
+        templateOptions: {
+          topic: 'forgotPassword',
+        },
+      },
+    ];
   }
 
   get buttonDisabled() {
-    return this.form.invalid && this.submitted;
+    return this.requestReminderForm.invalid && this.submitted;
   }
 
   submitForm() {
-    if (this.form.invalid) {
+    if (this.requestReminderForm.invalid) {
       this.submitted = true;
-      markAsDirtyRecursive(this.form);
+      markAsDirtyRecursive(this.requestReminderForm);
       return;
     }
 
-    this.submitPasswordReminder.emit(this.form.value);
+    this.submitPasswordReminder.emit(this.requestReminderForm.value);
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Forgot password form (request-reminder-form.component) uses the reactive form implementation.

## What Is the New Behavior?

Forgot password form uses formly for the form.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No
