### PR TITLE
refactor: use formly for order template preferences form

### DIFF
--- a/e2e/cypress/integration/pages/account/order-templates-overview.page.ts
+++ b/e2e/cypress/integration/pages/account/order-templates-overview.page.ts
@@ -9,7 +9,7 @@ export class OrderTemplatesOverviewPage {
 
   addOrderTemplate(name: string) {
     cy.get('a[data-testing-id="add-order-template"').click();
-    cy.get('[data-testing-id="order-template-dialog-name"]').find('[data-testing-id="title"]').clear().type(name);
+    cy.get('[data-testing-id="title"]').clear().type(name);
     cy.get('[data-testing-id="order-template-dialog-submit"]').click();
   }
 

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
@@ -13,20 +13,9 @@
   </div>
 
   <div class="modal-body">
-    <form [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm(); addModal.close('')">
+    <form [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm()">
       <!-- TODO: Show server error -->
-      <ish-input
-        [form]="orderTemplateForm"
-        controlName="title"
-        label="account.order_template.form.name.label"
-        markRequiredLabel="off"
-        [maxlength]="35"
-        [errorMessages]="{
-          required: 'account.order_template.form.name.error.required',
-          maxlength: 'account.order_template.form.name.error.maxlength'
-        }"
-        data-testing-id="order-template-dialog-name"
-      ></ish-input>
+      <formly-form [form]="orderTemplateForm" [fields]="fields" [model]="model"></formly-form>
     </form>
   </div>
 
@@ -40,7 +29,7 @@
     >
       {{ primaryButton | translate }}
     </button>
-    <button type="button" class="btn btn-secondary" (click)="addModal.close('')">
+    <button type="button" class="btn btn-secondary" (click)="hide()">
       {{ 'account.cancel.button.label' | translate }}
     </button>
   </div>

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.spec.ts
@@ -1,10 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
 import { anything, capture, spy, verify } from 'ts-mockito';
 
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { OrderTemplatePreferencesDialogComponent } from './order-template-preferences-dialog.component';
 
@@ -15,8 +13,8 @@ describe('Order Template Preferences Dialog Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MockComponent(InputComponent), OrderTemplatePreferencesDialogComponent],
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [OrderTemplatePreferencesDialogComponent],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 
@@ -34,9 +32,9 @@ describe('Order Template Preferences Dialog Component', () => {
 
   it('should emit new order template data when submit form was called and the form was valid', () => {
     fixture.detectChanges();
-    component.orderTemplateForm.setValue({
+    component.model = {
       title: 'test order template',
-    });
+    };
 
     const emitter = spy(component.submit);
 
@@ -53,7 +51,6 @@ describe('Order Template Preferences Dialog Component', () => {
   });
 
   it('should not emit new order template data when submit form was called and the form was invalid', () => {
-    component.ngOnChanges();
     fixture.detectChanges();
     const emitter = spy(component.submit);
     component.submitOrderTemplateForm();

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -163,7 +163,6 @@
   "account.order_template.delete.do_you_really.text": "Wollen Sie diese Bestellvorlage wirklich löschen?",
   "account.order_template.delete_order_template.confirmation": "Ihre Bestellvorlage \"{{0}}\" wurde gelöscht.",
   "account.order_template.edit.heading": "Bestellvorlage bearbeiten",
-  "account.order_template.form.name.error.maxlength": "Der Name der Bestellvorlage darf nicht länger als 35 Zeichen sein. ",
   "account.order_template.form.name.error.required": "Geben Sie einen Namen für die Bestellvorlage an.",
   "account.order_template.form.name.label": "Name der Bestellvorlage",
   "account.order_template.items": {

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -163,7 +163,6 @@
   "account.order_template.delete.do_you_really.text": "Do you really want to delete this order template?",
   "account.order_template.delete_order_template.confirmation": "Your order template \"{{0}}\" has been deleted.",
   "account.order_template.edit.heading": "Edit Order Template",
-  "account.order_template.form.name.error.maxlength": "The order template name must not exceed 35 characters.",
   "account.order_template.form.name.error.required": "Please enter an order template name.",
   "account.order_template.form.name.label": "Order Template Name",
   "account.order_template.items": {

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -163,7 +163,6 @@
   "account.order_template.delete.do_you_really.text": "Voulez-vous vraiment supprimer ce modèle de commande ?",
   "account.order_template.delete_order_template.confirmation": "Votre modèle de commande \"{{0}}\" a été supprimé.",
   "account.order_template.edit.heading": "Modifier le modèle de commande",
-  "account.order_template.form.name.error.maxlength": "Le nom du modèle de commande ne doit pas dépasser 35 caractères. ",
   "account.order_template.form.name.error.required": "Veuillez entrer un nom pour le modèle de commande.",
   "account.order_template.form.name.label": "Nom du modèle de commande",
   "account.order_template.items": {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Order template forms (order-template-preferences-dialog, select-order-template-modal) use the reactive form implementation.

## What Is the New Behavior?

Order template forms use formly for the form.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No

