### PR TITLE
fix: auth0 silentRefresh requires offline_access scope

### DIFF
--- a/src/app/core/identity-provider/auth0.identity-provider.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.ts
@@ -66,7 +66,7 @@ export class Auth0IdentityProvider implements IdentityProvider {
 
       // Scopes ("rights") the Angular application wants get delegated
       // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-      scope: 'openid email profile',
+      scope: 'openid email profile offline_access',
 
       // Using Authorization Code Flow
       // (PKCE is activated by default for authorization code flow)


### PR DESCRIPTION
see: https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/refreshing-a-token.html

![image](https://user-images.githubusercontent.com/23452927/113397316-1ec04e00-939d-11eb-96be-1c28a8ef4c90.png)


<!--

## PR Type
[X] Bugfix

## What Is the Current Behavior?

The authentication flow uses an automatic silent refresh, which is responsible to refresh the id and auth token before it expires. Currently this refresh token is failing: 
![image](https://user-images.githubusercontent.com/62572390/113348176-2f85ab00-932e-11eb-9541-91a593001bd6.png)

And according to the documentation, the offline_access scope is required to trigger the silent refresh.

![image](https://user-images.githubusercontent.com/62572390/113348321-58a63b80-932e-11eb-8b99-72c7fa336ab8.png)


## What Is the New Behavior?
Adding the offline_access scope will properly refresh the tokens before they expire.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[X] No

## Other Information
