### PR TITLE
fix: basket acceleration if cost center is required but missing

### DIFF
--- a/src/app/core/models/basket-validation/basket-validation.model.ts
+++ b/src/app/core/models/basket-validation/basket-validation.model.ts
@@ -10,6 +10,7 @@ export type BasketValidationScopeType =
   | 'Shipping'
   | 'Payment'
   | 'Promotion'
+  | 'CostCenter'
   | 'All'
   /* no scope: a minimum is validated */
   | '';

--- a/src/app/core/store/customer/basket/basket-validation.effects.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.ts
@@ -46,7 +46,7 @@ export class BasketValidationEffects {
     { scopes: ['InvoiceAddress', 'ShippingAddress', 'Addresses'], route: '/checkout/address' },
     { scopes: ['Shipping'], route: '/checkout/shipping' },
     { scopes: ['Payment'], route: '/checkout/payment' },
-    { scopes: ['All'], route: '/checkout/review' },
+    { scopes: ['All', 'CostCenter'], route: '/checkout/review' }, // ToDo: has to be changed if the cost center approval has been implemented
     { scopes: ['All'], route: 'auto' }, // targetRoute will be calculated in dependence of the validation result
   ];
 


### PR DESCRIPTION

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If a cost center approval is required for a complete basket the basket acceleration doesn't work properly. The user cannot enter the checkout any more.

Issue Number: Closes #

## What Is the New Behavior?
The user is routed to the checkout review page in this case.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
Steps to repeat:
- login as jlink@test.intershop.de
- add some products to basket, basket total has to be more than 500 USD
- click the 'checkout' button on cart page
- continue the checkout process until you reach the review page
- go back to cart page 
- click checkout
- => nothing happens

