### PR TITLE
fix: display a product unavailable image on product detail page

### DIFF
--- a/src/app/pages/product/product-images/product-images.component.spec.ts
+++ b/src/app/pages/product/product-images/product-images.component.spec.ts
@@ -16,9 +16,10 @@ describe('Product Images Component', () => {
   let component: ProductImagesComponent;
   let fixture: ComponentFixture<ProductImagesComponent>;
   let element: HTMLElement;
+  let context: ProductContextFacade;
 
   beforeEach(async () => {
-    const context = mock(ProductContextFacade);
+    context = mock(ProductContextFacade);
     when(context.select('product')).thenReturn(
       of({
         sku: 'sku',
@@ -116,5 +117,18 @@ describe('Product Images Component', () => {
   it('should render product image component on component', () => {
     fixture.detectChanges();
     expect(element.getElementsByTagName('ish-product-image')).toBeTruthy();
+  });
+
+  it('should render product image unavailable on component', () => {
+    when(context.select('product')).thenReturn(
+      of({
+        sku: 'sku',
+        name: 'Lenco',
+        images: [],
+      } as ProductView)
+    );
+
+    fixture.detectChanges();
+    expect(element.getElementsByTagName('ish-product-image')).toHaveLength(2);
   });
 });

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -37,8 +37,11 @@ export class ProductImagesComponent implements OnInit {
     this.product$ = this.context.select('product');
   }
 
-  getImageViewIDs$(imageType: string) {
-    return this.product$.pipe(map(p => ProductHelper.getImageViewIDs(p, imageType)));
+  getImageViewIDs$(imageType: string): Observable<string[]> {
+    return this.product$.pipe(
+      map(p => ProductHelper.getImageViewIDs(p, imageType)),
+      map(ids => (ids?.length ? ids : ['default']))
+    );
   }
 
   /**


### PR DESCRIPTION

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the product has no product images of size 'L' there is no product image displayed on product detail page.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What Is the New Behavior?
A fallback product image (not_available.png) is shown 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
see ISREST-1168
