### PR TITLE
feat: add feature toggle for guest checkout

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,10 @@ kb_sync_latest_only
 
 # Migrations
 
+## 0.29 to 0.30
+
+We introduced the feature toggle 'guestCheckout' in the `environment.model.ts`.
+
 ## 0.28 to 0.29
 
 We activated TypeScript's [`noImplicitAny`](https://www.typescriptlang.org/tsconfig#noImplicitAny).

--- a/e2e/cypress/integration/pages/checkout/checkout-addresses.page.ts
+++ b/e2e/cypress/integration/pages/checkout/checkout-addresses.page.ts
@@ -13,6 +13,11 @@ export class CheckoutAddressesPage {
     waitLoadingEnd(1000);
   }
 
+  registerBeforeCheckout() {
+    cy.get('a[data-testing-id="registration-link"]').click();
+    waitLoadingEnd(1000);
+  }
+
   fillInvoiceAddressForm(address: AddressDetailsTypes, email: string) {
     Object.keys(address).forEach(key => fillFormField('[data-testing-id="invoiceAddressForm"]', key, address[key]));
     fillFormField(this.tag, 'email', email);
@@ -65,5 +70,9 @@ export class CheckoutAddressesPage {
 
   get infoMessage() {
     return cy.get('ish-basket-validation-results').find('.alert-info');
+  }
+
+  get invoiceToAddress() {
+    return cy.get(`[data-testing-id="invoiceToAddress"]`).find('address');
   }
 }

--- a/e2e/cypress/integration/specs/checkout/register-before-checkout.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/register-before-checkout.b2c.e2e-spec.ts
@@ -1,0 +1,64 @@
+import { at } from '../../framework';
+import { Registration, RegistrationPage, sensibleDefaults } from '../../pages/account/registration.page';
+import { CartPage } from '../../pages/checkout/cart.page';
+import { AddressDetailsTypes, CheckoutAddressesPage } from '../../pages/checkout/checkout-addresses.page';
+import { ProductDetailPage } from '../../pages/shopping/product-detail.page';
+
+const _ = {
+  catalog: 'Home-Entertainment',
+  category: {
+    id: 'Home-Entertainment.SmartHome',
+    name: 'Smart Home',
+  },
+  product: {
+    sku: '201807171',
+    price: 185.5,
+  },
+  address: {
+    countryCode: 'DE',
+    firstName: 'Pablo',
+    lastName: 'Parkes',
+    addressLine1: 'Marbacher Str. 87',
+    city: 'Stuttgart',
+    postalCode: '12345',
+  } as AddressDetailsTypes,
+  email: 'p.parkes@test.com',
+  user: {
+    login: `testuser${new Date().getTime()}@test.intershop.de`,
+    ...sensibleDefaults,
+  } as Registration,
+};
+
+describe('Anonymous Checkout with registration', () => {
+  before(() => {
+    ProductDetailPage.navigateTo(_.product.sku);
+  });
+
+  it('should add a product to cart', () => {
+    at(ProductDetailPage, page => {
+      page.addProductToCart().its('response.statusCode').should('equal', 201);
+      page.header.miniCart.total.should('contain', _.product.price);
+      page.header.miniCart.goToCart();
+    });
+    at(CartPage);
+  });
+
+  it('should start checkout by navigating to the registration page', () => {
+    at(CartPage, page => page.beginCheckout());
+    at(CheckoutAddressesPage, page => {
+      page.registerBeforeCheckout();
+    });
+    at(RegistrationPage);
+  });
+
+  it('should continue checkout after registration', () => {
+    at(RegistrationPage, page => {
+      page.fillForm(_.user);
+      page.acceptTAC();
+      page.submitAndObserve().its('response.statusCode').should('equal', 201);
+    });
+    at(CheckoutAddressesPage, page => {
+      page.invoiceToAddress.should('contain', _.user.lastName);
+    });
+  });
+});

--- a/scripts/init-local-environment.js
+++ b/scripts/init-local-environment.js
@@ -31,7 +31,7 @@ const b2b = 0;
 
 const extraFeatures: typeof environment.features =
   // default
-  b2b ? ['advancedVariationHandling', 'businessCustomerRegistration', 'quoting', 'quickorder', 'orderTemplates', 'punchout'] : ['wishlists'];
+  b2b ? ['advancedVariationHandling', 'businessCustomerRegistration', 'quoting', 'quickorder', 'orderTemplates', 'punchout'] : ['guestCheckout', 'wishlists'];
   // none
   // [];
 

--- a/src/app/core/services/registration-form-configuration/registration-form-configuration.service.spec.ts
+++ b/src/app/core/services/registration-form-configuration/registration-form-configuration.service.spec.ts
@@ -124,6 +124,7 @@ describe('Registration Form Configuration Service', () => {
       expect(registrationConfigurationService.extractConfig(snapshot)).toMatchInlineSnapshot(`
         Object {
           "businessCustomer": false,
+          "cancelUrl": undefined,
           "sso": false,
           "userId": undefined,
         }
@@ -132,7 +133,7 @@ describe('Registration Form Configuration Service', () => {
 
     it('should set configuration parameters depending on router', () => {
       const snapshot = {
-        queryParams: { userid: 'uid' } as Params,
+        queryParams: { userid: 'uid', cancelUrl: '/checkout' } as Params,
         url: [{ path: '/register' } as UrlSegment, { path: 'sso' } as UrlSegment],
       } as ActivatedRouteSnapshot;
       when(featureToggleService.enabled(anyString())).thenReturn(true);
@@ -140,6 +141,7 @@ describe('Registration Form Configuration Service', () => {
       expect(registrationConfigurationService.extractConfig(snapshot)).toMatchInlineSnapshot(`
         Object {
           "businessCustomer": true,
+          "cancelUrl": "/checkout",
           "sso": true,
           "userId": "uid",
         }

--- a/src/app/core/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/core/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -20,6 +20,7 @@ export interface RegistrationConfigType {
   businessCustomer?: boolean;
   sso?: boolean;
   userId?: string;
+  cancelUrl?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -37,6 +38,7 @@ export class RegistrationFormConfigurationService {
       sso: !!route.url.find(segment => segment.path.includes('sso')),
       userId: route.queryParams.userid,
       businessCustomer: this.featureToggle.enabled('businessCustomerRegistration'),
+      cancelUrl: route.queryParams.cancelUrl,
     };
   }
 
@@ -167,7 +169,7 @@ export class RegistrationFormConfigurationService {
   }
 
   cancelRegistrationForm(config: RegistrationConfigType): void {
-    config.sso ? this.accountFacade.cancelRegistration() : this.router.navigate(['/home']);
+    config.sso ? this.accountFacade.cancelRegistration() : this.router.navigate([config.cancelUrl ?? '/home']);
   }
 
   canDeactivate(config: RegistrationConfigType): boolean | Observable<boolean> {

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
@@ -10,7 +10,7 @@
     <ish-identity-provider-login></ish-identity-provider-login>
   </div>
   <!-- checkout as guest -->
-  <div class="col-lg-6">
+  <div *ishFeature="'guestCheckout'" class="col-lg-6">
     <h2>{{ 'checkout.addresses.checkout_as_guest.heading' | translate }}</h2>
     <p>{{ 'checkout.address.anonymous.guestcheckout.text' | translate }}</p>
     <button

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
@@ -4,106 +4,133 @@
     <ish-error-message [error]="error" [toast]="false"></ish-error-message>
   </div>
 
-  <!--- login --->
+  <!-- login -->
   <div class="col-lg-6">
     <h2>{{ 'checkout.account.login.returning_customer.heading' | translate }}</h2>
     <ish-identity-provider-login></ish-identity-provider-login>
   </div>
-  <!-- checkout as guest -->
-  <div *ishFeature="'guestCheckout'" class="col-lg-6">
-    <h2>{{ 'checkout.addresses.checkout_as_guest.heading' | translate }}</h2>
-    <p>{{ 'checkout.address.anonymous.guestcheckout.text' | translate }}</p>
-    <button
-      *ngIf="isAddressFormCollapsed"
-      class="btn btn-secondary"
-      type="button"
-      (click)="showAddressForm()"
-      [attr.aria-expanded]="!isAddressFormCollapsed"
-      aria-controls="collapseBasic"
-      data-testing-id="guest-checkout-button"
-    >
-      {{ 'checkout.addresses.checkout_as_guest.heading' | translate }}
-    </button>
 
-    <!-- create address form -->
-    <div
-      id="collapseBasic"
-      class="section"
-      [ngbCollapse]="isAddressFormCollapsed"
-      data-testing-id="create-address-form"
-    >
-      <form
-        #addressForm="ngForm"
-        [formGroup]="form"
-        (ngSubmit)="submitAddressForm()"
-        class="form-horizontal"
-        novalidate="novalidate"
+  <div class="col-lg-6">
+    <!-- registration -->
+    <div class="section">
+      <h2>{{ 'account.new_user.heading' | translate }}</h2>
+      <p>{{ 'account.create.benefit.text' | translate }}</p>
+      <ul>
+        <li>{{ 'account.create.benefit1.text' | translate }}</li>
+        <li>{{ 'account.create.benefit2.text' | translate }}</li>
+        <li>{{ 'account.create.benefit3.text' | translate }}</li>
+        <li>{{ 'account.create.benefit4.text' | translate }}</li>
+        <li>{{ 'account.create.benefit5.text' | translate }}</li>
+      </ul>
+      <a
+        class="btn btn-secondary"
+        routerLink="/register"
+        [queryParams]="{ returnUrl: '/checkout', cancelUrl: '/checkout' }"
+        data-testing-id="registration-link"
+        >{{ 'account.create.button.label' | translate }}
+      </a>
+    </div>
+
+    <!-- checkout as guest -->
+    <div *ishFeature="'guestCheckout'">
+      <h2>{{ 'checkout.addresses.checkout_as_guest.heading' | translate }}</h2>
+      <p>{{ 'checkout.address.anonymous.guestcheckout.text' | translate }}</p>
+      <button
+        *ngIf="isAddressFormCollapsed"
+        class="btn btn-secondary"
+        type="button"
+        (click)="showAddressForm()"
+        [attr.aria-expanded]="!isAddressFormCollapsed"
+        aria-controls="collapseBasic"
+        data-testing-id="guest-checkout-button"
       >
-        <h3 class="subheading">{{ 'checkout.addresses.billing_address.heading' | translate }}</h3>
-        <p class="indicates-required">
-          <span class="required">*</span>{{ 'account.required_field.message' | translate }}
-        </p>
-        <!-- Invoice Address -->
-        <ish-formly-address-form #invoiceAddress data-testing-id="invoiceAddressForm" [parentForm]="invoiceAddressForm">
-        </ish-formly-address-form>
-        <!-- Taxation ID input field -->
-        <ish-input
-          *ishFeature="'businessCustomerRegistration'"
-          [form]="form"
-          controlName="taxationID"
-          label="account.address.taxation.label"
-        ></ish-input>
-        <!-- Email address input field-->
-        <ish-input
-          [form]="form"
-          controlName="email"
-          type="email"
-          label="checkout.addresses.email.label"
-          [errorMessages]="{
-            required: 'account.email.error.email',
-            email: 'checkout.addresses.email.invalid.error'
-          }"
-        ></ish-input>
-        <div class="offset-md-4 col-md-8">
-          <small class="form-text">{{ 'account.address.email.hint' | translate }}</small>
-        </div>
+        {{ 'checkout.addresses.checkout_as_guest.heading' | translate }}
+      </button>
 
-        <!-- Shipping Address Selection Radio boxes-->
-        <div class="section">
-          <h3>{{ 'checkout.addresses.shipping_address.heading' | translate }}</h3>
-          <div class="radio">
-            <label for="shipOption1">
-              <input type="radio" formControlName="shipOption" value="shipToInvoiceAddress" id="shipOption1" />
-              {{ 'checkout.addresses.shipping_address.option1.text' | translate }}
-            </label>
-          </div>
-          <div class="radio">
-            <label for="shipOption2">
-              <input type="radio" formControlName="shipOption" value="shipToDifferentAddress" id="shipOption2" />
-              {{ 'checkout.addresses.shipping_address.option2.text' | translate }}
-            </label>
-          </div>
-        </div>
-        <div [ngbCollapse]="!isShippingAddressFormExpanded" data-testing-id="shipping-address-form">
-          <!-- Shipping Address -->
+      <!-- create address form -->
+      <div
+        id="collapseBasic"
+        class="section"
+        [ngbCollapse]="isAddressFormCollapsed"
+        data-testing-id="create-address-form"
+      >
+        <form
+          #addressForm="ngForm"
+          [formGroup]="form"
+          (ngSubmit)="submitAddressForm()"
+          class="form-horizontal"
+          novalidate="novalidate"
+        >
+          <h3 class="subheading">{{ 'checkout.addresses.billing_address.heading' | translate }}</h3>
+          <p class="indicates-required">
+            <span class="required">*</span>{{ 'account.required_field.message' | translate }}
+          </p>
+          <!-- Invoice Address -->
           <ish-formly-address-form
-            #shippingAddress
-            data-testing-id="shippingAddressForm"
-            [parentForm]="shippingAddressForm"
+            #invoiceAddress
+            data-testing-id="invoiceAddressForm"
+            [parentForm]="invoiceAddressForm"
           >
           </ish-formly-address-form>
-        </div>
-        <div [ngClass]="{ 'row form-group': isShippingAddressFormExpanded }">
-          <div [ngClass]="{ 'offset-md-4 col-md-8': isShippingAddressFormExpanded }">
-            <button class="btn btn-primary" type="submit" [disabled]="nextDisabled">
-              {{ 'checkout.button.label' | translate }}
-            </button>
-            <button (click)="cancelAddressForm()" type="button" class="btn btn-secondary">
-              {{ 'checkout.address.cancel.button.label' | translate }}
-            </button>
+          <!-- Taxation ID input field -->
+          <ish-input
+            *ishFeature="'businessCustomerRegistration'"
+            [form]="form"
+            controlName="taxationID"
+            label="account.address.taxation.label"
+          ></ish-input>
+          <!-- Email address input field-->
+          <ish-input
+            [form]="form"
+            controlName="email"
+            type="email"
+            label="checkout.addresses.email.label"
+            [errorMessages]="{
+              required: 'account.email.error.email',
+              email: 'checkout.addresses.email.invalid.error'
+            }"
+          ></ish-input>
+          <div class="offset-md-4 col-md-8">
+            <small class="form-text">{{ 'account.address.email.hint' | translate }}</small>
           </div>
-        </div>
-      </form>
+
+          <!-- Shipping Address Selection Radio boxes-->
+          <div class="section">
+            <h3>{{ 'checkout.addresses.shipping_address.heading' | translate }}</h3>
+            <div class="radio">
+              <label for="shipOption1">
+                <input type="radio" formControlName="shipOption" value="shipToInvoiceAddress" id="shipOption1" />
+                {{ 'checkout.addresses.shipping_address.option1.text' | translate }}
+              </label>
+            </div>
+            <div class="radio">
+              <label for="shipOption2">
+                <input type="radio" formControlName="shipOption" value="shipToDifferentAddress" id="shipOption2" />
+                {{ 'checkout.addresses.shipping_address.option2.text' | translate }}
+              </label>
+            </div>
+          </div>
+          <div [ngbCollapse]="!isShippingAddressFormExpanded" data-testing-id="shipping-address-form">
+            <!-- Shipping Address -->
+            <ish-formly-address-form
+              #shippingAddress
+              data-testing-id="shippingAddressForm"
+              [parentForm]="shippingAddressForm"
+            >
+            </ish-formly-address-form>
+          </div>
+          <div [ngClass]="{ 'row form-group': isShippingAddressFormExpanded }">
+            <div [ngClass]="{ 'offset-md-4 col-md-8': isShippingAddressFormExpanded }">
+              <button class="btn btn-primary" type="submit" [disabled]="nextDisabled">
+                {{ 'checkout.button.label' | translate }}
+              </button>
+              <button (click)="cancelAddressForm()" type="button" class="btn btn-secondary">
+                {{ 'checkout.address.cancel.button.label' | translate }}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
@@ -37,6 +38,7 @@ describe('Checkout Address Anonymous Component', () => {
         FeatureToggleModule.forTesting('guestCheckout'),
         NgbCollapseModule,
         ReactiveFormsModule,
+        RouterTestingModule,
         TranslateModule.forRoot(),
       ],
       providers: [{ provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) }],
@@ -59,6 +61,11 @@ describe('Checkout Address Anonymous Component', () => {
   it('should render login container component on page', () => {
     fixture.detectChanges();
     expect(element.querySelector('ish-identity-provider-login')).toBeTruthy();
+  });
+
+  it('should render registration link on page', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('a[data-testing-id="registration-link"]')).toBeTruthy();
   });
 
   it('should initially have shipping and invoice address forms on page', () => {

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
@@ -2,11 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent, MockDirective } from 'ng-mocks';
+import { MockComponent } from 'ng-mocks';
 import { anything, instance, mock, verify } from 'ts-mockito';
 
-import { FeatureToggleDirective } from 'ish-core/directives/feature-toggle.directive';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
 import { IdentityProviderLoginComponent } from 'ish-shared/components/login/identity-provider-login/identity-provider-login.component';
@@ -32,9 +32,13 @@ describe('Checkout Address Anonymous Component', () => {
         MockComponent(FormlyAddressFormComponent),
         MockComponent(IdentityProviderLoginComponent),
         MockComponent(InputComponent),
-        MockDirective(FeatureToggleDirective),
       ],
-      imports: [NgbCollapseModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      imports: [
+        FeatureToggleModule.forTesting('guestCheckout'),
+        NgbCollapseModule,
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+      ],
       providers: [{ provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) }],
     }).compileComponents();
   });

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -39,6 +39,7 @@ export interface Environment {
     | 'tracking'
     | 'tacton'
     /* B2C features */
+    | 'guestCheckout'
     | 'wishlists'
   )[];
 
@@ -104,8 +105,8 @@ export const ENVIRONMENT_DEFAULTS: Environment = {
   icmApplication: 'rest',
   identityProvider: 'ICM',
 
-  /* FEATURE TOGGLES */
-  features: ['compare', 'recently', 'rating', 'wishlists'],
+  /* FEATURE TOOGLES */
+  features: ['compare', 'guestCheckout', 'recently', 'rating', 'wishlists'],
 
   /* PROGRESSIVE WEB APP CONFIGURATIONS */
   smallBreakpointWidth: 576,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Anonymous users are allowed to checkout and order items.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #638

## What Is the New Behavior?
The guest checkout can be enabled/disabled with the help of the feature toggle 'guestCheckout' in the environment.ts.
It is possible to register after the user has started the checkout process. After registration he is automatically navigated back to the checkout.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] Yes, the guest checkout has to be enabled in the environment.ts, otherwise this feature is not available.
[ ] No

## Other Information

Limitations: In case of SSO the user is not automatically navigated back to the checkout after login/registration.