### PR TITLE
feat: load translations with webpack

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -219,21 +219,27 @@ To dynamically set the default locale, use the URL parameter `lang` when rewriti
 
 ## Extend Locales
 
-To add other languages except English, German or French, you have to create a new json-mapping-file with all translations, e.g., _./src/assets/i18n/nl_NL.json_).
-Add the locale in the file _./src/environment/environments.ts_.
-Additionally, for Angular's built-in components, e.g., currency-pipe, you have to register locale data similar to `localeDe` and `localeFr` with `registerLocaleData(localeNl)` in _./src/app/core/configuration.module.ts._
+To add other languages except English, German or French:
 
-```typescript
-...
-import localeNl from '@angular/common/locales/nl';
-...
-export class ConfigurationModule {
-  constructor(@Inject(LOCALE_ID) lang: string, translateService: TranslateService) {
-    registerLocaleData(localeNl);
-    ...
-  }
-}
-```
+1. Create a new json-mapping-file with all translations, e.g., `src/assets/i18n/nl_NL.json`.
+
+2. Add the locale to the environments under `src/environments`, e.g.
+
+   ```typescript
+    { lang: 'nl_NL', currency: 'EUR', value: 'nl', displayName: 'Dutch', displayLong: 'Dutch (Netherlands)' }
+   ```
+
+3. Import the Angular locale data in the [`InternationalizationModule`](../../src/app/core/internationalization.module.ts):
+
+   ```typescript
+   import localeNl from '@angular/common/locales/nl';
+   ```
+
+4. Register the locale using `registerLocaleData` in the constructor:
+
+   ```typescript
+   registerLocaleData(localeNl);
+   ```
 
 # Further References
 

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -1,111 +1,18 @@
-import { HTTP_INTERCEPTORS, HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler, NgModule } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 import { ServerModule, ServerTransferStateModule } from '@angular/platform-server';
 import { META_REDUCERS } from '@ngrx/store';
-import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
-import { Observable, OperatorFunction, combineLatest, of, throwError } from 'rxjs';
-import { catchError, first, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 
 import { configurationMeta } from 'ish-core/configurations/configuration.meta';
-import { COOKIE_CONSENT_VERSION, DISPLAY_VERSION, SSR_TRANSLATIONS } from 'ish-core/configurations/state-keys';
+import { COOKIE_CONSENT_VERSION, DISPLAY_VERSION } from 'ish-core/configurations/state-keys';
 import { UniversalLogInterceptor } from 'ish-core/interceptors/universal-log.interceptor';
 import { UniversalMockInterceptor } from 'ish-core/interceptors/universal-mock.interceptor';
-import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
 
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
-
-type Translations = Record<string, string | Record<string, string>>;
-
-function appendSlash(): OperatorFunction<string, string> {
-  return (source$: Observable<string>) => source$.pipe(map(url => `${url}/`));
-}
-
-function filterAndTransformKeys(translations: Record<string, string>): Translations {
-  const filtered: Translations = {};
-  const prefix = /^pwa-/;
-  for (const key in translations) {
-    if (prefix.test(key)) {
-      const value = translations[key];
-      try {
-        const parsed = JSON.parse(value);
-        filtered[key.replace(prefix, '')] = parsed;
-      } catch {
-        filtered[key.replace(prefix, '')] = value;
-      }
-    }
-  }
-  return filtered;
-}
-
-class TranslateUniversalLoader implements TranslateLoader {
-  constructor(
-    private stateProperties: StatePropertiesService,
-    private httpClient: HttpClient,
-    private transferState: TransferState
-  ) {}
-
-  getTranslation(lang: string): Observable<string> {
-    const local$ = of(lang).pipe(
-      map(() => {
-        let rootPath = process.cwd();
-        if (rootPath && rootPath.indexOf('browser') > 0) {
-          rootPath = process.cwd().split('browser')[0];
-        }
-        const file = join(rootPath, 'dist', 'browser', 'assets', 'i18n', `${lang}.json`);
-        if (!existsSync(file)) {
-          const errString = `Localization file '${file}' not found!`;
-          console.error(errString);
-          return throwError(errString);
-        } else {
-          return JSON.parse(readFileSync(file, 'utf8'));
-        }
-      })
-    );
-    return this.icmURL.pipe(
-      switchMap(url =>
-        this.httpClient.get(`${url};loc=${lang}/localizations`, {
-          params: {
-            searchKeys: 'pwa-',
-          },
-        })
-      ),
-      map(filterAndTransformKeys),
-      withLatestFrom(local$),
-      map(([translations, localTranslations]) => ({
-        ...localTranslations,
-        ...translations,
-      })),
-      tap((translations: Translations) => this.transferState.set(SSR_TRANSLATIONS, translations)),
-      catchError(() => local$)
-    );
-  }
-
-  get icmURL(): Observable<string> {
-    return combineLatest([
-      this.stateProperties.getStateOrEnvOrDefault('ICM_BASE_URL', 'icmBaseURL').pipe(appendSlash()),
-      this.stateProperties.getStateOrEnvOrDefault('ICM_SERVER', 'icmServer').pipe(appendSlash()),
-      this.stateProperties.getStateOrEnvOrDefault('ICM_CHANNEL', 'icmChannel').pipe(appendSlash()),
-      this.stateProperties.getStateOrEnvOrDefault('ICM_APPLICATION', 'icmApplication'),
-    ]).pipe(
-      first(),
-      map(arr => arr.join(''))
-    );
-  }
-}
-
-export function translateLoaderFactory(
-  stateProperties: StatePropertiesService,
-  httpClient: HttpClient,
-  transferState: TransferState
-) {
-  return new TranslateUniversalLoader(stateProperties, httpClient, transferState);
-}
 
 export class UniversalErrorHandler implements ErrorHandler {
   handleError(error: Error): void {
@@ -118,18 +25,7 @@ export class UniversalErrorHandler implements ErrorHandler {
 }
 
 @NgModule({
-  imports: [
-    AppModule,
-    ServerModule,
-    ServerTransferStateModule,
-    TranslateModule.forRoot({
-      loader: {
-        provide: TranslateLoader,
-        useFactory: translateLoaderFactory,
-        deps: [StatePropertiesService, HttpClient, TransferState],
-      },
-    }),
-  ],
+  imports: [AppModule, ServerModule, ServerTransferStateModule],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: UniversalMockInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UniversalLogInterceptor, multi: true },

--- a/src/app/core/internationalization.module.ts
+++ b/src/app/core/internationalization.module.ts
@@ -15,21 +15,22 @@ import { whenTruthy } from './utils/operators';
 
 export type Translations = Record<string, string | Record<string, string>>;
 
-function filterAndTransformKeys(translations: Record<string, string>): Translations {
-  const filtered: Translations = {};
-  const prefix = /^pwa-/;
-  for (const key in translations) {
-    if (prefix.test(key)) {
-      const value = translations[key];
-      try {
-        const parsed = JSON.parse(value);
-        filtered[key.replace(prefix, '')] = parsed;
-      } catch {
-        filtered[key.replace(prefix, '')] = value;
-      }
+function maybeJSON(val: string) {
+  if (val.startsWith('{')) {
+    try {
+      return JSON.parse(val);
+    } catch {
+      // default
     }
   }
-  return filtered;
+  return val;
+}
+
+function filterAndTransformKeys(translations: Record<string, string>): Translations {
+  return Object.entries(translations)
+    .filter(([key]) => key.startsWith('pwa-'))
+    .map(([key, value]) => [key.substring(4), maybeJSON(value)])
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
 }
 
 @Injectable()

--- a/src/app/core/internationalization.module.ts
+++ b/src/app/core/internationalization.module.ts
@@ -5,19 +5,15 @@ import localeFr from '@angular/common/locales/fr';
 import { Inject, Injectable, LOCALE_ID, NgModule } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
-import { Observable, OperatorFunction, combineLatest, of } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { catchError, first, map, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { SSR_LOCALE, SSR_TRANSLATIONS } from './configurations/state-keys';
 import { StatePropertiesService } from './utils/state-transfer/state-properties.service';
 
-export type Translations = Record<string, string | Record<string, string>>;
+type Translations = Record<string, string | Record<string, string>>;
 
-export function appendSlash(): OperatorFunction<string, string> {
-  return (source$: Observable<string>) => source$.pipe(map(url => `${url}/`));
-}
-
-export function filterAndTransformKeys(translations: Record<string, string>): Translations {
+function filterAndTransformKeys(translations: Record<string, string>): Translations {
   const filtered: Translations = {};
   const prefix = /^pwa-/;
   for (const key in translations) {
@@ -75,13 +71,13 @@ class ICMTranslateLoader implements TranslateLoader {
 
   get icmURL(): Observable<string> {
     return combineLatest([
-      this.stateProperties.getStateOrEnvOrDefault('ICM_BASE_URL', 'icmBaseURL').pipe(appendSlash()),
-      this.stateProperties.getStateOrEnvOrDefault('ICM_SERVER', 'icmServer').pipe(appendSlash()),
-      this.stateProperties.getStateOrEnvOrDefault('ICM_CHANNEL', 'icmChannel').pipe(appendSlash()),
-      this.stateProperties.getStateOrEnvOrDefault('ICM_APPLICATION', 'icmApplication'),
+      this.stateProperties.getStateOrEnvOrDefault<string>('ICM_BASE_URL', 'icmBaseURL'),
+      this.stateProperties.getStateOrEnvOrDefault<string>('ICM_SERVER', 'icmServer'),
+      this.stateProperties.getStateOrEnvOrDefault<string>('ICM_CHANNEL', 'icmChannel'),
+      this.stateProperties.getStateOrEnvOrDefault<string>('ICM_APPLICATION', 'icmApplication'),
     ]).pipe(
       first(),
-      map(arr => arr.join(''))
+      map(arr => arr.join('/'))
     );
   }
 }

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -132,6 +132,14 @@ export default (
             return 'tracking';
           }
 
+          // move translation files into own bundles
+          const i18nMatch = /[\\/]assets[\\/]i18n[\\/](.*?)\.json/.exec(identifier);
+          const locale = i18nMatch && i18nMatch[1];
+
+          if (locale) {
+            return locale.replace('_', '-');
+          }
+
           const match = /[\\/](extensions|projects)[\\/](.*?)[\\/](src[\\/]app[\\/])?(.*)/.exec(identifier);
           const feature = match && match[2];
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

`ngx-translate` translation files are loaded with [TranslateHttpLoader](https://github.com/ngx-translate/http-loader#1-setup-the-translatemodule-to-use-the-translatehttploader) on the browser side and a special translate loader on the server side. Due to this handling, the translation files are not automatically output-hashed via Angular CLI. This can lead to misbehavior, when new keys are added but the browser still holds the old translation file in the browser cache.

## What Is the New Behavior?

- Translation files are consistently loaded via webpack and automatically output-hashed
- ~~The old mechanism of `registerLocaleData` is exchanged with the [new one](https://angular.io/guide/i18n#import-global-variants-of-the-locale-data)~~ Doesn't work with FF
- Translation file ~~and Angular locale data~~ is put into its own bundle and pulled when needed.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
