### PR TITLE
fix: cms carousel component should handle not completely filled slides

### DIFF
--- a/src/app/core/utils/functions.spec.ts
+++ b/src/app/core/utils/functions.spec.ts
@@ -27,12 +27,15 @@ describe('Functions', () => {
       expect(arraySlices(arr, 6)).toEqual([[1, 2, 3, 4, 5, 6]]);
     });
 
-    it('should return truncated result for length 8', () => {
-      expect(arraySlices(arr, 8)).toBeEmpty();
+    it('should return correctly sliced arrays of length 8', () => {
+      expect(arraySlices(arr, 8)).toEqual([[1, 2, 3, 4, 5, 6]]);
     });
 
-    it('should return truncated result for length 4', () => {
-      expect(arraySlices(arr, 4)).toEqual([[1, 2, 3, 4]]);
+    it('should return correctly sliced arrays of length 4', () => {
+      expect(arraySlices(arr, 4)).toEqual([
+        [1, 2, 3, 4],
+        [5, 6],
+      ]);
     });
 
     it('should return undefined when input is undefined or empty', () => {

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -8,7 +8,7 @@ import { Observable, isObservable, of } from 'rxjs';
 export const arraySlices = <T>(input: T[], sliceLength: number): T[][] =>
   input && input.length && sliceLength > 0
     ? // determine slice indexes
-      range(0, Math.floor(input.length / sliceLength))
+      range(0, Math.ceil(input.length / sliceLength))
         // cut array into slices
         .map(n => input.slice(n * sliceLength, (n + 1) * sliceLength))
     : undefined;


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

It is not possible to display not fully completed slides in cms-carousel-component.

Issue Number: Closes #450

## What Is the New Behavior?

Not fully completed slides are displayed in cms-carousel-component.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x] No

## Other Information
