### PR TITLE
fix: add missing text for navigation toggle

### DIFF
--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -694,6 +694,7 @@
   "checkout.widget.security_privacy_policy.link": "<a href=\"{{0}}\" target=\"_blank\">Sicherheits- und Datenschutzhinweise lesen</a>",
   "checkout.widget.shipping-address.heading": "Lieferadresse",
   "checkout.widget.shipping_method.heading": "Versandart",
+  "common.button.navbarCollapsed.text": "Navigation umschalten",
   "common.button.spinning.label": "Wird hinzugefügt...",
   "common.home.link": "Home",
   "common.view_all.link": "Alle anzeigen",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -696,6 +696,7 @@
   "checkout.widget.security_privacy_policy.link": "<a href=\"{{0}}\" target=\"_blank\">Read our Security & Privacy Policy</a>",
   "checkout.widget.shipping-address.heading": "Shipping Address",
   "checkout.widget.shipping_method.heading": "Shipping Method",
+  "common.button.navbarCollapsed.text": "Toggle navigation",
   "common.button.spinning.label": "Adding...",
   "common.home.link": "Home",
   "common.view_all.link": "View All",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -696,6 +696,7 @@
   "checkout.widget.security_privacy_policy.link": "<a href=\"{{0}}\" target=\"_blank\">Lire notre Politique de sécurité et de confidentialité</a>",
   "checkout.widget.shipping-address.heading": "Adresse de livraison",
   "checkout.widget.shipping_method.heading": "Mode d’expédition",
+  "common.button.navbarCollapsed.text": "Basculer la navigation",
   "common.button.spinning.label": "En train d’ajouter...",
   "common.home.link": "Accueil",
   "common.view_all.link": "Tout afficher",


### PR DESCRIPTION
## PR Type
[x] Bugfix

## What Is the Current Behavior?
Translations for common.button.navbarCollapsed.text is missing in PWA.

Issue Number: Closes #660

## What Is the New Behavior?
Translations for common.button.navbarCollapsed.text is added in PWA.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No
