### PR TITLE
fix: in case of multiple buckets display message on checkout review page

### DIFF
--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -12,6 +12,7 @@ import { Basket } from 'ish-core/models/basket/basket.model';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
+import { resetOrderErrors } from 'ish-core/store/customer/orders';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
@@ -210,7 +211,7 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
+  describe('loadBasketEligibleShippingMethods$', () => {
     beforeEach(() => {
       when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
         of([BasketMockData.getShippingMethod()])
@@ -262,7 +263,7 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
+  describe('updateBasket$', () => {
     beforeEach(() => {
       when(basketServiceMock.updateBasket(anything())).thenReturn(of(BasketMockData.getBasket()));
 
@@ -311,7 +312,7 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
+  describe('updateBasketShippingMethod$', () => {
     it('should trigger the updateBasket action if called', () => {
       const shippingId = 'shippingId';
       const action = updateBasketShippingMethod({ shippingId });
@@ -325,7 +326,7 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
+  describe('setCustomAttributeToBasket$', () => {
     beforeEach(() => {
       when(basketServiceMock.createBasketAttribute(anything())).thenReturn(of(undefined));
       when(basketServiceMock.updateBasketAttribute(anything())).thenReturn(of(undefined));
@@ -394,7 +395,7 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
+  describe('deleteCustomAttributeFromBasket$', () => {
     beforeEach(() => {
       when(basketServiceMock.deleteBasketAttribute(anyString())).thenReturn(of(undefined));
 
@@ -468,20 +469,21 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
-    it('should fire ResetBasketErrors when route basket or checkout/* is navigated', done => {
+  describe('routeListenerForResettingBasketErrors', () => {
+    it('should fire ResetBasketErrors when route basket or checkout/* is navigated', () => {
       router.navigateByUrl('/checkout/payment');
 
-      actions$ = of(
-        routerTestNavigatedAction({
-          routerState: { url: '/checkout/payment' },
-        })
-      );
-
-      effects.routeListenerForResettingBasketErrors$.subscribe(action => {
-        expect(action).toMatchInlineSnapshot(`[Basket Internal] Reset Basket and Basket Promotion Errors`);
-        done();
+      const action = routerTestNavigatedAction({
+        routerState: { url: '/checkout/payment' },
       });
+      actions$ = of(action);
+
+      const completion1 = resetBasketErrors();
+      const completion2 = resetOrderErrors();
+      actions$ = hot('-a', { a: action });
+      const expected$ = cold('-(cd)', { c: completion1, d: completion2 });
+
+      expect(effects.routeListenerForResettingBasketErrors$).toBeObservable(expected$);
     });
 
     it('should not fire ResetBasketErrors when route basket or checkout/* is navigated with query param error=true', () => {
@@ -506,7 +508,7 @@ describe('Basket Effects', () => {
     });
   });
 
-  describe('Basket Effects', () => {
+  describe('createRequisition$', () => {
     beforeEach(() => {
       store$.dispatch(loadBasketSuccess({ basket: { id: 'BID' } as Basket }));
     });

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -20,6 +20,7 @@ import {
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { mapToRouterState } from 'ish-core/store/core/router';
+import { resetOrderErrors } from 'ish-core/store/customer/orders';
 import { createUser, loadUserByAPIToken, loginUser, loginUserSuccess } from 'ish-core/store/customer/user';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
@@ -264,7 +265,7 @@ export class BasketEffects {
       ofType(routerNavigatedAction),
       mapToRouterState(),
       filter(routerState => /^\/(basket|checkout.*)/.test(routerState.url) && !routerState.queryParams?.error),
-      mapTo(resetBasketErrors())
+      concatMapTo([resetBasketErrors(), resetOrderErrors()])
     )
   );
 

--- a/src/app/core/store/customer/orders/orders.actions.ts
+++ b/src/app/core/store/customer/orders/orders.actions.ts
@@ -38,3 +38,5 @@ export const selectOrderAfterRedirectFail = createAction(
   '[Orders API] Select Order Fail After Checkout Redirect',
   httpError()
 );
+
+export const resetOrderErrors = createAction('[Order Internal] Reset Order Errors');

--- a/src/app/core/store/customer/orders/orders.reducer.ts
+++ b/src/app/core/store/customer/orders/orders.reducer.ts
@@ -15,6 +15,7 @@ import {
   loadOrders,
   loadOrdersFail,
   loadOrdersSuccess,
+  resetOrderErrors,
   selectOrder,
 } from './orders.actions';
 
@@ -57,5 +58,10 @@ export const ordersReducer = createReducer(
     return {
       ...orderAdapter.setAll(orders, state),
     };
-  })
+  }),
+
+  on(resetOrderErrors, state => ({
+    ...state,
+    error: undefined,
+  }))
 );

--- a/src/app/core/store/customer/orders/orders.selectors.spec.ts
+++ b/src/app/core/store/customer/orders/orders.selectors.spec.ts
@@ -15,6 +15,7 @@ import {
   loadOrders,
   loadOrdersFail,
   loadOrdersSuccess,
+  resetOrderErrors,
   selectOrder,
 } from './orders.actions';
 import {
@@ -142,6 +143,7 @@ describe('Orders Selectors', () => {
         expect(loadedOrder.lineItems).toHaveLength(1);
         expect(loadedOrder.lineItems[0].id).toEqual('test');
         expect(loadedOrder.lineItems[0].productSKU).toEqual('sku');
+        expect(getOrdersError(store$.state)).toBeFalsy();
       });
     });
 
@@ -153,6 +155,16 @@ describe('Orders Selectors', () => {
       it('should not have loaded orders on error', () => {
         expect(getOrdersLoading(store$.state)).toBeFalse();
         expect(getOrders(store$.state)).toBeEmpty();
+      });
+
+      it('should not return the error on error', () => {
+        expect(getOrdersError(store$.state)).toBeTruthy();
+      });
+
+      it('should reset the error on error', () => {
+        store$.dispatch(resetOrderErrors());
+
+        expect(getOrdersError(store$.state)).toBeFalsy();
       });
     });
   });

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
@@ -18,6 +18,9 @@
   <!-- Error Message-->
   <div class="col-md-12">
     <ish-error-message [error]="error" [toast]="false"></ish-error-message>
+    <div *ngIf="multipleBuckets" role="alert" class="alert alert-danger">
+      {{ 'checkout.shipping.no_methods.message' | translate }}
+    </div>
     <ish-basket-validation-results></ish-basket-validation-results>
   </div>
 
@@ -62,7 +65,7 @@
         editRouterLink="/checkout/shipping"
         class="infobox-wrapper col-md-6"
       >
-        <p>{{ basket.commonShippingMethod.name }}</p>
+        <p>{{ basket.commonShippingMethod?.name }}</p>
       </ish-info-box>
 
       <!-- Payment Method -->

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
@@ -18,12 +18,14 @@ export class CheckoutReviewComponent implements OnInit {
 
   form: FormGroup;
   submitted = false;
+  multipleBuckets = false;
 
   ngOnInit() {
     // create t&c form
     this.form = new FormGroup({
       termsAndConditions: new FormControl(false, Validators.pattern('true')),
     });
+    this.multipleBuckets = !this.basket?.commonShippingMethod;
   }
 
   /**
@@ -39,6 +41,6 @@ export class CheckoutReviewComponent implements OnInit {
   }
 
   get formDisabled() {
-    return this.form.invalid && this.submitted;
+    return (this.form.invalid && this.submitted) || this.multipleBuckets;
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
1. If the basket contains items that cannot be shipped together, but it is complete and validated successfully, the user is navigated from the cart page to the review page (in case of basket acceleration), but the review page is corrupt.
2. If the user submits a basket but the order could not be created (e.g. because a payment is not authorized), an error is displayed on checkout review page. If the user navigates to another page, e.g. the payment page and fixes the problem and he navigates to the review page again, the order creation error is displayed again.

Issue Number: Closes #

## What Is the New Behavior?
1. If items cannot be shipped together an error message is shown on checkout review page and the submit order button is disabled.
2. After navigating from the checkout review page order creation errors are reseted and they are not shown again, if the user enters the checkout review page.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
