### PR TITLE
fix: repair data refresh on product pages

### DIFF
--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -258,11 +258,18 @@ export class ProductContextFacade extends RxState<ProductContext> {
     );
   }
 
+  private get isMaximumLevel(): boolean {
+    return (
+      this.get('requiredCompletenessLevel') === ProductCompletenessLevel.Detail ||
+      this.get('requiredCompletenessLevel') === true
+    );
+  }
+
   private postProductFetch(product: ProductView, displayProperties: Partial<ProductContextDisplayProperties>) {
     if (
       (ProductHelper.isRetailSet(product) || ProductHelper.isMasterProduct(product)) &&
       displayProperties.price &&
-      this.get('requiredCompletenessLevel') !== ProductCompletenessLevel.Detail
+      !this.isMaximumLevel
     ) {
       this.set('requiredCompletenessLevel', () => ProductCompletenessLevel.Detail);
     }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

Data is not properly refreshed while switching between product detail pages once a product master or retail set is chosen.

Steps:
- open browser development tools, network tab, filter for `products/`
- go to master product: https://intershoppwa-b2b.azurewebsites.net/sku201807231
- switch to first variation (product call is being made)
- switch back to master via "Choose Another Variation"
  -> no call is made to refresh the master product data

## What Is the New Behavior?

Level `true` (which means always refetch (set in `SelectedProductContextFacade`)) is not being overridden in `postProductFetch` of `ProductContextFacade`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
