### PR TITLE
feat: basic auth support for nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,10 @@ services:
       # COMPRESSION: 0
       # DEVICE_DETECTION: 0
       # MULTI_CHANNEL_SOURCE: env:///ASDF?type=application/yaml
+      # BASIC_AUTH: 'developer:!InterShop00!'
+      # BASIC_AUTH_IP_WHITELIST: |
+      #   # - 172.22.0.1
+      #   - 1.2.3.4
       MULTI_CHANNEL: |
         .+:
           - baseHref: /en
@@ -39,6 +43,7 @@ services:
           - baseHref: /de
             channel: default
             lang: de_DE
+            protected: false
           - baseHref: /fr
             channel: default
             lang: fr_FR

--- a/docs/guides/multi-site-configurations.md
+++ b/docs/guides/multi-site-configurations.md
@@ -35,6 +35,7 @@ All other properties are optional:
 - **features**: Comma-separated list of activated features
 - **lang**: The default language as defined in the Angular CLI environment
 - **theme**: The theme used for the channel (format: `<theme-name>(|<icon-color>)?`)
+- **protected**: Selectively unprotect a given domain and/or baseHref. Only applies in combination with globally activated nginx basic authentication.
 
 Dynamically directing the PWA to different ICM installations can be done by using:
 
@@ -185,6 +186,23 @@ To see what is possible through multi-site handling, have a look at this extende
   application: smb-responsive
   features: quoting
   theme: 'blue|688dc3'
+```
+
+### Extended Example with two domains, one with basic auth (except /fr), the other without
+
+```yaml
+de.+\.com:
+  lang: de_DE
+  channel: inspired-inTRONICS-DE
+  protected: false
+ca.+\.com:
+  - baseHref: /fr
+    channel: inspired-inTRONICS-CA
+    lang: fr_FR
+    protected: false
+  - baseHref: /en
+    channel: inspired-inTRONICS-CA
+    lang: en_US
 ```
 
 # Further References

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -23,6 +23,27 @@ For HTTP, the server will run on default port 80.
 If HTTPS is chosen as an upstream, it will run on default port 443.
 In the latter case the files `server.key` and `server.crt` have to be supplied in the container folder `/etx/nginx` (either by volume mapping with `docker run` or in the image itself by `docker build`).
 
+### Basic Auth
+
+For deploying to test environments that should not be indexed by search bots or should not be accessible by the public, the nginx container can be set up with basic authentication.
+Just supply a single user-password combination as environment variable, i.e. `BASIC_AUTH=<user>:<password>`.
+You can also whitelist IPs by supplying a YAML list to the environment variable `BASIC_AUTH_IP_WHITELIST`:
+
+```yaml
+nginx:
+  environment:
+    BASIC_AUTH: 'developer:!InterShop00!'
+    BASIC_AUTH_IP_WHITELIST: |
+      - 172.22.0.1
+      - 1.2.3.4
+```
+
+Entries of the IP whitelist are added to the nginx config as [`allow`](http://nginx.org/en/docs/http/ngx_http_access_module.html) statements, which also supports IP ranges.
+Please refer to the linked nginx documentation on how to configure this.
+
+After activating basic authentication for your setup globally you can also selectively deactivate it per site.
+See [Multi-Site Configurations](../guides/multi-site-configurations.md#Examples) for examples on how to do that.
+
 ### Multi-Site
 
 If the nginx container is run without further configuration, the default Angular CLI environment properties are not overridden.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,7 +15,7 @@ ADD https://github.com/hairyhenderson/gomplate/releases/download/v3.8.0/gomplate
 
 FROM ubuntu:latest
 RUN apt-get update && \
-  apt-get install -y gettext-base libssl1.1 && \
+  apt-get install -y gettext-base libssl1.1 apache2-utils && \
   apt-get -y autoremove && \
   apt-get clean && \
   rm -r /var/cache/apt /var/lib/apt/lists

--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -11,6 +11,13 @@
         {{- $icmScheme := "" }}{{ if (has . "icmScheme") }}{{ $icmScheme = join ( slice "icmScheme" .icmScheme ) "=" }}{{ end }}
         {{- $icmPort := "" }}{{ if (has . "icmPort") }}{{ $icmPort = join ( slice "icmPort" .icmPort ) "=" }}{{ end }}
         {{- $icmHost := "default" }}{{ if (has . "icmHost") }}{{ $icmHost = .icmHost }}{{ end }}
+
+        {{- $protected := true }}{{ if (has . "protected") }}{{ $protected = .protected }}{{ end }}
+      {{- if $protected }}
+      {{ else }}
+        allow all;
+        auth_basic off;
+      {{ end }}
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -60,9 +67,23 @@ server {
     error_log /dev/stdout notice;
     rewrite_log on;
   {{- end }}
+  {{ if getenv "BASIC_AUTH" }}
+    {{ if getenv "BASIC_AUTH_IP_WHITELIST" }}
+    satisfy any;
+    {{- range $ip := (ds "ipwhitelist") }}
+    allow {{ $ip }};
+    {{- end }}
+    deny all;
+    {{- end }}
+    auth_basic              "Protected Area";
+    auth_basic_user_file    /etc/nginx/.htpasswd;
+  {{- end }}
 
     # let ICM handle everything ICM related
     location ~* ^/INTERSHOP.*$ {
+        allow all;
+        auth_basic off;
+
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -80,6 +101,9 @@ server {
 
     # respect cache entries of static assets
     location ~* ^/(ngx_pagespeed_beacon|metrics|assets|.*\.(js|css|ico|json|txt|webmanifest|woff|woff2))(.*)$ {
+        allow all;
+        auth_basic off;
+
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -103,6 +127,8 @@ server {
   {{- if (has ($mapping | jsonpath "$..baseHref") "/") }}
   {{- else }}
     location / {
+        allow all;
+        auth_basic off;
         {{ $first := index $mapping 0 -}}
         rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" permanent;
         rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri" permanent;

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -7,7 +7,12 @@ set -e
 
 [ -f "/etc/nginx/conf.d/default.conf" ] && rm /etc/nginx/conf.d/default.conf
 
-find /etc/nginx/features/*.conf | xargs -I{} echo {} | sed -e "s%.*\/\(\w*\).conf%\1%" | grep -E '^\w+$' | while read feature; do echo "# $feature" ; env | grep -iqE "^$feature=(on|1|true|yes)$" && echo "include /etc/nginx/features/${feature}.conf;" || echo "include /etc/nginx/features/${feature}-off[.]conf;" ; done >/etc/nginx/conf.d/features.conf
+if [ -n "$BASIC_AUTH" ]
+then
+  htpasswd -bc /etc/nginx/.htpasswd $(echo "$BASIC_AUTH" | sed 's/:/ /')
+fi
+
+find /etc/nginx/features/*.conf -print0 | xargs -0 -I{} echo {} | sed -e "s%.*\/\(\w*\).conf%\1%" | grep -E '^\w+$' | while read feature; do echo "# $feature" ; env | grep -iqE "^$feature=(on|1|true|yes)$" && echo "include /etc/nginx/features/${feature}.conf;" || echo "include /etc/nginx/features/${feature}-off[.]conf;" ; done >/etc/nginx/conf.d/features.conf
 
 if [ -z "$MULTI_CHANNEL_SOURCE" ]
 then
@@ -19,7 +24,7 @@ then
   fi
 fi
 
-/gomplate -d "domains=$MULTI_CHANNEL_SOURCE" </etc/nginx/conf.d/channel.conf.tmpl >/etc/nginx/conf.d/multi-channel.conf
+/gomplate -d "domains=$MULTI_CHANNEL_SOURCE" -d 'ipwhitelist=env:///BASIC_AUTH_IP_WHITELIST?type=application/yaml' </etc/nginx/conf.d/channel.conf.tmpl >/etc/nginx/conf.d/multi-channel.conf
 
 # Generate Pagespeed config based on environment variables
 env | grep NPSC_ | sed -e 's/^NPSC_//g' -e "s/\([A-Z_]*\)=/\L\1=/g" -e "s/_\([a-zA-Z]\)/\u\1/g" -e "s/^\([a-zA-Z]\)/\u\1/g" -e 's/=.*$//' -e 's/\=/ /' -e 's/^/\pagespeed /' > /tmp/pagespeed-prefix.txt


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

For Intershop CaaS environments, UAT and INT deployments are configured to use basic auth, so that the shop is not publicly visible or indexed by search engines.
This setup however is performed on the Kubernetes nginx ingress, where it doesn't differentiate between page responses and retrieval of static assets. Some of the assets can not be retrieved by the PWA without setting up cross-origin use-credentials, and even then (with multiple basic auth dialogs popping up), fonts are not properly retrieved.

## What Is the New Behavior?

The PWA nginx container can be set up using basic auth: https://github.com/intershop/intershop-pwa/blob/feat/nginx-basic-auth/docs/guides/nginx-startup.md#basic-auth
Whitelisting IPs is also supported.
The nginx only guards page responses and makes static assets freely available.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
