### PR TITLE
fix: set punchout cookies with "SameSite=None; Secure" to work in iframes

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -85,7 +85,7 @@ export class ApiTokenService {
           if (cookieContent) {
             cookiesService.put('apiToken', cookieContent, {
               expires: new Date(Date.now() + 3600000),
-              secure: (isPlatformBrowser(platformId) && location.protocol === 'https:') || false,
+              secure: true,
               sameSite: 'Strict',
             });
           } else {

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -146,7 +146,7 @@ export class CookiesService {
     str += opts.domain ? ';domain=' + opts.domain : '';
     str += expires ? ';expires=' + expires.toUTCString() : '';
     str += opts.sameSite ? ';SameSite=' + opts.sameSite : '';
-    str += opts.secure ? ';secure' : '';
+    str += opts.secure && location.protocol === 'https:' ? ';secure' : '';
     const cookiesLength = str.length + 1;
     if (cookiesLength > 4096) {
       // tslint:disable-next-line: no-console

--- a/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
+++ b/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
@@ -76,9 +76,18 @@ export class PunchoutPageGuard implements CanActivate {
             return this.punchoutService.getCxmlPunchoutSession(route.queryParamMap.get('sid')).pipe(
               // persist cXML session information (sid, returnURL, basketId) in cookies for later basket transfer
               tap(data => {
-                this.cookiesService.put('punchout_SID', route.queryParamMap.get('sid'), { sameSite: 'Strict' });
-                this.cookiesService.put('punchout_ReturnURL', data.returnURL, { sameSite: 'Strict' });
-                this.cookiesService.put('punchout_BasketID', data.basketId, { sameSite: 'Strict' });
+                this.cookiesService.put('punchout_SID', route.queryParamMap.get('sid'), {
+                  sameSite: 'None',
+                  secure: true,
+                });
+                this.cookiesService.put('punchout_ReturnURL', data.returnURL, {
+                  sameSite: 'None',
+                  secure: true,
+                });
+                this.cookiesService.put('punchout_BasketID', data.basketId, {
+                  sameSite: 'None',
+                  secure: true,
+                });
               }),
               // use the basketId basket for the current PWA session (instead of default current basket)
               // TODO: if load basket error (currently no error page) -> logout and do not use default 'current' basket
@@ -91,7 +100,10 @@ export class PunchoutPageGuard implements CanActivate {
             // handle OCI punchout with HOOK_URL
           } else if (route.queryParamMap.get('HOOK_URL')) {
             // save HOOK_URL to cookie for later basket transfer
-            this.cookiesService.put('punchout_HookURL', route.queryParamMap.get('HOOK_URL'), { sameSite: 'Strict' });
+            this.cookiesService.put('punchout_HookURL', route.queryParamMap.get('HOOK_URL'), {
+              sameSite: 'None',
+              secure: true,
+            });
 
             // create a new basket for every punchout session to avoid basket conflicts for concurrent punchout sessions
             this.checkoutFacade.createBasket();


### PR DESCRIPTION
## PR Type
[x] Bugfix

## What Is the Current Behavior?
A PWA punchout session does not work within an iframe that is often used by punchout systems, e.g. https://punchoutcommerce.com/tools/cxml-punchout-tester. This is due to necessary cookies (e.g. for the return url) not being set properly in such combinations.

## What Is the New Behavior?
The punchout cookies are set with "SameSite=None; Secure" that allows for the required cookies being set in iframe environments too.

## Does this PR Introduce a Breaking Change?
[x] No

