### PR TITLE
feat: add bctx to url as matrix param

### DIFF
--- a/src/app/extensions/organization-hierarchies/interceptors/tx-selected-group.interceptor.ts
+++ b/src/app/extensions/organization-hierarchies/interceptors/tx-selected-group.interceptor.ts
@@ -2,13 +2,19 @@ import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/c
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable, iif } from 'rxjs';
-import { concatMap, first, map } from 'rxjs/operators';
+import { concatMap, first, map, withLatestFrom } from 'rxjs/operators';
 
-import { getSelectedGroupPath } from '../store/group';
+import { getRestEndpoint } from 'ish-core/store/core/configuration';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
+
+import { getSelectedGroupDetails } from '../store/group';
 
 @Injectable()
 export class TxSelectedGroupInterceptor implements HttpInterceptor {
   constructor(private store: Store) {}
+
+  static seperator = '@';
+  static matrixparam = 'bctx';
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return this.store.pipe(
@@ -17,11 +23,23 @@ export class TxSelectedGroupInterceptor implements HttpInterceptor {
         iif(
           () => !!store.organizationHierarchies,
           this.store.pipe(
-            select(getSelectedGroupPath),
-            map(groups => groups.reduce((acc, val, index) => (index > 0 ? `${val.id},${acc}` : val.id), '')),
-            map(path =>
-              path?.length > 0 && !req?.headers.has('BuyingGroupID')
-                ? req.clone({ headers: req.headers.set('BuyingGroupID', path) })
+            select(getSelectedGroupDetails),
+            withLatestFrom(this.store.pipe(select(getRestEndpoint)), this.store.pipe(select(getLoggedInCustomer))),
+            map(([group, baseurl, customer]) =>
+              group && !req?.url.includes(TxSelectedGroupInterceptor.matrixparam)
+                ? req.clone({
+                    url: req.url
+                      .substring(0, baseurl.length)
+                      .concat(
+                        ';',
+                        TxSelectedGroupInterceptor.matrixparam,
+                        '=',
+                        group.id,
+                        TxSelectedGroupInterceptor.seperator,
+                        customer.customerNo,
+                        req.url.substring(baseurl.length)
+                      ),
+                  })
                 : req
             ),
             first(),

--- a/src/app/extensions/organization-hierarchies/store/group/group.selectors.spec.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.selectors.spec.ts
@@ -13,7 +13,6 @@ import {
   getGroupsOfOrganization,
   getGroupsOfOrganizationCount,
   getSelectedGroupDetails,
-  getSelectedGroupPath,
 } from './group.selectors';
 
 describe('Group Selectors', () => {
@@ -101,23 +100,6 @@ describe('Group Selectors', () => {
     it('should set selected to undefined', () => {
       store$.dispatch(selectGroup({ id: '3' }));
       expect(getSelectedGroupDetails(store$.state)).toBeFalsy();
-    });
-
-    it('should get all groups from selected up to the root', () => {
-      store$.dispatch(selectGroup({ id: '2' }));
-      expect(getSelectedGroupPath(store$.state)).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "id": "2",
-            "name": "Test 2",
-            "parentid": "1",
-          },
-          Object {
-            "id": "1",
-            "name": "Test 1",
-          },
-        ]
-      `);
     });
   });
 });

--- a/src/app/extensions/organization-hierarchies/store/group/group.selectors.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.selectors.ts
@@ -22,17 +22,3 @@ export const getSelectedGroupDetails = createSelector(
 );
 
 export const getGroupDetails = (id: string) => createSelector(selectEntities, entities => id && entities[id]);
-
-export const getSelectedGroupPath = createSelector(
-  selectEntities,
-  getSelectedGroupId,
-  (entities, id): OrganizationGroup[] => {
-    let current = id && entities[id];
-    const ret = new Array<OrganizationGroup>();
-    while (typeof current !== 'undefined') {
-      ret.push(current);
-      current = current.parentid ? entities[current.parentid] : undefined;
-    }
-    return ret;
-  }
-);


### PR DESCRIPTION
## PR Type
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Buying Context is currently transmitted as header parameter from PWA to ICM. After discussion there was the decision to transmit the Buying Context as matrix parameter.

Issue Number: ISREST-1172#

## What Is the New Behavior?

The Buying Context is transmitted as matrix parameter.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x ] No