### PR TITLE
feat: reload basket and orders after group switch

### DIFF
--- a/src/app/extensions/organization-hierarchies/facades/organization-hierarchies.facade.ts
+++ b/src/app/extensions/organization-hierarchies/facades/organization-hierarchies.facade.ts
@@ -3,18 +3,17 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { switchMap, take, tap } from 'rxjs/operators';
 
-import { loadOrders } from 'ish-core/store/customer/orders';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 import { OrganizationGroup } from '../models/organization-group/organization-group.model';
 import {
+  assignGroup,
   getGroupDetails,
   getGroupsOfOrganization,
   getGroupsOfOrganizationCount,
   getSelectedGroupDetails,
   loadGroups,
-  selectGroup,
 } from '../store/group';
 
 // tslint:disable:member-ordering
@@ -36,9 +35,8 @@ export class OrganizationHierarchiesFacade {
     );
   }
 
-  selectGroup(id: string): void {
-    this.store.dispatch(selectGroup({ id }));
-    this.store.dispatch(loadOrders());
+  assignGroup(id: string): void {
+    this.store.dispatch(assignGroup({ id }));
   }
 
   getDetailsOfGroup$(id: string): Observable<OrganizationGroup> {

--- a/src/app/extensions/organization-hierarchies/shared/hierarchy-switch/hierarchy-switch.component.spec.ts
+++ b/src/app/extensions/organization-hierarchies/shared/hierarchy-switch/hierarchy-switch.component.spec.ts
@@ -65,11 +65,11 @@ describe('Hierarchy Switch Component', () => {
 
   it('should invoke select group at facade if a group has been selected', () => {
     fixture.componentInstance.groupSelected(groupA);
-    verify(organizationHierarchiesFacade.selectGroup('root')).once();
+    verify(organizationHierarchiesFacade.assignGroup('root')).once();
   });
 
   it('should not invoke select group at facade if nothing was selected', () => {
     fixture.componentInstance.groupSelected(undefined);
-    verify(organizationHierarchiesFacade.selectGroup('root')).never();
+    verify(organizationHierarchiesFacade.assignGroup('root')).never();
   });
 });

--- a/src/app/extensions/organization-hierarchies/shared/hierarchy-switch/hierarchy-switch.component.ts
+++ b/src/app/extensions/organization-hierarchies/shared/hierarchy-switch/hierarchy-switch.component.ts
@@ -33,7 +33,7 @@ export class HierarchySwitchComponent implements OnInit {
 
   groupSelected(group: OrganizationGroup): void {
     if (group) {
-      this.facade.selectGroup(group.id);
+      this.facade.assignGroup(group.id);
     }
   }
 

--- a/src/app/extensions/organization-hierarchies/store/group/group.actions.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.actions.ts
@@ -13,4 +13,4 @@ export const loadGroupsSuccess = createAction(
   payload<{ groups: OrganizationGroup[] }>()
 );
 
-export const selectGroup = createAction('[Organizational Groups API] Select Group', payload<{ id: string }>());
+export const assignGroup = createAction('[Organizational Groups API] Assign Group', payload<{ id: string }>());

--- a/src/app/extensions/organization-hierarchies/store/group/group.effects.spec.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.effects.spec.ts
@@ -3,23 +3,32 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { Observable, of } from 'rxjs';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 
+import { BasketBaseData } from 'ish-core/models/basket/basket.interface';
+import { BasketService } from 'ish-core/services/basket/basket.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { loadBasket } from 'ish-core/store/customer/basket';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
+import { loadOrders } from 'ish-core/store/customer/orders';
 
 import { OrganizationHierarchiesService } from '../../services/organization-hierarchies/organization-hierarchies.service';
 
-import { loadGroups, loadGroupsSuccess } from './group.actions';
+import { assignGroup, loadGroups, loadGroupsSuccess } from './group.actions';
 import { GroupEffects } from './group.effects';
 
 describe('Group Effects', () => {
   let actions$: Observable<Action>;
   let effects: GroupEffects;
   let orgServiceMock: OrganizationHierarchiesService;
+  let basketServiceMock: BasketService;
+
+  const basket = { id: '1', calculated: true, totals: undefined } as BasketBaseData;
+  const baskets = [basket] as BasketBaseData[];
 
   beforeEach(() => {
     orgServiceMock = mock(OrganizationHierarchiesService);
+    basketServiceMock = mock(BasketService);
     when(orgServiceMock.getGroups(anything())).thenReturn(of([]));
 
     TestBed.configureTestingModule({
@@ -28,6 +37,7 @@ describe('Group Effects', () => {
         GroupEffects,
         provideMockActions(() => actions$),
         { provide: OrganizationHierarchiesService, useFactory: () => instance(orgServiceMock) },
+        { provide: BasketService, useFactory: () => instance(basketServiceMock) },
       ],
     });
 
@@ -42,6 +52,41 @@ describe('Group Effects', () => {
       const expected$ = cold('-c-c-c', { c: completion });
 
       expect(effects.loadGroups$).toBeObservable(expected$);
+    });
+  });
+
+  describe('assignGroups$', () => {
+    it('should call the basketService for getBaskets', done => {
+      when(basketServiceMock.getBaskets()).thenReturn(of(undefined));
+
+      const action = assignGroup({ id: 'HomeschoolingIstDoof' });
+      actions$ = of(action);
+
+      effects.assignGroup$.subscribe(() => {
+        verify(basketServiceMock.getBaskets()).once();
+        done();
+      });
+    });
+
+    it('should dispatch action of type LoadBasket and LoadOrders', () => {
+      when(basketServiceMock.getBaskets()).thenReturn(of(baskets));
+      const action = assignGroup({ id: 'Anna' });
+      const completion1 = loadBasket();
+      const completion2 = loadOrders();
+      actions$ = hot('-a----a----a', { a: action });
+      const expected$ = cold('-(cd)-(cd)-(cd)', { c: completion1, d: completion2 });
+
+      expect(effects.assignGroup$).toBeObservable(expected$);
+    });
+
+    it('should dispatch only action of type LoadOrders', () => {
+      when(basketServiceMock.getBaskets()).thenReturn(of([]));
+      const action = assignGroup({ id: 'Aaron' });
+      const completion = loadOrders();
+      actions$ = hot('-a-a-a', { a: action });
+      const expected$ = cold('-c-c-c', { c: completion });
+
+      expect(effects.assignGroup$).toBeObservable(expected$);
     });
   });
 });

--- a/src/app/extensions/organization-hierarchies/store/group/group.effects.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.effects.ts
@@ -1,19 +1,23 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { map, switchMap, withLatestFrom } from 'rxjs/operators';
+import { map, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
 
+import { BasketService } from 'ish-core/services/basket/basket.service';
+import { loadBasket } from 'ish-core/store/customer/basket';
+import { loadOrders } from 'ish-core/store/customer/orders';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { mapErrorToAction } from 'ish-core/utils/operators';
 
 import { OrganizationHierarchiesService } from '../../services/organization-hierarchies/organization-hierarchies.service';
 
-import { loadGroups, loadGroupsFail, loadGroupsSuccess } from './group.actions';
+import { assignGroup, loadGroups, loadGroupsFail, loadGroupsSuccess } from './group.actions';
 
 @Injectable()
 export class GroupEffects {
   constructor(
     private actions$: Actions,
+    private basketService: BasketService,
     private store: Store,
     private organizationService: OrganizationHierarchiesService
   ) {}
@@ -26,6 +30,23 @@ export class GroupEffects {
         this.organizationService.getGroups(customer).pipe(
           map(groups => loadGroupsSuccess({ groups })),
           mapErrorToAction(loadGroupsFail)
+        )
+      )
+    )
+  );
+
+  assignGroup$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(assignGroup),
+      mergeMap(() =>
+        this.basketService.getBaskets().pipe(
+          switchMap(baskets => {
+            if (baskets?.length > 0) {
+              return [loadBasket(), loadOrders()];
+            } else {
+              return [loadOrders()];
+            }
+          })
         )
       )
     )

--- a/src/app/extensions/organization-hierarchies/store/group/group.reducer.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.reducer.ts
@@ -3,7 +3,7 @@ import { createReducer, on } from '@ngrx/store';
 
 import { OrganizationGroup } from '../../models/organization-group/organization-group.model';
 
-import { loadGroupsSuccess, selectGroup } from './group.actions';
+import { assignGroup, loadGroupsSuccess } from './group.actions';
 
 export const groupAdapter = createEntityAdapter<OrganizationGroup>({
   selectId: group => group.id,
@@ -22,12 +22,14 @@ const initialState: GroupState = groupAdapter.getInitialState({
 export const groupReducer = createReducer(
   initialState,
   on(loadGroupsSuccess, (state: GroupState, action) => {
-    const { groups } = action.payload;
+    const groups = action.payload.groups as OrganizationGroup[];
+    const newState = groupAdapter.upsertMany(groups, state);
     return {
-      ...groupAdapter.upsertMany(groups, state),
+      ...newState,
+      selected: newState?.ids?.length ? (newState.ids[0] as string) : undefined,
     };
   }),
-  on(selectGroup, (state: GroupState, action) => {
+  on(assignGroup, (state: GroupState, action) => {
     const { id } = action.payload;
     return {
       ...state,

--- a/src/app/extensions/organization-hierarchies/store/group/group.selectors.spec.ts
+++ b/src/app/extensions/organization-hierarchies/store/group/group.selectors.spec.ts
@@ -7,7 +7,7 @@ import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ng
 import { OrganizationGroup } from '../../models/organization-group/organization-group.model';
 import { OrganizationHierarchiesStoreModule } from '../organization-hierarchies-store.module';
 
-import { loadGroups, loadGroupsFail, loadGroupsSuccess, selectGroup } from './group.actions';
+import { assignGroup, loadGroups, loadGroupsFail, loadGroupsSuccess } from './group.actions';
 import {
   getGroupDetails,
   getGroupsOfOrganization,
@@ -78,7 +78,7 @@ describe('Group Selectors', () => {
     });
 
     it('should set selected to 1', () => {
-      store$.dispatch(selectGroup({ id: '1' }));
+      store$.dispatch(assignGroup({ id: '1' }));
       expect(getSelectedGroupDetails(store$.state)).toMatchInlineSnapshot(`
         Object {
           "id": "1",
@@ -88,7 +88,7 @@ describe('Group Selectors', () => {
     });
 
     it('should set selected to 2', () => {
-      store$.dispatch(selectGroup({ id: '2' }));
+      store$.dispatch(assignGroup({ id: '2' }));
       expect(getSelectedGroupDetails(store$.state)).toMatchInlineSnapshot(`
         Object {
           "id": "2",
@@ -99,12 +99,12 @@ describe('Group Selectors', () => {
     });
 
     it('should set selected to undefined', () => {
-      store$.dispatch(selectGroup({ id: '3' }));
+      store$.dispatch(assignGroup({ id: '3' }));
       expect(getSelectedGroupDetails(store$.state)).toBeFalsy();
     });
 
     it('should get all groups from selected up to the root', () => {
-      store$.dispatch(selectGroup({ id: '2' }));
+      store$.dispatch(assignGroup({ id: '2' }));
       expect(getSelectedGroupPath(store$.state)).toMatchInlineSnapshot(`
         Array [
           Object {


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

If the customer select a new buying group neither the basket as well the corresponding orders will reloaded. This leads to a misbehavior because the current basket may does not belongs to buying context. Also orders will displayed which are may ordered in a different context.

Issue Number: ISREST-1175

## What Is the New Behavior?

If the customer select a new buying group the basket as well the corresponding orders will reloaded.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No
