### PR TITLE
fix: plp filter should not break on router actions

### DIFF
--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -3,7 +3,7 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { from } from 'rxjs';
-import { concatMap, filter, map, mergeMap, switchMap, switchMapTo, withLatestFrom } from 'rxjs/operators';
+import { concatMap, filter, map, mergeMap, switchMap, switchMapTo, take, withLatestFrom } from 'rxjs/operators';
 
 import { MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH } from 'ish-core/configurations/injection-keys';
 import { CategoryHelper } from 'ish-core/models/category/category.model';
@@ -139,7 +139,8 @@ export class CategoriesEffects {
           select(getSelectedCategory),
           whenTruthy(),
           filter(cat => cat.hasOnlineProducts),
-          map(({ uniqueId }) => loadMoreProducts({ id: { type: 'category', value: uniqueId } }))
+          map(({ uniqueId }) => loadMoreProducts({ id: { type: 'category', value: uniqueId } })),
+          take(1)
         )
       )
     )

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -102,7 +102,8 @@ export class ProductListingEffects {
               page: p > 1 ? p : undefined, // same content for 0, 1 & undefined
               filters,
             };
-          })
+          }),
+          take(1)
         );
       }),
       distinctUntilChanged(isEqual),


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

PLP filters break sometimes, when router query params changes on current page (f.E. when opening sign in popup)

Issue Number: Closes #468 

## What Is the New Behavior?

PLP filters does not break, when router query params changes on current page (f.E. when opening sign in popup)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
