### PR TITLE
feat: omit default redirect in multi channel when one base href is root route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # export appropriate ICM_BASE_URL and use with
-# docker-compose up --build
+# docker compose up --build
 
 version: '3'
 services:

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -69,13 +69,29 @@ Multiple channels can also be configured via context paths, which re-configure t
     lang: de_DE
 ```
 
-The domain has to be supplied, to match all domains use `.+`.
+The domain has to be supplied.
+To match all domains use `.+`.
 The parameters `baseHref` and `channel` are mandatory.
 `baseHref` must start with `/`.
 Also note that context path channels have to be supplied as a list.
-The first entry is chosen as default channel, if the website is accessed without supplying a channel.
+The first entry is chosen as default channel, if the website is accessed without supplying a channel, meaning the context path `/`.
+It is also possible to explicitly set a channel configuration for the `/` context path.
+Such a configuration is shown in the following configuration that sets different languages for the according context paths but within the same channel.
 
-This configuration can be supplied simply by setting the environment variable `MULTI_CHANNEL`.
+```yaml
+'domain2':
+  - baseHref: /fr
+    channel: channel
+    lang: fr_FR
+  - baseHref: /de
+    channel: channel
+    lang: de_DE
+  - baseHref: /
+    channel: channel
+    lang: en_US
+```
+
+The configuration can be supplied simply by setting the environment variable `MULTI_CHANNEL`.
 Alternatively, the source can be supplied by setting `MULTI_CHANNEL_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources).
 If no environment variables for multi-channel configuration are given, the configuration will fall back to the content of [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), which can also be customized.
 

--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -100,11 +100,14 @@ server {
         {{- tmpl.Exec "LOCATION_TEMPLATE" . }}
     }
     {{ end }}
+  {{- if (has ($mapping | jsonpath "$..baseHref") "/") }}
+  {{- else }}
     location / {
         {{ $first := index $mapping 0 -}}
         rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" permanent;
         rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri" permanent;
     }
+  {{- end -}}
   {{- end }}
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
…

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

Multi Channel adds default root location redirecting to first baseHref in MultiChannel config

## What Is the New Behavior?

Check first if one multi channel config is also trying to map to root route.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

