### PR TITLE
fix: using regionCode instead of id for US new-address-form

### DIFF
--- a/e2e/cypress/integration/specs/checkout/checkout-validation.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/checkout-validation.b2c.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('Shopping User', () => {
 
   it('should remove validation messages after customer address changed', () => {
     at(CheckoutAddressesPage, page => {
-      page.changeInvoiceAddressRegion('US_CA');
+      page.changeInvoiceAddressRegion('CA');
       waitLoadingEnd(1000);
       page.validationMessage.should('not.exist');
     });

--- a/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
@@ -69,7 +69,7 @@ export class AddressFormUSConfiguration extends AddressFormConfiguration {
             placeholder: 'account.option.select.text',
             options: this.appFacade
               .regions$(this.countryCode)
-              .pipe(map(regions => regions?.map(region => ({ value: region.id, label: region.name })))),
+              .pipe(map(regions => regions?.map(region => ({ value: region.regionCode, label: region.name })))),
           },
           validation: {
             messages: {


### PR DESCRIPTION
## PR Type

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The US new address form uses the id (e.g. "US_CA") for the region select dropdown as value. So that Value is sent to the new address API endpoint.

The default address form uses the regionCode (e.g. "CA").
Which makes perfectly sense as even the Store distinguishes between id (US_CA), regionCode (CA) and regionName (California) in that way.

Another visual problem can be seen after saving that address. In the address field it says for example "San Jose, US_CA" where it should be "San Jose, CA".

Issue Number: no known issue number

## What Is the New Behavior?

The US new address form now uses the regionCode as select option values.
The regionCode is now sent to the new address API endpoint.
The address field now shows the regionCode to the end user (e.g. "San Jose, CA")

## Does this PR Introduce a Breaking Change?

[ ] Yes
[ ] No
[x] i don't expect a breaking change

## Other Information
