### PR TITLE
feat: individual page sizes for listings

### DIFF
--- a/src/app/core/configurations/injection-keys.ts
+++ b/src/app/core/configurations/injection-keys.ts
@@ -5,6 +5,7 @@ import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
 import { DataRetentionPolicy } from 'ish-core/utils/meta-reducers';
 
 import { environment } from '../../../environments/environment';
+import { Environment } from '../../../environments/environment.model';
 
 /**
  * Array of paths that always use mocked data
@@ -29,9 +30,12 @@ export const MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH = new InjectionToken<numbe
 /**
  * global definition of the product listing page size
  */
-export const PRODUCT_LISTING_ITEMS_PER_PAGE = new InjectionToken<number>('productListingItemsPerPage', {
-  factory: () => environment.productListingItemsPerPage,
-});
+export const PRODUCT_LISTING_ITEMS_PER_PAGE = new InjectionToken<Environment['productListingItemsPerPage']>(
+  'productListingItemsPerPage',
+  {
+    factory: () => environment.productListingItemsPerPage,
+  }
+);
 
 /**
  * default definition of the product listing view type

--- a/src/app/core/models/product-listing/product-listing.mapper.spec.ts
+++ b/src/app/core/models/product-listing/product-listing.mapper.spec.ts
@@ -1,21 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 
-import { PRODUCT_LISTING_ITEMS_PER_PAGE } from 'ish-core/configurations/injection-keys';
-
 import { ProductListingMapper } from './product-listing.mapper';
 
 describe('Product Listing Mapper', () => {
   let productListingMapper: ProductListingMapper;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [{ provide: PRODUCT_LISTING_ITEMS_PER_PAGE, useValue: 2 }],
-    });
+    TestBed.configureTestingModule({});
     productListingMapper = TestBed.inject(ProductListingMapper);
   });
 
   it('should map single page data to one page', () => {
-    expect(productListingMapper.createPages(['A', 'B'], 'test', 'dummy')).toMatchInlineSnapshot(`
+    expect(productListingMapper.createPages(['A', 'B'], 'test', 'dummy', 2)).toMatchInlineSnapshot(`
       Object {
         "1": Array [
           "A",
@@ -32,7 +28,7 @@ describe('Product Listing Mapper', () => {
   });
 
   it('should map multi page data to multiple pages', () => {
-    expect(productListingMapper.createPages(['A', 'B', 'C', 'D', 'E'], 'test', 'dummy')).toMatchInlineSnapshot(`
+    expect(productListingMapper.createPages(['A', 'B', 'C', 'D', 'E'], 'test', 'dummy', 2)).toMatchInlineSnapshot(`
       Object {
         "1": Array [
           "A",
@@ -57,7 +53,7 @@ describe('Product Listing Mapper', () => {
 
   it('should map extra arguments when supplied', () => {
     expect(
-      productListingMapper.createPages(['A', 'B', 'C', 'D'], 'test', 'dummy', {
+      productListingMapper.createPages(['A', 'B', 'C', 'D'], 'test', 'dummy', 2, {
         sortableAttributes: [{ name: 'name-desc' }],
         itemCount: 200,
         sorting: 'name-asc',

--- a/src/app/core/models/product-listing/product-listing.mapper.ts
+++ b/src/app/core/models/product-listing/product-listing.mapper.ts
@@ -1,19 +1,17 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { range } from 'lodash-es';
 
-import { PRODUCT_LISTING_ITEMS_PER_PAGE } from 'ish-core/configurations/injection-keys';
 import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 import { ProductListingType, SortableAttributesType } from './product-listing.model';
 
 @Injectable({ providedIn: 'root' })
 export class ProductListingMapper {
-  constructor(@Inject(PRODUCT_LISTING_ITEMS_PER_PAGE) private itemsPerPage: number) {}
-
   createPages(
     skus: string[],
     productListingType: string,
     productListingValue: string,
+    itemsPerPage: number,
     extras?: {
       startPage?: number;
       sortableAttributes?: SortableAttributesType[];
@@ -22,8 +20,8 @@ export class ProductListingMapper {
       filters?: URLFormParams;
     }
   ): ProductListingType {
-    const pages = range(0, Math.ceil(skus.length / this.itemsPerPage)).map(n =>
-      skus.slice(n * this.itemsPerPage, (n + 1) * this.itemsPerPage)
+    const pages = range(0, Math.ceil(skus.length / itemsPerPage)).map(n =>
+      skus.slice(n * itemsPerPage, (n + 1) * itemsPerPage)
     );
     const startPage = (extras && extras.startPage) || 1;
     const view: ProductListingType = {

--- a/src/app/core/services/filter/filter.service.spec.ts
+++ b/src/app/core/services/filter/filter.service.spec.ts
@@ -1,13 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { FilterNavigationData } from 'ish-core/models/filter-navigation/filter-navigation.interface';
 import { ApiService, AvailableOptions } from 'ish-core/services/api/api.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
-import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { URLFormParams } from 'ish-core/utils/url-form-params';
 
 import { FilterService } from './filter.service';
@@ -41,10 +38,9 @@ describe('Filter Service', () => {
     apiService = mock(ApiService);
 
     TestBed.configureTestingModule({
-      imports: [CoreStoreModule.forTesting(['configuration']), ShoppingStoreModule.forTesting('productListing')],
+      imports: [CoreStoreModule.forTesting(['configuration'])],
       providers: [{ provide: ApiService, useFactory: () => instance(apiService) }],
     });
-    TestBed.inject(Store).dispatch(setProductListingPageSize({ itemsPerPage: 2 }));
     filterService = TestBed.inject(FilterService);
   });
 
@@ -91,7 +87,7 @@ describe('Filter Service', () => {
   it("should get Product SKUs when 'getFilteredProducts' is called", done => {
     when(apiService.get(anything(), anything())).thenReturn(of(productsMock));
 
-    filterService.getFilteredProducts({ SearchParameter: ['b'] } as URLFormParams, 1).subscribe(data => {
+    filterService.getFilteredProducts({ SearchParameter: ['b'] } as URLFormParams, 2).subscribe(data => {
       expect(data?.products?.map(p => p.sku)).toMatchInlineSnapshot(`
         Array [
           "123",
@@ -105,7 +101,7 @@ describe('Filter Service', () => {
       const [resource, params] = capture(apiService.get).last();
       expect(resource).toMatchInlineSnapshot(`"products"`);
       expect((params as AvailableOptions)?.params?.toString()).toMatchInlineSnapshot(
-        `"amount=2&attrs=sku,salePrice,listPrice,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet&attributeGroup=PRODUCT_LABEL_ATTRIBUTES&returnSortKeys=true&offset=0&SearchParameter=b"`
+        `"amount=2&offset=0&attrs=sku,salePrice,listPrice,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet&attributeGroup=PRODUCT_LABEL_ATTRIBUTES&returnSortKeys=true&SearchParameter=b"`
       );
 
       done();

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -1,6 +1,5 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Store, select } from '@ngrx/store';
 import { Observable, of, throwError } from 'rxjs';
 import { defaultIfEmpty, map, switchMap } from 'rxjs/operators';
 
@@ -19,7 +18,6 @@ import {
   VariationProductMaster,
 } from 'ish-core/models/product/product.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
-import { getProductListingItemsPerPage } from 'ish-core/store/shopping/product-listing';
 import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 /**
@@ -30,16 +28,11 @@ export class ProductsService {
   static STUB_ATTRS =
     'sku,salePrice,listPrice,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet';
 
-  private itemsPerPage: number;
-
   constructor(
     private apiService: ApiService,
     private productMapper: ProductMapper,
-    store: Store,
     private featureToggleService: FeatureToggleService
-  ) {
-    store.pipe(select(getProductListingItemsPerPage)).subscribe(itemsPerPage => (this.itemsPerPage = itemsPerPage));
-  }
+  ) {}
 
   /**
    * Get the full Product data for the given Product SKU.
@@ -67,8 +60,9 @@ export class ProductsService {
    */
   getCategoryProducts(
     categoryUniqueId: string,
-    page: number,
-    sortKey?: string
+    amount: number,
+    sortKey?: string,
+    offset = 0
   ): Observable<{ products: Product[]; sortableAttributes: SortableAttributesType[]; total: number }> {
     if (!categoryUniqueId) {
       return throwError('getCategoryProducts() called without categoryUniqueId');
@@ -77,8 +71,8 @@ export class ProductsService {
     let params = new HttpParams()
       .set('attrs', ProductsService.STUB_ATTRS)
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
-      .set('amount', this.itemsPerPage.toString())
-      .set('offset', ((page - 1) * this.itemsPerPage).toString())
+      .set('amount', amount.toString())
+      .set('offset', offset.toString())
       .set('returnSortKeys', 'true')
       .set('productFilter', 'fallback_searchquerydefinition');
     if (sortKey) {
@@ -115,8 +109,9 @@ export class ProductsService {
    */
   searchProducts(
     searchTerm: string,
-    page: number = 1,
-    sortKey?: string
+    amount: number,
+    sortKey?: string,
+    offset = 0
   ): Observable<{ products: Product[]; sortableAttributes: SortableAttributesType[]; total: number }> {
     if (!searchTerm) {
       return throwError('searchProducts() called without searchTerm');
@@ -124,8 +119,8 @@ export class ProductsService {
 
     let params = new HttpParams()
       .set('searchTerm', searchTerm)
-      .set('amount', this.itemsPerPage.toString())
-      .set('offset', ((page - 1) * this.itemsPerPage).toString())
+      .set('amount', amount.toString())
+      .set('offset', offset.toString())
       .set('attrs', ProductsService.STUB_ATTRS)
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
@@ -156,8 +151,9 @@ export class ProductsService {
 
   getProductsForMaster(
     masterSKU: string,
-    page: number = 1,
-    sortKey?: string
+    amount: number,
+    sortKey?: string,
+    offset = 0
   ): Observable<{ products: Product[]; sortableAttributes: SortableAttributesType[]; total: number }> {
     if (!masterSKU) {
       return throwError('getProductsForMaster() called without masterSKU');
@@ -165,8 +161,8 @@ export class ProductsService {
 
     let params = new HttpParams()
       .set('MasterSKU', masterSKU)
-      .set('amount', this.itemsPerPage.toString())
-      .set('offset', ((page - 1) * this.itemsPerPage).toString())
+      .set('amount', amount.toString())
+      .set('offset', offset.toString())
       .set('attrs', ProductsService.STUB_ATTRS)
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');

--- a/src/app/core/store/content/parameters/parameters.effects.spec.ts
+++ b/src/app/core/store/content/parameters/parameters.effects.spec.ts
@@ -33,7 +33,7 @@ describe('Parameters Effects', () => {
 
   describe('loadParameters$', () => {
     it('should dispatch multiple actions when getFilteredProducts service is succesful', () => {
-      when(filterServiceMock.getFilteredProducts(anything(), anything(), anything(), anything())).thenReturn(
+      when(filterServiceMock.getFilteredProducts(anything(), anything())).thenReturn(
         of({ total: 1, products: [{ name: 'test', sku: 'sku' } as Product], sortableAttributes: [] })
       );
       const action = loadParametersProductListFilter({

--- a/src/app/core/store/content/parameters/parameters.effects.ts
+++ b/src/app/core/store/content/parameters/parameters.effects.ts
@@ -22,7 +22,7 @@ export class ParametersEffects {
       ofType(loadParametersProductListFilter),
       mapToPayload(),
       concatMap(({ id, searchParameter, amount }) =>
-        this.filterService.getFilteredProducts(searchParameter, 1, undefined, amount).pipe(
+        this.filterService.getFilteredProducts(searchParameter, amount).pipe(
           mergeMap(({ products }) => [
             ...products.map((product: Product) => loadProductSuccess({ product })),
             loadParametersProductListFilterSuccess({ id, productList: products.map(p => p.sku) }),

--- a/src/app/core/store/shopping/filter/filter.effects.spec.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.spec.ts
@@ -1,13 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Action } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
 import { Observable, of, throwError } from 'rxjs';
 import { toArray } from 'rxjs/operators';
-import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { anyNumber, anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { FilterService } from 'ish-core/services/filter/filter.service';
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
+import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 
 import {
@@ -47,7 +50,7 @@ describe('Filter Effects', () => {
       }
     });
 
-    when(filterServiceMock.getFilteredProducts(anything(), anything(), anything())).thenCall(a => {
+    when(filterServiceMock.getFilteredProducts(anything(), anyNumber(), anything(), anyNumber())).thenCall(a => {
       if (a.name === 'invalid') {
         return throwError(makeHttpError({ message: 'invalid' }));
       } else {
@@ -66,6 +69,7 @@ describe('Filter Effects', () => {
       }
     });
     TestBed.configureTestingModule({
+      imports: [CoreStoreModule.forTesting(), ShoppingStoreModule.forTesting('productListing')],
       providers: [
         FilterEffects,
         provideMockActions(() => actions$),
@@ -74,6 +78,8 @@ describe('Filter Effects', () => {
     });
 
     effects = TestBed.inject(FilterEffects);
+    const store$ = TestBed.inject(Store);
+    store$.dispatch(setProductListingPageSize({ itemsPerPage: 2 }));
   });
 
   describe('loadAvailableFilterForCategories$', () => {

--- a/src/app/core/store/shopping/filter/filter.effects.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { map, mergeMap, switchMap } from 'rxjs/operators';
+import { Store, select } from '@ngrx/store';
+import { first, map, mergeMap, switchMap } from 'rxjs/operators';
 
 import { ProductListingMapper } from 'ish-core/models/product-listing/product-listing.mapper';
 import { Product } from 'ish-core/models/product/product.model';
 import { FilterService } from 'ish-core/services/filter/filter.service';
-import { setProductListingPages } from 'ish-core/store/shopping/product-listing';
+import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
 import { loadProductFail, loadProductSuccess } from 'ish-core/store/shopping/products';
-import { mapErrorToAction, mapToPayload, mapToPayloadProperty } from 'ish-core/utils/operators';
+import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
 import {
   applyFilter,
@@ -26,7 +27,8 @@ export class FilterEffects {
   constructor(
     private actions$: Actions,
     private filterService: FilterService,
-    private productListingMapper: ProductListingMapper
+    private productListingMapper: ProductListingMapper,
+    private store: Store
   ) {}
 
   loadAvailableFilterForCategories$ = createEffect(() =>
@@ -86,25 +88,35 @@ export class FilterEffects {
       ofType(loadProductsForFilter),
       mapToPayload(),
       switchMap(({ id, searchParameter, page, sorting }) =>
-        this.filterService.getFilteredProducts(searchParameter, page, sorting).pipe(
-          mergeMap(({ products, total, sortableAttributes }) => [
-            ...products.map((product: Product) => loadProductSuccess({ product })),
-            setProductListingPages(
-              this.productListingMapper.createPages(
-                products.map(p => p.sku),
-                id.type,
-                id.value,
-                {
-                  filters: id.filters,
-                  itemCount: total,
-                  startPage: page,
-                  sortableAttributes,
-                  sorting,
-                }
+        this.store.pipe(
+          select(getProductListingItemsPerPage(id.type)),
+          whenTruthy(),
+          first(),
+          switchMap(pageSize =>
+            this.filterService
+              .getFilteredProducts(searchParameter, pageSize, sorting, ((page || 1) - 1) * pageSize)
+              .pipe(
+                mergeMap(({ products, total, sortableAttributes }) => [
+                  ...products.map((product: Product) => loadProductSuccess({ product })),
+                  setProductListingPages(
+                    this.productListingMapper.createPages(
+                      products.map(p => p.sku),
+                      id.type,
+                      id.value,
+                      pageSize,
+                      {
+                        filters: id.filters,
+                        itemCount: total,
+                        startPage: page,
+                        sortableAttributes,
+                        sorting,
+                      }
+                    )
+                  ),
+                ]),
+                mapErrorToAction(loadProductFail)
               )
-            ),
-          ]),
-          mapErrorToAction(loadProductFail)
+          )
         )
       )
     )

--- a/src/app/core/store/shopping/product-listing/product-listing.actions.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.actions.ts
@@ -12,7 +12,7 @@ export const setProductListingPages = createAction(
 
 export const setProductListingPageSize = createAction(
   '[Product Listing Internal] Set Product Listing Page Size',
-  payload<{ itemsPerPage: number }>()
+  payload<{ itemsPerPage: number | { [id: string]: number } }>()
 );
 
 export const loadMoreProducts = createAction(

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -43,7 +43,7 @@ describe('Product Listing Effects', () => {
 
   describe('initializePageSize$', () => {
     it('should set page size once and only for the first incoming action', () => {
-      expect(getProductListingItemsPerPage(store$.state)).toEqual(7);
+      expect(getProductListingItemsPerPage('dummy')(store$.state)).toEqual(7);
     });
   });
 

--- a/src/app/core/store/shopping/product-listing/product-listing.reducer.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.reducer.ts
@@ -40,7 +40,7 @@ export const adapter = createEntityAdapter<ProductListingType>({
  */
 export interface ProductListingState extends EntityState<ProductListingType> {
   loading: boolean;
-  itemsPerPage: number;
+  itemsPerPage: number | { [id: string]: number };
   viewType: ViewType;
   currentSettings: { [id: string]: Pick<ProductListingID, 'filters' | 'sorting'> };
 }

--- a/src/app/core/store/shopping/product-listing/product-listing.selectors.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.selectors.ts
@@ -16,7 +16,10 @@ const getProductListingState = createSelector(getShoppingState, state => state.p
 
 export const getProductListingLoading = createSelector(getProductListingState, state => state.loading);
 
-export const getProductListingItemsPerPage = createSelector(getProductListingState, state => state.itemsPerPage);
+export const getProductListingItemsPerPage = (key: string) =>
+  createSelector(getProductListingState, state =>
+    typeof state.itemsPerPage === 'object' ? state.itemsPerPage[key] : state.itemsPerPage
+  );
 
 export const getProductListingViewType = createSelector(getProductListingState, state => state.viewType);
 
@@ -97,7 +100,7 @@ function calculateLookUpID(
 export const getProductListingView = (id: ProductListingID) =>
   createSelectorFactory<object, ProductListingView>(projector => resultMemoize(projector, isEqual))(
     getProductListingEntities,
-    getProductListingItemsPerPage,
+    getProductListingItemsPerPage(id.type),
     getProductListingSettings,
     (
       entities: Dictionary<ProductListingType>,

--- a/src/app/core/store/shopping/products/products.effects.spec.ts
+++ b/src/app/core/store/shopping/products/products.effects.spec.ts
@@ -55,7 +55,7 @@ describe('Products Effects', () => {
       }
     });
 
-    when(productsServiceMock.getCategoryProducts('123', anyNumber(), anything())).thenReturn(
+    when(productsServiceMock.getCategoryProducts('123', anyNumber(), anything(), anyNumber())).thenReturn(
       of({
         sortableAttributes: [{ name: 'name-asc' }, { name: 'name-desc' }],
         products: [{ sku: 'P222' }, { sku: 'P333' }] as Product[],
@@ -72,7 +72,7 @@ describe('Products Effects', () => {
           { path: 'product/:sku', component: DummyComponent },
           { path: '**', component: DummyComponent },
         ]),
-        ShoppingStoreModule.forTesting('products', 'categories'),
+        ShoppingStoreModule.forTesting('products', 'categories', 'productListing'),
       ],
       providers: [
         ProductsEffects,
@@ -191,7 +191,7 @@ describe('Products Effects', () => {
       actions$ = of(loadProductsForCategory({ categoryId: '123', sorting: 'name-asc' }));
 
       effects.loadProductsForCategory$.subscribe(() => {
-        verify(productsServiceMock.getCategoryProducts('123', anyNumber(), 'name-asc')).once();
+        verify(productsServiceMock.getCategoryProducts('123', anyNumber(), 'name-asc', anyNumber())).once();
         done();
       });
     });
@@ -216,7 +216,7 @@ describe('Products Effects', () => {
     });
 
     it('should not die if repeating errors are encountered', () => {
-      when(productsServiceMock.getCategoryProducts(anything(), anyNumber(), anything())).thenReturn(
+      when(productsServiceMock.getCategoryProducts(anything(), anyNumber(), anything(), anyNumber())).thenReturn(
         throwError(makeHttpError({ message: 'ERROR' }))
       );
       actions$ = hot('-a-a-a', {

--- a/src/app/core/store/shopping/search/search.effects.spec.ts
+++ b/src/app/core/store/shopping/search/search.effects.spec.ts
@@ -36,12 +36,12 @@ describe('Search Effects', () => {
     when(suggestServiceMock.search(anyString())).thenReturn(of<SuggestTerm[]>(suggests));
     productsServiceMock = mock(ProductsService);
     const skus = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
-    when(productsServiceMock.searchProducts(anyString(), anyNumber(), anything())).thenCall(
-      (searchTerm: string, page: number, itemsPerPage: number) => {
+    when(productsServiceMock.searchProducts(anyString(), anyNumber(), anything(), anyNumber())).thenCall(
+      (searchTerm: string, amount: number, _, offset: number) => {
         if (!searchTerm) {
           return throwError(makeHttpError({ message: 'ERROR' }));
         } else {
-          const currentSlice = skus.slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage);
+          const currentSlice = skus.slice(offset, amount + offset);
           return of({
             products: currentSlice.map(sku => ({ sku })),
             sortKeys: [],
@@ -228,13 +228,13 @@ describe('Search Effects', () => {
       router.navigate(['search', searchTerm]);
       tick(500);
 
-      verify(productsServiceMock.searchProducts(searchTerm, 1, anything())).once();
+      verify(productsServiceMock.searchProducts(searchTerm, 12, anything(), 0)).once();
 
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: searchTerm }, page: 2 }));
-      verify(productsServiceMock.searchProducts(searchTerm, 2, anything())).once();
+      verify(productsServiceMock.searchProducts(searchTerm, 12, anything(), 12)).once();
 
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: searchTerm }, page: 3 }));
-      verify(productsServiceMock.searchProducts(searchTerm, 3, anything())).once();
+      verify(productsServiceMock.searchProducts(searchTerm, 12, anything(), 24)).once();
     }));
   });
 });

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -114,14 +114,14 @@ describe('Shopping Store', () => {
         return throwError(makeHttpError({ message: `error loading product ${sku}` }));
       }
     });
-    when(productsServiceMock.getCategoryProducts('A.123.456', anyNumber(), anything())).thenReturn(
+    when(productsServiceMock.getCategoryProducts('A.123.456', anyNumber(), anything(), anyNumber())).thenReturn(
       of({
         sortableAttributes: [],
         products: [{ sku: 'P1' }, { sku: 'P2' }] as Product[],
         total: 2,
       })
     );
-    when(productsServiceMock.searchProducts('something', anyNumber(), anything())).thenReturn(
+    when(productsServiceMock.searchProducts('something', anyNumber(), anything(), anyNumber())).thenReturn(
       of({ products: [{ sku: 'P2' } as Product], sortableAttributes: [], total: 1 })
     );
 

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -67,7 +67,13 @@ export interface Environment {
   mainNavigationMaxSubCategoriesDepth: number;
 
   // global definition of the product listing page size
-  productListingItemsPerPage: number;
+  productListingItemsPerPage:
+    | number
+    | {
+        category: number;
+        search: number;
+        master: number;
+      };
 
   // default viewType used for product listings
   defaultProductListingViewType: ViewType;
@@ -119,7 +125,11 @@ export const ENVIRONMENT_DEFAULTS: Environment = {
   largeBreakpointWidth: 992,
   extralargeBreakpointWidth: 1200,
   mainNavigationMaxSubCategoriesDepth: 2,
-  productListingItemsPerPage: 9,
+  productListingItemsPerPage: {
+    category: 9,
+    search: 12,
+    master: 6,
+  },
   defaultProductListingViewType: 'grid',
   defaultDeviceType: 'mobile',
   defaultLocale: 'en_US',


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

Only one page size can be set for all master-page, category-page and search-page listings.

## What Is the New Behavior?

Page sizes for listings of master-page, category-page and search-page can also be set individually.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
