### PR TITLE
fix: timing issue when fetching CMS content include data after logout

### DIFF
--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable, combineLatest } from 'rxjs';
-import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { delay, filter, map, switchMap, tap } from 'rxjs/operators';
 
 import { CallParameters } from 'ish-core/models/call-parameters/call-parameters.model';
 import { getContentInclude, loadContentInclude } from 'ish-core/store/content/includes';
@@ -23,6 +23,7 @@ export class CMSFacade {
 
   contentInclude$(includeId$: Observable<string>) {
     return combineLatest([includeId$.pipe(whenTruthy()), this.store.pipe(select(getPGID))]).pipe(
+      delay(0), // delay ensures the apiToken cookie is deleted before a cms request without a pgid is triggered
       tap(([includeId]) => this.store.dispatch(loadContentInclude({ includeId }))),
       switchMap(([includeId]) => this.store.pipe(select(getContentInclude(includeId), whenTruthy())))
     );


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When re-fetching content for (several) content includes after the user logs out the `/cms/includes` REST calls might result in an error stating `Bad Request (Matrix parameter "pgid" is required if auth token is present)`.
This happens since the CMS content include REST calls are re-triggered if the `PGID` changes (that is the case when a user logs in or logs out). If at this point in time the `apiToken` cookie is not yet removed (something that is done when logging out) the re-triggered REST call is done without a `pgid` but still with the auth token information of the `apiToken` cookie. This results in the mentioned REST error. In general this seems to be a timing issue since the `apiToken` cookie will be deleted after a user logs out.

## What Is the New Behavior?
The timing issue is fixed so that the REST call is now triggered after the cookie has been removed resulting in no further errors.

## Does this PR Introduce a Breaking Change?

[x] No
