### PR TITLE
fix: breadcrumb styling harmonization

### DIFF
--- a/src/app/extensions/quickorder/pages/quickorder/quickorder-page.component.html
+++ b/src/app/extensions/quickorder/pages/quickorder/quickorder-page.component.html
@@ -1,151 +1,153 @@
-<form [formGroup]="quickOrderForm" (ngSubmit)="onAddProducts()">
-  <ish-breadcrumb></ish-breadcrumb>
-  <div class="row">
-    <div class="col-md-12">
-      <h1>{{ 'quickorder.page.title' | translate }}</h1>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-8">
-      <h3>{{ 'quickorder.page.subtitle' | translate }}</h3>
-      <p>{{ 'quickorder.page.subtitle.description' | translate }}</p>
-      <div class="list-header d-sm-flex">
-        <div class="col-md-6 list-header-item no-seperator">{{ 'quickorder.page.product.id' | translate }}</div>
-        <div class="col-md-2 list-header-item no-seperator">{{ 'quickorder.page.product.quantity' | translate }}</div>
+<div class="content-page">
+  <form [formGroup]="quickOrderForm" (ngSubmit)="onAddProducts()">
+    <ish-breadcrumb></ish-breadcrumb>
+    <div class="row">
+      <div class="col-md-12">
+        <h1>{{ 'quickorder.page.title' | translate }}</h1>
       </div>
+    </div>
+    <div class="row">
+      <div class="col-md-8">
+        <h3>{{ 'quickorder.page.subtitle' | translate }}</h3>
+        <p>{{ 'quickorder.page.subtitle.description' | translate }}</p>
+        <div class="list-header d-sm-flex">
+          <div class="col-md-6 list-header-item no-seperator">{{ 'quickorder.page.product.id' | translate }}</div>
+          <div class="col-md-2 list-header-item no-seperator">{{ 'quickorder.page.product.quantity' | translate }}</div>
+        </div>
 
-      <div class="pt-1">
-        <div formArrayName="quickOrderLines">
-          <div
-            class="row list-item-row py-2"
-            *ngFor="let item of quickOrderLines.controls; let i = index"
-            [formGroupName]="i"
-            [attr.data-testing-id]="'quickorder-line-' + i"
-          >
-            <div class="col-sm-6 list-item search-container">
-              <div class="d-sm-none">{{ 'quickorder.page.product.id' | translate }}</div>
-              <div class="quickorder-search-container position-relative">
+        <div class="pt-1">
+          <div formArrayName="quickOrderLines">
+            <div
+              class="row list-item-row py-2"
+              *ngFor="let item of quickOrderLines.controls; let i = index"
+              [formGroupName]="i"
+              [attr.data-testing-id]="'quickorder-line-' + i"
+            >
+              <div class="col-sm-6 list-item search-container">
+                <div class="d-sm-none">{{ 'quickorder.page.product.id' | translate }}</div>
+                <div class="quickorder-search-container position-relative">
+                  <ish-input
+                    type="text"
+                    controlName="sku"
+                    inputClass="w-100 col-12"
+                    [form]="item"
+                    [errorMessages]="{
+                      not_exists: 'quickorder.page.error.invalid.product' | translate: { '0': item.value.sku }
+                    }"
+                  ></ish-input>
+                  <ul class="search-suggest-results w-100" *ngIf="item.value.sku === searchSuggestions[0].sku">
+                    <li>
+                      <button type="button" class="search-result">
+                        <div class="row">
+                          <div class="col-sm-3">
+                            <img [src]="searchSuggestions[0].imgPath" class="product-image" height="110" width="110" />
+                          </div>
+                          <div class="col-sm-9">
+                            <span [innerHtml]="searchSuggestions[0].sku"></span>
+                            <span><br />{{ searchSuggestions[0].name }}</span>
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li>
+                      <button type="button" class="search-result">
+                        <div class="row">
+                          <div class="col-sm-3">
+                            <img [src]="searchSuggestions[0].imgPath" class="product-image" height="110" width="110" />
+                          </div>
+                          <div class="col-sm-9">
+                            <span [innerHtml]="searchSuggestions[0].sku"></span>
+                            <span><br />{{ searchSuggestions[0].name }}</span>
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div class="col-sm-2 list-item">
+                <div class="d-sm-none">{{ 'quickorder.page.product.quantity' | translate }}</div>
                 <ish-input
-                  type="text"
-                  controlName="sku"
-                  inputClass="w-100 col-12"
+                  type="number"
                   [form]="item"
+                  controlName="quantity"
+                  inputClass="w-100"
+                  [min]="1"
                   [errorMessages]="{
-                    not_exists: 'quickorder.page.error.invalid.product' | translate: { '0': item.value.sku }
+                    required: 'product.quantity.notempty.text',
+                    integer: 'product.quantity.integer.text',
+                    min: 'product.quantity.greaterthan.text' | translate: { '0': item.value.product.minOrderQuantity },
+                    max: 'product.quantity.lessthan.text' | translate: { '0': item.value.product.maxOrderQuantity }
                   }"
                 ></ish-input>
-                <ul class="search-suggest-results w-100" *ngIf="item.value.sku === searchSuggestions[0].sku">
-                  <li>
-                    <button type="button" class="search-result">
-                      <div class="row">
-                        <div class="col-sm-3">
-                          <img [src]="searchSuggestions[0].imgPath" class="product-image" height="110" width="110" />
-                        </div>
-                        <div class="col-sm-9">
-                          <span [innerHtml]="searchSuggestions[0].sku"></span>
-                          <span><br />{{ searchSuggestions[0].name }}</span>
-                        </div>
-                      </div>
-                    </button>
-                  </li>
-                  <li>
-                    <button type="button" class="search-result">
-                      <div class="row">
-                        <div class="col-sm-3">
-                          <img [src]="searchSuggestions[0].imgPath" class="product-image" height="110" width="110" />
-                        </div>
-                        <div class="col-sm-9">
-                          <span [innerHtml]="searchSuggestions[0].sku"></span>
-                          <span><br />{{ searchSuggestions[0].name }}</span>
-                        </div>
-                      </div>
-                    </button>
-                  </li>
-                </ul>
+              </div>
+              <div class="col-sm-2 list-item">
+                <a class="btn btn-link remove-row" title="remove-current-row" (click)="deleteItem(i)">{{
+                  'quickorder.page.remove.row' | translate
+                }}</a>
               </div>
             </div>
-            <div class="col-sm-2 list-item">
-              <div class="d-sm-none">{{ 'quickorder.page.product.quantity' | translate }}</div>
-              <ish-input
-                type="number"
-                [form]="item"
-                controlName="quantity"
-                inputClass="w-100"
-                [min]="1"
-                [errorMessages]="{
-                  required: 'product.quantity.notempty.text',
-                  integer: 'product.quantity.integer.text',
-                  min: 'product.quantity.greaterthan.text' | translate: { '0': item.value.product.minOrderQuantity },
-                  max: 'product.quantity.lessthan.text' | translate: { '0': item.value.product.maxOrderQuantity }
-                }"
-              ></ish-input>
-            </div>
-            <div class="col-sm-2 list-item">
-              <a class="btn btn-link remove-row" title="remove-current-row" (click)="deleteItem(i)">{{
-                'quickorder.page.remove.row' | translate
-              }}</a>
-            </div>
+            <a class="d-block" (click)="addRows(1)" data-testing-id="add-quickorder-line">{{
+              'quickorder.page.add.row' | translate
+            }}</a>
+            <hr class="mt-2 mb-4" />
           </div>
-          <a class="d-block" (click)="addRows(1)" data-testing-id="add-quickorder-line">{{
-            'quickorder.page.add.row' | translate
-          }}</a>
-          <hr class="mt-2 mb-4" />
         </div>
       </div>
     </div>
-  </div>
-  <div>
-    <button
-      type="submit"
-      class="btn btn-primary"
-      [disabled]="quickOrderFormDisabled"
-      data-testing-id="add-form-to-cart"
-    >
-      {{ 'quickorder.page.add.cart' | translate }}
-    </button>
-    <button type="reset" class="btn btn-link" (click)="resetFields()">
-      {{ 'quickorder.page.reset.form' | translate }}
-    </button>
-  </div>
-  <div class="row mt-4">
-    <div class="col-md-6">
-      <h3>{{ 'quickorder.page.csv.title' | translate }}</h3>
-      <p>{{ 'quickorder.page.csv.subtitle' | translate }}</p>
-      <form [formGroup]="csvForm" (ngSubmit)="addCsvToCart()">
-        <div class="form-group section section-seperator">
-          <input
-            type="file"
-            name="csvFile"
-            id="CSVFile"
-            size="35"
-            class="form-control"
-            accept=".csv"
-            (change)="uploadListener($event.target)"
-          />
-          <div [ngSwitch]="status" class="position-absolute">
-            <small *ngSwitchCase="'IncorrectInput'" class="has-error"
-              ><span class="form-text">{{ 'quickorder.page.csv.file.invalid.input' | translate }}</span></small
-            >
-            <small *ngSwitchCase="'InvalidFormat'" class="has-error"
-              ><span class="form-text">{{ 'quickorder.page.csv.file.invalid.format' | translate }}</span></small
-            >
-            <small *ngSwitchCase="'ValidFormat'" class="has-success"
-              ><span class="form-text">{{ 'quickorder.page.csv.file.uploaded' | translate }}</span></small
-            >
-            <small *ngSwitchDefault></small>
-          </div>
-        </div>
-        <div>
-          <button type="submit" class="btn btn-primary" name="addToCartCSV" disabled="csvForm.invalid">
-            {{ 'quickorder.page.add.cart' | translate }}
-          </button>
-          <button type="reset" class="btn btn-link" name="reset" (click)="resetCsvProductArray()">
-            {{ 'quickorder.page.csv.reset.form' | translate }}
-          </button>
-        </div>
-      </form>
+    <div>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="quickOrderFormDisabled"
+        data-testing-id="add-form-to-cart"
+      >
+        {{ 'quickorder.page.add.cart' | translate }}
+      </button>
+      <button type="reset" class="btn btn-link" (click)="resetFields()">
+        {{ 'quickorder.page.reset.form' | translate }}
+      </button>
     </div>
-  </div>
-</form>
+    <div class="row mt-4">
+      <div class="col-md-6">
+        <h3>{{ 'quickorder.page.csv.title' | translate }}</h3>
+        <p>{{ 'quickorder.page.csv.subtitle' | translate }}</p>
+        <form [formGroup]="csvForm" (ngSubmit)="addCsvToCart()">
+          <div class="form-group section section-seperator">
+            <input
+              type="file"
+              name="csvFile"
+              id="CSVFile"
+              size="35"
+              class="form-control"
+              accept=".csv"
+              (change)="uploadListener($event.target)"
+            />
+            <div [ngSwitch]="status" class="position-absolute">
+              <small *ngSwitchCase="'IncorrectInput'" class="has-error"
+                ><span class="form-text">{{ 'quickorder.page.csv.file.invalid.input' | translate }}</span></small
+              >
+              <small *ngSwitchCase="'InvalidFormat'" class="has-error"
+                ><span class="form-text">{{ 'quickorder.page.csv.file.invalid.format' | translate }}</span></small
+              >
+              <small *ngSwitchCase="'ValidFormat'" class="has-success"
+                ><span class="form-text">{{ 'quickorder.page.csv.file.uploaded' | translate }}</span></small
+              >
+              <small *ngSwitchDefault></small>
+            </div>
+          </div>
+          <div>
+            <button type="submit" class="btn btn-primary" name="addToCartCSV" disabled="csvForm.invalid">
+              {{ 'quickorder.page.add.cart' | translate }}
+            </button>
+            <button type="reset" class="btn btn-link" name="reset" (click)="resetCsvProductArray()">
+              {{ 'quickorder.page.csv.reset.form' | translate }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </form>
 
-<ish-loading *ngIf="loading$ | async"></ish-loading>
+  <ish-loading *ngIf="loading$ | async"></ish-loading>
+</div>

--- a/src/app/pages/contact/contact-page.component.html
+++ b/src/app/pages/contact/contact-page.component.html
@@ -1,19 +1,21 @@
-<ish-breadcrumb></ish-breadcrumb>
+<div class="content-page">
+  <ish-breadcrumb></ish-breadcrumb>
 
-<h1>{{ 'helpdesk.contact_us.heading' | translate }}</h1>
+  <h1>{{ 'helpdesk.contact_us.heading' | translate }}</h1>
 
-<ng-container *ngIf="(success$ | async) === undefined; else contactConfirmation">
-  <div class="row">
-    <div class="col-md-10 col-lg-8 col-xl-7">
-      <ish-contact-form (request)="createRequest($event)"></ish-contact-form>
+  <ng-container *ngIf="(success$ | async) === undefined; else contactConfirmation">
+    <div class="row">
+      <div class="col-md-10 col-lg-8 col-xl-7">
+        <ish-contact-form (request)="createRequest($event)"></ish-contact-form>
+      </div>
     </div>
-  </div>
 
-  <p [innerHTML]="'helpdesk.user_service.message' | translate"></p>
-</ng-container>
+    <p [innerHTML]="'helpdesk.user_service.message' | translate"></p>
+  </ng-container>
 
-<ng-template #contactConfirmation>
-  <ish-contact-confirmation [success]="success$ | async"></ish-contact-confirmation>
-</ng-template>
+  <ng-template #contactConfirmation>
+    <ish-contact-confirmation [success]="success$ | async"></ish-contact-confirmation>
+  </ng-template>
 
-<ish-loading *ngIf="loading$ | async"></ish-loading>
+  <ish-loading *ngIf="loading$ | async"></ish-loading>
+</div>

--- a/src/app/pages/product/product-page.component.html
+++ b/src/app/pages/product/product-page.component.html
@@ -1,4 +1,4 @@
-<div class="clearfix" data-testing-id="product-detail-page" itemscope itemtype="http://schema.org/Product">
+<div class="product-page clearfix" data-testing-id="product-detail-page" itemscope itemtype="http://schema.org/Product">
   <ish-loading *ngIf="productLoading$ | async"></ish-loading>
 
   <ish-breadcrumb></ish-breadcrumb>

--- a/src/app/pages/recently/recently-page.component.html
+++ b/src/app/pages/recently/recently-page.component.html
@@ -1,5 +1,3 @@
-<ish-breadcrumb></ish-breadcrumb>
-
 <ng-container *ngIf="products$ | async as products">
   <ish-recently-viewed-all [products]="products" (clearRecently)="clearAll()"></ish-recently-viewed-all>
 </ng-container>

--- a/src/app/pages/recently/recently-page.component.spec.ts
+++ b/src/app/pages/recently/recently-page.component.spec.ts
@@ -3,7 +3,6 @@ import { MockComponent } from 'ng-mocks';
 import { instance, mock } from 'ts-mockito';
 
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
-import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
 
 import { RecentlyPageComponent } from './recently-page.component';
 import { RecentlyViewedAllComponent } from './recently-viewed-all/recently-viewed-all.component';
@@ -15,11 +14,7 @@ describe('Recently Page Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        MockComponent(BreadcrumbComponent),
-        MockComponent(RecentlyViewedAllComponent),
-        RecentlyPageComponent,
-      ],
+      declarations: [MockComponent(RecentlyViewedAllComponent), RecentlyPageComponent],
       providers: [{ provide: ShoppingFacade, useFactory: () => instance(mock(ShoppingFacade)) }],
     }).compileComponents();
   });

--- a/src/app/pages/recently/recently-viewed-all/recently-viewed-all.component.html
+++ b/src/app/pages/recently/recently-viewed-all/recently-viewed-all.component.html
@@ -1,9 +1,10 @@
-<div class="row">
+<div class="content-page row">
   <ng-container *ngIf="products.length; else empty">
     <div class="col-md-3">
       <a (click)="clearAll()" data-testing-id="clear-all">{{ 'application.recentlyViewed.clear' | translate }}</a>
     </div>
     <div class="col-md-9">
+      <ish-breadcrumb></ish-breadcrumb>
       <h1>{{ 'application.recentlyViewed.product.heading' | translate }}</h1>
       <div class="product-list row">
         <div *ngFor="let productSku of products" class="col-6 col-lg-4 product-list-item grid-view">
@@ -15,6 +16,7 @@
 
   <ng-template #empty>
     <div class="col-md-12">
+      <ish-breadcrumb></ish-breadcrumb>
       <h1>{{ 'application.recentlyViewed.heading' | translate }}</h1>
       <p>{{ 'application.recentlyViewed.empty' | translate }}</p>
     </div>

--- a/src/app/pages/recently/recently-viewed-all/recently-viewed-all.component.spec.ts
+++ b/src/app/pages/recently/recently-viewed-all/recently-viewed-all.component.spec.ts
@@ -3,6 +3,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
+import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { RecentlyViewedAllComponent } from './recently-viewed-all.component';
@@ -15,6 +16,7 @@ describe('Recently Viewed All Component', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
+        MockComponent(BreadcrumbComponent),
         MockComponent(ProductItemComponent),
         MockDirective(ProductContextDirective),
         RecentlyViewedAllComponent,

--- a/src/app/pages/search/search-no-result/search-no-result.component.html
+++ b/src/app/pages/search/search-no-result/search-no-result.component.html
@@ -1,17 +1,19 @@
 <div class="no-search-result" data-testing-id="no-search-result-page">
+  <ish-breadcrumb></ish-breadcrumb>
+
   <h1 class="h2">{{ 'search.noResult.heading' | translate }}</h1>
 
   <p class="no-search-result-title" [innerHTML]="'search.noResult.message' | translate: { '0': searchTerm }"></p>
-</div>
 
-<div class="search-container main-search-container">
-  <ish-search-box
-    [configuration]="{
-      placeholder: 'search.searchbox.instructional_text' | translate,
-      autoSuggest: true,
-      maxAutoSuggests: 10
-    }"
-  ></ish-search-box>
-</div>
+  <div class="search-container main-search-container">
+    <ish-search-box
+      [configuration]="{
+        placeholder: 'search.searchbox.instructional_text' | translate,
+        autoSuggest: true,
+        maxAutoSuggests: 10
+      }"
+    ></ish-search-box>
+  </div>
 
-<div class="search-guidelines" [innerHTML]="'search.noresult.guidelines' | translate"></div>
+  <div class="search-guidelines" [innerHTML]="'search.noresult.guidelines' | translate"></div>
+</div>

--- a/src/app/pages/search/search-no-result/search-no-result.component.spec.ts
+++ b/src/app/pages/search/search-no-result/search-no-result.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 
+import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
 import { SearchBoxComponent } from 'ish-shared/components/search/search-box/search-box.component';
 
 import { SearchNoResultComponent } from './search-no-result.component';
@@ -15,7 +16,7 @@ describe('Search No Result Component', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
-      declarations: [MockComponent(SearchBoxComponent), SearchNoResultComponent],
+      declarations: [MockComponent(BreadcrumbComponent), MockComponent(SearchBoxComponent), SearchNoResultComponent],
     }).compileComponents();
   });
 

--- a/src/app/pages/search/search-page.component.html
+++ b/src/app/pages/search/search-page.component.html
@@ -10,7 +10,6 @@
 
   <!-- empty search result -->
   <ng-template #noResult>
-    <ish-breadcrumb></ish-breadcrumb>
     <ish-search-no-result *ngIf="!(searchLoading$ | async)" [searchTerm]="searchTerm"></ish-search-no-result>
   </ng-template>
 </ng-container>

--- a/src/app/pages/search/search-page.component.spec.ts
+++ b/src/app/pages/search/search-page.component.spec.ts
@@ -7,7 +7,6 @@ import { instance, mock, when } from 'ts-mockito';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
-import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
 
 import { SearchNoResultComponent } from './search-no-result/search-no-result.component';
 import { SearchPageComponent } from './search-page.component';
@@ -25,12 +24,7 @@ describe('Search Page Component', () => {
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      declarations: [
-        MockComponent(BreadcrumbComponent),
-        MockComponent(SearchNoResultComponent),
-        MockComponent(SearchResultComponent),
-        SearchPageComponent,
-      ],
+      declarations: [MockComponent(SearchNoResultComponent), MockComponent(SearchResultComponent), SearchPageComponent],
       providers: [
         { provide: AppFacade, useFactory: () => instance(mock(AppFacade)) },
         { provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) },
@@ -58,7 +52,6 @@ describe('Search Page Component', () => {
 
     expect(findAllCustomElements(element)).toMatchInlineSnapshot(`
       Array [
-        "ish-breadcrumb",
         "ish-search-no-result",
       ]
     `);

--- a/src/styles/global/breadcrumbs.scss
+++ b/src/styles/global/breadcrumbs.scss
@@ -1,7 +1,7 @@
 /******* GLOBAL BREADCRUMBS *********/
 
 .breadcrumbs {
-  padding: 0 $space-default $space-default $space-default;
+  padding: 0 $space-default 0 $space-default;
 
   @media (max-width: $screen-xs-max) {
     display: none;
@@ -31,8 +31,4 @@
       }
     }
   }
-}
-
-.col-md-9 .breadcrumbs {
-  padding-bottom: 0;
 }

--- a/src/styles/pages/account/account.scss
+++ b/src/styles/pages/account/account.scss
@@ -13,12 +13,6 @@
     padding: $space-default 0;
 
     h1,
-    h2,
-    h3 {
-      margin-top: 0;
-    }
-
-    h1,
     h2 {
       .btn {
         @media (max-width: $screen-xs-max) {

--- a/src/styles/pages/category/search-result.scss
+++ b/src/styles/pages/category/search-result.scss
@@ -23,6 +23,7 @@
 }
 
 .no-search-result {
+  padding: $space-default 0 $space-default 0;
   clear: both;
 
   .result-count-message {

--- a/src/styles/pages/productdetail/productdetail.scss
+++ b/src/styles/pages/productdetail/productdetail.scss
@@ -1,6 +1,10 @@
 //
 // PRODUCT DETAILS
 
+.product-page {
+  padding: $space-default 0 $space-default 0;
+}
+
 .product-details {
   padding: 0;
 


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The Breadcrumb styling (mainly the padding on top and bottom) is different for pages with side panel (category, my account, static content) or without (product detail, quick order, etc.).

## What Is the New Behavior?

Harmonized Breadcrumb styling with consistent padding on top and bottom.

## Does this PR Introduce a Breaking Change?

[x] No

