### PR TITLE
feat: replace i18nPlural pipe usage with translate compiler

### DIFF
--- a/docs/concepts/localization.md
+++ b/docs/concepts/localization.md
@@ -79,51 +79,9 @@ export class Component {
 
 ### Localization with Pluralization
 
-For more information refer to:
+The PWA uses an [ICU Message Format](http://userguide.icu-project.org/formatparse/messages) inspired way of supporting pluralization in translation keys.
 
-- [Feature: Pluralization](https://github.com/ngx-translate/core/issues/150)
-- [Angular - I18nPluralPipe](https://angular.io/api/common/I18nPluralPipe)
-
-Localization file:
-
-**en.json**
-
-```json
-{ ...
-  "product.items.label": {
-    "=0":"0 items",
-    "=1": "1 item",
-    "other": "# items"},
-  ...
-}
-```
-
-Parameter setting in HTML:
-
-**\*.component.html**
-
-```html
-<div>{{ 8 | i18nPlural: ( 'product.items.label' | translate ) }}</div>
-```
-
-Parameter setting in component and usage in HTML:
-
-**\*component.ts**
-
-```typescript
-export class Component {
-  products = ['product1','product2','product3'];
-  ...
-```
-
-**\*.component.html**
-
-```html
-<div>
-  {{ products.length | i18nPlural: {'=0': 'product.items.label.none','=1': 'product.items.label.singular','other':
-  'product.items.label.plural'} | translate:{'0': products.length} }}
-</div>
-```
+Have a look at the spec for [PWATranslateCompiler](../../src/app/core/utils/translate/pwa-translate-compiler.spec.ts) for an overview of supported methods.
 
 ### Localization with Formatted Dates
 

--- a/projects/requisition-management/src/app/components/requisitions-list/requisitions-list.component.html
+++ b/projects/requisition-management/src/app/components/requisitions-list/requisitions-list.component.html
@@ -139,7 +139,7 @@
   </table>
 
   <div data-testing-id="list-counter">
-    {{ requisitions?.length | i18nPlural: ('account.approvallist.items' | translate) || { other: '#' } }}
+    {{ 'account.approvallist.items' | translate: { '0': requisitions?.length } }}
   </div>
 </ng-container>
 

--- a/projects/requisition-management/src/app/components/requisitions-list/requisitions-list.component.spec.ts
+++ b/projects/requisition-management/src/app/components/requisitions-list/requisitions-list.component.spec.ts
@@ -54,7 +54,7 @@ describe('Requisitions List Component', () => {
     translate.setDefaultLang('en');
     translate.use('en');
     translate.setTranslation('en', {
-      'account.approvallist.items': { other: '# items' },
+      'account.approvallist.items': '{{0}} items',
     });
   });
 

--- a/src/app/core/internationalization.module.ts
+++ b/src/app/core/internationalization.module.ts
@@ -3,7 +3,13 @@ import localeDe from '@angular/common/locales/de';
 import localeFr from '@angular/common/locales/fr';
 import { Inject, LOCALE_ID, NgModule } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
-import { MissingTranslationHandler, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import {
+  MissingTranslationHandler,
+  TranslateCompiler,
+  TranslateLoader,
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 
 import { SSR_LOCALE } from './configurations/state-keys';
 import {
@@ -11,6 +17,7 @@ import {
   FallbackMissingTranslationHandler,
 } from './utils/translate/fallback-missing-translation-handler';
 import { ICMTranslateLoader } from './utils/translate/icm-translate-loader';
+import { PWATranslateCompiler } from './utils/translate/pwa-translate-compiler';
 
 @NgModule({
   imports: [
@@ -18,6 +25,7 @@ import { ICMTranslateLoader } from './utils/translate/icm-translate-loader';
       loader: { provide: TranslateLoader, useClass: ICMTranslateLoader },
       missingTranslationHandler: { provide: MissingTranslationHandler, useClass: FallbackMissingTranslationHandler },
       useDefaultLang: false,
+      compiler: { provide: TranslateCompiler, useClass: PWATranslateCompiler },
     }),
   ],
   providers: [{ provide: FALLBACK_LANG, useValue: 'en_US' }],

--- a/src/app/core/utils/translate/pwa-translate-compiler.spec.ts
+++ b/src/app/core/utils/translate/pwa-translate-compiler.spec.ts
@@ -1,0 +1,166 @@
+import { TestBed } from '@angular/core/testing';
+import { TranslateCompiler, TranslateModule, TranslateService } from '@ngx-translate/core';
+
+import { PWATranslateCompiler } from './pwa-translate-compiler';
+
+describe('Pwa Translate Compiler', () => {
+  let translate: TranslateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({
+          compiler: {
+            provide: TranslateCompiler,
+            useClass: PWATranslateCompiler,
+          },
+        }),
+      ],
+    });
+
+    translate = TestBed.inject(TranslateService);
+    translate.setDefaultLang('en');
+    translate.use('en');
+  });
+
+  describe('with default functionality', () => {
+    beforeEach(() => {
+      translate.set('simple', 'Hello World!');
+      translate.set('argument', 'Hello {{0}}!');
+    });
+
+    it('should translate static values when queried', () => {
+      expect(translate.instant('simple')).toMatchInlineSnapshot(`"Hello World!"`);
+    });
+
+    it('should translate values with arguments when queried', () => {
+      expect(translate.instant('argument', { 0: 'Alice' })).toMatchInlineSnapshot(`"Hello Alice!"`);
+    });
+  });
+
+  describe('with plural functionality', () => {
+    beforeEach(() => {
+      translate.set('plural', '{{0, plural, =0{0 items} =1{1 item} other{# items}}}');
+    });
+
+    it('should translate when no argument was given', () => {
+      expect(translate.instant('plural')).toMatchInlineSnapshot(`" items"`);
+    });
+
+    it('should translate when "0" argument was given', () => {
+      // tslint:disable-next-line: use-shorthand-property-in-object-creation
+      expect(translate.instant('plural', { 0: 0 })).toMatchInlineSnapshot(`"0 items"`);
+    });
+
+    it('should translate when "1" argument was given', () => {
+      expect(translate.instant('plural', { 0: 1 })).toMatchInlineSnapshot(`"1 item"`);
+    });
+
+    it('should translate when other argument was given', () => {
+      expect(translate.instant('plural', { 0: 20 })).toMatchInlineSnapshot(`"20 items"`);
+    });
+  });
+
+  describe('with plural functionality and content around', () => {
+    beforeEach(() => {
+      translate.set('plural', 'Content: {{0}} item{{0, plural, =1{} other{s}}}!');
+    });
+
+    it('should translate when no argument was given', () => {
+      expect(translate.instant('plural')).toMatchInlineSnapshot(`"Content:  items!"`);
+    });
+
+    it('should translate when "0" argument was given', () => {
+      // tslint:disable-next-line: use-shorthand-property-in-object-creation
+      expect(translate.instant('plural', { 0: 0 })).toMatchInlineSnapshot(`"Content: 0 items!"`);
+    });
+
+    it('should translate when "1" argument was given', () => {
+      expect(translate.instant('plural', { 0: 1 })).toMatchInlineSnapshot(`"Content: 1 item!"`);
+    });
+
+    it('should translate when other argument was given', () => {
+      expect(translate.instant('plural', { 0: 20 })).toMatchInlineSnapshot(`"Content: 20 items!"`);
+    });
+  });
+
+  describe('with select format', () => {
+    beforeEach(() => {
+      translate.set('select', '{{ gender, select, =male {He} =female {She} other {They} }} liked this.');
+    });
+
+    it('should translate when first case is given', () => {
+      expect(translate.instant('select', { gender: 'male' })).toMatchInlineSnapshot(`"He liked this."`);
+    });
+
+    it('should translate when second case is given', () => {
+      expect(translate.instant('select', { gender: 'female' })).toMatchInlineSnapshot(`"She liked this."`);
+    });
+
+    it('should translate when other case is given', () => {
+      expect(translate.instant('select')).toMatchInlineSnapshot(`"They liked this."`);
+    });
+  });
+
+  describe('with multiple instances', () => {
+    beforeEach(() => {
+      translate.set(
+        'multi',
+        "HEADLINE: {{ gender, select, =male {He} =female {She} other {They} }} {{like, select, =true{enjoyed} other{didn't like}}} buying {{ items, plural, =0{nothing} =1{# item} other{# items} }} at {{shop}}."
+      );
+    });
+
+    it.each`
+      gender      | items | like     | expected
+      ${'male'}   | ${0}  | ${true}  | ${'HEADLINE: He enjoyed buying nothing at inTRONICS.'}
+      ${'male'}   | ${0}  | ${false} | ${"HEADLINE: He didn't like buying nothing at inTRONICS."}
+      ${'female'} | ${0}  | ${true}  | ${'HEADLINE: She enjoyed buying nothing at inTRONICS.'}
+      ${'female'} | ${0}  | ${false} | ${"HEADLINE: She didn't like buying nothing at inTRONICS."}
+      ${'other'}  | ${0}  | ${true}  | ${'HEADLINE: They enjoyed buying nothing at inTRONICS.'}
+      ${'other'}  | ${0}  | ${false} | ${"HEADLINE: They didn't like buying nothing at inTRONICS."}
+      ${'male'}   | ${1}  | ${true}  | ${'HEADLINE: He enjoyed buying 1 item at inTRONICS.'}
+      ${'male'}   | ${1}  | ${false} | ${"HEADLINE: He didn't like buying 1 item at inTRONICS."}
+      ${'female'} | ${1}  | ${true}  | ${'HEADLINE: She enjoyed buying 1 item at inTRONICS.'}
+      ${'female'} | ${1}  | ${false} | ${"HEADLINE: She didn't like buying 1 item at inTRONICS."}
+      ${'other'}  | ${1}  | ${true}  | ${'HEADLINE: They enjoyed buying 1 item at inTRONICS.'}
+      ${'other'}  | ${1}  | ${false} | ${"HEADLINE: They didn't like buying 1 item at inTRONICS."}
+      ${'male'}   | ${2}  | ${true}  | ${'HEADLINE: He enjoyed buying 2 items at inTRONICS.'}
+      ${'male'}   | ${2}  | ${false} | ${"HEADLINE: He didn't like buying 2 items at inTRONICS."}
+      ${'female'} | ${2}  | ${true}  | ${'HEADLINE: She enjoyed buying 2 items at inTRONICS.'}
+      ${'female'} | ${2}  | ${false} | ${"HEADLINE: She didn't like buying 2 items at inTRONICS."}
+      ${'other'}  | ${2}  | ${true}  | ${'HEADLINE: They enjoyed buying 2 items at inTRONICS.'}
+      ${'other'}  | ${2}  | ${false} | ${"HEADLINE: They didn't like buying 2 items at inTRONICS."}
+    `(
+      'should translate when gender "$gender" with $items item(s) and $like is given',
+      ({ gender, items, like, expected }) => {
+        expect(translate.instant('multi', { gender, items, like, shop: 'inTRONICS' })).toEqual(expected);
+      }
+    );
+  });
+
+  describe('with nesting', () => {
+    beforeEach(() => {
+      translate.set(
+        'nesting',
+        `You {{items, plural,
+          =0{don't have anything}
+          other{have {{items, plural,
+            =1{one item}
+            =2{# items}
+            other{quite enough}
+          }}}
+        }}.`
+      );
+    });
+
+    it.each`
+      items | expected
+      ${0}  | ${"You don't have anything."}
+      ${1}  | ${'You have one item.'}
+      ${2}  | ${'You have 2 items.'}
+      ${3}  | ${'You have quite enough.'}
+    `('should translate when $items was given as argument', ({ items, expected }) => {
+      expect(translate.instant('nesting', { items })).toEqual(expected);
+    });
+  });
+});

--- a/src/app/core/utils/translate/pwa-translate-compiler.ts
+++ b/src/app/core/utils/translate/pwa-translate-compiler.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@angular/core';
+import { TranslateCompiler } from '@ngx-translate/core';
+
+import { Translations } from './translations.type';
+
+@Injectable()
+export class PWATranslateCompiler implements TranslateCompiler {
+  /**
+   * regular expression for grabbing everything in the form:
+   * {{<variable>, plural/select, <case>...<case>}}
+   *
+   * - beginning and ending double curly braces must always come
+   *   together without space in between
+   * - cases are matched not greedy (.*?) so the regex finds the
+   *   smallest match first (if nested, the inner first)
+   * - multi-line support with "/s" at the end
+   * - "\s*" captures (and ignores) additional whitespace
+   * - matching group at beginning and end to handle remaining text
+   */
+  private static PLURAL_REGEX = /(.*)\{\{\s*(\w+)\s*,\s*(plural|select)\s*,\s*(.*?\})\s*\}\}(.*)/s;
+
+  /**
+   * regular expression for matching provided cases
+   *
+   * - case can be either provided with "=<value>" or "other"
+   * - case template is everything inside curly braces
+   * - "\s*" captures (and ignores) additional whitespace
+   * - global matching ("/g") must be active to iterate over matches
+   */
+  private static CASE_REGEX = /(other|=\w+)\s*\{(.*?)\}/g;
+
+  /**
+   * regular expression for matching simple variables that
+   * have to be replaced
+   */
+  private static SIMPLE_VARIABLE_REGEX = /\{\{\s*(\w+)\s*\}\}/g;
+
+  private checkIfCompileNeeded(value: string | Function): value is string {
+    return typeof value === 'string' && PWATranslateCompiler.PLURAL_REGEX.test(value);
+  }
+
+  compile(template: string): string | Function {
+    if (this.checkIfCompileNeeded(template)) {
+      const match = PWATranslateCompiler.PLURAL_REGEX.exec(template);
+      const variable = match[2];
+      const cases = match[4];
+
+      // construct map for looking up case templates for incoming values
+      const casesMap: Record<string, string> = {};
+      let defaultCase: string;
+      for (let cm: RegExpExecArray; (cm = PWATranslateCompiler.CASE_REGEX.exec(cases)); ) {
+        const c = cm[1];
+        if (c.startsWith('=')) {
+          casesMap[c.substring(1)] = cm[2];
+        } else if (c === 'other') {
+          defaultCase = cm[2];
+        }
+      }
+
+      return (args: Record<string, unknown>) => {
+        const value = args?.[variable] ?? '';
+        const caseTemplate = casesMap[value?.toString()] ?? defaultCase;
+        const caseOutput = caseTemplate?.replace(/#/, value?.toString());
+        const result = `${match[1]}${caseOutput}${match[5]}`;
+
+        // if output still contains pluralization, do recursion
+        if (PWATranslateCompiler.PLURAL_REGEX.test(result)) {
+          return (this.compile(result) as Function)(args);
+        }
+
+        // replace all static variable values (if any)
+        return result?.replace(PWATranslateCompiler.SIMPLE_VARIABLE_REGEX, (_, repl) => args?.[repl]?.toString() ?? '');
+      };
+    }
+
+    return template;
+  }
+
+  compileTranslations(translations: Translations): Translations {
+    return Object.entries(translations)
+      .map<[string, string | Function]>(([key, value]) => {
+        if (this.checkIfCompileNeeded(value)) {
+          return [key, this.compile(value)];
+        }
+        return [key, value];
+      })
+      .reduce<Translations>((acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {});
+  }
+}

--- a/src/app/core/utils/translate/translations.type.ts
+++ b/src/app/core/utils/translate/translations.type.ts
@@ -1,1 +1,1 @@
-export type Translations = Record<string, string | Record<string, string>>;
+export type Translations = Record<string, string | Function>;

--- a/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.html
+++ b/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.html
@@ -23,7 +23,7 @@
     </div>
     <div class="col-3 list-item d-none d-md-block">{{ orderTemplate.creationDate | ishDate: 'shortDate' }}</div>
     <div class="col-2 list-item">
-      {{ orderTemplate.itemsCount | i18nPlural: ('account.order_template.items' | translate) || { other: '#' } }}
+      {{ 'account.order_template.items' | translate: { '0': orderTemplate.itemsCount } }}
     </div>
     <div class="col-5 col-md-2 list-item text-right">
       <a *ngIf="orderTemplate.items?.length" class="btn-tool d-inline-flex align-top">

--- a/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.spec.ts
+++ b/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.spec.ts
@@ -1,4 +1,3 @@
-import { I18nPluralPipe } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -59,7 +58,6 @@ describe('Account Order Template List Component', () => {
         MockComponent(ProductAddToBasketComponent),
         MockDirective(ProductContextDirective),
         MockPipe(DatePipe),
-        MockPipe(I18nPluralPipe),
       ],
       imports: [RouterTestingModule, TranslateModule.forRoot()],
     }).compileComponents();

--- a/src/app/extensions/wishlists/pages/account-wishlist/account-wishlist-list/account-wishlist-list.component.html
+++ b/src/app/extensions/wishlists/pages/account-wishlist/account-wishlist-list/account-wishlist-list.component.html
@@ -20,7 +20,7 @@
       }}</span>
     </div>
     <div class="col-2 list-item">
-      {{ wishlist.itemsCount | i18nPlural: ('account.wishlists.items' | translate) || { other: '#' } }}
+      {{ 'account.wishlists.items' | translate: { '0': wishlist.itemsCount } }}
     </div>
     <div class="col-3 list-item text-right">
       <a

--- a/src/app/pages/search/search-result/search-result.component.html
+++ b/src/app/pages/search/search-result/search-result.component.html
@@ -12,10 +12,7 @@
   <div class="col-md-9">
     <ish-breadcrumb></ish-breadcrumb>
     <h1>
-      {{
-        'search.title.text'
-          | translate: { '1': searchTerm, '2': totalItems | i18nPlural: ('search.title.items.text' | translate) }
-      }}
+      {{ 'search.title.text' | translate: { '1': searchTerm, '2': totalItems } }}
     </h1>
     <ish-product-listing
       [id]="{ type: 'search', value: searchTerm }"

--- a/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.html
+++ b/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.html
@@ -3,7 +3,7 @@
     <div class="row align-items-center">
       <div class="col-sm-3 col-4">
         <div *ngIf="itemCount >= 0" class="pagination-total text-nowrap">
-          {{ itemCount | i18nPlural: ('product.items.label' | translate) || { other: '#' } }}
+          {{ 'product.items.label' | translate: { '0': itemCount } }}
         </div>
       </div>
       <div class="col-sm-9 col-8">

--- a/src/app/shell/header/mini-basket/mini-basket.component.html
+++ b/src/app/shell/header/mini-basket/mini-basket.component.html
@@ -7,9 +7,7 @@
   <a (click)="toggleCollapse()">
     <fa-icon [icon]="['fas', 'shopping-cart']" class="header-icon"></fa-icon>
     <!-- TODO: check for a better solution for the plural and translate pipe combination for cases where the en_US.json is not yet loaded, current solution: || {"other": "#"} -->
-    <span>{{
-      itemCount$ | async | i18nPlural: ('shopping_cart.ministatus.items.text' | translate) || { other: '#' }
-    }}</span>
+    <span>{{ 'shopping_cart.ministatus.items.text' | translate: { '0': itemCount$ | async } }}</span>
     <ng-container *ngIf="itemTotal$ | async as itemTotal">
       <span> / </span> <span class="mini-cart-price">{{ itemTotal | ishPrice }}</span>
     </ng-container>

--- a/src/app/shell/header/mini-basket/mini-basket.component.spec.ts
+++ b/src/app/shell/header/mini-basket/mini-basket.component.spec.ts
@@ -51,7 +51,7 @@ describe('Mini Basket Component', () => {
     translate.setDefaultLang('en');
     translate.use('en');
     translate.setTranslation('en', {
-      'shopping_cart.ministatus.items.text': { other: '# items' },
+      'shopping_cart.ministatus.items.text': '{{0}} items',
       'shopping_cart.pli.qty.label': 'x',
       'shopping_cart.ministatus.view_cart.link': 'VIEW CART',
     });

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -45,11 +45,7 @@
   "account.addresses.remove_dialog.title": "Adresse löschen",
   "account.addresses.saved_address.heading": "Adressen",
   "account.addresses.update_address.button.label": "Änderungen speichern",
-  "account.approvallist.items": {
-    "=0": "0 Einträge",
-    "=1": "1 Eintrag",
-    "other": "# Einträge"
-  },
+  "account.approvallist.items": "{{0, plural, =1{1 Eintrag} other{# Einträge}}}",
   "account.approvallist.no_items_message": "Sie haben derzeit keine Bestellanforderungen.",
   "account.approvallist.table.approval_date": "Genehmigungsdatum",
   "account.approvallist.table.approver": "Genehmiger",
@@ -165,11 +161,7 @@
   "account.order_template.edit.heading": "Bestellvorlage bearbeiten",
   "account.order_template.form.name.error.required": "Geben Sie einen Namen für die Bestellvorlage an.",
   "account.order_template.form.name.label": "Name der Bestellvorlage",
-  "account.order_template.items": {
-    "=0": "0 Artikel",
-    "=1": "1 Artikel",
-    "other": "# Artikel"
-  },
+  "account.order_template.items": "{{0}} Artikel",
   "account.order_template.list.button.add_template.label": "Bestellvorlage hinzufügen",
   "account.order_template.list.link.back": "Zurück zu Bestellvorlagen",
   "account.order_template.list.link.remove": "Löschen",
@@ -464,9 +456,7 @@
   "account.wishlists.heading.tooltip.content": "Sie können eine oder mehrere persönliche Wunschlisten erstellen, um Artikel zu speichern und zu organisieren. Jede Liste hat andere Einstellungen:<br> <b>Als bevorzugte Liste einstellen</b> markiert eine Wunschliste als bevorzugte Liste und setzt alle anderen (wenn vorhanden) zurück auf Standard. Alle hinzugefügten Produkte werden standardmäßig zu dieser Wunschliste hinzugefügt.",
   "account.wishlists.heading.tooltip.headline": "Wunschlisten",
   "account.wishlists.heading.tooltip.link": "Wie funktionieren Wunschlisten?",
-  "account.wishlists.items": {
-    "other": "# Artikel"
-  },
+  "account.wishlists.items": "{{0}} Artikel",
   "account.wishlists.link": "Wunschlisten",
   "account.wishlists.move_wishlist_item.confirmation": "Der Artikel {{0}} wurde auf Ihre Wunschliste <a callback=\"callbackHideDialogModal\" href=\"{{1}}\">{{2}}</a> verschoben.",
   "account.wishlists.move_wishlist_item.move_button.text": "Verschieben",
@@ -771,18 +761,14 @@
   "product.compare.price.label": "Preis",
   "product.compare.ratings.label": "Bewertungen",
   "product.compare.remove.link": "Entfernen",
-  "product.compare.selected_product_count.message": "Sie haben {{0}} Produkte zum Vergleichen markiert.",
+  "product.compare.selected_product_count.message": "Sie haben {{0}} Produkt{{0, plural, =1{} other{e}}} zum Vergleichen markiert.",
   "product.description.heading": "Beschreibung",
   "product.details.heading": "Details",
   "product.email_a_friend.link": "Per E-Mail an einen Freund",
   "product.image.text.alttext": "Produktbild",
   "product.instock.text": "Verfügbar",
   "product.itemNumber.label": "Produkt-ID:",
-  "product.items.label": {
-    "=0": "0 Elemente",
-    "=1": "1 Element",
-    "other": "# Elemente"
-  },
+  "product.items.label": "{{0}} Element{{0, plural, =1{} other{e}}}",
   "product.manufacturer_name.label": "Herstellername",
   "product.manufacturer_sku.label": "Hersteller-SKU",
   "product.out_of_stock.text": "Nicht verfügbar",
@@ -922,12 +908,7 @@
   "search.searchbox.button.reset.title": "Suchbegriff entfernen",
   "search.searchbox.button.title": "Suche starten",
   "search.searchbox.instructional_text": "Suchen",
-  "search.title.items.text": {
-    "=0": "0 Artikel",
-    "=1": "1 Artikel",
-    "other": "# Artikel"
-  },
-  "search.title.text": "Suchergebnisse für \"{{1}}\" - {{2}}",
+  "search.title.text": "Suchergebnisse für \"{{1}}\" - {{2}} Artikel",
   "seo.applicationName": "Intershop PWA",
   "seo.defaults.description": "Intershop - Progressive Web App - Demo PWA",
   "seo.defaults.title": "Intershop Progressive Web App",
@@ -950,11 +931,7 @@
   "shopping_cart.empty.text": "Es liegen keine Artikel in Ihrem Warenkorb.",
   "shopping_cart.heading": "Ihr Warenkorb",
   "shopping_cart.ministatus.empty_cart.text": "Ihr Warenkorb ist leer.",
-  "shopping_cart.ministatus.items.text": {
-    "=0": "0 Artikel",
-    "=1": "1 Artikel",
-    "other": "# Artikel"
-  },
+  "shopping_cart.ministatus.items.text": "{{0}} Artikel",
   "shopping_cart.ministatus.view_cart.link": "Warenkorb ansehen",
   "shopping_cart.oci.transfer_basket.button": "Warenkorb übertragen",
   "shopping_cart.payment.creditCardExpiryDate.invalid.error": "Das Ablaufdatum der Kreditkarte muss eine Länge von 5 Zeichen und das Format nn/nn haben, wobei n eine Zahl ist.",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -45,11 +45,7 @@
   "account.addresses.remove_dialog.title": "Delete Address",
   "account.addresses.saved_address.heading": "Addresses",
   "account.addresses.update_address.button.label": "Save Changes",
-  "account.approvallist.items": {
-    "=0": "0 Items",
-    "=1": "1 Item",
-    "other": "# Items"
-  },
+  "account.approvallist.items": "{{0, plural, =1{1 Item} other{# Items}}}",
   "account.approvallist.no_items_message": "Currently no requisitions to display.",
   "account.approvallist.table.approval_date": "Approval Date",
   "account.approvallist.table.approver": "Approver",
@@ -165,11 +161,7 @@
   "account.order_template.edit.heading": "Edit Order Template",
   "account.order_template.form.name.error.required": "Please enter an order template name.",
   "account.order_template.form.name.label": "Order Template Name",
-  "account.order_template.items": {
-    "=0": "0 Items",
-    "=1": "1 Item",
-    "other": "# Items"
-  },
+  "account.order_template.items": "{{0, plural, =1{1 Item} other{# Items}}}",
   "account.order_template.list.button.add_template.label": "Add Order Template",
   "account.order_template.list.link.back": "Back to Order Templates",
   "account.order_template.list.link.remove": "Delete",
@@ -464,11 +456,7 @@
   "account.wishlists.heading.tooltip.content": "You can create one or more personal wish lists to save and organize items. Every list has its own settings:<br><br> <b>Set as Preferred</b> makes a wish list your preferred wish list and sets all other lists (if any) back to normal. All added products will be added by default to this wish list.",
   "account.wishlists.heading.tooltip.headline": "Wish Lists",
   "account.wishlists.heading.tooltip.link": "How do Wish Lists work?",
-  "account.wishlists.items": {
-    "=0": "0 Items",
-    "=1": "1 Item",
-    "other": "# Items"
-  },
+  "account.wishlists.items": "{{0, plural, =1{1 Item} other{# Items}}}",
   "account.wishlists.link": "Wish Lists",
   "account.wishlists.move_wishlist_item.confirmation": "The item {{0}} has been moved to your wish list <a callback=\"callbackHideDialogModal\" href=\"{{1}}\">{{2}}</a>.",
   "account.wishlists.move_wishlist_item.move_button.text": "Move",
@@ -773,18 +761,14 @@
   "product.compare.price.label": "Price",
   "product.compare.ratings.label": "Ratings",
   "product.compare.remove.link": "Remove",
-  "product.compare.selected_product_count.message": "You have selected {{0}} items to compare.",
+  "product.compare.selected_product_count.message": "You have selected {{0}} item{{0, plural, =1{} other{s}}} to compare.",
   "product.description.heading": "Description",
   "product.details.heading": "Details",
   "product.email_a_friend.link": "E-mail a friend",
   "product.image.text.alttext": "product photo",
   "product.instock.text": "In Stock",
   "product.itemNumber.label": "Product ID:",
-  "product.items.label": {
-    "=0": "0 list items",
-    "=1": "1 list item",
-    "other": "# list items"
-  },
+  "product.items.label": "{{0}} list item{{0, plural, =1{} other{s}}}",
   "product.manufacturer_name.label": "Manufacturer Name",
   "product.manufacturer_sku.label": "Manufacturer SKU",
   "product.out_of_stock.text": "Out of Stock",
@@ -924,12 +908,7 @@
   "search.searchbox.button.reset.title": "Remove search term",
   "search.searchbox.button.title": "Start search",
   "search.searchbox.instructional_text": "Search",
-  "search.title.items.text": {
-    "=0": "0 items",
-    "=1": "1 item",
-    "other": "# items"
-  },
-  "search.title.text": "Search Results for \"{{1}}\" - {{2}}",
+  "search.title.text": "Search Results for \"{{1}}\" - {{2}} item{{2, plural, =1{} other{s}}}",
   "seo.applicationName": "Intershop PWA",
   "seo.defaults.description": "Intershop - Progressive Web App - Demo PWA",
   "seo.defaults.title": "Intershop Progressive Web App",
@@ -952,11 +931,7 @@
   "shopping_cart.empty.text": "There are no items in your cart.",
   "shopping_cart.heading": "Your Shopping Cart",
   "shopping_cart.ministatus.empty_cart.text": "Your cart is currently empty.",
-  "shopping_cart.ministatus.items.text": {
-    "=0": "0 items",
-    "=1": "1 item",
-    "other": "# items"
-  },
+  "shopping_cart.ministatus.items.text": "{{0, plural, =1{1 item} other{# items}}}",
   "shopping_cart.ministatus.view_cart.link": "View Cart",
   "shopping_cart.oci.transfer_basket.button": "Transfer Cart",
   "shopping_cart.payment.creditCardExpiryDate.invalid.error": "The credit card expiration date must be 5 characters long and in the format nn/nn, where n is a number.",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -45,11 +45,7 @@
   "account.addresses.remove_dialog.title": "Supprimer l’adresse",
   "account.addresses.saved_address.heading": "Adresses",
   "account.addresses.update_address.button.label": "Enregistrer les modifications",
-  "account.approvallist.items": {
-    "=0": "0 Entrées",
-    "=1": "1 Entrée",
-    "other": "# Entrées"
-  },
+  "account.approvallist.items": "{{0, plural, =1{1 Entrée} other{# Entrées}}}",
   "account.approvallist.no_items_message": "Aucune réquisition à afficher.",
   "account.approvallist.table.approval_date": "Date d’approbation",
   "account.approvallist.table.approver": "Approbateur",
@@ -165,11 +161,7 @@
   "account.order_template.edit.heading": "Modifier le modèle de commande",
   "account.order_template.form.name.error.required": "Veuillez entrer un nom pour le modèle de commande.",
   "account.order_template.form.name.label": "Nom du modèle de commande",
-  "account.order_template.items": {
-    "=0": "0 Articles",
-    "=1": "1 Article",
-    "other": "# Articles"
-  },
+  "account.order_template.items": "{{0, plural, =1{1 Article} other{# Articles}}}",
   "account.order_template.list.button.add_template.label": "Ajouter un modèle de commande",
   "account.order_template.list.link.back": "Retour aux modèles de commande",
   "account.order_template.list.link.remove": "Supprimer",
@@ -464,11 +456,7 @@
   "account.wishlists.heading.tooltip.content": "Vous pouvez créer une ou plusieurs listes de souhaits personnelles pour sauvegarder et organiser des articles. Chaque liste a ses propres paramètres : <br><br><b>Définir comme Préférée</b> fait d’une liste de souhaits votre liste de souhaits préférée et remet toutes les autres listes (s’il y en a) à l’état normal. Tous les produits ajoutés seront ajoutés par défaut à cette liste de souhaits.",
   "account.wishlists.heading.tooltip.headline": "Listes de souhaits",
   "account.wishlists.heading.tooltip.link": "Comment fonctionnent les listes de souhaits ?",
-  "account.wishlists.items": {
-    "=0": "0 Articles",
-    "=1": "1 Article",
-    "other": "# Articles"
-  },
+  "account.wishlists.items": "{{0, plural, =1{1 Article} other{# Articles}}}",
   "account.wishlists.link": "Listes de souhaits",
   "account.wishlists.move_wishlist_item.confirmation": "L’article {{0}} à été déplacé vers votre liste de souhaits <a callback=\"callbackHideDialogModal\" href=\"{{1}}\">{{2}}</a>.",
   "account.wishlists.move_wishlist_item.move_button.text": "Déplacer",
@@ -773,18 +761,14 @@
   "product.compare.price.label": "Prix",
   "product.compare.ratings.label": "Évaluations",
   "product.compare.remove.link": "Supprimer",
-  "product.compare.selected_product_count.message": "Vous avez sélectionné {{0}} articles à comparer.",
+  "product.compare.selected_product_count.message": "Vous avez sélectionné {{0}} article{{0, plural, =1{} other{s}}} à comparer.",
   "product.description.heading": "Description",
   "product.details.heading": "Détails",
   "product.email_a_friend.link": "Envoyer un courriel à un(e) ami(e)",
   "product.image.text.alttext": "photo du produit",
   "product.instock.text": "En stock",
   "product.itemNumber.label": "ID produit :",
-  "product.items.label": {
-    "=0": "0 articles",
-    "=1": "1 article",
-    "other": "# articles"
-  },
+  "product.items.label": "{{0}} article{{0, plural, =1{} other{s}}}",
   "product.manufacturer_name.label": "Nom du fabricant",
   "product.manufacturer_sku.label": "UGS du fabricant",
   "product.out_of_stock.text": "Stock épuisé",
@@ -924,12 +908,7 @@
   "search.searchbox.button.reset.title": "Retirer terme de recherche",
   "search.searchbox.button.title": "Lancer la recherche.",
   "search.searchbox.instructional_text": "Rechercher",
-  "search.title.items.text": {
-    "=0": "0 articles",
-    "=1": "1 article",
-    "other": "# articles"
-  },
-  "search.title.text": "Résultats de recherche pour « {{1}} » - {{2}}",
+  "search.title.text": "Résultats de recherche pour « {{1}} » - {{2}} article{{2, plural, =1{} other{s}}}",
   "seo.applicationName": "Intershop PWA",
   "seo.defaults.description": "Intershop - Progressive Web App - Demo PWA",
   "seo.defaults.title": "Intershop Progressive Web App",
@@ -952,11 +931,7 @@
   "shopping_cart.empty.text": "Il n’y a aucun article dans votre panier.",
   "shopping_cart.heading": "Votre panier",
   "shopping_cart.ministatus.empty_cart.text": "Votre panier est actuellement vide.",
-  "shopping_cart.ministatus.items.text": {
-    "=0": "0 articles",
-    "=1": "1 article",
-    "other": "# articles"
-  },
+  "shopping_cart.ministatus.items.text": "{{0, plural, =1{1 article} other{# articles}}}",
   "shopping_cart.ministatus.view_cart.link": "Afficher le panier",
   "shopping_cart.oci.transfer_basket.button": "Transférer le panier",
   "shopping_cart.payment.creditCardExpiryDate.invalid.error": "La date d’expiration de la carte de crédit doit contenir 5 caractères et être au format nn/nn, où n est un nombre.",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature
[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

ngx-translate does not support pluralization out of the box and a serious hack using i18nPlural pipe from Angular has to be used.

## What Is the New Behavior?

Added a custom translate compiler, that handles pluralization.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Using the [ngx-translate-messageformat-compiler](https://www.npmjs.com/package/ngx-translate-messageformat-compiler) did not work and would also pull additional dependencies.