### PR TITLE
refactor: add formly components to checkout address anonymous component

### DIFF
--- a/docs/guides/formly.md
+++ b/docs/guides/formly.md
@@ -234,6 +234,7 @@ Refer to the tables below for an overview of these parts.
 | ish-password-field   | Password input field that automatically adds a password validator and error message          | ----                                                                                                                          |
 | ish-fieldset-field   | Wraps fields in a `<fieldset>` tag for styling                                               | `fieldsetClass`: Class that will be added to the fieldset tag. `childClass`: Class that will be added to the child div.       |
 | ish-captcha-field    | Includes the `<ish-lazy-captcha>` component and adds the relevant `formControls` to the form | `topic`: Topic that will be passed to the Captcha component.                                                                  |
+| ish-radio-field      | Basic radio input                                                                            | ----                                                                                                                          |
 
 ### Wrappers
 
@@ -246,6 +247,7 @@ Refer to the tables below for an overview of these parts.
 | description                    | Adds a custom description to any field                                                                                                                                                                                  | `customDescription`: `string` or `{key: string; args: any}` that will be translated                                           |
 | tooltip                        | Adds a tooltip to a field. Includes `<ish-field-tooltip>` component.                                                                                                                                                    | `tooltip`: `{ title?: string; text: string; link: string }` that defines the different tooltip texts.                         |
 | input-addon                    | Adds a prepended or appended text to a field, e.g. a currency or unit.                                                                                                                                                  | `addonLeft?`: `{ text: string; }, addonRight?: {text: string}` that defines the addon texts.                                  |
+| form-field-radio-horizontal    | Adds a label next to the radio field and adds red styling for invalid fields.                                                                                                                                           | `labelClass`: Classes that will be added to the label `<div>`                                                                 |
 
 ### Extensions
 

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
@@ -61,64 +61,7 @@
           class="form-horizontal"
           novalidate="novalidate"
         >
-          <h3 class="subheading">{{ 'checkout.addresses.billing_address.heading' | translate }}</h3>
-          <p class="indicates-required">
-            <span class="required">*</span>{{ 'account.required_field.message' | translate }}
-          </p>
-          <!-- Invoice Address -->
-          <ish-formly-address-form
-            #invoiceAddress
-            data-testing-id="invoiceAddressForm"
-            [parentForm]="invoiceAddressForm"
-          >
-          </ish-formly-address-form>
-          <!-- Taxation ID input field -->
-          <ish-input
-            *ishFeature="'businessCustomerRegistration'"
-            [form]="form"
-            controlName="taxationID"
-            label="account.address.taxation.label"
-          ></ish-input>
-          <!-- Email address input field-->
-          <ish-input
-            [form]="form"
-            controlName="email"
-            type="email"
-            label="checkout.addresses.email.label"
-            [errorMessages]="{
-              required: 'account.email.error.email',
-              email: 'checkout.addresses.email.invalid.error'
-            }"
-          ></ish-input>
-          <div class="offset-md-4 col-md-8">
-            <small class="form-text">{{ 'account.address.email.hint' | translate }}</small>
-          </div>
-
-          <!-- Shipping Address Selection Radio boxes-->
-          <div class="section">
-            <h3>{{ 'checkout.addresses.shipping_address.heading' | translate }}</h3>
-            <div class="radio">
-              <label for="shipOption1">
-                <input type="radio" formControlName="shipOption" value="shipToInvoiceAddress" id="shipOption1" />
-                {{ 'checkout.addresses.shipping_address.option1.text' | translate }}
-              </label>
-            </div>
-            <div class="radio">
-              <label for="shipOption2">
-                <input type="radio" formControlName="shipOption" value="shipToDifferentAddress" id="shipOption2" />
-                {{ 'checkout.addresses.shipping_address.option2.text' | translate }}
-              </label>
-            </div>
-          </div>
-          <div [ngbCollapse]="!isShippingAddressFormExpanded" data-testing-id="shipping-address-form">
-            <!-- Shipping Address -->
-            <ish-formly-address-form
-              #shippingAddress
-              data-testing-id="shippingAddressForm"
-              [parentForm]="shippingAddressForm"
-            >
-            </ish-formly-address-form>
-          </div>
+          <ish-checkout-address-anonymous-form [parentForm]="form"></ish-checkout-address-anonymous-form>
           <div [ngClass]="{ 'row form-group': isShippingAddressFormExpanded }">
             <div [ngClass]="{ 'offset-md-4 col-md-8': isShippingAddressFormExpanded }">
               <button class="btn btn-primary" type="submit" [disabled]="nextDisabled">

--- a/src/app/pages/checkout-address/checkout-address-page.module.ts
+++ b/src/app/pages/checkout-address/checkout-address-page.module.ts
@@ -5,10 +5,16 @@ import { SharedModule } from 'ish-shared/shared.module';
 import { CheckoutAddressAnonymousComponent } from './checkout-address-anonymous/checkout-address-anonymous.component';
 import { CheckoutAddressPageComponent } from './checkout-address-page.component';
 import { CheckoutAddressComponent } from './checkout-address/checkout-address.component';
+import { CheckoutAddressAnonymousFormComponent } from './formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component';
 
 @NgModule({
   imports: [SharedModule],
-  declarations: [CheckoutAddressAnonymousComponent, CheckoutAddressComponent, CheckoutAddressPageComponent],
+  declarations: [
+    CheckoutAddressAnonymousComponent,
+    CheckoutAddressAnonymousFormComponent,
+    CheckoutAddressComponent,
+    CheckoutAddressPageComponent,
+  ],
 })
 export class CheckoutAddressPageModule {
   static component = CheckoutAddressPageComponent;

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.html
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.html
@@ -1,0 +1,26 @@
+<h3 class="subheading">{{ 'checkout.addresses.billing_address.heading' | translate }}</h3>
+<p class="indicates-required"><span class="required">*</span>{{ 'account.required_field.message' | translate }}</p>
+
+<!-- Invoice Address -->
+<ish-formly-address-form
+  #invoiceAddress
+  data-testing-id="invoiceAddressForm"
+  [parentForm]="invoiceAddressForm"
+  [businessCustomer]="isBusinessCustomer"
+>
+</ish-formly-address-form>
+
+<!-- Taxation ID and Email address input field-->
+<formly-form [form]="form" [fields]="addressFields" [options]="addressOptions"></formly-form>
+
+<!-- Shipping Address Selection Radio boxes-->
+<div class="section">
+  <h3>{{ 'checkout.addresses.shipping_address.heading' | translate }}</h3>
+  <formly-form [form]="form" [fields]="shipOptionFields" [options]="shipOptionOptions"></formly-form>
+</div>
+
+<!-- Shipping Address -->
+<div [ngbCollapse]="!isShippingAddressFormExpanded" data-testing-id="shipping-address-form">
+  <ish-formly-address-form #shippingAddress [parentForm]="shippingAddressForm" [businessCustomer]="isBusinessCustomer">
+  </ish-formly-address-form>
+</div>

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.spec.ts
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
+import { FormlyModule } from '@ngx-formly/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
+import { instance, mock, when } from 'ts-mockito';
+
+import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+import { FormlyAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-form/formly-address-form.component';
+import { FormlyTestingComponentsModule } from 'ish-shared/formly/dev/testing/formly-testing-components.module';
+import { FormlyTestingExampleComponent } from 'ish-shared/formly/dev/testing/formly-testing-example/formly-testing-example.component';
+import { FormlyTestingFieldgroupExampleComponent } from 'ish-shared/formly/dev/testing/formly-testing-fieldgroup-example/formly-testing-fieldgroup-example.component';
+
+import { CheckoutAddressAnonymousFormComponent } from './checkout-address-anonymous-form.component';
+
+describe('Checkout Address Anonymous Form Component', () => {
+  let component: CheckoutAddressAnonymousFormComponent;
+  let fixture: ComponentFixture<CheckoutAddressAnonymousFormComponent>;
+  let element: HTMLElement;
+  let fb: FormBuilder;
+  let featureToggleService: FeatureToggleService;
+
+  beforeEach(async () => {
+    featureToggleService = mock(FeatureToggleService);
+    await TestBed.configureTestingModule({
+      declarations: [CheckoutAddressAnonymousFormComponent, MockComponent(FormlyAddressFormComponent)],
+      imports: [
+        FormlyModule.forRoot({
+          types: [
+            { name: 'ish-text-input-field', component: FormlyTestingExampleComponent },
+            { name: 'ish-fieldset-field', component: FormlyTestingFieldgroupExampleComponent },
+            { name: 'ish-email-field', component: FormlyTestingExampleComponent },
+            { name: 'ish-radio-field', component: FormlyTestingExampleComponent },
+          ],
+        }),
+        FormlyTestingComponentsModule,
+        NgbCollapseModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [{ provide: FeatureToggleService, useFactory: () => instance(featureToggleService) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CheckoutAddressAnonymousFormComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    fb = TestBed.inject(FormBuilder);
+
+    component.parentForm = fb.group({});
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should set input field for taxation-id, when businessCustomerRegistration feature is enabled', () => {
+    when(featureToggleService.enabled('businessCustomerRegistration')).thenReturn(true);
+    fixture.detectChanges();
+    expect(component.parentForm.get('additionalAddressAttributes').value).toContainKey('taxationID');
+  });
+
+  it('should add shipping address form to parent form, when shipOption is set to shipToDifferentAddress', () => {
+    fixture.detectChanges();
+
+    component.form.get('shipOption').setValue('shipToDifferentAddress');
+
+    fixture.detectChanges();
+
+    expect(component.isShippingAddressFormExpanded).toBeTrue();
+    expect(component.parentForm.get('shippingAddress')).toBeTruthy();
+  });
+});

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.ts
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.ts
@@ -1,0 +1,127 @@
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+
+@Component({
+  selector: 'ish-checkout-address-anonymous-form',
+  templateUrl: './checkout-address-anonymous-form.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CheckoutAddressAnonymousFormComponent implements OnInit, OnDestroy {
+  @Input() parentForm: FormGroup;
+  formControl: FormControl;
+
+  invoiceAddressForm = new FormGroup({});
+  shippingAddressForm = new FormGroup({});
+  form: FormGroup = new FormGroup({});
+
+  addressFields: FormlyFieldConfig[];
+  addressOptions: FormlyFormOptions = {};
+
+  shipOptionFields: FormlyFieldConfig[];
+  shipOptionOptions: FormlyFormOptions = {};
+
+  isBusinessCustomer = false;
+
+  private destroy$ = new Subject();
+
+  get isShippingAddressFormExpanded() {
+    return this.form && this.form.get('shipOption').value === 'shipToDifferentAddress';
+  }
+
+  constructor(private featureToggleService: FeatureToggleService) {}
+
+  ngOnInit() {
+    this.addressFields = [
+      {
+        type: 'ish-fieldset-field',
+        fieldGroup: [
+          {
+            key: 'email',
+            type: 'ish-email-field',
+            templateOptions: {
+              required: true,
+              label: 'checkout.addresses.email.label',
+              forceRequiredStar: true,
+              customDescription: {
+                class: 'form-text',
+                key: 'account.address.email.hint',
+              },
+              postWrappers: ['description'],
+            },
+            validation: {
+              messages: {
+                required: 'account.email.error.email',
+                email: 'checkout.addresses.email.invalid.error',
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    if (this.featureToggleService.enabled('businessCustomerRegistration')) {
+      this.addressFields = [this.createTaxationIDField(), ...this.addressFields];
+      this.isBusinessCustomer = true;
+    }
+
+    this.shipOptionFields = [
+      {
+        type: 'ish-radio-field',
+        key: 'shipOption',
+        defaultValue: 'shipToInvoiceAddress',
+        templateOptions: {
+          label: 'checkout.addresses.shipping_address.option1.text',
+          id: 'shipOption1',
+          value: 'shipToInvoiceAddress',
+        },
+      },
+      {
+        type: 'ish-radio-field',
+        key: 'shipOption',
+        defaultValue: 'shipToInvoiceAddress',
+        templateOptions: {
+          label: 'checkout.addresses.shipping_address.option2.text',
+          id: 'shipOption2',
+          value: 'shipToDifferentAddress',
+        },
+      },
+    ];
+    this.parentForm.setControl('invoiceAddress', this.invoiceAddressForm);
+    this.parentForm.setControl('additionalAddressAttributes', this.form);
+
+    // add / remove shipping form if shipTo address option changes
+    this.parentForm
+      .get('additionalAddressAttributes')
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(attributes => {
+        attributes.shipOption === 'shipToInvoiceAddress'
+          ? this.parentForm.removeControl('shippingAddress')
+          : this.parentForm.setControl('shippingAddress', this.shippingAddressForm);
+      });
+  }
+
+  private createTaxationIDField(): FormlyFieldConfig {
+    return {
+      type: 'ish-fieldset-field',
+      fieldGroup: [
+        {
+          key: 'taxationID',
+          type: 'ish-text-input-field',
+          templateOptions: {
+            label: 'account.address.taxation.label',
+          },
+        },
+      ],
+    };
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/shared/formly/formly.module.ts
+++ b/src/app/shared/formly/formly.module.ts
@@ -23,6 +23,7 @@ import { CheckboxFieldComponent } from './types/checkbox-field/checkbox-field.co
 import { EmailFieldComponent } from './types/email-field/email-field.component';
 import { FieldsetFieldComponent } from './types/fieldset-field/fieldset-field.component';
 import { PasswordFieldComponent } from './types/password-field/password-field.component';
+import { RadioFieldComponent } from './types/radio-field/radio-field.component';
 import { SelectFieldComponent } from './types/select-field/select-field.component';
 import { TextInputFieldComponent } from './types/text-input-field/text-input-field.component';
 import { TextareaFieldComponent } from './types/textarea-field/textarea-field.component';
@@ -30,6 +31,7 @@ import { DescriptionWrapperComponent } from './wrappers/description-wrapper/desc
 import { HorizontalCheckboxWrapperComponent } from './wrappers/horizontal-checkbox-wrapper/horizontal-checkbox-wrapper.component';
 import { HorizontalWrapperComponent } from './wrappers/horizontal-wrapper/horizontal-wrapper.component';
 import { InputAddonWrapperComponent } from './wrappers/input-addon-wrapper/input-addon-wrapper.component';
+import { RadioHorizontalWrapperComponent } from './wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component';
 import { TextareaDescriptionWrapperComponent } from './wrappers/textarea-description-wrapper/textarea-description-wrapper.component';
 import { TooltipWrapperComponent } from './wrappers/tooltip-wrapper/tooltip-wrapper.component';
 import { ValidationWrapperComponent } from './wrappers/validation-wrapper/validation-wrapper.component';
@@ -76,6 +78,11 @@ import { ValidationWrapperComponent } from './wrappers/validation-wrapper/valida
           name: 'ish-fieldset-field',
           component: FieldsetFieldComponent,
         },
+        {
+          name: 'ish-radio-field',
+          component: RadioFieldComponent,
+          wrappers: ['form-field-radio-horizontal'],
+        },
       ],
       wrappers: [
         { name: 'form-field-horizontal', component: HorizontalWrapperComponent },
@@ -85,6 +92,7 @@ import { ValidationWrapperComponent } from './wrappers/validation-wrapper/valida
         { name: 'tooltip', component: TooltipWrapperComponent },
         { name: 'validation', component: ValidationWrapperComponent },
         { name: 'description', component: DescriptionWrapperComponent },
+        { name: 'form-field-radio-horizontal', component: RadioHorizontalWrapperComponent },
       ],
       extras: {
         lazyRender: true,
@@ -117,6 +125,8 @@ import { ValidationWrapperComponent } from './wrappers/validation-wrapper/valida
     HorizontalWrapperComponent,
     InputAddonWrapperComponent,
     PasswordFieldComponent,
+    RadioFieldComponent,
+    RadioHorizontalWrapperComponent,
     SelectFieldComponent,
     TextInputFieldComponent,
     TextareaDescriptionWrapperComponent,

--- a/src/app/shared/formly/types/radio-field/radio-field.component.html
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.html
@@ -1,0 +1,8 @@
+<input
+  class="form-check-input"
+  type="radio"
+  [formControl]="formControl"
+  [value]="to.value"
+  [id]="to.id"
+  [attr.data-testing-id]="'radio-' + to.id"
+/>

--- a/src/app/shared/formly/types/radio-field/radio-field.component.spec.ts
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+
+import { FormlyTestingComponentsModule } from 'ish-shared/formly/dev/testing/formly-testing-components.module';
+import { FormlyTestingContainerComponent } from 'ish-shared/formly/dev/testing/formly-testing-container/formly-testing-container.component';
+
+import { RadioFieldComponent } from './radio-field.component';
+
+describe('Radio Field Component', () => {
+  let component: FormlyTestingContainerComponent;
+  let fixture: ComponentFixture<FormlyTestingContainerComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RadioFieldComponent],
+      imports: [
+        FormlyModule.forRoot({
+          types: [{ name: 'radio', component: RadioFieldComponent }],
+        }),
+        FormlyTestingComponentsModule,
+        ReactiveFormsModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    const testComponentInputs = {
+      model: { radio: '' },
+      fields: [
+        {
+          key: 'radio',
+          type: 'radio',
+        },
+      ],
+      form: new FormGroup({}),
+    };
+    fixture = TestBed.createComponent(FormlyTestingContainerComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.testComponentInputs = testComponentInputs;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should be rendered after creation', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('ish-radio-field')).toBeTruthy();
+  });
+});

--- a/src/app/shared/formly/types/radio-field/radio-field.component.ts
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { FieldType } from '@ngx-formly/core';
+
+@Component({
+  selector: 'ish-radio-field',
+  templateUrl: './radio-field.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RadioFieldComponent extends FieldType {
+  formControl: FormControl;
+}

--- a/src/app/shared/formly/wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component.html
@@ -1,0 +1,6 @@
+<div class="radio" [class.formly-has-error]="showError">
+  <ng-template #fieldComponent></ng-template>
+  <label class="form-check-label" [for]="to.id" [ngClass]="to.labelClass">
+    {{ to.label | translate }}
+  </label>
+</div>

--- a/src/app/shared/formly/wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component.spec.ts
+++ b/src/app/shared/formly/wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { MockPipe } from 'ng-mocks';
+
+import { FormlyTestingComponentsModule } from 'ish-shared/formly/dev/testing/formly-testing-components.module';
+import { FormlyTestingContainerComponent } from 'ish-shared/formly/dev/testing/formly-testing-container/formly-testing-container.component';
+import { FormlyTestingExampleComponent } from 'ish-shared/formly/dev/testing/formly-testing-example/formly-testing-example.component';
+
+import { RadioHorizontalWrapperComponent } from './radio-horizontal-wrapper.component';
+
+describe('Radio Horizontal Wrapper Component', () => {
+  let component: FormlyTestingContainerComponent;
+  let fixture: ComponentFixture<FormlyTestingContainerComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        FormlyModule.forRoot({
+          types: [{ name: 'example', component: FormlyTestingExampleComponent }],
+          wrappers: [
+            {
+              name: 'form-field-radio-horizontal',
+              component: RadioHorizontalWrapperComponent,
+            },
+          ],
+        }),
+        FormlyTestingComponentsModule,
+      ],
+      declarations: [MockPipe(TranslatePipe), RadioHorizontalWrapperComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormlyTestingContainerComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.testComponentInputs = {
+      fields: [
+        {
+          key: 'example',
+          type: 'example',
+          wrappers: ['form-field-radio-horizontal'],
+        },
+      ] as FormlyFieldConfig[],
+      model: {
+        example: undefined,
+      },
+      form: new FormGroup({}),
+    };
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(element.querySelector('ish-radio-horizontal-wrapper')).toBeTruthy();
+  });
+
+  it('should be rendered after creation', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('ish-radio-horizontal-wrapper')).toBeTruthy();
+  });
+});

--- a/src/app/shared/formly/wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/radio-horizontal-wrapper/radio-horizontal-wrapper.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FieldWrapper } from '@ngx-formly/core';
+
+@Component({
+  selector: 'ish-radio-horizontal-wrapper',
+  templateUrl: './radio-horizontal-wrapper.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RadioHorizontalWrapperComponent extends FieldWrapper {}


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Checkout Address Anonymous component contains formly and reactive form components.

Issue Number: Closes #

## What Is the New Behavior?

Checkout Address Anonymous component should only contain formly components.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
