### PR TITLE
fix: add permission check to edit the company profile

### DIFF
--- a/src/app/core/directives/authorization-toggle.directive.ts
+++ b/src/app/core/directives/authorization-toggle.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, OnDestroy, TemplateRef, ViewContainerRef } from '@angular/core';
+import { ChangeDetectorRef, Directive, Input, OnDestroy, TemplateRef, ViewContainerRef } from '@angular/core';
 import { ReplaySubject, Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
@@ -14,6 +14,7 @@ export class AuthorizationToggleDirective implements OnDestroy {
   private destroy$ = new Subject();
 
   constructor(
+    private cdRef: ChangeDetectorRef,
     private templateRef: TemplateRef<unknown>,
     private viewContainer: ViewContainerRef,
     private authorizationToggle: AuthorizationToggleService
@@ -24,6 +25,7 @@ export class AuthorizationToggleDirective implements OnDestroy {
       } else {
         this.viewContainer.clear();
       }
+      this.cdRef.markForCheck();
     });
   }
 

--- a/src/app/pages/account-profile/account-profile-page.module.ts
+++ b/src/app/pages/account-profile/account-profile-page.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { AuthorizationToggleGuard } from 'ish-core/authorization-toggle.module';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { AccountProfilePageComponent } from './account-profile-page.component';
@@ -45,7 +46,9 @@ const routes: Routes = [
   },
   {
     path: 'company',
+    canActivate: [AuthorizationToggleGuard],
     data: {
+      permission: 'APP_B2B_MANAGE_USERS',
       breadcrumbData: [
         { key: 'account.profile.link', link: '/account/profile' },
         { key: 'account.company_profile.heading' },

--- a/src/app/pages/account-profile/account-profile/account-profile.component.html
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.html
@@ -88,6 +88,7 @@
   </div>
   <div class="col-2 col-lg-4">
     <a
+      *ishIsAuthorizedTo="'APP_B2B_MANAGE_USERS'"
       routerLink="/account/profile/company"
       class="btn-tool"
       title="{{ 'account.profile.update.link' | translate }}"

--- a/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
+++ b/src/app/pages/account-profile/account-profile/account-profile.component.spec.ts
@@ -3,6 +3,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
 
+import { AuthorizationToggleModule } from 'ish-core/authorization-toggle.module';
 import { IdentityProviderCapabilityDirective } from 'ish-core/directives/identity-provider-capability.directive';
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { IdentityProviderModule } from 'ish-core/identity-provider.module';
@@ -27,7 +28,11 @@ describe('Account Profile Component', () => {
         MockComponent(FaIconComponent),
         MockDirective(ServerHtmlDirective),
       ],
-      imports: [IdentityProviderModule.forTesting(), TranslateModule.forRoot()],
+      imports: [
+        AuthorizationToggleModule.forTesting('APP_B2B_MANAGE_USERS'),
+        IdentityProviderModule.forTesting(),
+        TranslateModule.forRoot(),
+      ],
     }).compileComponents();
   });
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
All b2b users can edit the company profile data no matter which permissions they have.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #724

## What Is the New Behavior?
Only b2b users with permission B2B_MANAGE_USERS (admin) can edit the company profile data.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
