### PR TITLE
fix: don't display multiple bucket message after redirect before checkout

### DIFF
--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
 import { FormGroup, Validators } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 
@@ -11,7 +20,7 @@ import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
   templateUrl: './checkout-review.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CheckoutReviewComponent implements OnInit {
+export class CheckoutReviewComponent implements OnInit, OnChanges {
   @Input() basket: Basket;
   @Input() error: HttpError;
   @Input() submitting: boolean;
@@ -27,9 +36,13 @@ export class CheckoutReviewComponent implements OnInit {
   multipleBuckets = false;
 
   ngOnInit() {
-    this.multipleBuckets = !this.basket?.commonShippingMethod;
-
     this.fields = this.setFields();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.basket) {
+      this.multipleBuckets = !this.basket?.commonShippingMethod || !this.basket?.commonShipToAddress;
+    }
   }
 
   /**

--- a/src/app/shared/components/basket/basket-address-summary/basket-address-summary.component.html
+++ b/src/app/shared/components/basket/basket-address-summary/basket-address-summary.component.html
@@ -22,7 +22,7 @@
     <h5>{{ 'checkout.address.shipping.label' | translate }}</h5>
   </div>
   <div data-testing-id="address-summary-ship-to-address">
-    <address *ngIf="basket.invoiceToAddress.id === basket.commonShipToAddress.id; else shippingAddress">
+    <address *ngIf="basket.invoiceToAddress.id === basket.commonShipToAddress?.id; else shippingAddress">
       {{ 'checkout.same_as_billing_address.text' | translate }}
     </address>
     <ng-template #shippingAddress> <ish-address [address]="basket.commonShipToAddress"></ish-address> </ng-template>


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user selects a payment method on checkout payment page that requires a redirect before checkout on the checkout review page an error message is wrongly shown: There is no shipping method available that allows these products to be shipped together.

Issue Number: Closes #

## What Is the New Behavior?
After redirect before checkout the error message is only shown if an error occured.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
