### PR TITLE
deps: upgrade cypress to 7.x

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "cypress": "^6.0.0",
+    "cypress": "^7.0.0",
     "cypress-failed-log": "^2.0.0",
     "cypress-log-to-output": "^1.1.2",
     "typescript": "*"


### PR DESCRIPTION
## PR Type

[x] Other: dependency upgrade 

## What Is the Current Behavior?
An outdated Cypress 6.x is used.

## What Is the New Behavior?
Cypress 7.x is used.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
New try since #732 had to be removed due to failures in the `develop` branch.

- [x] The existing e2e tests are not affected by this upgrade.
- [ ] Integration / Universal (b2b) (pull_request) has no error (Run sh e2e/test-universal.sh --> "TEST 7: searching 'add-to-compare' in 'http://localhost:4200/catComputers.1835.151': FAILURE"



