### PR TITLE
fix: display edit line item link only for variation products

### DIFF
--- a/src/app/shared/components/line-item/line-item-edit/line-item-edit.component.html
+++ b/src/app/shared/components/line-item/line-item-edit/line-item-edit.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="product$ | async as product">
   <a
+    *ngIf="product.type === 'VariationProduct'"
     (click)="show()"
     class="line-item-edit-link"
     rel="nofollow"


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the feature toggle 'advancedVariationhandling' is turned off the edit link is shown for all products in the cart.

## What Is the New Behavior?
If the feature toggle 'advancedVariationhandling' is turned off the edit link is shown only for variation products in the cart.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
