### PR TITLE
feat: forward mouse event to callback handler in server-html directive

### DIFF
--- a/src/app/core/directives/server-html.directive.ts
+++ b/src/app/core/directives/server-html.directive.ts
@@ -20,7 +20,7 @@ import { LinkParser } from 'ish-core/utils/link-parser';
 })
 export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnChanges {
   @Input() callbacks: {
-    [key: string]: () => void;
+    [key: string]: (event?: MouseEvent) => void;
   };
 
   constructor(
@@ -84,7 +84,7 @@ export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnC
 
         // handle links with callback functions, e.g. <a callback="availableCallbackFunction">
         if (cb && this.callbacks && typeof this.callbacks[cb] === 'function') {
-          this.callbacks[cb]();
+          this.callbacks[cb](event);
         }
 
         if (


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## What Is the Current Behavior?

Callback handlers in `ServerHtmlDirective` don't see the `MouseEvent` and can not do something like `event.preventDefault()`.

## What Is the New Behavior?

The `MouseEvent` is forwarded to the callback handler as an optional argument.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
