### PR TITLE
fix: adapt project SCSS definitions in regards to sass '/' deprecation warnings

### DIFF
--- a/src/styles/components/cookies.scss
+++ b/src/styles/components/cookies.scss
@@ -25,7 +25,7 @@
   .cookie-option {
     label {
       span {
-        padding-left: $space-default / 2;
+        padding-left: $space-default * 0.5;
         font-family: $font-family-bold;
       }
     }

--- a/src/styles/components/footer/footer.scss
+++ b/src/styles/components/footer/footer.scss
@@ -66,14 +66,14 @@ footer {
     border-bottom: $border-width-default solid $border-color-default;
 
     ul {
-      padding: $space-default ($space-default + ($space-default/2)) ($space-default * 2);
+      padding: $space-default ($space-default * 1.5) ($space-default * 2);
       margin: 0;
       list-style: none;
     }
   }
 
   .link-group-title {
-    padding: $space-default ($space-default + ($space-default/2));
+    padding: $space-default ($space-default * 1.5);
     margin: 0 (-$space-default);
     cursor: pointer;
     border-bottom: $border-width-default solid $border-color-default;
@@ -139,7 +139,7 @@ footer {
   @media (max-width: $screen-sm-max) {
     float: none;
     width: 100%;
-    padding: ($space-default + ($space-default / 2));
+    padding: ($space-default * 1.5);
   }
 
   .newsletter-form {

--- a/src/styles/components/header/header.scss
+++ b/src/styles/components/header/header.scss
@@ -122,7 +122,7 @@ header {
 
   li {
     float: left;
-    padding-right: ($space-default * 3 / 2);
+    padding-right: ($space-default * 1.5);
     font-family: $font-family-bold;
     font-size: 12px;
     color: $text-color-quarternary;
@@ -149,8 +149,8 @@ header {
 }
 
 .separator {
-  padding-right: ($space-default / 2);
-  padding-left: ($space-default / 2);
+  padding-right: ($space-default * 0.5);
+  padding-left: ($space-default * 0.5);
 }
 
 .ng-fa-icon.header-icon {

--- a/src/styles/components/header/language-switch.scss
+++ b/src/styles/components/header/language-switch.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .language-switch {
   margin-left: ($space-default * 2);
   font-family: $font-family-bold;
@@ -19,7 +21,7 @@
     .language-switch-link {
       display: block;
       padding-right: $space-default;
-      padding-left: $space-default / 2;
+      padding-left: $space-default * 0.5;
       color: $text-color-quinary !important;
 
       //language selector when dropdown is shown
@@ -44,7 +46,7 @@
 
     .language-switch-container {
       z-index: 9999;
-      padding: ($space-default * 2/3) $space-default;
+      padding: math.div($space-default * 2, 3) $space-default;
       background: $color-inverse;
       box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.2);
 

--- a/src/styles/components/header/main-navigation.scss
+++ b/src/styles/components/header/main-navigation.scss
@@ -46,7 +46,7 @@
         > a {
           float: left;
           width: calc(100% - #{$toggler-width});
-          padding: $space-default ($grid-gutter-width / 2) !important;
+          padding: $space-default ($grid-gutter-width * 0.5) !important;
           font-size: $font-size-menu-item-mobile;
           line-height: 1.3125rem;
         }
@@ -224,10 +224,10 @@
       z-index: 9999;
       display: block;
       width: 720px;
-      padding: 25px 25px ($grid-gutter-width / 2) 25px;
+      padding: 25px 25px ($grid-gutter-width * 0.5) 25px;
       margin: 0;
       visibility: hidden;
-      border-top: ($space-default / 2) solid $border-color-default;
+      border-top: ($space-default * 0.5) solid $border-color-default;
 
       @media (max-width: $screen-xs-max) {
         visibility: visible;

--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -1,5 +1,7 @@
 /*********** SEARCH CONTAINER **********/
 
+@use 'sass:math';
+
 .search-container {
   position: relative;
 
@@ -134,7 +136,7 @@
     &.form-control {
       float: right;
       height: $search-container-height;
-      padding-left: ($search-container-height / 2);
+      padding-left: ($search-container-height * 0.5);
       font-size: 14px;
       color: $white;
       background: $color-primary;
@@ -180,7 +182,7 @@
 
     .btn-search {
       @include media-breakpoint-down(md) {
-        right: $space-default * 2/3;
+        right: math.div($space-default * 2, 3);
         margin-right: 0;
       }
     }

--- a/src/styles/components/header/user-information-mobile.scss
+++ b/src/styles/components/header/user-information-mobile.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .user-info-box {
   padding-bottom: 10px;
   //overflow: hidden;
@@ -26,7 +28,7 @@
     padding-bottom: 0;
 
     ul {
-      padding: $space-default * 2/3;
+      padding: math.div($space-default * 2, 3);
       margin-bottom: 0;
 
       li a {

--- a/src/styles/global/breadcrumbs.scss
+++ b/src/styles/global/breadcrumbs.scss
@@ -19,7 +19,7 @@
     text-transform: uppercase;
 
     span {
-      margin: 0 ($space-default / 2);
+      margin: 0 ($space-default * 0.5);
     }
 
     a {

--- a/src/styles/global/buttons.scss
+++ b/src/styles/global/buttons.scss
@@ -1,6 +1,8 @@
 //
 // BUTTONS
 
+@use 'sass:math';
+
 .btn {
   font-family: $font-family-bold;
   text-transform: uppercase;
@@ -54,10 +56,10 @@
 // multiple buttons margin handling (use "button-group" in case the buttons are not direct siblings)
 .button-group .btn,
 .btn:not(:only-child) {
-  margin-bottom: $space-default/3;
+  margin-bottom: math.div($space-default, 3);
 
   &:not(.float-right) {
-    margin-right: $space-default/3;
+    margin-right: math.div($space-default, 3);
 
     @media (max-width: $screen-xs-max) {
       margin-right: 0;
@@ -65,7 +67,7 @@
   }
 
   &.float-right {
-    margin-left: $space-default/3;
+    margin-left: math.div($space-default, 3);
 
     @media (max-width: $screen-xs-max) {
       margin-left: 0;

--- a/src/styles/global/forms/fields.scss
+++ b/src/styles/global/forms/fields.scss
@@ -14,7 +14,7 @@ fieldset {
 }
 
 input[type='radio'] ~ input[type='text'] {
-  margin-left: $space-default / 2;
+  margin-left: $space-default * 0.5;
 
   @media (max-width: $screen-xs-max) {
     display: inline-block;

--- a/src/styles/global/forms/forms.scss
+++ b/src/styles/global/forms/forms.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .form-check {
   height: auto;
   padding-bottom: 0;
@@ -6,7 +8,7 @@
 
 .has-feedback {
   .form-control[type='number'] {
-    padding: $grid-gutter-width / 5 $grid-gutter-width / 2.5;
+    padding: $grid-gutter-width * 0.2 math.div($grid-gutter-width, 2.5);
   }
 
   .form-control[type='number'] + * .form-control-feedback {
@@ -121,7 +123,7 @@ input.form-check-input {
         .icon-checked {
           position: absolute;
           right: 15px;
-          padding-top: $space-default/6;
+          padding-top: math.div($space-default, 6);
         }
       }
     }
@@ -146,7 +148,7 @@ input.form-check-input {
       &::after {
         position: absolute;
         top: calc(#{$input-height} / 2);
-        right: $space-default/2;
+        right: $space-default * 0.5;
       }
     }
   }

--- a/src/styles/global/forms/labels.scss
+++ b/src/styles/global/forms/labels.scss
@@ -1,6 +1,6 @@
 .form-inline {
   label {
-    padding-right: ($space-default / 4);
+    padding-right: ($space-default * 0.25);
   }
 }
 

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -1,13 +1,15 @@
 //
 // LAYOUT
 // contains layout and presentation classes for the global page structure (header, footer, global navigation, ...)
+@use 'sass:math';
+
 .main-container {
   background: $color-inverse;
 }
 
 .container {
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width * 0.5);
+  padding-left: ($grid-gutter-width * 0.5);
   margin-right: auto;
   margin-left: auto;
 }
@@ -41,7 +43,7 @@ h4,
 .h4 h5,
 .h5 h6,
 .h6 {
-  margin-top: ($space-default * 2/3);
+  margin-top: math.div($space-default * 2, 3);
   margin-bottom: $space-default;
   font-family: $font-family-regular;
 }
@@ -115,7 +117,7 @@ img {
 //
 // Global Panels
 .grey-panel {
-  padding: ($space-default + ($space-default / 2)) 0;
+  padding: ($space-default * 1.5) 0;
   background: $color-tertiary;
 }
 
@@ -145,7 +147,7 @@ img {
 
 // Help Text
 .form-text {
-  margin: $space-default / 3 0 $space-default / 2;
+  margin: math.div($space-default, 3) 0 $space-default * 0.5;
   color: $text-color-quarternary;
 }
 
@@ -172,7 +174,7 @@ img.marketing {
 // Detail links and tooltips
 [data-toggle='popover'] {
   .ng-fa-icon {
-    padding-left: $space-default/4;
+    padding-left: $space-default * 0.25;
     font-size: 120%;
   }
 }
@@ -184,7 +186,7 @@ img.marketing {
 .details-link,
 .details-tooltip {
   display: inline-block;
-  padding-left: $space-default/2;
+  padding-left: $space-default * 0.5;
   font-family: $font-family-regular;
   font-size: 90%;
   text-transform: none;

--- a/src/styles/global/icons.scss
+++ b/src/styles/global/icons.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .ng-fa-icon {
   line-height: 1;
 }
@@ -8,7 +10,7 @@
   }
 
   & ~ .btn-tool {
-    margin-left: $space-default * 2 / 3;
+    margin-left: math.div($space-default * 2, 3);
   }
 }
 
@@ -24,7 +26,7 @@
 
       & ~ .btn-tool {
         margin-top: 7.5px;
-        margin-left: $space-default * 2 / 3;
+        margin-left: math.div($space-default * 2, 3);
       }
     }
   }

--- a/src/styles/global/line-item.scss
+++ b/src/styles/global/line-item.scss
@@ -8,5 +8,5 @@
 
 .line-item-edit-link {
   display: inline-block;
-  margin-bottom: $space-default / 2;
+  margin-bottom: $space-default * 0.5;
 }

--- a/src/styles/global/lists.scss
+++ b/src/styles/global/lists.scss
@@ -1,14 +1,14 @@
 //
 // DL - List
 .dl-horizontal {
-  margin-bottom: ($space-default / 2);
+  margin-bottom: ($space-default * 0.5);
 
   dt {
     font-weight: normal;
   }
 
   dt + dd {
-    margin-bottom: ($space-default / 4);
+    margin-bottom: ($space-default * 0.25);
   }
 
   // displays a separator (e.g. colon) after the definition type field

--- a/src/styles/global/notifications.scss
+++ b/src/styles/global/notifications.scss
@@ -64,7 +64,7 @@
 
     .btn {
       width: 100%;
-      margin-top: $space-default/2;
+      margin-top: $space-default * 0.5;
     }
 
     .list-item-row {

--- a/src/styles/global/panel.scss
+++ b/src/styles/global/panel.scss
@@ -1,6 +1,8 @@
 //
 // PANEL
 // TODO: reimplement as cards? https://getbootstrap.com/docs/4.0/migration/#components
+@use 'sass:math';
+
 .panel {
   margin-bottom: ($space-default * 2);
   background-color: $color-inverse;
@@ -29,11 +31,11 @@
 }
 
 .panel-body {
-  padding: ($space-default + ($space-default / 2)) 0;
+  padding: ($space-default * 1.5) 0;
 }
 
 .panel-heading {
-  padding: ($space-default / 2) 0;
+  padding: ($space-default * 0.5) 0;
   border-bottom: $border-width-default solid transparent;
 
   a:hover {
@@ -73,7 +75,7 @@
 }
 
 .panel-footer {
-  padding: $space-default ($space-default + ($space-default / 2));
+  padding: $space-default ($space-default * 1.5);
   background-color: $color-tertiary;
   border-top: $border-width-default solid $border-color-light;
 }
@@ -86,7 +88,7 @@
     overflow: hidden;
 
     + .panel {
-      margin-top: ($space-default / 2);
+      margin-top: ($space-default * 0.5);
     }
   }
 
@@ -165,7 +167,7 @@
       padding: 0;
 
       h4 {
-        padding: $grid-gutter-width / 3 $grid-gutter-width / 2;
+        padding: math.div($grid-gutter-width, 3) $grid-gutter-width * 0.5;
       }
 
       a {
@@ -179,7 +181,7 @@
 
       + .panel-collapse {
         .panel-body {
-          padding: $grid-gutter-width / 2;
+          padding: $grid-gutter-width * 0.5;
           border-top: 1px solid $border-color-light;
         }
       }

--- a/src/styles/global/promotions.scss
+++ b/src/styles/global/promotions.scss
@@ -16,18 +16,18 @@
 
   .promotion-short-title {
     display: inline;
-    padding-right: $space-default/2;
+    padding-right: $space-default * 0.5;
   }
 
   .promotion-long-title {
     display: inline;
-    padding-right: $space-default/2;
+    padding-right: $space-default * 0.5;
   }
 }
 
 .promotion-title {
   display: inline;
-  padding-right: $space-default/2;
+  padding-right: $space-default * 0.5;
 }
 
 .promotion-details-and-remove-links {

--- a/src/styles/global/share-tools.scss
+++ b/src/styles/global/share-tools.scss
@@ -1,6 +1,8 @@
 //
 // SHARE TOOLS
 
+@use 'sass:math';
+
 .share-tools {
   display: flex;
   justify-content: flex-end;
@@ -11,7 +13,7 @@
   > li {
     max-width: 50px;
     height: 27px;
-    padding: 0 $space-default * 2 / 3;
+    padding: 0 math.div($space-default * 2, 3);
     margin: 0;
     overflow: hidden;
     font-size: 18px;
@@ -58,7 +60,7 @@
       }
 
       .share-label {
-        padding-left: ($space-default / 2);
+        padding-left: ($space-default * 0.5);
         font-size: $font-size-base;
         line-height: 26px;
         color: $text-color-quarternary;

--- a/src/styles/global/tables.scss
+++ b/src/styles/global/tables.scss
@@ -1,4 +1,6 @@
 // SPECIFIC TABLE MIXINS
+@use 'sass:math';
+
 @mixin list-header-mixin() {
   border-top: 0;
   border-bottom: 1px solid $border-color-default;
@@ -120,8 +122,8 @@
     }
 
     &.list-item-row-big {
-      padding-bottom: ($space-default / 2);
-      margin-top: ($space-default / 2);
+      padding-bottom: ($space-default * 0.5);
+      margin-top: ($space-default * 0.5);
       border-bottom: 1px solid $border-color-lighter;
 
       &:first-child {
@@ -165,7 +167,7 @@
 
       @media (max-width: $screen-xs-max) {
         label {
-          margin-right: $space-default / 2;
+          margin-right: $space-default * 0.5;
         }
       }
     }
@@ -285,7 +287,7 @@
 table.mobile-optimized,
 table.mobile-optimized.table-lg {
   @include media-breakpoint-only(xs) {
-    margin-bottom: $space-default/3;
+    margin-bottom: math.div($space-default, 3);
 
     thead {
       display: none;
@@ -294,7 +296,7 @@ table.mobile-optimized.table-lg {
     tr {
       float: left;
       width: 100%;
-      padding-bottom: $space-default * 2/3;
+      padding-bottom: math.div($space-default * 2, 3);
       margin-bottom: $space-default;
       border-bottom: 1px solid $border-color-lighter;
 
@@ -309,7 +311,7 @@ table.mobile-optimized.table-lg {
         &::before {
           float: left;
           width: 40%;
-          margin-bottom: $space-default/3;
+          margin-bottom: math.div($space-default, 3);
           content: '';
         }
         &[data-label]::before {

--- a/src/styles/global/toasts.scss
+++ b/src/styles/global/toasts.scss
@@ -40,7 +40,7 @@
       }
 
       & + div {
-        margin-top: $space-default / 2;
+        margin-top: $space-default * 0.5;
       }
     }
   }

--- a/src/styles/pages/account/account-navigation.scss
+++ b/src/styles/pages/account/account-navigation.scss
@@ -1,9 +1,11 @@
 //
 // ACCOUNT NAVIGATION
 
+@use 'sass:math';
+
 .account-navigation {
   li {
-    padding: $space-default * 2/3 $space-default * 2/3 ($space-default / 2);
+    padding: math.div($space-default * 2, 3) math.div($space-default * 2, 3) ($space-default * 0.5);
     background: $color-tertiary;
     border: $border-width-default solid $border-color-lighter;
     border-width: 0 1px 1px 1px;
@@ -25,7 +27,7 @@
     }
 
     .ng-fa-icon {
-      margin-right: ($space-default / 2);
+      margin-right: ($space-default * 0.5);
       font-size: 14px;
       color: $text-color-quarternary;
     }
@@ -73,7 +75,7 @@
     padding-top: $space-default;
     padding-bottom: $space-default;
     margin-top: -15px;
-    margin-bottom: ($space-default + ($space-default / 2));
+    margin-bottom: ($space-default * 1.5);
     background: $color-tertiary;
     border-top: $border-width-default solid lighten($border-color-default, 100%);
   }
@@ -82,7 +84,7 @@
     padding-top: $space-default;
     padding-bottom: $space-default;
     margin-top: -25px;
-    margin-bottom: ($space-default + ($space-default / 2));
+    margin-bottom: ($space-default * 1.5);
     background: $color-tertiary;
     border-top: $border-width-default solid lighten($border-color-default, 100%);
   }

--- a/src/styles/pages/category/filter-panel.scss
+++ b/src/styles/pages/category/filter-panel.scss
@@ -2,6 +2,8 @@
 
 /* FILTER PANEL */
 
+@use 'sass:math';
+
 .category-panel h3 {
   text-transform: uppercase;
 }
@@ -101,13 +103,13 @@
           display: inline-block;
           width: 15px;
           height: 15px;
-          margin-right: ($space-default / 3);
+          margin-right: math.div($space-default, 3);
           background-color: $color-tertiary;
           border: 1px solid $border-color-light;
         }
 
         &.filter-count {
-          margin-left: ($space-default / 3);
+          margin-left: math.div($space-default, 3);
         }
       }
     }
@@ -137,7 +139,7 @@
           display: inline-block;
           width: 15px;
           height: 15px;
-          margin-right: ($space-default / 3);
+          margin-right: math.div($space-default, 3);
           background-color: $color-corporate;
           border: 1px solid $border-color-default;
         }

--- a/src/styles/pages/category/filter-row.scss
+++ b/src/styles/pages/category/filter-row.scss
@@ -1,8 +1,10 @@
 /**************** CATEGORY FILTER ROW ******************/
 
+@use 'sass:math';
+
 .filters-row {
   z-index: 99999;
-  padding: ($space-default * 2/3) 0;
+  padding: math.div($space-default * 2, 3) 0;
   margin: $space-default 0;
   background-color: $color-tertiary;
 
@@ -63,7 +65,7 @@
 
     label {
       float: right;
-      margin-right: ($space-default * 2/3);
+      margin-right: math.div($space-default * 2, 3);
       margin-bottom: 0;
       font-weight: normal;
       line-height: $input-height;
@@ -114,8 +116,8 @@
     white-space: nowrap;
 
     .form-control-feedback {
-      padding-left: $space-default/6;
-      font-size: $font-size-base * 4/5;
+      padding-left: math.div($space-default, 6);
+      font-size: $font-size-base * 0.8;
       color: $text-color-corporate;
     }
   }

--- a/src/styles/pages/category/product-list.scss
+++ b/src/styles/pages/category/product-list.scss
@@ -1,6 +1,8 @@
 //
 // PRODUCT LIST
 
+@use 'sass:math';
+
 .product-list {
   position: relative;
   padding: 0;
@@ -28,7 +30,7 @@
         }
 
         .form-group {
-          margin-bottom: $space-default / 3;
+          margin-bottom: math.div($space-default, 3);
 
           label {
             padding-bottom: 0;
@@ -68,7 +70,7 @@
 
         .form-group {
           margin-right: 0;
-          margin-bottom: $space-default / 2;
+          margin-bottom: $space-default * 0.5;
           margin-left: 0;
 
           label {
@@ -329,18 +331,18 @@
 .product-variation {
   &.read-only {
     label {
-      padding-right: $space-default / 3;
+      padding-right: math.div($space-default, 3);
       margin-bottom: 0;
     }
     &:last-of-type {
-      margin-bottom: $space-default * 2/3;
+      margin-bottom: math.div($space-default * 2, 3);
     }
   }
 }
 
 .product-list-actions-container {
   .action-container {
-    margin-top: $space-default/2;
+    margin-top: $space-default * 0.5;
   }
 
   .product-quantity .form-group {

--- a/src/styles/pages/checkout/checkout.scss
+++ b/src/styles/pages/checkout/checkout.scss
@@ -40,7 +40,7 @@
 
 .packslip-message {
   .form-check {
-    margin-bottom: ($space-default/2);
+    margin-bottom: ($space-default * 0.5);
   }
 }
 

--- a/src/styles/pages/checkout/progress-bar.scss
+++ b/src/styles/pages/checkout/progress-bar.scss
@@ -21,7 +21,7 @@
 
     @media (max-width: $screen-xs-max) {
       padding-top: $space-default;
-      padding-left: $space-default/4;
+      padding-left: $space-default * 0.25;
       line-height: 25px;
       text-align: center;
 
@@ -57,7 +57,7 @@
   color: $text-color-inverse;
   text-align: center;
   background: $border-color-light;
-  border-radius: (($space-default * 3) / 2);
+  border-radius: (($space-default * 3) * 0.5);
 }
 
 .progress-complete {

--- a/src/styles/pages/checkout/quick-cart.scss
+++ b/src/styles/pages/checkout/quick-cart.scss
@@ -52,13 +52,13 @@ ul {
 
     .ng-fa-icon {
       padding: 0;
-      margin-right: ($space-default / 2);
+      margin-right: ($space-default * 0.5);
       font-size: 17px;
     }
   }
 
   > a {
-    padding: 0 ($space-default / 2);
+    padding: 0 ($space-default * 0.5);
     white-space: nowrap;
   }
 
@@ -172,8 +172,8 @@ ul {
 
     a {
       display: block;
-      padding-top: ($space-default / 2);
-      padding-bottom: ($space-default / 4);
+      padding-top: ($space-default * 0.5);
+      padding-bottom: ($space-default * 0.25);
       margin: 0;
       overflow: hidden;
       font-family: $font-family-condensedregular;
@@ -186,7 +186,7 @@ ul {
     }
 
     .product-price {
-      padding-bottom: ($space-default / 4);
+      padding-bottom: ($space-default * 0.25);
       font-family: $font-family-condensedbold;
       font-size: $font-size-lg;
       color: $text-color-primary;

--- a/src/styles/pages/checkout/shopping-cart.scss
+++ b/src/styles/pages/checkout/shopping-cart.scss
@@ -1,5 +1,7 @@
 /************* SHOPPING CART LAYOUT ***************/
 
+@use 'sass:math';
+
 .cart-header {
   .share-tools {
     margin-top: $space-default;
@@ -27,7 +29,7 @@
 }
 
 .cart-group-details {
-  padding-bottom: ($space-default / 2);
+  padding-bottom: ($space-default * 0.5);
 }
 
 .cart-line-actions {
@@ -35,14 +37,14 @@
 }
 
 .cart-summary {
-  padding: ($space-default + ($space-default / 2));
+  padding: ($space-default * 1.5);
   border: $border-width-default solid $border-color-light;
   border-width: 1px 1px 0 1px;
 
   .form-inline {
     * {
       margin-top: $space-default;
-      margin-right: ($space-default / 2);
+      margin-right: ($space-default * 0.5);
     }
 
     *:last-child {
@@ -52,7 +54,7 @@
   }
 
   .alert {
-    margin-top: ($space-default / 2);
+    margin-top: ($space-default * 0.5);
     margin-bottom: 0;
 
     a {
@@ -75,7 +77,7 @@
 }
 
 .address-summary {
-  padding: ($space-default + ($space-default / 2));
+  padding: ($space-default * 1.5);
   border: $border-width-default solid $border-color-light;
   border-width: 1px 1px 0 1px;
 
@@ -95,7 +97,7 @@
 }
 
 .cost-summary {
-  padding: ($space-default + ($space-default / 2));
+  padding: ($space-default * 1.5);
   margin-bottom: $space-default;
   font-size: $font-size-sm;
   background: $color-tertiary;
@@ -148,7 +150,7 @@
 }
 
 .cart-variations {
-  padding-top: ($space-default / 2);
+  padding-top: ($space-default * 0.5);
   font-size: 90%;
 
   dd {
@@ -183,18 +185,18 @@
 .order-summary {
   @media (min-width: $screen-md-min) {
     h2 {
-      margin-top: ($space-default / 4);
+      margin-top: ($space-default * 0.25);
     }
   }
 
   @media (max-width: $screen-xs-max) {
-    margin: ($space-default + ($space-default / 2)) 0;
+    margin: ($space-default * 1.5) 0;
   }
 }
 
 @media (max-width: $screen-xs-max) {
   .mobile-cart-item-label {
-    padding: ($space-default / 2) 0 3px 0;
+    padding: ($space-default * 0.5) 0 3px 0;
     margin: 0;
     font-size: 90%;
     font-weight: bold;
@@ -205,7 +207,7 @@
   }
 
   .cart-separator {
-    margin: 0 - ($space-default + ($space-default / 2)) ($space-default * 2) - ($space-default + ($space-default / 2));
+    margin: 0 - ($space-default * 1.5) ($space-default * 2) - ($space-default * 1.5);
   }
 
   .mobile-cart-img {
@@ -249,13 +251,13 @@
 
 .pli-description {
   ul {
-    padding-left: $space-default/3 * 4;
+    padding-left: math.div($space-default, 3) * 4;
     list-style-position: outside;
   }
 
   .btn-tool {
     display: inline-block;
-    padding: 0 $space-default/3;
+    padding: 0 math.div($space-default, 3);
     margin-top: ($space-default);
     margin-bottom: 0;
 
@@ -268,7 +270,7 @@
     dt {
       float: left;
       width: auto;
-      padding-right: $space-default/6;
+      padding-right: math.div($space-default, 6);
     }
 
     dd {

--- a/src/styles/pages/content-pages/page-content.scss
+++ b/src/styles/pages/content-pages/page-content.scss
@@ -1,5 +1,7 @@
 //
 
+@use 'sass:math';
+
 .content-page {
   padding: $space-default 0 $space-default 0;
 }
@@ -23,7 +25,7 @@ ol {
 /* purgecss start ignore */
 .helpdesk-info-box {
   width: 100%;
-  padding: $space-default/2;
+  padding: $space-default * 0.5;
   margin-bottom: $space-default;
   color: $text-color-inverse;
   background: $color-corporate;
@@ -70,13 +72,13 @@ ol {
 
     li {
       padding-top: 0;
-      padding-bottom: $space-default / 3;
+      padding-bottom: math.div($space-default, 3);
       font-family: $font-family-regular;
       font-size: $font-size-lg;
       text-decoration: none;
 
       a {
-        font-size: ($grid-gutter-width / 2);
+        font-size: ($grid-gutter-width * 0.5);
       }
     }
   }

--- a/src/styles/pages/homepage/homepage.scss
+++ b/src/styles/pages/homepage/homepage.scss
@@ -1,6 +1,8 @@
 //
 // HOMEPAGE
 
+@use 'sass:math';
+
 .homepage {
   header {
     margin-bottom: 0;
@@ -56,13 +58,13 @@
   margin-top: $space-default;
 
   p {
-    margin-bottom: $space-default / 3;
+    margin-bottom: math.div($space-default, 3);
     font-family: $font-family-condensedbold;
     font-size: $font-size-lg;
     text-transform: uppercase;
   }
 
   a {
-    padding-right: $space-default / 2;
+    padding-right: $space-default * 0.5;
   }
 }

--- a/src/styles/pages/payment/payment.scss
+++ b/src/styles/pages/payment/payment.scss
@@ -10,7 +10,7 @@
     margin-top: $space-default;
   }
   .panel {
-    margin-top: $space-default / 2;
+    margin-top: $space-default * 0.5;
     margin-bottom: 0;
     background-color: #f7f7f7;
 
@@ -22,7 +22,7 @@
 
     .form-check > label {
       display: inline-block;
-      margin-bottom: $space-default / 2;
+      margin-bottom: $space-default * 0.5;
     }
   }
 

--- a/src/styles/pages/productdetail/product-images.scss
+++ b/src/styles/pages/productdetail/product-images.scss
@@ -1,6 +1,8 @@
 //
 // PRODUCT IMAGES
 
+@use 'sass:math';
+
 .product-detail-img {
   .carousel {
     float: left;
@@ -65,7 +67,7 @@
 
 .product-thumb-set {
   float: left;
-  padding: $space-default / 3;
+  padding: math.div($space-default, 3);
   margin-bottom: $space-default;
   cursor: pointer;
   border: 1px solid $border-color-lighter;

--- a/src/styles/pages/productdetail/product-info.scss
+++ b/src/styles/pages/productdetail/product-info.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .product-title {
   font-family: $font-family-condensedbold;
   font-size: 16px;
@@ -14,7 +16,7 @@ a.product-title {
   color: $text-color-quarternary;
 
   label {
-    padding-right: ($space-default / 3);
+    padding-right: math.div($space-default, 3);
   }
 }
 
@@ -81,7 +83,7 @@ a.product-title {
 
     &.read-only {
       label {
-        padding-right: $space-default / 3;
+        padding-right: math.div($space-default, 3);
       }
     }
 
@@ -93,7 +95,7 @@ a.product-title {
 
   .product-variation {
     .form-group {
-      margin-bottom: $space-default / 3;
+      margin-bottom: math.div($space-default, 3);
 
       label {
         padding-top: 0;
@@ -115,7 +117,7 @@ a.product-title {
   }
 
   .btn.btn-block {
-    margin-bottom: $space-default / 2;
+    margin-bottom: $space-default * 0.5;
   }
 
   .secondary-actions {
@@ -148,7 +150,7 @@ a.product-title {
   a {
     &.product-title {
       display: block;
-      padding-top: ($space-default / 2);
+      padding-top: ($space-default * 0.5);
       font-family: $font-family-condensedregular;
       font-size: 14px;
       color: $text-color-secondary;
@@ -179,7 +181,7 @@ a.product-title {
   a {
     &.product-title {
       display: block;
-      padding-top: ($space-default / 2);
+      padding-top: ($space-default * 0.5);
       font-family: $font-family-condensedregular;
       font-size: 14px;
       color: $text-color-secondary;
@@ -190,11 +192,11 @@ a.product-title {
 }
 
 .product-end-of-live-status {
-  padding-bottom: ($space-default / 3);
+  padding-bottom: math.div($space-default, 3);
 }
 
 .product-lifecycle-status {
-  padding-bottom: ($space-default / 3);
+  padding-bottom: math.div($space-default, 3);
   color: $text-color-special;
 
   span {

--- a/src/styles/pages/productdetail/productdetail.scss
+++ b/src/styles/pages/productdetail/productdetail.scss
@@ -1,6 +1,8 @@
 //
 // PRODUCT DETAILS
 
+@use 'sass:math';
+
 .product-page {
   padding: $space-default 0 $space-default 0;
 }
@@ -44,7 +46,7 @@
   margin-bottom: ($space-default * 3);
 
   @media (max-width: $screen-sm-max) {
-    margin-top: ($space-default / 3);
+    margin-top: math.div($space-default, 3);
     margin-bottom: ($space-default);
   }
 
@@ -81,7 +83,7 @@
   margin: $space-default 0;
 
   .panel-heading {
-    padding: ($space-default / 3) 0;
+    padding: math.div($space-default, 3) 0;
 
     a {
       color: $text-color-quarternary;
@@ -104,7 +106,7 @@
 
     .product-attachments-list-item {
       .ng-fa-icon {
-        margin-left: $space-default * 2/3;
+        margin-left: math.div($space-default * 2, 3);
         font-size: 22px;
       }
     }
@@ -121,7 +123,7 @@
   }
 
   .product-warranty-list {
-    margin-top: $space-default / 3;
+    margin-top: math.div($space-default, 3);
   }
 }
 

--- a/src/styles/pages/productdetail/rating.scss
+++ b/src/styles/pages/productdetail/rating.scss
@@ -60,7 +60,7 @@
   display: block;
   float: left;
   padding: 0;
-  margin: 0 ($space-default / 2) 0 0;
+  margin: 0 ($space-default * 0.5) 0 0;
   clear: both;
   list-style: none;
 


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Build-related changes


## What Is the Current Behavior?

Introduced by the the latest `@angular-devkit/build-angular` update that updates `sass` from 1.32.12 to 1.35.1 a lot of deprecation warnings where printed when building the project or running `ng serve`.

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
Recommendation: math.div($spacer, 2)
More info and automated migrator: https://sass-lang.com/d/slash-div
```

## What Is the New Behavior?

The project SCSS definitions were changed in regards to the sass '/' deprecation warnings.

Only Bootstrap SCSS compile warnings persist that result from the original Bootstrap definitions that cannot be changed in the project itself. Hopefully they will be fixed in the Bootstrap sources (see https://github.com/twbs/bootstrap/issues/34353).

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
https://sass-lang.com/documentation/breaking-changes/slash-div
https://github.com/sass/dart-sass/blob/master/CHANGELOG.md#1330
https://github.com/twbs/bootstrap/issues/34353