### PR TITLE
test: simplify router action serialize

### DIFF
--- a/src/app/core/store/core/router/router.integration.spec.ts
+++ b/src/app/core/store/core/router/router.integration.spec.ts
@@ -106,15 +106,9 @@ describe('Router Integration', () => {
       expect(selectUrl(store$.state)).toMatchInlineSnapshot(`"/"`);
       expect(selectPath(store$.state)).toMatchInlineSnapshot(`"**"`);
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/","params":{},"queryParams":{},"data":{},"path":"**"}
-          event: {"id":1,"url":"/","urlAfterRedirects":"/"}
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/","params":{},"queryParams":{},"data":{},"path":"**"}
-          event: {"id":1,"url":"/","urlAfterRedirects":"/"}
+        @ngrx/router-store/request: /
+        @ngrx/router-store/navigation: /
+        @ngrx/router-store/navigated: /
       `);
     }));
 
@@ -152,15 +146,9 @@ describe('Router Integration', () => {
       expect(selectUrl(store$.state)).toMatchInlineSnapshot(`"/any;foo=urlParam;bar=bar?bar=bar&foo=queryParam"`);
       expect(selectPath(store$.state)).toMatchInlineSnapshot(`"**"`);
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/any;foo=urlParam;bar=bar?bar=bar&foo=queryPa...
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/any;foo=urlParam;bar=bar?bar=bar&foo=queryParam","p...
-          event: {"id":1,"url":"/any;foo=urlParam;bar=bar?bar=bar&foo=queryPa...
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/any;foo=urlParam;bar=bar?bar=bar&foo=queryParam","p...
-          event: {"id":1,"url":"/any;foo=urlParam;bar=bar?bar=bar&foo=queryPa...
+        @ngrx/router-store/request: /any;foo=urlParam;bar=bar?bar=bar&foo=queryParam
+        @ngrx/router-store/navigation: /any;foo=urlParam;bar=bar?bar=bar&foo=queryParam
+        @ngrx/router-store/navigated: /any;foo=urlParam;bar=bar?bar=bar&foo=queryParam
       `);
     }));
 
@@ -206,15 +194,9 @@ describe('Router Integration', () => {
       expect(selectUrl(store$.state)).toMatchInlineSnapshot(`"/test/very/deep/routes;bar=bar?bar=bar&foo=queryParam"`);
       expect(selectPath(store$.state)).toMatchInlineSnapshot(`"test/:foo/deep/routes"`);
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/test/very/deep/routes;bar=bar?bar=bar&foo=qu...
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/test/very/deep/routes;bar=bar?bar=bar&foo=queryPara...
-          event: {"id":1,"url":"/test/very/deep/routes;bar=bar?bar=bar&foo=qu...
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/test/very/deep/routes;bar=bar?bar=bar&foo=queryPara...
-          event: {"id":1,"url":"/test/very/deep/routes;bar=bar?bar=bar&foo=qu...
+        @ngrx/router-store/request: /test/very/deep/routes;bar=bar?bar=bar&foo=queryParam
+        @ngrx/router-store/navigation: /test/very/deep/routes;bar=bar?bar=bar&foo=queryParam
+        @ngrx/router-store/navigated: /test/very/deep/routes;bar=bar?bar=bar&foo=queryParam
       `);
     }));
   });

--- a/src/app/core/store/core/server-config/server-config.effects.spec.ts
+++ b/src/app/core/store/core/server-config/server-config.effects.spec.ts
@@ -42,8 +42,7 @@ describe('Server Config Effects', () => {
     store$.dispatch(routerTestNavigationAction({ routerState: { url: '/any' } }));
 
     expect(store$.actionsArray()).toMatchInlineSnapshot(`
-      @ngrx/router-store/navigation:
-        routerState: {"url":"/any"}
+      @ngrx/router-store/navigation: /any
       [Configuration Internal] Get the ICM configuration
       [Configuration API] Get the ICM configuration Success:
         config: {}

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -203,15 +203,9 @@ describe('Shopping Store', () => {
 
     it('should just load toplevel categories when no specific shopping page is loaded', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/home"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/home","params":{},"queryParams":{},"data":{},"path"...
-          event: {"id":1,"url":"/home","urlAfterRedirects":"/home"}
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/home","params":{},"queryParams":{},"data":{},"path"...
-          event: {"id":1,"url":"/home","urlAfterRedirects":"/home"}
+        @ngrx/router-store/request: /home
+        @ngrx/router-store/navigation: /home
+        @ngrx/router-store/navigated: /home
       `);
 
       expect(getCategoryIds(store.state)).toBeEmpty();
@@ -238,12 +232,8 @@ describe('Shopping Store', () => {
 
       it('should have toplevel loading and category loading actions when going to a category page', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/home","params":{},"queryParams":{},"data":{},"path"...
-            event: {"id":2,"url":"/category/A.123"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
-            event: {"id":2,"url":"/category/A.123","urlAfterRedirects":"/catego...
+          @ngrx/router-store/request: /category/A.123
+          @ngrx/router-store/navigation: /category/A.123
           [Categories Internal] Load Category:
             categoryId: "A.123"
           [Categories API] Load Category Success:
@@ -256,9 +246,7 @@ describe('Shopping Store', () => {
             categories: tree(A,A.123)
           [Viewconf Internal] Set Breadcrumb Data:
             breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123"}]
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
-            event: {"id":2,"url":"/category/A.123","urlAfterRedirects":"/catego...
+          @ngrx/router-store/navigated: /category/A.123
           [Viewconf Internal] Set Breadcrumb Data:
             breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123"}]
         `);
@@ -296,17 +284,11 @@ describe('Shopping Store', () => {
 
       it('should trigger required actions when searching', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/home","params":{},"queryParams":{},"data":{},"path"...
-            event: {"id":2,"url":"/search/something"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/search/something","params":{"searchTerm":"something...
-            event: {"id":2,"url":"/search/something","urlAfterRedirects":"/sear...
+          @ngrx/router-store/request: /search/something
+          @ngrx/router-store/navigation: /search/something
           [Viewconf Internal] Set Breadcrumb Data:
             breadcrumbData: [{"text":"search.breadcrumbs.your_search.label something"}]
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/search/something","params":{"searchTerm":"something...
-            event: {"id":2,"url":"/search/something","urlAfterRedirects":"/sear...
+          @ngrx/router-store/navigated: /search/something
           [Product Listing] Load More Products:
             id: {"type":"search","value":"something"}
           [Viewconf Internal] Set Breadcrumb Data:
@@ -343,12 +325,8 @@ describe('Shopping Store', () => {
 
         it('should reload the product data when selected', fakeAsync(() => {
           expect(store.actionsArray()).toMatchInlineSnapshot(`
-            @ngrx/router-store/request:
-              routerState: {"url":"/search/something","params":{"searchTerm":"something...
-              event: {"id":3,"url":"/product/P2"}
-            @ngrx/router-store/navigation:
-              routerState: {"url":"/product/P2","params":{"sku":"P2"},"queryParams":{},...
-              event: {"id":3,"url":"/product/P2","urlAfterRedirects":"/product/P2"}
+            @ngrx/router-store/request: /product/P2
+            @ngrx/router-store/navigation: /product/P2
             [Recently Viewed Internal] Add Product to Recently:
               sku: "P2"
               group: undefined
@@ -356,9 +334,7 @@ describe('Shopping Store', () => {
               sku: "P2"
             [Products API] Load Product Success:
               product: {"sku":"P2","name":"nP2"}
-            @ngrx/router-store/navigated:
-              routerState: {"url":"/product/P2","params":{"sku":"P2"},"queryParams":{},...
-              event: {"id":3,"url":"/product/P2","urlAfterRedirects":"/product/P2"}
+            @ngrx/router-store/navigated: /product/P2
           `);
         }));
       });
@@ -384,12 +360,8 @@ describe('Shopping Store', () => {
 
     it('should have toplevel loading and category loading actions when going to a category page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/category/A.123"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
-          event: {"id":1,"url":"/category/A.123","urlAfterRedirects":"/catego...
+        @ngrx/router-store/request: /category/A.123
+        @ngrx/router-store/navigation: /category/A.123
         [Categories Internal] Load Category:
           categoryId: "A.123"
         [Categories API] Load Category Success:
@@ -398,9 +370,7 @@ describe('Shopping Store', () => {
           categoryId: "A"
         [Categories API] Load Category Success:
           categories: tree(A,A.123)
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
-          event: {"id":1,"url":"/category/A.123","urlAfterRedirects":"/catego...
+        @ngrx/router-store/navigated: /category/A.123
         [Viewconf Internal] Set Breadcrumb Data:
           breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123"}]
       `);
@@ -426,15 +396,9 @@ describe('Shopping Store', () => {
 
       it('should trigger actions for deselecting category and product when no longer in category or product', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/category/A.123","params":{"categoryUniqueId":"A.123...
-            event: {"id":2,"url":"/compare"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
+          @ngrx/router-store/request: /compare
+          @ngrx/router-store/navigation: /compare
+          @ngrx/router-store/navigated: /compare
         `);
       }));
 
@@ -464,12 +428,8 @@ describe('Shopping Store', () => {
 
     it('should have all required actions when going to a family page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/category/A.123.456"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-          event: {"id":1,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+        @ngrx/router-store/request: /category/A.123.456
+        @ngrx/router-store/navigation: /category/A.123.456
         [Categories Internal] Load Category:
           categoryId: "A.123.456"
         [Categories API] Load Category Success:
@@ -482,9 +442,7 @@ describe('Shopping Store', () => {
           categories: tree(A,A.123)
         [Categories API] Load Category Success:
           categories: tree(A.123,A.123.456)
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-          event: {"id":1,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+        @ngrx/router-store/navigated: /category/A.123.456
         [Product Listing] Load More Products:
           id: {"type":"category","value":"A.123.456"}
         [Viewconf Internal] Set Breadcrumb Data:
@@ -527,12 +485,8 @@ describe('Shopping Store', () => {
 
       it('should reload the product when selected', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-            event: {"id":2,"url":"/category/A.123.456/product/P1"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-            event: {"id":2,"url":"/category/A.123.456/product/P1","urlAfterRedi...
+          @ngrx/router-store/request: /category/A.123.456/product/P1
+          @ngrx/router-store/navigation: /category/A.123.456/product/P1
           [Recently Viewed Internal] Add Product to Recently:
             sku: "P1"
             group: undefined
@@ -540,9 +494,7 @@ describe('Shopping Store', () => {
             sku: "P1"
           [Products API] Load Product Success:
             product: {"sku":"P1","name":"nP1"}
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-            event: {"id":2,"url":"/category/A.123.456/product/P1","urlAfterRedi...
+          @ngrx/router-store/navigated: /category/A.123.456/product/P1
         `);
       }));
 
@@ -559,19 +511,13 @@ describe('Shopping Store', () => {
 
         it('should deselect product when navigating back', fakeAsync(() => {
           expect(store.actionsArray()).toMatchInlineSnapshot(`
-            @ngrx/router-store/request:
-              routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-              event: {"id":3,"url":"/category/A.123.456"}
-            @ngrx/router-store/navigation:
-              routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-              event: {"id":3,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+            @ngrx/router-store/request: /category/A.123.456
+            @ngrx/router-store/navigation: /category/A.123.456
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
             [Viewconf Internal] Set Breadcrumb Data:
               breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
-            @ngrx/router-store/navigated:
-              routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-              event: {"id":3,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+            @ngrx/router-store/navigated: /category/A.123.456
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
             [Viewconf Internal] Set Breadcrumb Data:
@@ -590,17 +536,11 @@ describe('Shopping Store', () => {
 
       it('should load the right filters for search', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-            event: {"id":2,"url":"/search/something"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/search/something","params":{"searchTerm":"something...
-            event: {"id":2,"url":"/search/something","urlAfterRedirects":"/sear...
+          @ngrx/router-store/request: /search/something
+          @ngrx/router-store/navigation: /search/something
           [Viewconf Internal] Set Breadcrumb Data:
             breadcrumbData: [{"text":"search.breadcrumbs.your_search.label something"}]
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/search/something","params":{"searchTerm":"something...
-            event: {"id":2,"url":"/search/something","urlAfterRedirects":"/sear...
+          @ngrx/router-store/navigated: /search/something
           [Product Listing] Load More Products:
             id: {"type":"search","value":"something"}
           [Viewconf Internal] Set Breadcrumb Data:
@@ -637,12 +577,8 @@ describe('Shopping Store', () => {
 
         it('should load the right filters for family page again', fakeAsync(() => {
           expect(store.actionsArray()).toMatchInlineSnapshot(`
-            @ngrx/router-store/request:
-              routerState: {"url":"/search/something","params":{"searchTerm":"something...
-              event: {"id":3,"url":"/category/A.123.456"}
-            @ngrx/router-store/navigation:
-              routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-              event: {"id":3,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+            @ngrx/router-store/request: /category/A.123.456
+            @ngrx/router-store/navigation: /category/A.123.456
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
             [Viewconf Internal] Set Breadcrumb Data:
@@ -658,9 +594,7 @@ describe('Shopping Store', () => {
               uniqueId: "A.123.456"
             [Filter API] Load Filter Success:
               filterNavigation: {}
-            @ngrx/router-store/navigated:
-              routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-              event: {"id":3,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+            @ngrx/router-store/navigated: /category/A.123.456
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
             [Viewconf Internal] Set Breadcrumb Data:
@@ -690,15 +624,9 @@ describe('Shopping Store', () => {
 
       it('should trigger actions for deselecting category and product when no longer in category or product', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-            event: {"id":2,"url":"/compare"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
+          @ngrx/router-store/request: /compare
+          @ngrx/router-store/navigation: /compare
+          @ngrx/router-store/navigated: /compare
         `);
       }));
 
@@ -728,12 +656,8 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/category/A.123.456/product/P1"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-          event: {"id":1,"url":"/category/A.123.456/product/P1","urlAfterRedi...
+        @ngrx/router-store/request: /category/A.123.456/product/P1
+        @ngrx/router-store/navigation: /category/A.123.456/product/P1
         [Categories Internal] Load Category:
           categoryId: "A.123.456"
         [Categories API] Load Category Success:
@@ -753,9 +677,7 @@ describe('Shopping Store', () => {
         [Recently Viewed Internal] Add Product to Recently:
           sku: "P1"
           group: undefined
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-          event: {"id":1,"url":"/category/A.123.456/product/P1","urlAfterRedi...
+        @ngrx/router-store/navigated: /category/A.123.456/product/P1
       `);
     }));
 
@@ -783,12 +705,8 @@ describe('Shopping Store', () => {
 
       it('should trigger actions for products when they are not yet loaded', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-            event: {"id":2,"url":"/category/A.123.456"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-            event: {"id":2,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+          @ngrx/router-store/request: /category/A.123.456
+          @ngrx/router-store/navigation: /category/A.123.456
           [Product Listing] Load More Products:
             id: {"type":"category","value":"A.123.456"}
           [Viewconf Internal] Set Breadcrumb Data:
@@ -815,9 +733,7 @@ describe('Shopping Store', () => {
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/category/A.123.456","params":{"categoryUniqueId":"A...
-            event: {"id":2,"url":"/category/A.123.456","urlAfterRedirects":"/ca...
+          @ngrx/router-store/navigated: /category/A.123.456
           [Product Listing] Load More Products:
             id: {"type":"category","value":"A.123.456"}
           [Viewconf Internal] Set Breadcrumb Data:
@@ -850,15 +766,9 @@ describe('Shopping Store', () => {
 
       it('should trigger actions for deselecting category and product when no longer in category or product', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/category/A.123.456/product/P1","params":{"categoryU...
-            event: {"id":2,"url":"/compare"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
+          @ngrx/router-store/request: /compare
+          @ngrx/router-store/navigation: /compare
+          @ngrx/router-store/navigated: /compare
         `);
       }));
 
@@ -882,12 +792,8 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/product/P1"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/product/P1","params":{"sku":"P1"},"queryParams":{},...
-          event: {"id":1,"url":"/product/P1","urlAfterRedirects":"/product/P1"}
+        @ngrx/router-store/request: /product/P1
+        @ngrx/router-store/navigation: /product/P1
         [Products Internal] Load Product:
           sku: "P1"
         [Products API] Load Product Success:
@@ -895,9 +801,7 @@ describe('Shopping Store', () => {
         [Recently Viewed Internal] Add Product to Recently:
           sku: "P1"
           group: undefined
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/product/P1","params":{"sku":"P1"},"queryParams":{},...
-          event: {"id":1,"url":"/product/P1","urlAfterRedirects":"/product/P1"}
+        @ngrx/router-store/navigated: /product/P1
       `);
     }));
 
@@ -915,15 +819,9 @@ describe('Shopping Store', () => {
 
       it('should trigger actions for deselecting category and product when no longer in category or product', fakeAsync(() => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
-          @ngrx/router-store/request:
-            routerState: {"url":"/product/P1","params":{"sku":"P1"},"queryParams":{},...
-            event: {"id":2,"url":"/compare"}
-          @ngrx/router-store/navigation:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
-          @ngrx/router-store/navigated:
-            routerState: {"url":"/compare","params":{},"queryParams":{},"data":{},"pa...
-            event: {"id":2,"url":"/compare","urlAfterRedirects":"/compare"}
+          @ngrx/router-store/request: /compare
+          @ngrx/router-store/navigation: /compare
+          @ngrx/router-store/navigated: /compare
         `);
       }));
 
@@ -953,12 +851,8 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page with invalid product sku', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/category/A.123.456/product/P3"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/category/A.123.456/product/P3","params":{"categoryU...
-          event: {"id":1,"url":"/category/A.123.456/product/P3","urlAfterRedi...
+        @ngrx/router-store/request: /category/A.123.456/product/P3
+        @ngrx/router-store/navigation: /category/A.123.456/product/P3
         [Categories Internal] Load Category:
           categoryId: "A.123.456"
         [Categories API] Load Category Success:
@@ -976,19 +870,10 @@ describe('Shopping Store', () => {
           categories: tree(A,A.123)
         [Categories API] Load Category Success:
           categories: tree(A.123,A.123.456)
-        @ngrx/router-store/cancel:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          storeState: {"configuration":{"defaultLocale":"en_US","locales":[3],"ser...
-          event: {"id":1,"url":"/category/A.123.456/product/P3"}
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":2,"url":"/error"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
-          event: {"id":2,"url":"/error","urlAfterRedirects":"/error"}
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
-          event: {"id":2,"url":"/error","urlAfterRedirects":"/error"}
+        @ngrx/router-store/cancel: /category/A.123.456/product/P3
+        @ngrx/router-store/request: /error
+        @ngrx/router-store/navigation: /error
+        @ngrx/router-store/navigated: /error
       `);
     }));
 
@@ -1015,29 +900,16 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a category page with invalid category uniqueId', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/category/A.123.XXX"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/category/A.123.XXX","params":{"categoryUniqueId":"A...
-          event: {"id":1,"url":"/category/A.123.XXX","urlAfterRedirects":"/ca...
+        @ngrx/router-store/request: /category/A.123.XXX
+        @ngrx/router-store/navigation: /category/A.123.XXX
         [Categories Internal] Load Category:
           categoryId: "A.123.XXX"
         [Categories API] Load Category Fail:
           error: {"name":"HttpErrorResponse","message":"error loading categor...
-        @ngrx/router-store/cancel:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          storeState: {"configuration":{"defaultLocale":"en_US","locales":[3],"ser...
-          event: {"id":1,"url":"/category/A.123.XXX"}
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":2,"url":"/error"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
-          event: {"id":2,"url":"/error","urlAfterRedirects":"/error"}
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/error","params":{},"queryParams":{},"data":{"header...
-          event: {"id":2,"url":"/error","urlAfterRedirects":"/error"}
+        @ngrx/router-store/cancel: /category/A.123.XXX
+        @ngrx/router-store/request: /error
+        @ngrx/router-store/navigation: /error
+        @ngrx/router-store/navigated: /error
       `);
     }));
 
@@ -1059,15 +931,9 @@ describe('Shopping Store', () => {
 
     it('should trigger required actions when searching', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        @ngrx/router-store/request:
-          routerState: {"url":"","params":{},"queryParams":{},"data":{}}
-          event: {"id":1,"url":"/search/something"}
-        @ngrx/router-store/navigation:
-          routerState: {"url":"/search/something","params":{"searchTerm":"something...
-          event: {"id":1,"url":"/search/something","urlAfterRedirects":"/sear...
-        @ngrx/router-store/navigated:
-          routerState: {"url":"/search/something","params":{"searchTerm":"something...
-          event: {"id":1,"url":"/search/something","urlAfterRedirects":"/sear...
+        @ngrx/router-store/request: /search/something
+        @ngrx/router-store/navigation: /search/something
+        @ngrx/router-store/navigated: /search/something
         [Product Listing] Load More Products:
           id: {"type":"search","value":"something"}
         [Viewconf Internal] Set Breadcrumb Data:

--- a/src/jest-serializer/NgrxActionSerializer.js
+++ b/src/jest-serializer/NgrxActionSerializer.js
@@ -21,7 +21,9 @@ const serializePayload = v => {
 
 const print = (val, _, indent) => {
   let ret = val.type;
-  if (val.payload) {
+  if (val.type.startsWith('@ngrx/router-store/')) {
+    ret += ': ' + (val.payload?.event?.url || val.payload?.routerState?.url);
+  } else if (val.payload) {
     const stringified = serializePayload(val.payload);
     ret += ':\n' + indent(stringified);
   }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Router actions when serialized in jest snapshots contain unnecessary properties. The cancel action even prints out (for whatever reason) a slice of the current NgRx state, that always has to be updated when something changes:
https://github.com/intershop/intershop-pwa/blob/c08eebee46ddbcfcd16477781c1b4dbb5ab982f0/src/app/core/store/shopping/shopping-store.spec.ts#L979-L982

## What Is the New Behavior?

Router actions are only printing the navigation URLs associated with then.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No
