### PR TITLE
fix: add support for CMS component "Product List (Filter)" - use correct scope configuration

### DIFF
--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -80,7 +80,7 @@ export class CMSFacade {
     id = scope ? `${id}@${scope}` : id;
     id = amount ? `${id}@${amount}` : id;
 
-    if (categoryId && scope !== 'Global') {
+    if (categoryId && scope !== 'GlobalScope') {
       searchParameter.category = [CategoryHelper.getCategoryPath(categoryId)];
     }
 


### PR DESCRIPTION

## PR Type

[x] Bugfix


## What Is the Current Behavior?

The "Global" Scope configuration of the "Product List (Filter)" component is not evaluated right in the PWA rendering logic.

## What Is the New Behavior?

The "Global" Scope configuration of the "Product List (Filter)" component with the value "GlobalScope" instead of "Global" is evaluated right in the PWA rendering logic.

## Does this PR Introduce a Breaking Change?

[x] No
