### PR TITLE
explore: what if the ICM API could fetch multiple products at once?

### DIFF
--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -1,7 +1,7 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
-import { defaultIfEmpty, map, switchMap } from 'rxjs/operators';
+import { catchError, defaultIfEmpty, map, switchMap } from 'rxjs/operators';
 
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { CategoryHelper } from 'ish-core/models/category/category.model';
@@ -49,6 +49,17 @@ export class ProductsService {
     return this.apiService
       .get<ProductData>(`products/${sku}`, { params })
       .pipe(map(element => this.productMapper.fromData(element)));
+  }
+
+  getProducts(skus: string[]): Observable<Product[]> {
+    return this.apiService
+      .get(`products`, { params: new HttpParams().set('skus', skus.join(',')), skipApiErrorHandling: true })
+      .pipe(
+        unpackEnvelope<ProductData>(),
+        map(elements => elements.map(element => this.productMapper.fromData(element))),
+        // the API doesn't exist
+        catchError(() => of([]))
+      );
   }
 
   /**

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -107,6 +107,7 @@ describe('Shopping Store', () => {
     when(countryServiceMock.getCountries()).thenReturn(EMPTY);
 
     productsServiceMock = mock(ProductsService);
+    when(productsServiceMock.getProducts(anything())).thenReturn(EMPTY);
     when(productsServiceMock.getProduct(anyString())).thenCall(sku => {
       if (['P1', 'P2'].find(x => x === sku)) {
         return of({ sku, name: 'n' + sku });


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Other: Showcase

## What Is the Current Behavior?

Feature request #764

## What Is the New Behavior?

Solution if the API could actually fetch multiple products at once.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No


[AB#118537](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118537)