### PR TITLE
feat: disable ngrx Store Devtools in production environments

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -80,7 +80,13 @@
                 }
               ],
               "serviceWorker": false,
-              "ngswConfigPath": "ngsw-config.json"
+              "ngswConfigPath": "ngsw-config.json",
+              "fileReplacements": [
+                {
+                  "replace": "src/app/core/store/store-devtools.module.ts",
+                  "with": "src/app/core/store/store-devtools.module.prod.ts"
+                }
+              ]
             },
             "local": {
               "optimization": false,
@@ -133,7 +139,6 @@
               "path": "./templates/webpack/webpack.custom.ts",
               "replaceDuplicatePlugins": true
             },
-            "showCircularDependencies": false,
             "outputPath": "dist/server",
             "main": "server.ts",
             "optimization": true,

--- a/angular.json
+++ b/angular.json
@@ -84,7 +84,7 @@
               "fileReplacements": [
                 {
                   "replace": "src/app/core/store/store-devtools.module.ts",
-                  "with": "src/app/core/store/store-devtools.module.prod.ts"
+                  "with": "src/app/core/store/store-devtools.module.production.ts"
                 }
               ]
             },
@@ -139,6 +139,7 @@
               "path": "./templates/webpack/webpack.custom.ts",
               "replaceDuplicatePlugins": true
             },
+            "showCircularDependencies": false,
             "outputPath": "dist/server",
             "main": "server.ts",
             "optimization": true,

--- a/scripts/find-dead-code.ts
+++ b/scripts/find-dead-code.ts
@@ -128,7 +128,7 @@ function checkNode(node: Node) {
     return;
   }
 
-  if (/\/src\/environments\//.test(node.getSourceFile().getFilePath())) {
+  if (/\/src\/environments\/|.*.production.ts$/.test(node.getSourceFile().getFilePath())) {
     return;
   }
 

--- a/src/app/core/state-management.module.ts
+++ b/src/app/core/state-management.module.ts
@@ -2,29 +2,21 @@ import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserTransferStateModule, TransferState } from '@angular/platform-browser';
 import { Actions } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 
 import { ngrxStateTransfer } from './configurations/ngrx-state-transfer';
 import { ContentStoreModule } from './store/content/content-store.module';
 import { CoreStoreModule } from './store/core/core-store.module';
-import { setStickyHeader } from './store/core/viewconf';
 import { CustomerStoreModule } from './store/customer/customer-store.module';
 import { GeneralStoreModule } from './store/general/general-store.module';
 import { HybridStoreModule } from './store/hybrid/hybrid-store.module';
-import { loadProductIfNotLoaded } from './store/shopping/products';
-import { loadPromotion } from './store/shopping/promotions';
-import { suggestSearch } from './store/shopping/search';
 import { ShoppingStoreModule } from './store/shopping/shopping-store.module';
+import { storeDevtoolsModule } from './store/store-devtools.module';
 
 @NgModule({
   imports: [
     BrowserTransferStateModule,
     CoreStoreModule,
-    StoreDevtoolsModule.instrument({
-      maxAge: PRODUCTION_MODE ? 25 : 200,
-      logOnly: PRODUCTION_MODE, // Restrict extension to log-only mode
-      actionsBlocklist: [loadPromotion.type, loadProductIfNotLoaded.type, setStickyHeader.type, suggestSearch.type],
-    }),
+    storeDevtoolsModule, // disable the Store Devtools In Production (https://ngrx.io/guide/store-devtools/recipes/exclude)
     GeneralStoreModule,
     CustomerStoreModule,
     ContentStoreModule,

--- a/src/app/core/state-management.module.ts
+++ b/src/app/core/state-management.module.ts
@@ -16,7 +16,7 @@ import { storeDevtoolsModule } from './store/store-devtools.module';
   imports: [
     BrowserTransferStateModule,
     CoreStoreModule,
-    storeDevtoolsModule, // disable the Store Devtools In Production (https://ngrx.io/guide/store-devtools/recipes/exclude)
+    storeDevtoolsModule, // disable the Store Devtools in production (https://ngrx.io/guide/store-devtools/recipes/exclude)
     GeneralStoreModule,
     CustomerStoreModule,
     ContentStoreModule,

--- a/src/app/core/store/store-devtools.module.prod.ts
+++ b/src/app/core/store/store-devtools.module.prod.ts
@@ -1,3 +1,0 @@
-// tslint:disable: no-any
-// not-dead-code
-export const storeDevtoolsModule: any[] = [];

--- a/src/app/core/store/store-devtools.module.prod.ts
+++ b/src/app/core/store/store-devtools.module.prod.ts
@@ -1,0 +1,3 @@
+// tslint:disable: no-any
+// not-dead-code
+export const storeDevtoolsModule: any[] = [];

--- a/src/app/core/store/store-devtools.module.production.ts
+++ b/src/app/core/store/store-devtools.module.production.ts
@@ -1,0 +1,2 @@
+// not-dead-code
+export const storeDevtoolsModule: unknown[] = [];

--- a/src/app/core/store/store-devtools.module.ts
+++ b/src/app/core/store/store-devtools.module.ts
@@ -1,0 +1,13 @@
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+
+import { setStickyHeader } from 'ish-core/store/core/viewconf';
+import { loadProductIfNotLoaded } from 'ish-core/store/shopping/products';
+import { loadPromotion } from 'ish-core/store/shopping/promotions';
+import { suggestSearch } from 'ish-core/store/shopping/search';
+
+export const storeDevtoolsModule = [
+  StoreDevtoolsModule.instrument({
+    maxAge: 200,
+    actionsBlocklist: [loadPromotion.type, loadProductIfNotLoaded.type, setStickyHeader.type, suggestSearch.type],
+  }),
+];

--- a/src/app/core/store/store-devtools.module.ts
+++ b/src/app/core/store/store-devtools.module.ts
@@ -5,9 +5,12 @@ import { loadProductIfNotLoaded } from 'ish-core/store/shopping/products';
 import { loadPromotion } from 'ish-core/store/shopping/promotions';
 import { suggestSearch } from 'ish-core/store/shopping/search';
 
+// remove the 'store-devtools.module.ts' fileReplacements in 'angular.json' to enable Store Devtools in production
+
 export const storeDevtoolsModule = [
   StoreDevtoolsModule.instrument({
-    maxAge: 200,
+    maxAge: PRODUCTION_MODE ? 25 : 200,
+    logOnly: PRODUCTION_MODE, // restrict extension to log-only mode
     actionsBlocklist: [loadPromotion.type, loadProductIfNotLoaded.type, setStickyHeader.type, suggestSearch.type],
   }),
 ];

--- a/tslint.json
+++ b/tslint.json
@@ -208,7 +208,7 @@
     "ng-module-sorted-fields": {
       "severity": "error",
       "options": {
-        "ignore-tokens": ["AppRouting", "StoreDevtoolsModule"]
+        "ignore-tokens": ["AppRouting", "storeDevtoolsModule"]
       }
     },
     "ish-ordered-imports": true,
@@ -795,7 +795,8 @@
           "utils/dev/",
           "core/utils/",
           ".*.actions.ts$",
-          ".*.model.ts$"
+          ".*.model.ts$",
+          "store-devtools.module"
         ]
       }
     }


### PR DESCRIPTION
## PR Type

[x] Feature

## Description

The current PWA configuration exposes the ngrx store debugging information in production deployments too.

![image](https://user-images.githubusercontent.com/50741106/124751709-3e7c8a80-df27-11eb-84cd-892de8275a48.png)

Since this is seldomly wanted in production environments the new configuration disables this information completely for such deployments.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

https://ngrx.io/guide/store-devtools/recipes/exclude

[AB#64608](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/64608)