### PR TITLE
ci: enable setup-node caching

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -16,9 +16,10 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -33,9 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci
@@ -77,9 +78,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci
@@ -104,9 +106,10 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci
@@ -126,9 +129,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,10 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,9 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci
@@ -68,9 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Download Build Output
         uses: actions/download-artifact@v2

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,9 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install root dependencies
         run: npm ci
@@ -45,9 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Install Clean Repository
         run: |


### PR DESCRIPTION
## PR Type

[x] CI-related changes

## What Is the New Behavior?

The setup-node action v2 now supports dependency caching. Maybe this can help us make our ci pipeline faster.

https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#64630](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/64630)