### PR TITLE
fix: set canonical link and 'og:url' info independent from SSR container context to 'https'

### DIFF
--- a/e2e/test-universal.sh
+++ b/e2e/test-universal.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 PWA_BASE_URL=${PWA_BASE_URL:-"http://localhost:4200"}
+PWA_CANONICAL_BASE_URL=${PWA_CANONICAL_BASE_URL:-"https://localhost:4200"}
 
 universalTest() {
   NUM="$1"
@@ -24,10 +25,10 @@ universalTest 7 "${PWA_BASE_URL}/catComputers.1835.151" "add-to-compare"
 universalTest 8 "${PWA_BASE_URL}/home" "intershop-pwa-state"
 universalTest 9 "${PWA_BASE_URL}/home" "&q;baseURL&q;:"
 universalTest 10 "${PWA_BASE_URL}/home" "<ish-content-include includeid=.include.homepage.content.pagelet2-Include"
-universalTest 11 "${PWA_BASE_URL}/home" "<link rel=.canonical. href=.${PWA_BASE_URL}/home.>"
-universalTest 12 "${PWA_BASE_URL}/home" "<meta property=.og:image. content=.${PWA_BASE_URL}[^>]*og-image-default"
+universalTest 11 "${PWA_BASE_URL}/home" "<link rel=.canonical. href=.${PWA_CANONICAL_BASE_URL}/home.>"
+universalTest 12 "${PWA_BASE_URL}/home" "<meta property=.og:image. content=.${PWA_CANONICAL_BASE_URL}[^>]*og-image-default"
 universalTest 13 "${PWA_BASE_URL}/home" "<title>inTRONICS Home | Intershop PWA</title>"
-universalTest 14 "${PWA_BASE_URL}/sku6997041" "<link rel=.canonical. href=.${PWA_BASE_URL}/Notebooks/Asus-Eee-PC-1008P-Karim-Rashid-sku6997041-catComputers.1835.151.>"
+universalTest 14 "${PWA_BASE_URL}/sku6997041" "<link rel=.canonical. href=.${PWA_CANONICAL_BASE_URL}/Notebooks/Asus-Eee-PC-1008P-Karim-Rashid-sku6997041-catComputers.1835.151.>"
 universalTest 15 "${PWA_BASE_URL}/sku6997041" "<meta property=.og:image. content=[^>]*6997041"
 universalTest 16 "${PWA_BASE_URL}/sku6997041" "<title>Asus Eee PC 1008P .Karim Rashid. [^>]* | Intershop PWA</title>"
 universalTest 17 "${PWA_BASE_URL}/home;device=tablet" "class=.header container tablet"

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -123,7 +123,7 @@ export class SeoEffects {
           description: 'seo.defaults.description',
           robots: 'index, follow',
           'og:type': 'website',
-          'og:image': `${this.baseURL(false)}assets/img/og-image-default.jpg`,
+          'og:image': `${this.baseURL(false)}assets/img/og-image-default.jpg`.replace('http:', 'https:'),
           ...attributes,
         })),
         distinctUntilChanged(isEqual),
@@ -191,14 +191,17 @@ export class SeoEffects {
   }
 
   private setCanonicalLink(url: string) {
+    // the canonical URL of a production system should always be with 'https:'
+    // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
+    const canonicalUrl = url.replace('http:', 'https:');
     let canonicalLink = this.doc.querySelector('link[rel="canonical"]');
     if (!canonicalLink) {
       canonicalLink = this.doc.createElement('link');
       canonicalLink.setAttribute('rel', 'canonical');
       this.doc.head.appendChild(canonicalLink);
     }
-    canonicalLink.setAttribute('href', url);
-    this.addOrModifyTag({ property: 'og:url', content: url });
+    canonicalLink.setAttribute('href', canonicalUrl);
+    this.addOrModifyTag({ property: 'og:url', content: canonicalUrl });
   }
 
   private setSeoAttributes(seoAttributes: SeoAttributes) {


### PR DESCRIPTION
Production PWAs should always be run in a secure context but the PWA SSR container itself is usually not run in a secure context in production. The SSL certification is handled outside the PWAs context. This makes it hard to get the correct protocol from the PWA SSR context even though it is a secure context to the user. For this reason we always set the canonical link URLs and the 'og:url' to 'https:' to prevent false non indexable canonical links.

## PR Type

[x] Bugfix

## Does this PR Introduce a Breaking Change?

[x] No

Issue number: #749 

[AB#64674](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/64674)