### PR TITLE
refactor: adapt order template modal with formly

### DIFF
--- a/e2e/cypress/integration/pages/account/add-to-order-template.module.ts
+++ b/e2e/cypress/integration/pages/account/add-to-order-template.module.ts
@@ -9,7 +9,7 @@ export class AddToOrderTemplateModule {
 
   addProductToOrderTemplateFromPage(title: string = '', modal: boolean = false) {
     if (modal) {
-      cy.get(`[data-testing-id="${title}"]`).click();
+      cy.get(`[data-testing-id="radio-${title}"]`).click();
       cy.get('.modal-footer button.btn-primary').click();
     }
     this.closeAddProductToOrderTemplateModal('link');
@@ -21,7 +21,7 @@ export class AddToOrderTemplateModule {
         .find(`ish-product-item div[data-testing-sku="${product}"] ish-product-add-to-order-template button`)
         .click();
       if (title) {
-        cy.get(`[data-testing-id="${title}"]`).click();
+        cy.get(`[data-testing-id="radio-${title}"]`).click();
       }
       cy.get('.modal-footer button.btn-primary').click();
       this.closeAddProductToOrderTemplateModal('link');

--- a/e2e/cypress/integration/pages/account/order-templates-details.page.ts
+++ b/e2e/cypress/integration/pages/account/order-templates-details.page.ts
@@ -45,7 +45,7 @@ export class OrderTemplatesDetailsPage {
 
   moveProductToOrderTemplate(productId: string, listName: string) {
     this.getOrderTemplateItemById(productId).find('[data-testing-id="move-order-template"]').click();
-    cy.get(`[data-testing-id="${listName}"]`).check();
+    cy.get(`[data-testing-id="radio-${listName}"]`).check();
     cy.get('ngb-modal-window').find('button[class="btn btn-primary"]').click();
     cy.get('[data-testing-id="order-template-success-link"] a').click();
   }

--- a/src/app/extensions/order-templates/order-templates.module.ts
+++ b/src/app/extensions/order-templates/order-templates.module.ts
@@ -6,6 +6,7 @@ import { BasketCreateOrderTemplateComponent } from './shared/basket-create-order
 import { OrderTemplatePreferencesDialogComponent } from './shared/order-template-preferences-dialog/order-template-preferences-dialog.component';
 import { OrderTemplateWidgetComponent } from './shared/order-template-widget/order-template-widget.component';
 import { ProductAddToOrderTemplateComponent } from './shared/product-add-to-order-template/product-add-to-order-template.component';
+import { SelectOrderTemplateFormComponent } from './shared/select-order-template-form/select-order-template-form.component';
 import { SelectOrderTemplateModalComponent } from './shared/select-order-template-modal/select-order-template-modal.component';
 
 @NgModule({
@@ -15,6 +16,7 @@ import { SelectOrderTemplateModalComponent } from './shared/select-order-templat
     OrderTemplatePreferencesDialogComponent,
     OrderTemplateWidgetComponent,
     ProductAddToOrderTemplateComponent,
+    SelectOrderTemplateFormComponent,
     SelectOrderTemplateModalComponent,
   ],
   exports: [OrderTemplatePreferencesDialogComponent, OrderTemplateWidgetComponent, SelectOrderTemplateModalComponent],

--- a/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.html
@@ -1,0 +1,9 @@
+<ng-container *ngIf="(orderTemplatesOptions$ | async).length === 0; else radioButtonForm">
+  <formly-form [form]="formGroup" [fields]="singleFieldConfig"></formly-form>
+</ng-container>
+
+<ng-template #radioButtonForm>
+  <div class="col-md-12">
+    <formly-form [form]="formGroup" [fields]="multipleFieldConfig$ | async"></formly-form>
+  </div>
+</ng-template>

--- a/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { instance, mock } from 'ts-mockito';
+
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
+
+import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
+
+import { SelectOrderTemplateFormComponent } from './select-order-template-form.component';
+
+describe('Select Order Template Form Component', () => {
+  let component: SelectOrderTemplateFormComponent;
+  let fixture: ComponentFixture<SelectOrderTemplateFormComponent>;
+  let element: HTMLElement;
+  let orderTemplatesFacade: OrderTemplatesFacade;
+
+  beforeEach(async () => {
+    orderTemplatesFacade = mock(OrderTemplatesFacade);
+    await TestBed.configureTestingModule({
+      declarations: [SelectOrderTemplateFormComponent],
+      imports: [FormlyTestingModule],
+      providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplatesFacade) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SelectOrderTemplateFormComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+});

--- a/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { instance, mock } from 'ts-mockito';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
 
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
@@ -13,16 +15,26 @@ describe('Select Order Template Form Component', () => {
   let element: HTMLElement;
   let orderTemplatesFacade: OrderTemplatesFacade;
 
+  const orderTemplateDetails = {
+    title: 'testing order template',
+    id: '.SKsEQAE4FIAAAFuNiUBWx0d',
+    itemsCount: 0,
+    public: false,
+  };
+
   beforeEach(async () => {
     orderTemplatesFacade = mock(OrderTemplatesFacade);
     await TestBed.configureTestingModule({
       declarations: [SelectOrderTemplateFormComponent],
-      imports: [FormlyTestingModule],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
       providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplatesFacade) }],
     }).compileComponents();
   });
 
   beforeEach(() => {
+    when(orderTemplatesFacade.orderTemplatesSelectOptions$(anything())).thenReturn(
+      of([{ value: orderTemplateDetails.id, label: orderTemplateDetails.title }])
+    );
     fixture = TestBed.createComponent(SelectOrderTemplateFormComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.ts
@@ -1,0 +1,100 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { SelectOption } from 'ish-shared/forms/components/select/select.component';
+
+import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
+
+@Component({
+  selector: 'ish-select-order-template-form',
+  templateUrl: './select-order-template-form.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SelectOrderTemplateFormComponent implements OnInit {
+  @Input() formGroup: FormGroup;
+
+  /**
+   * changes the some logic and the translations keys between add or move a product (default: 'add')
+   */
+  @Input() addMoveProduct: 'add' | 'move' = 'add';
+
+  orderTemplatesOptions$: Observable<SelectOption[]>;
+
+  singleFieldConfig: FormlyFieldConfig[];
+  multipleFieldConfig$: Observable<FormlyFieldConfig[]>;
+
+  constructor(private orderTemplatesFacade: OrderTemplatesFacade, private translate: TranslateService) {}
+
+  ngOnInit(): void {
+    this.orderTemplatesOptions$ = this.orderTemplatesFacade.orderTemplatesSelectOptions$(
+      this.addMoveProduct === 'move'
+    );
+
+    // formly config for the single input field form (no or no other order templates exist)
+    this.singleFieldConfig = [
+      {
+        type: 'ish-text-input-field',
+        key: 'newOrderTemplate',
+        defaultValue: this.translate.instant('account.order_template.new_order_template.text'),
+        templateOptions: {
+          required: true,
+        },
+        validation: {
+          messages: { required: 'account.order_template.name.error.required' },
+        },
+      },
+    ];
+
+    // formly config for the radio button form (one or more other order templates exist)
+    this.multipleFieldConfig$ = this.orderTemplatesOptions$.pipe(
+      map(orderTemplateOptions =>
+        orderTemplateOptions.map(option => ({
+          type: 'ish-radio-field',
+          key: 'orderTemplate',
+          defaultValue: orderTemplateOptions[0].value,
+          templateOptions: {
+            fieldClass: ' ',
+            value: option.value,
+            label: option.label,
+          },
+        }))
+      ),
+      map(formlyConfig => [
+        ...formlyConfig,
+        {
+          fieldGroupClassName: 'form-check d-flex',
+          fieldGroup: [
+            {
+              type: 'ish-radio-field',
+              key: 'orderTemplate',
+              templateOptions: {
+                fieldClass: ' ',
+                value: 'new',
+              },
+            },
+            {
+              type: 'ish-text-input-field',
+              key: 'newOrderTemplate',
+              className: 'w-75 position-relative validation-offset-0',
+              wrappers: ['validation'],
+              defaultValue: this.translate.instant('account.order_template.new_order_template.text'),
+              templateOptions: {
+                required: true,
+              },
+              validation: {
+                messages: { required: 'account.order_template.name.error.required' },
+              },
+              expressionProperties: {
+                'templateOptions.disabled': model => model.orderTemplate !== 'new',
+              },
+            },
+          ],
+        },
+      ])
+    );
+  }
+}

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -14,55 +14,17 @@
 
   <ng-container *ngIf="showForm; else showSuccess">
     <div class="modal-body">
-      <form [formGroup]="updateOrderTemplateForm" (ngSubmit)="submitForm()">
-        <ng-container
-          *ngIf="orderTemplateOptions === undefined || orderTemplateOptions.length === 0; else radioButtonForm"
-        >
-          <ish-input
-            controlName="newOrderTemplate"
-            [errorMessages]="{ required: 'account.order_template.name.error.required' }"
-            [form]="updateOrderTemplateForm"
-          ></ish-input>
-        </ng-container>
+      <div class="col-md-12">
+        <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+          <ng-container *ngIf="(orderTemplateOptions$ | async).length === 0; else radioButtonForm">
+            <formly-form [form]="formGroup" [fields]="singleFieldConfig" [model]="model"></formly-form>
+          </ng-container>
 
-        <ng-template #radioButtonForm>
-          <div class="form-group">
-            <div class="radio" *ngFor="let option of orderTemplateOptions; let i = index">
-              <label>
-                <input
-                  type="radio"
-                  name="orderTemplate"
-                  formControlName="orderTemplate"
-                  [value]="option.value"
-                  id="orderTemplate_{{ i }}"
-                  [attr.data-testing-id]="option.label"
-                />
-                {{ option.label }}
-              </label>
-            </div>
-            <div class="radio">
-              <label class="d-flex align-items-center">
-                <input
-                  type="radio"
-                  name="orderTemplate"
-                  formControlName="orderTemplate"
-                  value="newTemplate"
-                  class="mb-3"
-                  id="orderTemplate"
-                />
-                <ish-input
-                  class="w-75"
-                  controlName="newOrderTemplate"
-                  [disabled]="newOrderTemplateDisabled ? true : null"
-                  [errorMessages]="{ required: 'account.order_template.name.error.required' }"
-                  [form]="updateOrderTemplateForm"
-                  inputClass="col-md-12"
-                ></ish-input>
-              </label>
-            </div>
-          </div>
-        </ng-template>
-      </form>
+          <ng-template #radioButtonForm>
+            <formly-form [form]="formGroup" [fields]="multipleFieldConfig$ | async" [model]="model"></formly-form>
+          </ng-template>
+        </form>
+      </div>
     </div>
 
     <div class="modal-footer">
@@ -80,7 +42,12 @@
       <span
         [ishServerHtml]="
           successTranslationKey
-            | translate: { '0': product.name, '1': selectedOrderTemplateTitle, '2': selectedOrderTemplateRoute }
+            | translate
+              : {
+                  '0': product.name,
+                  '1': selectedOrderTemplateTitle$ | async,
+                  '2': selectedOrderTemplateRoute$ | async
+                }
         "
         [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
         data-testing-id="order-template-success-link"

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -14,17 +14,17 @@
 
   <ng-container *ngIf="showForm; else showSuccess">
     <div class="modal-body">
-      <div class="col-md-12">
-        <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
-          <ng-container *ngIf="(orderTemplateOptions$ | async).length === 0; else radioButtonForm">
-            <formly-form [form]="formGroup" [fields]="singleFieldConfig" [model]="model"></formly-form>
-          </ng-container>
+      <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+        <ng-container *ngIf="(orderTemplateOptions$ | async).length === 0; else radioButtonForm">
+          <formly-form [form]="formGroup" [fields]="singleFieldConfig" [model]="model"></formly-form>
+        </ng-container>
 
-          <ng-template #radioButtonForm>
+        <ng-template #radioButtonForm>
+          <div class="col-md-12">
             <formly-form [form]="formGroup" [fields]="multipleFieldConfig$ | async" [model]="model"></formly-form>
-          </ng-template>
-        </form>
-      </div>
+          </div>
+        </ng-template>
+      </form>
     </div>
 
     <div class="modal-footer">

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -15,15 +15,10 @@
   <ng-container *ngIf="showForm; else showSuccess">
     <div class="modal-body">
       <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
-        <ng-container *ngIf="(orderTemplateOptions$ | async).length === 0; else radioButtonForm">
-          <formly-form [form]="formGroup" [fields]="singleFieldConfig" [model]="model"></formly-form>
-        </ng-container>
-
-        <ng-template #radioButtonForm>
-          <div class="col-md-12">
-            <formly-form [form]="formGroup" [fields]="multipleFieldConfig$ | async" [model]="model"></formly-form>
-          </div>
-        </ng-template>
+        <ish-select-order-template-form
+          [formGroup]="formGroup"
+          [addMoveProduct]="addMoveProduct"
+        ></ish-select-order-template-form>
       </form>
     </div>
 

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -1,13 +1,12 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent, MockDirective } from 'ng-mocks';
+import { MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
-import { InputComponent } from 'ish-shared/forms/components/input/input.component';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
 
@@ -50,11 +49,7 @@ describe('Select Order Template Modal Component', () => {
     orderTemplateFacadeMock = mock(OrderTemplatesFacade);
 
     await TestBed.configureTestingModule({
-      declarations: [
-        MockComponent(InputComponent),
-        MockDirective(ServerHtmlDirective),
-        SelectOrderTemplateModalComponent,
-      ],
+      declarations: [MockDirective(ServerHtmlDirective), SelectOrderTemplateModalComponent],
       imports: [FormlyTestingModule, NgbModalModule, TranslateModule.forRoot()],
       providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplateFacadeMock) }],
     }).compileComponents();

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -145,7 +145,7 @@ Object {
     startup();
 
     const emitter = spy(component.submitEmitter);
-    component.formGroup.patchValue({ newList: '' });
+    component.formGroup.patchValue({ newOrderTemplate: '' });
 
     component.submitForm();
     tick(100);

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -9,6 +9,7 @@ import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
+import { SelectOrderTemplateFormComponent } from '../select-order-template-form/select-order-template-form.component';
 
 import { SelectOrderTemplateModalComponent } from './select-order-template-modal.component';
 
@@ -49,7 +50,11 @@ describe('Select Order Template Modal Component', () => {
     orderTemplateFacadeMock = mock(OrderTemplatesFacade);
 
     await TestBed.configureTestingModule({
-      declarations: [MockDirective(ServerHtmlDirective), SelectOrderTemplateModalComponent],
+      declarations: [
+        MockDirective(ServerHtmlDirective),
+        SelectOrderTemplateFormComponent,
+        SelectOrderTemplateModalComponent,
+      ],
       imports: [FormlyTestingModule, NgbModalModule, TranslateModule.forRoot()],
       providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplateFacadeMock) }],
     }).compileComponents();
@@ -61,7 +66,9 @@ describe('Select Order Template Modal Component', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement;
     when(orderTemplateFacadeMock.currentOrderTemplate$).thenReturn(of(orderTemplateDetails));
-    when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([orderTemplateDetails]));
+    when(orderTemplateFacadeMock.orderTemplatesSelectOptions$(anything())).thenReturn(
+      of([{ value: orderTemplateDetails.id, label: orderTemplateDetails.title }])
+    );
   });
 
   it('should be created', () => {
@@ -107,7 +114,7 @@ Object {
   }));
 
   it('should emit correct object on single field form submit with new orderTemplate', fakeAsync(() => {
-    when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([]));
+    when(orderTemplateFacadeMock.orderTemplatesSelectOptions$(anything())).thenReturn(of([]));
     startup();
 
     const emitter = spy(component.submitEmitter);
@@ -136,7 +143,7 @@ Object {
   });
 
   it('should not emit on single field form submit with no orderTemplate name', fakeAsync(() => {
-    when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([]));
+    when(orderTemplateFacadeMock.orderTemplatesSelectOptions$(anything())).thenReturn(of([]));
     startup();
 
     const emitter = spy(component.submitEmitter);

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -74,7 +74,7 @@ describe('Select Order Template Modal Component', () => {
     startup();
 
     const emitter = spy(component.submitEmitter);
-    component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+    component.formGroup.patchValue({ orderTemplate: orderTemplateDetails.id });
 
     component.submitForm();
     tick(1000);
@@ -150,7 +150,7 @@ Object {
   it('should switch modal contents after successful submit', fakeAsync(() => {
     startup();
 
-    component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+    component.formGroup.patchValue({ orderTemplate: orderTemplateDetails.id });
 
     component.submitForm();
     tick(1000);
@@ -160,7 +160,7 @@ Object {
   describe('selectedOrderTemplateTitle$', () => {
     it('should return correct title of known order template', done => {
       startup();
-      component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+      component.formGroup.patchValue({ orderTemplate: orderTemplateDetails.id });
       component.selectedOrderTemplateTitle$.subscribe(t => {
         expect(t).toBe('testing order template');
         done();
@@ -181,7 +181,7 @@ Object {
   describe('selectedOrderTemplateRoute$', () => {
     it('should return correct route of known order template', done => {
       startup();
-      component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+      component.formGroup.patchValue({ orderTemplate: orderTemplateDetails.id });
 
       component.selectedOrderTemplateRoute$.subscribe(r => {
         expect(r).toBe('route://account/order-templates/.SKsEQAE4FIAAAFuNiUBWx0d');

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -1,5 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
@@ -7,6 +6,7 @@ import { of } from 'rxjs';
 import { anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 import { InputComponent } from 'ish-shared/forms/components/input/input.component';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
@@ -25,6 +25,27 @@ describe('Select Order Template Modal Component', () => {
     public: false,
   };
 
+  /**
+   * A fixture.detectChanges() is necessary to make sure the newOrderTemplate
+   * formControl is not disabled from its expressionProperty
+   */
+  function updateOrderTemplateAndNew(newOrderTemplate: string = 'New Ordertemplate Title') {
+    component.formGroup.patchValue({ orderTemplate: 'new' });
+    fixture.detectChanges();
+    component.formGroup.patchValue({ newOrderTemplate });
+  }
+
+  /**
+   * emulates a realistic startup scenario:
+   * the component is initialized before the show() function is called and
+   * real functionality begins
+   */
+  function startup() {
+    fixture.detectChanges();
+    component.show();
+    fixture.detectChanges();
+  }
+
   beforeEach(async () => {
     orderTemplateFacadeMock = mock(OrderTemplatesFacade);
 
@@ -34,7 +55,7 @@ describe('Select Order Template Modal Component', () => {
         MockDirective(ServerHtmlDirective),
         SelectOrderTemplateModalComponent,
       ],
-      imports: [NgbModalModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      imports: [FormlyTestingModule, NgbModalModule, TranslateModule.forRoot()],
       providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplateFacadeMock) }],
     }).compileComponents();
   });
@@ -46,11 +67,6 @@ describe('Select Order Template Modal Component', () => {
     element = fixture.nativeElement;
     when(orderTemplateFacadeMock.currentOrderTemplate$).thenReturn(of(orderTemplateDetails));
     when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([orderTemplateDetails]));
-
-    fixture.detectChanges();
-    component.show();
-
-    component.orderTemplateOptions = [{ value: 'orderTemplate', label: 'Order Template' }];
   });
 
   it('should be created', () => {
@@ -59,79 +75,133 @@ describe('Select Order Template Modal Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
-  it('should emit correct object on form submit with known order template', () => {
+  it('should emit correct object on form submit with known order template', fakeAsync(() => {
+    startup();
+
     const emitter = spy(component.submitEmitter);
-    component.updateOrderTemplateForm.patchValue({ orderTemplate: 'orderTemplate' });
+    component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
 
     component.submitForm();
+    tick(1000);
     verify(emitter.emit(anything())).once();
     const [arg] = capture(emitter.emit).last();
-    expect(arg).toEqual({
-      id: 'orderTemplate',
-      title: 'Order Template',
-    });
-  });
+    expect(arg).toMatchInlineSnapshot(`
+Object {
+  "id": ".SKsEQAE4FIAAAFuNiUBWx0d",
+  "title": "testing order template",
+}
+`);
+  }));
 
-  it('should emit correct object on form submit with new ordertemplate', () => {
+  it('should emit correct object on form submit with new ordertemplate', fakeAsync(() => {
+    startup();
+
     const emitter = spy(component.submitEmitter);
-    component.updateOrderTemplateForm.patchValue({
-      orderTemplate: 'newTemplate',
-      newOrderTemplate: 'New Order Template Title',
-    });
+    updateOrderTemplateAndNew();
 
     component.submitForm();
+    tick(1000);
     verify(emitter.emit(anything())).once();
     const [arg] = capture(emitter.emit).last();
-    expect(arg).toEqual({
-      id: undefined,
-      title: 'New Order Template Title',
-    });
-  });
+    expect(arg).toMatchInlineSnapshot(`
+Object {
+  "id": undefined,
+  "title": "New Ordertemplate Title",
+}
+`);
+  }));
 
-  it('should switch modal contents after successful submit', () => {
-    component.updateOrderTemplateForm.patchValue({ orderTemplate: 'orderTemplate' });
+  it('should emit correct object on single field form submit with new orderTemplate', fakeAsync(() => {
+    when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([]));
+    startup();
+
+    const emitter = spy(component.submitEmitter);
+    component.formGroup.patchValue({ newOrderTemplate: 'New Ordertemplate Title' });
 
     component.submitForm();
+    tick(1000);
+    verify(emitter.emit(anything())).once();
+    const [arg] = capture(emitter.emit).last();
+    expect(arg).toMatchInlineSnapshot(`
+Object {
+  "id": undefined,
+  "title": "New Ordertemplate Title",
+}
+`);
+  }));
+
+  it('should not emit on radio button form submit with no new orderTemplate name', () => {
+    startup();
+
+    const emitter = spy(component.submitEmitter);
+    updateOrderTemplateAndNew('');
+
+    component.submitForm();
+    verify(emitter.emit(anything())).never();
+  });
+
+  it('should not emit on single field form submit with no orderTemplate name', fakeAsync(() => {
+    when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([]));
+    startup();
+
+    const emitter = spy(component.submitEmitter);
+    component.formGroup.patchValue({ newList: '' });
+
+    component.submitForm();
+    tick(100);
+    verify(emitter.emit(anything())).never();
+  }));
+
+  it('should switch modal contents after successful submit', fakeAsync(() => {
+    startup();
+
+    component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+
+    component.submitForm();
+    tick(1000);
     expect(element.querySelector('form')).toBeFalsy();
-  });
+  }));
 
-  it('should ensure that newOrderTemplate remove Validator after being deselected', () => {
-    component.updateOrderTemplateForm.patchValue({ orderTemplate: 'orderTemplate', newOrderTemplate: '' });
-    expect(component.updateOrderTemplateForm.get('newOrderTemplate').validator).toBeNull();
-  });
-
-  describe('selectedOrderTemplateTitle', () => {
-    it('should return correct title of known order template', () => {
-      component.updateOrderTemplateForm.patchValue({ orderTemplate: 'orderTemplate' });
-      const title = component.selectedOrderTemplateTitle;
-      expect(title).toBe('Order Template');
-    });
-
-    it('should return correct title of new order template', () => {
-      component.updateOrderTemplateForm.patchValue({
-        orderTemplate: 'newTemplate',
-        newOrderTemplate: 'New Order Template Title',
+  describe('selectedOrderTemplateTitle$', () => {
+    it('should return correct title of known order template', done => {
+      startup();
+      component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+      component.selectedOrderTemplateTitle$.subscribe(t => {
+        expect(t).toBe('testing order template');
+        done();
       });
-      const title = component.selectedOrderTemplateTitle;
-      expect(title).toBe('New Order Template Title');
+    });
+
+    it('should return correct title of new order template', done => {
+      startup();
+      updateOrderTemplateAndNew();
+
+      component.selectedOrderTemplateTitle$.subscribe(t => {
+        expect(t).toBe('New Ordertemplate Title');
+        done();
+      });
     });
   });
 
-  describe('selectedOrderTemplateRoute', () => {
-    it('should return correct route of known order template', () => {
-      component.updateOrderTemplateForm.patchValue({ orderTemplate: 'orderTemplate' });
-      const route = component.selectedOrderTemplateRoute;
-      expect(route).toBe('route://account/order-templates/orderTemplate');
+  describe('selectedOrderTemplateRoute$', () => {
+    it('should return correct route of known order template', done => {
+      startup();
+      component.formGroup.patchValue({ orderTemplate: '.SKsEQAE4FIAAAFuNiUBWx0d' });
+
+      component.selectedOrderTemplateRoute$.subscribe(r => {
+        expect(r).toBe('route://account/order-templates/.SKsEQAE4FIAAAFuNiUBWx0d');
+        done();
+      });
     });
 
-    it('should return correct route of new order template', () => {
-      component.updateOrderTemplateForm.patchValue({
-        orderTemplate: 'newTemplate',
-        newOrderTemplate: 'New Order Template Title',
+    it('should return correct route of new order template', done => {
+      startup();
+      updateOrderTemplateAndNew();
+
+      component.selectedOrderTemplateRoute$.subscribe(r => {
+        expect(r).toBe('route://account/order-templates/.SKsEQAE4FIAAAFuNiUBWx0d');
       });
-      component.idAfterCreate = 'idAfterCreate';
-      const route = component.selectedOrderTemplateRoute;
-      expect(route).toBe('route://account/order-templates/idAfterCreate');
+      done();
     });
   });
 });

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
@@ -195,6 +195,26 @@ export class SelectOrderTemplateModalComponent implements OnInit, OnDestroy {
   show() {
     this.showForm = true;
     this.modal = this.ngbModal.open(this.modalTemplate);
+
+    // set default values after init (for example after closing and reopening the modal)
+    this.orderTemplateOptions$
+      .pipe(
+        filter(opts => opts.length > 0),
+        map(options => options[0]),
+        take(1),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(option => {
+        this.formGroup.get('orderTemplate')?.setValue(option.value);
+
+        const defaultValue = this.translate.instant('account.order_template.new_order_template.text');
+        this.formGroup.get('newOrderTemplate')?.setValue(defaultValue);
+        this.model = {
+          ...this.model,
+          orderTemplate: option.value,
+          newOrderTemplate: defaultValue,
+        };
+      });
   }
 
   /**

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
@@ -12,6 +12,7 @@ import {
 import { FormGroup } from '@angular/forms';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
+import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subject, of } from 'rxjs';
 import { filter, map, startWith, take, takeUntil, withLatestFrom } from 'rxjs/operators';
 
@@ -54,16 +55,20 @@ export class SelectOrderTemplateModalComponent implements OnInit, OnDestroy {
 
   @ViewChild('modal', { static: false }) modalTemplate: TemplateRef<unknown>;
 
-  constructor(private ngbModal: NgbModal, private orderTemplatesFacade: OrderTemplatesFacade) {}
+  constructor(
+    private ngbModal: NgbModal,
+    private orderTemplatesFacade: OrderTemplatesFacade,
+    private translate: TranslateService
+  ) {}
 
   ngOnInit() {
     this.singleFieldConfig = [
       {
         type: 'ish-text-input-field',
         key: 'newOrderTemplate',
+        defaultValue: this.translate.instant('account.order_template.new_order_template.text'),
         templateOptions: {
           required: true,
-          placeholder: 'account.order_template.new_order_template.text',
         },
         validation: {
           messages: { required: 'account.order_template.name.error.required' },
@@ -119,9 +124,9 @@ export class SelectOrderTemplateModalComponent implements OnInit, OnDestroy {
               key: 'newOrderTemplate',
               className: 'w-75 position-relative validation-offset-0',
               wrappers: ['validation'],
+              defaultValue: this.translate.instant('account.order_template.new_order_template.text'),
               templateOptions: {
                 required: true,
-                placeholder: 'account.order_template.name.error.required',
               },
               validation: {
                 messages: { required: 'account.order_template.name.error.required' },

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
@@ -14,13 +14,12 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subject, of } from 'rxjs';
-import { filter, map, startWith, take, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { filter, map, take, takeUntil } from 'rxjs/operators';
 
 import { SelectOption } from 'ish-shared/forms/components/select/select.component';
 import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
-import { OrderTemplate } from '../../models/order-template/order-template.model';
 
 /**
  * The order template select modal displays a list of order templates. The user can select one order template  or enter a name for a new order template  in order to add or move an item to the selected order template .
@@ -62,6 +61,9 @@ export class SelectOrderTemplateModalComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
+    this.orderTemplateOptions$ = this.orderTemplatesFacade.orderTemplatesSelectOptions$(this.addMoveProduct === 'add');
+
+    // formly config for the single input field form (no or no other order templates exist)
     this.singleFieldConfig = [
       {
         type: 'ish-text-input-field',
@@ -76,23 +78,7 @@ export class SelectOrderTemplateModalComponent implements OnInit, OnDestroy {
       },
     ];
 
-    this.orderTemplateOptions$ = this.orderTemplatesFacade.orderTemplates$.pipe(
-      startWith([] as OrderTemplate[]),
-      map(orderTemplates =>
-        orderTemplates.map(orderTemplate => ({
-          value: orderTemplate.id,
-          label: orderTemplate.title,
-        }))
-      ),
-      withLatestFrom(this.orderTemplatesFacade.currentOrderTemplate$),
-      map(([orderTemplateOptions, currentOrderTemplate]) => {
-        if (this.addMoveProduct === 'move' && currentOrderTemplate) {
-          return orderTemplateOptions.filter(option => option.value !== currentOrderTemplate.id);
-        }
-        return orderTemplateOptions;
-      })
-    );
-
+    // formly config for the radio button form (one or more other order templates exist)
     this.multipleFieldConfig$ = this.orderTemplateOptions$.pipe(
       map(orderTemplateOptions =>
         orderTemplateOptions.map(option => ({


### PR DESCRIPTION
<!--<br />## PR Checklist<br />Please check if your PR fulfills the following requirements:<br /><br />[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md<br /><br />--><br /><br />## PR Type<br /><br /><!--<br />What kind of change does this PR introduce?<br />Please check the one that applies to this PR using "x".<br />--><br /><br />[ ] Bugfix<br />[ ] Feature<br />[ ] Code style update (formatting, local variables)<br />[x] Refactoring (no functional changes, no API changes)<br />[ ] Build-related changes<br />[ ] CI-related changes<br />[ ] Documentation content changes<br />[ ] Application / infrastructure changes<br />[ ] Other: <!--Please describe.--><br /><br />## What Is the Current Behavior?<br /><br />Currently, the order template modal still uses the old way of defining forms. We want to change this to formly as part of the rework.<br /><br />## What Is the New Behavior?<br /><br />Now, the order template modal uses formly to construct the form. Additionally, the component has been refactored to be more functional.<br /><br />## Does this PR Introduce a Breaking Change?<br /><br /><!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --><br /><br />[ ] Yes<br />[x] No<br /><br />## Other Information<br />

[AB#65084](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65084)