### PR TITLE
fix: display an error message in case the customer creation failed

### DIFF
--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -705,6 +705,7 @@
   "cookies.modal.accept_all": "Alle akzeptieren",
   "cookies.modal.cancel": "Abbrechen",
   "cookies.modal.save": "Einstellungen speichern",
+  "customer.creation_failed.error": "Bitte versuchen Sie es später noch einmal oder kontaktieren Sie unseren Kundensupport.",
   "customer.credentials.login.not_unique.error": "Die angegebene E-Mail-Adresse wird bereits verwendet. Prüfen Sie die Richtigkeit der Eingabe oder geben Sie eine andere E-Mail-Adresse an.",
   "customer.credentials.passwordreset.invalid_password.error.PasswordExpressionViolation": "Das Kennwort muss mindestens 7 Zeichen enthalten, bestehend aus Zahlen und Buchstaben, ohne Leerzeichen.",
   "customer.missing_fields.error": "Fehlende Felder",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -705,6 +705,7 @@
   "cookies.modal.accept_all": "Accept All",
   "cookies.modal.cancel": "Cancel",
   "cookies.modal.save": "Save Settings",
+  "customer.creation_failed.error": "Unfortunately, something went wrong while creating your customer account. Please try again later or contact our customer support.",
   "customer.credentials.login.not_unique.error": "A user with that e-mail address already exists. Please check the information for accuracy or enter a different e-mail address.",
   "customer.credentials.passwordreset.invalid_password.error.PasswordExpressionViolation": "The password must include 7 characters minimum, containing numbers and letters, no spaces.",
   "customer.missing_fields.error": "Missing fields",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -705,6 +705,7 @@
   "cookies.modal.accept_all": "Autoriser tous",
   "cookies.modal.cancel": "Annuler",
   "cookies.modal.save": "Enregistrer les paramètres",
+  "customer.creation_failed.error": "Malheureusement quelque chose s'est mal passé lors de la création de votre compte client. Veuillez réessayer plus tard ou contacter notre service client.",
   "customer.credentials.login.not_unique.error": "Un utilisateur avec cette adresse courriel existe déjà. Veuillez vérifier l’exactitude des informations ou entrer une adresse courriel différente.",
   "customer.credentials.passwordreset.invalid_password.error.PasswordExpressionViolation": "Le mot de passe doit comporter un minimum de 7 caractères, comprenant des chiffres et des lettres, sans espaces.",
   "customer.missing_fields.error": "Champs manquants",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?
If the registration failed because the customer could not be created only an error key customer.creation_failed.error is displayed.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #786

## What Is the New Behavior?
An error message is shown.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No

## Other Information
see the issue #786 for steps to repeat

[AB#65466](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65466)