### PR TITLE
fix: checkout shipping selection error and test

### DIFF
--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.html
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.html
@@ -11,7 +11,7 @@
     <div class="col-md-12 col-lg-8">
       <div class="section" *ngIf="shippingMethods$ | async as shippingMethods">
         <div *ngIf="shippingMethods.length; else noShippingMethods" class="shipping-methods">
-          <div *ngIf="nextDisabled && !(basketError$ | async)" role="alert" class="alert alert-danger">
+          <div *ngIf="!(basketError$ | async) && nextDisabled" role="alert" class="alert alert-danger">
             {{ 'checkout.shipping_method.no_Selection.error' | translate }}
           </div>
           <h3>{{ 'checkout.shipping_method.selection.heading' | translate }}</h3>

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.spec.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.spec.ts
@@ -81,7 +81,7 @@ describe('Checkout Shipping Page Component', () => {
     expect(element.querySelector('[role="alert"]')).toBeFalsy();
   });
 
-  it('should render an error if the user clicks next and has currently no shipping method selected', fakeAsync(() => {
+  it('should render an error if the user clicks next and has currently no shipping method selected', () => {
     when(checkoutFacade.basket$).thenReturn(of({ ...BasketMockData.getBasket(), commonShippingMethod: undefined }));
 
     fixture.detectChanges();
@@ -92,7 +92,7 @@ describe('Checkout Shipping Page Component', () => {
     fixture.detectChanges();
 
     expect(element.querySelector('[role="alert"]')).toBeTruthy();
-  }));
+  });
 
   it('should continue checkout if selection is valid', fakeAsync(() => {
     fixture.detectChanges();

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.spec.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.spec.ts
@@ -81,15 +81,15 @@ describe('Checkout Shipping Page Component', () => {
     expect(element.querySelector('[role="alert"]')).toBeFalsy();
   });
 
-  // tslint:disable-next-line
-  it.skip('should render an error if the user clicks next and has currently no shipping method selected', fakeAsync(() => {
+  it('should render an error if the user clicks next and has currently no shipping method selected', fakeAsync(() => {
     when(checkoutFacade.basket$).thenReturn(of({ ...BasketMockData.getBasket(), commonShippingMethod: undefined }));
+
     fixture.detectChanges();
 
     expect(element.querySelector('[role="alert"]')).toBeFalsy();
 
     component.goToNextStep();
-    tick(1000);
+    fixture.detectChanges();
 
     expect(element.querySelector('[role="alert"]')).toBeTruthy();
   }));

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { Observable, Subject, combineLatest } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
@@ -24,7 +24,11 @@ export class CheckoutShippingPageComponent implements OnInit, OnDestroy {
 
   nextDisabled = false;
 
-  constructor(private checkoutFacade: CheckoutFacade, private accountFacade: AccountFacade) {}
+  constructor(
+    private checkoutFacade: CheckoutFacade,
+    private accountFacade: AccountFacade,
+    private cd: ChangeDetectorRef
+  ) {}
 
   ngOnInit() {
     this.basket$ = this.checkoutFacade.basket$;
@@ -42,6 +46,7 @@ export class CheckoutShippingPageComponent implements OnInit, OnDestroy {
       .pipe(take(1), takeUntil(this.destroy$))
       .subscribe(([shippingMethods, basket]) => {
         this.nextDisabled = !basket || !shippingMethods || !shippingMethods.length || !basket.commonShippingMethod;
+        this.cd.markForCheck();
         if (!this.nextDisabled) {
           this.checkoutFacade.continue(3);
         }


### PR DESCRIPTION
<!--<br />## PR Checklist<br />Please check if your PR fulfills the following requirements:<br /><br />[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md<br />[ ] Tests for the changes have been added (for bug fixes / features)<br />[ ] Docs have been added / updated (for bug fixes / features)<br />[ ] Visual changes have been approved by VD / IAD (if applicable)<br />--><br /><br />## PR Type<br /><br /><!--<br />What kind of change does this PR introduce?<br />Please check the one that applies to this PR using "x".<br />--><br /><br />[x] Bugfix<br />[ ] Feature<br />[ ] Code style update (formatting, local variables)<br />[ ] Refactoring (no functional changes, no API changes)<br />[ ] Build-related changes<br />[ ] CI-related changes<br />[ ] Documentation content changes<br />[ ] Application / infrastructure changes<br />[ ] Other: <!--Please describe.--><br /><br />## What Is the Current Behavior?<br /><br />Currently, the checkout shipping page has a skipped test and an error message is not shown. This is because the nextDisabled variable is changed inside a subscribe block and not automatically updated in the template. <br /><br />## What Is the New Behavior?<br /><br />Now, the subscription updates the component to be checked in the next change detection cycle. This fixes the issue and lets the test run again.<br /><br />## Does this PR Introduce a Breaking Change?<br /><br /><!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --><br /><br />[ ] Yes<br />[ x] No<br /><br />## Other Information<br />

[AB#65492](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65492)