### PR TITLE
refactor: use customerType to differentiate between private and business customers

### DIFF
--- a/src/app/core/models/customer/customer.interface.ts
+++ b/src/app/core/models/customer/customer.interface.ts
@@ -5,11 +5,14 @@ import { Customer } from './customer.model';
 
 export type CustomerType = 'PrivateCustomer' | 'SMBCustomer';
 
+type CustomerDataType = 'PRIVATE' | 'SMBCustomer';
+
 /**
  * response data type for signIn user
  */
 export interface CustomerData extends Customer {
-  type: CustomerType;
+  type: CustomerType; // REST resource
+  customerType?: CustomerDataType; // type to differentiate between private/SMC customers after first customer get request
   title?: string;
   firstName?: string;
   lastName?: string;

--- a/src/app/core/models/customer/customer.mapper.ts
+++ b/src/app/core/models/customer/customer.mapper.ts
@@ -53,7 +53,6 @@ export class CustomerMapper {
   }
 
   private static isBusinessCustomer(data: CustomerData): boolean {
-    // ToDo: #IS-30018 use the customer type for this decision
     if (data.type === 'PrivateCustomer') {
       return false;
     }

--- a/src/app/core/services/user/user.service.spec.ts
+++ b/src/app/core/services/user/user.service.spec.ts
@@ -40,8 +40,12 @@ describe('User Service', () => {
   describe('SignIn a user', () => {
     it('should login a user when correct credentials are entered', done => {
       const loginDetail = { login: 'patricia@test.intershop.de', password: '!InterShop00!' };
-      when(apiServiceMock.get('customers/-', anything())).thenReturn(of({ customerNo: 'PC' } as Customer));
-      when(apiServiceMock.get('privatecustomers/-')).thenReturn(of({ customerNo: 'PC' } as Customer));
+      when(apiServiceMock.get('customers/-', anything())).thenReturn(
+        of({ customerNo: 'PC', customerType: 'PRIVATE' } as CustomerData)
+      );
+      when(apiServiceMock.get('privatecustomers/-')).thenReturn(
+        of({ customerNo: 'PC', customerType: 'PRIVATE' } as CustomerData)
+      );
 
       userService.signInUser(loginDetail).subscribe(data => {
         const [, options] = capture<{}, { headers: HttpHeaders }>(apiServiceMock.get).beforeLast();
@@ -56,8 +60,10 @@ describe('User Service', () => {
 
     it('should login a private user when correct credentials are entered', done => {
       const loginDetail = { login: 'patricia@test.intershop.de', password: '!InterShop00!' };
-      when(apiServiceMock.get('customers/-', anything())).thenReturn(of({ customerNo: 'PC' } as Customer));
-      when(apiServiceMock.get('privatecustomers/-')).thenReturn(of({ customerNo: 'PC' } as Customer));
+      when(apiServiceMock.get('customers/-', anything())).thenReturn(
+        of({ customerNo: 'PC', customerType: 'PRIVATE' } as CustomerData)
+      );
+      when(apiServiceMock.get('privatecustomers/-')).thenReturn(of({ customerNo: 'PC' } as CustomerData));
 
       userService.signInUser(loginDetail).subscribe(() => {
         verify(apiServiceMock.get(`customers/-`, anything())).once();
@@ -69,7 +75,7 @@ describe('User Service', () => {
     it('should login a business user when correct credentials are entered', done => {
       const loginDetail = { login: 'patricia@test.intershop.de', password: '!InterShop00!' };
       when(apiServiceMock.get(anything(), anything())).thenReturn(
-        of({ customerNo: 'PC', companyName: 'xyz' } as Customer)
+        of({ customerNo: 'PC', customerType: 'SMBCustomer' } as CustomerData)
       );
 
       userService.signInUser(loginDetail).subscribe(() => {
@@ -92,7 +98,7 @@ describe('User Service', () => {
 
     it('should login a user by token when requested and successful', done => {
       when(apiServiceMock.get(anything(), anything())).thenReturn(
-        of({ customerNo: '4711', type: 'SMBCustomer', companyName: 'xyz' } as CustomerData)
+        of({ customerNo: '4711', type: 'SMBCustomer', customerType: 'SMBCustomer' } as CustomerData)
       );
 
       userService.signInUserByToken().subscribe(() => {
@@ -106,7 +112,7 @@ describe('User Service', () => {
 
     it('should login a user by given token when requested and successful', done => {
       when(apiServiceMock.get(anything(), anything())).thenReturn(
-        of({ customerNo: '4711', type: 'SMBCustomer', companyName: 'xyz' } as CustomerData)
+        of({ customerNo: '4711', type: 'SMBCustomer', customerType: 'SMBCustomer' } as CustomerData)
       );
 
       userService.signInUserByToken('12345').subscribe(() => {
@@ -134,8 +140,12 @@ describe('User Service', () => {
 
     it("should create a new individual user when 'createUser' is called", done => {
       when(apiServiceMock.post(anyString(), anything(), anything())).thenReturn(of({}));
-      when(apiServiceMock.get(anything(), anything())).thenReturn(of({ customerNo: 'PC' } as Customer));
-      when(apiServiceMock.get(anything())).thenReturn(of({ customerNo: 'PC' } as Customer));
+      when(apiServiceMock.get(anything(), anything())).thenReturn(
+        of({ customerNo: 'PC', customerType: 'PRIVATE' } as CustomerData)
+      );
+      when(apiServiceMock.get(anything())).thenReturn(
+        of({ customerNo: 'PC', customerType: 'PRIVATE' } as CustomerData)
+      );
 
       const payload = {
         customer: { customerNo: '4711', isBusinessCustomer: false } as Customer,

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -79,8 +79,9 @@ export class UserService {
     return this.apiService.get<CustomerData>('customers/-', options).pipe(
       withLatestFrom(this.appFacade.isAppTypeREST$),
       concatMap(([data, isAppTypeRest]) =>
-        // ToDo: #IS-30018 use the customer type for this decision
-        isAppTypeRest && !data.companyName ? this.apiService.get<CustomerData>('privatecustomers/-') : of(data)
+        isAppTypeRest && data.customerType === 'PRIVATE'
+          ? this.apiService.get<CustomerData>('privatecustomers/-')
+          : of(data)
       ),
       map(CustomerMapper.mapLoginData)
     );


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?
After login the companyName attribute of the response has been taken to decide if a get request for the privateCustomers REST resource is necessary

## What Is the New Behavior?
Now the customerType attribute of the response is taken as criterion for this decision.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#65496](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65496)