### PR TITLE
refactor: adapt account-address component with formly

### DIFF
--- a/src/app/pages/account-addresses/account-addresses-page.component.html
+++ b/src/app/pages/account-addresses/account-addresses-page.component.html
@@ -1,11 +1,5 @@
 <div class="loading-container">
-  <ish-account-addresses
-    [user]="user$ | async"
-    [addresses]="addresses$ | async"
-    [error]="(errorAddresses$ | async) || (errorUser$ | async)"
-    (createCustomerAddress)="createCustomerAddress($event)"
-    (deleteCustomerAddress)="deleteCustomerAddress($event)"
-  ></ish-account-addresses>
+  <ish-account-addresses [error]="(errorAddresses$ | async) || (errorUser$ | async)"></ish-account-addresses>
 
   <ish-loading *ngIf="loading$ | async"></ish-loading>
 </div>

--- a/src/app/pages/account-addresses/account-addresses-page.component.ts
+++ b/src/app/pages/account-addresses/account-addresses-page.component.ts
@@ -2,9 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
-import { Address } from 'ish-core/models/address/address.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { User } from 'ish-core/models/user/user.model';
 
 /**
  * The Account Addresses Page Container Component renders the account addresses page of a logged in user using the {@link AccountAddressesPageComponent}

--- a/src/app/pages/account-addresses/account-addresses-page.component.ts
+++ b/src/app/pages/account-addresses/account-addresses-page.component.ts
@@ -15,27 +15,15 @@ import { User } from 'ish-core/models/user/user.model';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AccountAddressesPageComponent implements OnInit {
-  addresses$: Observable<Address[]>;
   loading$: Observable<boolean>;
   errorAddresses$: Observable<HttpError>;
-  user$: Observable<User>;
   errorUser$: Observable<HttpError>;
 
   constructor(private accountFacade: AccountFacade) {}
 
   ngOnInit() {
-    this.addresses$ = this.accountFacade.addresses$();
     this.loading$ = this.accountFacade.addressesLoading$;
     this.errorAddresses$ = this.accountFacade.addressesError$;
-    this.user$ = this.accountFacade.user$;
     this.errorUser$ = this.accountFacade.userError$;
-  }
-
-  createCustomerAddress(address: Address) {
-    this.accountFacade.createCustomerAddress(address);
-  }
-
-  deleteCustomerAddress(addressId: string) {
-    this.accountFacade.deleteCustomerAddress(addressId);
   }
 }

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.html
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.html
@@ -34,7 +34,7 @@
 <div class="my-account-address-list shift-content">
   <div class="myAccount-addressBook">
     <!-- display saved addresses -->
-    <ng-container *ngIf="addresses && addresses.length > 0; else emptyList">
+    <ng-container *ngIf="(addresses$ | async)?.length; else emptyList">
       <!-- preferred invoice address == preferred shipping address -->
       <ng-container *ngIf="hasPreferredAddresses && preferredAddressesEqual">
         <div class="section" data-testing-id="preferred-invoice-and-shipping-address">
@@ -43,21 +43,10 @@
 
           <div class="col-sm-7 col-md-5">
             <form [formGroup]="preferredAddressForm">
-              <ish-select-address
+              <formly-form
                 [form]="preferredAddressForm"
-                controlName="preferredInvoiceAddressUrn"
-                [addresses]="invoiceAddresses"
-                [emptyOptionLabel]="'account.addresses.preferredinvoice.button.label' | translate"
-                inputClass="w-100"
-              ></ish-select-address>
-
-              <ish-select-address
-                [form]="preferredAddressForm"
-                controlName="preferredShippingAddressUrn"
-                [addresses]="shippingAddresses"
-                [emptyOptionLabel]="'account.addresses.preferredshipping.button.label' | translate"
-                inputClass="w-100"
-              ></ish-select-address>
+                [fields]="[selectInvoiceConfig, selectShippingConfig]"
+              ></formly-form>
             </form>
           </div>
         </div>
@@ -76,13 +65,7 @@
           </ng-template>
           <div class="col-sm-7 col-md-5">
             <form [formGroup]="preferredAddressForm">
-              <ish-select-address
-                [form]="preferredAddressForm"
-                controlName="preferredInvoiceAddressUrn"
-                [addresses]="invoiceAddresses"
-                [emptyOptionLabel]="'account.addresses.preferredinvoice.button.label' | translate"
-                inputClass="w-100"
-              ></ish-select-address>
+              <formly-form [form]="preferredAddressForm" [fields]="[selectInvoiceConfig]"></formly-form>
             </form>
           </div>
         </div>
@@ -98,13 +81,7 @@
           </ng-template>
           <div class="col-sm-7 col-md-5">
             <form [formGroup]="preferredAddressForm">
-              <ish-select-address
-                [form]="preferredAddressForm"
-                controlName="preferredShippingAddressUrn"
-                [addresses]="shippingAddresses"
-                [emptyOptionLabel]="'account.addresses.preferredshipping.button.label' | translate"
-                inputClass="w-100"
-              ></ish-select-address>
+              <formly-form [form]="preferredAddressForm" [fields]="[selectShippingConfig]"></formly-form>
             </form>
           </div>
         </div>
@@ -120,7 +97,7 @@
                 <div class="float-right">
                   <!-- delete address: is only possible if the customer has more than one address -->
                   <a
-                    *ngIf="addresses.length > 1"
+                    *ngIf="(addresses$ | async)?.length > 1"
                     class="btn-tool"
                     title="{{ 'account.addresses.delete_address.text' | translate }}"
                     (click)="modalDialog.show(currentAddress)"

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.spec.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.spec.ts
@@ -1,24 +1,21 @@
-import { SimpleChange, SimpleChanges } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
-import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
+import { of } from 'rxjs';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Address } from 'ish-core/models/address/address.model';
-import { User } from 'ish-core/models/user/user.model';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { AddressComponent } from 'ish-shared/components/address/address/address.component';
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
 import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { FormlyCustomerAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component';
-import { SelectAddressComponent } from 'ish-shared/forms/components/select-address/select-address.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { AccountAddressesComponent } from './account-addresses.component';
-import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
-import { of } from 'rxjs';
 
 const mockAddresses = [
   {
@@ -90,7 +87,11 @@ describe('Account Addresses Component', () => {
       ],
       imports: [FormlyTestingModule, TranslateModule.forRoot()],
       providers: [{ provide: AccountFacade, useFactory: () => instance(accountFacade) }],
-    }).compileComponents();
+    })
+      .overrideComponent(AccountAddressesComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
   });
 
   beforeEach(() => {
@@ -244,10 +245,12 @@ describe('Account Addresses Component', () => {
     expect(element.querySelector('[data-testing-id=create-address-form]')).toBeFalsy();
   });
 
-  it('should render create address form if showCreateAddressForm is called', () => {
+  it('should render create address form if showCreateAddressForm is called', async () => {
     fixture.detectChanges();
     component.showCreateAddressForm();
     fixture.detectChanges();
+
+    await fixture.whenStable();
 
     expect(component.isCreateAddressFormCollapsed).toBeFalse();
     expect(element.querySelector('[data-testing-id=create-address-form]')).toBeTruthy();

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.spec.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.spec.ts
@@ -1,10 +1,10 @@
 import { SimpleChange, SimpleChanges } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
-import { instance, mock, spy, verify } from 'ts-mockito';
+import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Address } from 'ish-core/models/address/address.model';
@@ -17,14 +17,68 @@ import { FormlyCustomerAddressFormComponent } from 'ish-shared/formly-address-fo
 import { SelectAddressComponent } from 'ish-shared/forms/components/select-address/select-address.component';
 
 import { AccountAddressesComponent } from './account-addresses.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
+import { of } from 'rxjs';
+
+const mockAddresses = [
+  {
+    id: '0001"',
+    urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1001',
+    title: 'Ms.',
+    firstName: 'Patricia',
+    lastName: 'Miller',
+    addressLine1: 'Potsdamer Str. 20',
+    postalCode: '14483',
+    city: 'Berlin',
+  },
+  {
+    id: '0002"',
+    urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1002',
+    title: 'Ms.',
+    firstName: 'Patricia',
+    lastName: 'Miller',
+    addressLine1: 'Berliner Str. 20',
+    postalCode: '14482',
+    city: 'Berlin',
+  },
+  {
+    id: '0003"',
+    urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1003',
+    title: 'Ms.',
+    firstName: 'Patricia',
+    lastName: 'Miller',
+    addressLine1: 'Neue Promenade 5',
+    postalCode: '10178',
+    city: 'Berlin',
+    companyName1: 'Intershop Communications AG',
+  },
+  {
+    id: '0004"',
+    urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1004',
+    title: 'Ms.',
+    firstName: 'Patricia',
+    lastName: 'Miller',
+    addressLine1: 'Intershop Tower',
+    postalCode: '07743',
+    city: 'Jena',
+    companyName1: 'Intershop Communications AG',
+  },
+] as Address[];
+
+const patriciaInfo = {
+  firstName: 'Patricia',
+  lastName: 'Miller',
+  email: 'patricia@test.intershop.de',
+};
 
 describe('Account Addresses Component', () => {
   let component: AccountAddressesComponent;
   let fixture: ComponentFixture<AccountAddressesComponent>;
   let element: HTMLElement;
-  let addressChange: SimpleChanges;
+  let accountFacade: AccountFacade;
 
   beforeEach(async () => {
+    accountFacade = mock(AccountFacade);
     await TestBed.configureTestingModule({
       declarations: [
         AccountAddressesComponent,
@@ -33,10 +87,9 @@ describe('Account Addresses Component', () => {
         MockComponent(FaIconComponent),
         MockComponent(FormlyCustomerAddressFormComponent),
         MockComponent(ModalDialogComponent),
-        MockComponent(SelectAddressComponent),
       ],
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
-      providers: [{ provide: AccountFacade, useFactory: () => instance(mock(AccountFacade)) }],
+      imports: [FormlyTestingModule, TranslateModule.forRoot()],
+      providers: [{ provide: AccountFacade, useFactory: () => instance(accountFacade) }],
     }).compileComponents();
   });
 
@@ -45,66 +98,14 @@ describe('Account Addresses Component', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement;
 
-    component.addresses = [
-      {
-        id: '0001"',
-        urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1001',
-        title: 'Ms.',
-        firstName: 'Patricia',
-        lastName: 'Miller',
-        addressLine1: 'Potsdamer Str. 20',
-        postalCode: '14483',
-        city: 'Berlin',
-      },
-      {
-        id: '0002"',
-        urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1002',
-        title: 'Ms.',
-        firstName: 'Patricia',
-        lastName: 'Miller',
-        addressLine1: 'Berliner Str. 20',
-        postalCode: '14482',
-        city: 'Berlin',
-      },
-      {
-        id: '0003"',
-        urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1003',
-        title: 'Ms.',
-        firstName: 'Patricia',
-        lastName: 'Miller',
-        addressLine1: 'Neue Promenade 5',
-        postalCode: '10178',
-        city: 'Berlin',
-        companyName1: 'Intershop Communications AG',
-      },
-      {
-        id: '0004"',
-        urn: 'urn:address:customer:JgEKAE8BA50AAAFgDtAd1LZU:1004',
-        title: 'Ms.',
-        firstName: 'Patricia',
-        lastName: 'Miller',
-        addressLine1: 'Intershop Tower',
-        postalCode: '07743',
-        city: 'Jena',
-        companyName1: 'Intershop Communications AG',
-      },
-    ] as Address[];
+    when(accountFacade.addresses$()).thenReturn(of(mockAddresses));
 
-    component.user = {
-      firstName: 'Patricia',
-      lastName: 'Miller',
-      email: 'patricia@test.intershop.de',
-      preferredInvoiceToAddressUrn: component.addresses[0].urn,
-    } as User;
-
-    component.preferredAddressForm = new FormGroup({
-      preferredInvoiceAddressUrn: new FormControl(''),
-      preferredShippingAddressUrn: new FormControl(''),
-    });
-
-    addressChange = {
-      addresses: new SimpleChange(undefined, component.addresses, false),
-    };
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: mockAddresses[0].urn,
+      })
+    );
   });
 
   it('should be created', () => {
@@ -114,51 +115,67 @@ describe('Account Addresses Component', () => {
   });
 
   it('should display only one preferred address if preferred invoice and shipping address are equal', () => {
-    component.user.preferredShipToAddressUrn = component.addresses[0].urn;
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: mockAddresses[0].urn,
+        preferredShipToAddressUrn: mockAddresses[0].urn,
+      })
+    );
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(component.preferredAddressesEqual).toBeTruthy();
     expect(element.querySelector('div[data-testing-id=preferred-invoice-and-shipping-address]')).toBeTruthy();
     expect(
-      element.querySelectorAll('div[data-testing-id=preferred-invoice-and-shipping-address] ish-select-address')
+      element.querySelectorAll('div[data-testing-id=preferred-invoice-and-shipping-address] formly-field')
     ).toHaveLength(2);
     expect(element.querySelector('div[data-testing-id=preferred-invoice-address]')).toBeFalsy();
     expect(element.querySelector('div[data-testing-id=preferred-shipping-address]')).toBeFalsy();
   });
 
   it('should display both preferred addresses if preferred invoice and shipping address are not equal', () => {
-    component.user.preferredShipToAddressUrn = component.addresses[1].urn;
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: mockAddresses[0].urn,
+        preferredShipToAddressUrn: mockAddresses[1].urn,
+      })
+    );
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=preferred-invoice-and-shipping-address]')).toBeFalsy();
     expect(element.querySelector('div[data-testing-id=preferred-invoice-address]')).toBeTruthy();
-    expect(element.querySelectorAll('div[data-testing-id=preferred-invoice-address] ish-select-address')).toHaveLength(
-      1
-    );
+    expect(element.querySelectorAll('div[data-testing-id=preferred-invoice-address] formly-field')).toHaveLength(1);
     expect(element.querySelector('div[data-testing-id=preferred-shipping-address]')).toBeTruthy();
-    expect(element.querySelectorAll('div[data-testing-id=preferred-shipping-address] ish-select-address')).toHaveLength(
-      1
-    );
+    expect(element.querySelectorAll('div[data-testing-id=preferred-shipping-address] formly-field')).toHaveLength(1);
   });
 
   it('should not display further addresses if only preferred invoice and shipping addresses are available', () => {
-    component.user.preferredShipToAddressUrn = component.addresses[1].urn;
-    component.addresses = [component.addresses[0], component.addresses[1]] as Address[];
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: mockAddresses[0].urn,
+        preferredShipToAddressUrn: mockAddresses[1].urn,
+      })
+    );
+    when(accountFacade.addresses$()).thenReturn(of([mockAddresses[0], mockAddresses[1]]));
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=further-addresses]')).toBeFalsy();
   });
 
   it('should display the proper headlines and info texts if no preferred addresses are available', () => {
-    component.user.preferredInvoiceToAddressUrn = undefined;
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: undefined,
+        preferredShipToAddressUrn: undefined,
+      })
+    );
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=preferred-invoice-and-shipping-address]')).toBeFalsy();
@@ -167,9 +184,14 @@ describe('Account Addresses Component', () => {
   });
 
   it('should not filter further addresses if no preferred addresses are available', () => {
-    component.user.preferredInvoiceToAddressUrn = undefined;
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: undefined,
+        preferredShipToAddressUrn: undefined,
+      })
+    );
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=further-addresses]')).toBeTruthy();
@@ -177,9 +199,14 @@ describe('Account Addresses Component', () => {
   });
 
   it('should reduce further addresses by two if both preferred addresses are available', () => {
-    component.user.preferredShipToAddressUrn = component.addresses[1].urn;
+    when(accountFacade.user$).thenReturn(
+      of({
+        ...patriciaInfo,
+        preferredInvoiceToAddressUrn: mockAddresses[0].urn,
+        preferredShipToAddressUrn: mockAddresses[1].urn,
+      })
+    );
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=further-addresses]')).toBeTruthy();
@@ -187,7 +214,6 @@ describe('Account Addresses Component', () => {
   });
 
   it('should reduce further addresses by one if only one preferred address is available', () => {
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=further-addresses]')).toBeTruthy();
@@ -195,9 +221,8 @@ describe('Account Addresses Component', () => {
   });
 
   it('should not display any address if user has no saved addresses', () => {
-    component.addresses = [] as Address[];
+    when(accountFacade.addresses$()).thenReturn(of([]));
 
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('div[data-testing-id=preferred-invoice-and-shipping-address]')).toBeFalsy();
@@ -208,7 +233,6 @@ describe('Account Addresses Component', () => {
   });
 
   it('should not show no addresses info if there are addresses available', () => {
-    component.ngOnChanges(addressChange);
     fixture.detectChanges();
 
     expect(element.querySelector('p.empty-list')).toBeFalsy();
@@ -221,6 +245,7 @@ describe('Account Addresses Component', () => {
   });
 
   it('should render create address form if showCreateAddressForm is called', () => {
+    fixture.detectChanges();
     component.showCreateAddressForm();
     fixture.detectChanges();
 
@@ -237,19 +262,17 @@ describe('Account Addresses Component', () => {
 
   it('should emit createCustomerAddress event when createCustomerAddress is triggered', () => {
     const address = { urn: '123' } as Address;
-    const emitter = spy(component.createCustomerAddress);
 
     component.createAddress(address);
 
-    verify(emitter.emit(address)).once();
+    verify(accountFacade.createCustomerAddress(anything())).once();
   });
 
   it('should emit deleteCustomerAddress event when deleteCustomerAddress is triggered', () => {
     const address = { id: '123' } as Address;
-    const emitter = spy(component.deleteCustomerAddress);
 
     component.deleteAddress(address);
 
-    verify(emitter.emit(address.id)).once();
+    verify(accountFacade.deleteCustomerAddress(anything())).once();
   });
 });

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
@@ -9,6 +9,7 @@ import { AddressHelper } from 'ish-core/models/address/address.helper';
 import { Address } from 'ish-core/models/address/address.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
+import { whenTruthy } from 'ish-core/utils/operators';
 import { mapToAddressOptions } from 'ish-shared/forms/utils/forms.service';
 
 /**
@@ -86,7 +87,7 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
         }
       });
 
-    const addressesAndUser$ = combineLatest([this.addresses$, this.user$]);
+    const addressesAndUser$ = combineLatest([this.addresses$.pipe(whenTruthy()), this.user$.pipe(whenTruthy())]);
 
     // Selectbox formly configurations
     this.selectInvoiceConfig = {

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
@@ -1,25 +1,14 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
-import { combineLatest, Observable, Subject } from 'rxjs';
-import { distinct, distinctUntilChanged, filter, map, shareReplay, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { Observable, Subject, combineLatest } from 'rxjs';
+import { distinctUntilChanged, filter, map, shareReplay, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AddressHelper } from 'ish-core/models/address/address.helper';
 import { Address } from 'ish-core/models/address/address.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
-import { FormlyFieldConfig } from '@ngx-formly/core';
-import { log } from 'ish-core/utils/dev/operators';
 import { SelectOption } from 'ish-shared/forms/components/select/select.component';
 
 /**
@@ -56,7 +45,7 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
   constructor(private accountFacade: AccountFacade) {}
 
   ngOnInit() {
-    this.addresses$ = this.accountFacade.addresses$().pipe(shareReplay());
+    this.addresses$ = this.accountFacade.addresses$().pipe(shareReplay(1));
     this.user$ = this.accountFacade.user$;
 
     // trigger set preferred invoice address if it changes
@@ -69,7 +58,6 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(([urn, user]) => {
-        console.log('valueChange invoice');
         if (urn) {
           this.accountFacade.updateUser(
             { ...user, preferredInvoiceToAddressUrn: urn },
@@ -89,8 +77,6 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(([urn, user]) => {
-        console.log('valueChange shipping');
-
         if (urn) {
           this.accountFacade.updateUser(
             { ...user, preferredShipToAddressUrn: urn },
@@ -180,7 +166,8 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
     this.accountFacade.deleteCustomerAddress(address.id);
   }
 
-  // helpers
+  // helper methods
+
   private transformAddressToSelectOption(address: Address): SelectOption {
     return {
       label: `${address.firstName} ${address.lastName}, ${address.addressLine1}, ${address.city}`,

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
@@ -93,7 +93,7 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
       key: 'preferredInvoiceAddressUrn',
       type: 'ish-select-field',
       templateOptions: {
-        fieldClass: ' ',
+        fieldClass: 'w-100',
         options: addressesAndUser$.pipe(
           map(([addresses, user]) =>
             addresses.filter(
@@ -113,7 +113,7 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
       key: 'preferredShippingAddressUrn',
       type: 'ish-select-field',
       templateOptions: {
-        fieldClass: ' ',
+        fieldClass: 'w-100',
         options: addressesAndUser$.pipe(
           map(([addresses, user]) =>
             addresses.filter(

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
@@ -9,7 +9,7 @@ import { AddressHelper } from 'ish-core/models/address/address.helper';
 import { Address } from 'ish-core/models/address/address.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
-import { SelectOption } from 'ish-shared/forms/components/select/select.component';
+import { mapToAddressOptions } from 'ish-shared/forms/utils/forms.service';
 
 /**
  * The Account Address Page Component displays the preferred InvoiceTo and ShipTo addresses of the user
@@ -95,17 +95,15 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
       templateOptions: {
         fieldClass: ' ',
         options: addressesAndUser$.pipe(
-          // distinctUntilChanged(([paddresses, puser], [caddresses, cuser]) => paddresses === caddresses),
           map(([addresses, user]) =>
-            addresses
-              .filter(
-                (address: Address) =>
-                  ((user.preferredInvoiceToAddressUrn && address.urn !== user.preferredInvoiceToAddressUrn) ||
-                    !user.preferredInvoiceToAddressUrn) &&
-                  address.invoiceToAddress
-              )
-              .map(this.transformAddressToSelectOption)
-          )
+            addresses.filter(
+              (address: Address) =>
+                ((user.preferredInvoiceToAddressUrn && address.urn !== user.preferredInvoiceToAddressUrn) ||
+                  !user.preferredInvoiceToAddressUrn) &&
+                address.invoiceToAddress
+            )
+          ),
+          mapToAddressOptions()
         ),
         placeholder: 'account.addresses.preferredinvoice.button.label',
       },
@@ -118,15 +116,14 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
         fieldClass: ' ',
         options: addressesAndUser$.pipe(
           map(([addresses, user]) =>
-            addresses
-              .filter(
-                (address: Address) =>
-                  ((user.preferredShipToAddressUrn && address.urn !== user.preferredShipToAddressUrn) ||
-                    !user.preferredShipToAddressUrn) &&
-                  address.shipToAddress
-              )
-              .map(this.transformAddressToSelectOption)
-          )
+            addresses.filter(
+              (address: Address) =>
+                ((user.preferredShipToAddressUrn && address.urn !== user.preferredShipToAddressUrn) ||
+                  !user.preferredShipToAddressUrn) &&
+                address.shipToAddress
+            )
+          ),
+          mapToAddressOptions()
         ),
         placeholder: 'account.addresses.preferredshipping.button.label',
       },
@@ -167,13 +164,6 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
   }
 
   // helper methods
-
-  private transformAddressToSelectOption(address: Address): SelectOption {
-    return {
-      label: `${address.firstName} ${address.lastName}, ${address.addressLine1}, ${address.city}`,
-      value: address.urn,
-    };
-  }
 
   private getAddress(addresses: Address[], urn: string) {
     return addresses && !!urn ? addresses.find(address => address.urn === urn) : undefined;

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
@@ -14,7 +14,6 @@ import { findAllCustomElements, findAllDataTestingIDs } from 'ish-core/utils/dev
 import { AddressComponent } from 'ish-shared/components/address/address/address.component';
 import { FormlyCustomerAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
-import { FormsService } from 'ish-shared/forms/utils/forms.service';
 
 import { BasketInvoiceAddressWidgetComponent } from './basket-invoice-address-widget.component';
 
@@ -24,7 +23,6 @@ describe('Basket Invoice Address Widget Component', () => {
   let element: HTMLElement;
   let checkoutFacade: CheckoutFacade;
   let accountFacade: AccountFacade;
-  let formsService: FormsService;
 
   beforeEach(async () => {
     checkoutFacade = mock(CheckoutFacade);
@@ -33,8 +31,6 @@ describe('Basket Invoice Address Widget Component', () => {
 
     accountFacade = mock(AccountFacade);
     when(accountFacade.addresses$()).thenReturn(EMPTY);
-
-    formsService = mock(FormsService);
 
     await TestBed.configureTestingModule({
       imports: [FormlyTestingModule, TranslateModule.forRoot()],
@@ -48,7 +44,6 @@ describe('Basket Invoice Address Widget Component', () => {
       providers: [
         { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
         { provide: AccountFacade, useFactory: () => instance(accountFacade) },
-        { provide: FormsService, useFactory: () => instance(formsService) },
       ],
     }).compileComponents();
   });

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
@@ -40,11 +40,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject();
 
-  constructor(
-    private checkoutFacade: CheckoutFacade,
-    private accountFacade: AccountFacade,
-    private formsService: FormsService
-  ) {}
+  constructor(private checkoutFacade: CheckoutFacade, private accountFacade: AccountFacade) {}
 
   ngOnInit() {
     this.invoiceAddress$ = this.checkoutFacade.basketInvoiceAddress$;
@@ -77,7 +73,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
         type: 'ish-select-field',
         templateOptions: {
           fieldClass: 'col-12',
-          options: this.formsService.getAddressOptions(this.addresses$),
+          options: FormsService.getAddressOptions(this.addresses$),
           placeholder: this.emptyOptionLabel,
         },
         hooks: {

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
@@ -15,7 +15,6 @@ import { AddressComponent } from 'ish-shared/components/address/address/address.
 import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { FormlyCustomerAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
-import { FormsService } from 'ish-shared/forms/utils/forms.service';
 
 import { BasketShippingAddressWidgetComponent } from './basket-shipping-address-widget.component';
 
@@ -25,7 +24,6 @@ describe('Basket Shipping Address Widget Component', () => {
   let element: HTMLElement;
   let checkoutFacade: CheckoutFacade;
   let accountFacade: AccountFacade;
-  let formsService: FormsService;
 
   beforeEach(async () => {
     checkoutFacade = mock(CheckoutFacade);
@@ -34,8 +32,6 @@ describe('Basket Shipping Address Widget Component', () => {
 
     accountFacade = mock(AccountFacade);
     when(accountFacade.addresses$()).thenReturn(EMPTY);
-
-    formsService = mock(FormsService);
 
     await TestBed.configureTestingModule({
       imports: [FormlyTestingModule, TranslateModule.forRoot()],
@@ -50,7 +46,6 @@ describe('Basket Shipping Address Widget Component', () => {
       providers: [
         { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
         { provide: AccountFacade, useFactory: () => instance(accountFacade) },
-        { provide: FormsService, useFactory: () => instance(formsService) },
       ],
     }).compileComponents();
   });

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
@@ -43,11 +43,7 @@ export class BasketShippingAddressWidgetComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject();
 
-  constructor(
-    private accountFacade: AccountFacade,
-    private checkoutFacade: CheckoutFacade,
-    private formsService: FormsService
-  ) {
+  constructor(private accountFacade: AccountFacade, private checkoutFacade: CheckoutFacade) {
     this.form = new FormGroup({
       id: new FormControl(''),
     });
@@ -86,7 +82,7 @@ export class BasketShippingAddressWidgetComponent implements OnInit, OnDestroy {
         type: 'ish-select-field',
         templateOptions: {
           fieldClass: 'col-12',
-          options: this.formsService.getAddressOptions(this.addresses$),
+          options: FormsService.getAddressOptions(this.addresses$),
           placeholder: this.emptyOptionLabel,
         },
         hooks: {

--- a/src/app/shared/forms/utils/forms.service.spec.ts
+++ b/src/app/shared/forms/utils/forms.service.spec.ts
@@ -53,15 +53,13 @@ describe('Forms Service', () => {
 
   describe('getAddressOptions', () => {
     it('should return address options if addresses are given', done => {
-      formsService
-        .getAddressOptions(
-          of([
-            { id: '12345', firstName: 'Patricia', lastName: 'Miller', addressLine1: 'Potsdamer Str.', city: 'Berlin' },
-            { id: '67890', firstName: 'Bernhard', lastName: 'Boldner', addressLine1: 'Berliner Str.', city: 'Hamburg' },
-          ] as Address[])
-        )
-        .subscribe(options => {
-          expect(options).toMatchInlineSnapshot(`
+      FormsService.getAddressOptions(
+        of([
+          { id: '12345', firstName: 'Patricia', lastName: 'Miller', addressLine1: 'Potsdamer Str.', city: 'Berlin' },
+          { id: '67890', firstName: 'Bernhard', lastName: 'Boldner', addressLine1: 'Berliner Str.', city: 'Hamburg' },
+        ] as Address[])
+      ).subscribe(options => {
+        expect(options).toMatchInlineSnapshot(`
           Array [
             Object {
               "label": "Patricia Miller, Potsdamer Str., Berlin",
@@ -73,8 +71,8 @@ describe('Forms Service', () => {
             },
           ]
         `);
-          done();
-        });
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
<!--<br />## PR Checklist<br />Please check if your PR fulfills the following requirements:<br /><br />[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md<br />[ ] Tests for the changes have been added (for bug fixes / features)<br />[ ] Docs have been added / updated (for bug fixes / features)<br />[ ] Visual changes have been approved by VD / IAD (if applicable)<br />--><br /><br />## PR Type<br /><br /><!--<br />What kind of change does this PR introduce?<br />Please check the one that applies to this PR using "x".<br />--><br /><br />[ ] Bugfix<br />[ ] Feature<br />[ ] Code style update (formatting, local variables)<br />[x] Refactoring (no functional changes, no API changes)<br />[ ] Build-related changes<br />[ ] CI-related changes<br />[ ] Documentation content changes<br />[ ] Application / infrastructure changes<br />[ ] Other: <!--Please describe.--><br /><br />## What Is the Current Behavior?<br /><br />Currently, the account-address component uses the old select-address component, which is a specification of ish-select.<br /><br /><br />## What Is the New Behavior?<br /><br />Now, the page uses formly and is refactored to be more functional.<br /><br />## Does this PR Introduce a Breaking Change?<br /><br /><!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --><br /><br />[ ] Yes<br />[x] No<br /><br />## Other Information<br />

[AB#65504](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65504)