### PR TITLE
fix: translate-select-options without expressionProperty

### DIFF
--- a/src/app/pages/contact/contact-form/contact-form.component.ts
+++ b/src/app/pages/contact/contact-form/contact-form.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { Observable } from 'rxjs';
-import { map, startWith } from 'rxjs/operators';
+import { map, shareReplay, startWith } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Contact } from 'ish-core/models/contact/contact.model';
@@ -85,7 +85,8 @@ export class ContactFormComponent implements OnInit {
           required: true,
           options: this.accountFacade.contactSubjects$().pipe(
             startWith([] as string[]),
-            map(subjects => subjects.map(subject => ({ value: subject, label: subject })))
+            map(subjects => subjects.map(subject => ({ value: subject, label: subject }))),
+            shareReplay(1)
           ),
           placeholder: 'account.option.select.text',
         },

--- a/src/app/shared/formly/extensions/translate-select-options.extension.ts
+++ b/src/app/shared/formly/extensions/translate-select-options.extension.ts
@@ -17,23 +17,16 @@ class TranslateSelectOptionsExtension implements FormlyExtension {
     if (!to || !to.options) {
       return;
     }
-    field.expressionProperties = {
-      ...field.expressionProperties,
-      'templateOptions.processedOptions': (model, _, fld) =>
-        (isObservable(fld.templateOptions.options)
-          ? fld.templateOptions.options
-          : of(fld.templateOptions.options)
-        ).pipe(
-          startWith([]),
-          map(options => (to.placeholder ? [{ value: '', label: to.placeholder }] : []).concat(options ?? [])),
-          tap(() => {
-            if (to.placeholder && !fld.formControl.value && !model[fld.key as string]) {
-              fld.formControl.setValue('');
-            }
-          }),
-          map(options => options?.map(option => ({ ...option, label: this.translate.instant(option.label) })))
-        ),
-    };
+    field.templateOptions.processedOptions = (isObservable(to.options) ? to.options : of(to.options)).pipe(
+      startWith([]),
+      map(options => (to.placeholder ? [{ value: '', label: to.placeholder }] : []).concat(options ?? [])),
+      tap(() => {
+        if (to.placeholder && !field.formControl.value && !field.model[field.key as string]) {
+          field.formControl.setValue('');
+        }
+      }),
+      map(options => options?.map(option => ({ ...option, label: this.translate.instant(option.label) })))
+    );
   }
 }
 


### PR DESCRIPTION
<!--<br />## PR Checklist<br />Please check if your PR fulfills the following requirements:<br /><br />[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md<br />[ ] Tests for the changes have been added (for bug fixes / features)<br />[ ] Docs have been added / updated (for bug fixes / features)<br />[ ] Visual changes have been approved by VD / IAD (if applicable)<br />--><br /><br />## PR Type<br /><br /><!--<br />What kind of change does this PR introduce?<br />Please check the one that applies to this PR using "x".<br />--><br /><br />[x] Bugfix<br />[ ] Feature<br />[ ] Code style update (formatting, local variables)<br />[ ] Refactoring (no functional changes, no API changes)<br />[ ] Build-related changes<br />[ ] CI-related changes<br />[ ] Documentation content changes<br />[ ] Application / infrastructure changes<br />[ ] Other: <!--Please describe.--><br /><br />## What Is the Current Behavior?<br /><br />Selectboxes don't work anymore. You can't select values even though the selection is updated in the model (which is the reason no tests failed).<br /><br />## What Is the New Behavior?<br /><br />Formly 5.10.22 introduced a bugfix that causes expressionProperties that return observables to always be reevaluated. This exposed a flaw in the translate-select-options extension. I have now moved away from using expressionProperties to an obervable. The usage of expressionProperties was a misuse anyways.<br /><br />Select boxes work normally again. <br /><br />## Does this PR Introduce a Breaking Change?<br /><br /><!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --><br /><br />[ ] Yes<br />[x] No<br /><br />## Other Information<br />

[AB#65743](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65743)