### PR TITLE
feat: readiness and liveness probe for pm2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,4 +25,6 @@ templates
 !/dist/server.crt
 !/dist/server.js
 !/dist/server.key
+!/dist/readinessprobe.js
+!/dist/livenessprobe.js
 # synchronize-marker:dist-scripts:end

--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,6 @@ Thumbs.db
 !/dist/server.crt
 !/dist/server.js
 !/dist/server.key
+!/dist/readinessprobe.js
+!/dist/livenessprobe.js
 # synchronize-marker:dist-scripts:end

--- a/dist/healthcheck.js
+++ b/dist/healthcheck.js
@@ -9,19 +9,7 @@ if (process.env.TRUST_ICM) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 }
 
-const [icmProtocol, icmBase] = process.env['ICM_BASE_URL'].split('://');
-let [, icmHost, icmPort] = /^(.*?):?([0-9]+)?$/.exec(icmBase);
-icmPort = icmPort || (icmProtocol === 'http' ? '80' : '443');
-
-const icmClient = require(icmProtocol);
 const pwaClient = process.env.SSL ? require('https') : require('http');
-
-const optionsICMRest = {
-  host: icmHost,
-  port: icmPort,
-  path: '/INTERSHOP/rest/WFS',
-  timeout: 10000,
-};
 
 const optionsAngularUniversal = {
   host: 'localhost',
@@ -33,38 +21,30 @@ const errFunc = function (err) {
   process.exit(1);
 };
 
-console.log(`checking for ICM on ${icmProtocol}://${icmHost}:${icmPort}`);
-const requestICMRest = icmClient.request(optionsICMRest, res => {
-  console.log(`STATUS ICM REST: ${res.statusCode === 404 ? 'OK' : res.statusMessage}`);
-  if (res.statusCode == 404) {
-    let ports = require('./ecosystem-ports').ports;
+let ports = require('./ecosystem-ports').ports;
 
-    if (process.env.ACTIVE_THEMES) {
-      const active = process.env.ACTIVE_THEMES.split(',');
-      ports = Object.entries(ports)
-        .filter(([theme]) => active.includes(theme))
-        .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+if (process.env.ACTIVE_THEMES) {
+  const active = process.env.ACTIVE_THEMES.split(',');
+  ports = Object.entries(ports)
+    .filter(([theme]) => active.includes(theme))
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+}
+
+const portsToCheck = [process.env.PORT || 4200];
+if (Object.keys(ports).length > 1) {
+  portsToCheck.push(...Object.values(ports));
+}
+
+portsToCheck.forEach(port => {
+  const requestAngularUniversal = pwaClient.request({ ...optionsAngularUniversal, port }, res => {
+    console.log(`STATUS STOREFRONT (${port}): ${res.statusCode} ${res.statusMessage}`);
+    if (res.statusCode !== 200) {
+      process.exit(1);
     }
+  });
+  requestAngularUniversal.on('error', errFunc);
 
-    const portsToCheck = [process.env.PORT || 4200];
-    if (Object.keys(ports).length > 1) {
-      portsToCheck.push(...Object.values(ports));
-    }
-
-    portsToCheck.forEach(port => {
-      const requestAngularUniversal = pwaClient.request({ ...optionsAngularUniversal, port }, res => {
-        console.log(`STATUS STOREFRONT (${port}): ${res.statusCode} ${res.statusMessage}`);
-        if (res.statusCode !== 200) {
-          process.exit(1);
-        }
-      });
-      requestAngularUniversal.on('error', errFunc);
-
-      requestAngularUniversal.end();
-    });
-  } else {
-    process.exit(1);
-  }
+  requestAngularUniversal.end();
 });
 
 requestICMRest.on('error', errFunc);

--- a/dist/livenessprobe.js
+++ b/dist/livenessprobe.js
@@ -1,0 +1,34 @@
+const pm2 = require('pm2');
+let ports = require('./ecosystem-ports').ports;
+
+if (process.env.ACTIVE_THEMES) {
+  const active = process.env.ACTIVE_THEMES.split(',');
+  ports = Object.entries(ports)
+    .filter(([theme]) => active.includes(theme))
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+}
+
+pm2.connect(err1 => {
+  if (!err1) {
+    pm2.list((err2, list) => {
+      if (!err2) {
+        Object.entries(ports).forEach(([theme]) => {
+          if (
+            list
+              .filter(el => el.name === theme)
+              .find(el => el.pm2_env.status === 'online' || el.pm2_env.status === 'launching')
+          ) {
+            process.exit(0);
+          }
+        });
+        process.exit(1);
+      } else {
+        console.log('pm2 list error:', err2);
+        process.exit(1);
+      }
+    });
+  } else {
+    console.log('pm2 connection error:', err1);
+    process.exit(1);
+  }
+});

--- a/dist/livenessprobe.js
+++ b/dist/livenessprobe.js
@@ -12,16 +12,14 @@ pm2.connect(err1 => {
   if (!err1) {
     pm2.list((err2, list) => {
       if (!err2) {
-        Object.entries(ports).forEach(([theme]) => {
-          if (
+        const allUp = Object.entries(ports)
+          .map(([theme]) =>
             list
               .filter(el => el.name === theme)
               .find(el => el.pm2_env.status === 'online' || el.pm2_env.status === 'launching')
-          ) {
-            process.exit(0);
-          }
-        });
-        process.exit(1);
+          )
+          .reduce((acc, val) => acc && !!val, true);
+        process.exit(allUp ? 0 : 1);
       } else {
         console.log('pm2 list error:', err2);
         process.exit(1);

--- a/dist/readinessprobe.js
+++ b/dist/readinessprobe.js
@@ -1,0 +1,30 @@
+const pm2 = require('pm2');
+let ports = require('./ecosystem-ports').ports;
+
+if (process.env.ACTIVE_THEMES) {
+  const active = process.env.ACTIVE_THEMES.split(',');
+  ports = Object.entries(ports)
+    .filter(([theme]) => active.includes(theme))
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+}
+
+pm2.connect(err1 => {
+  if (!err1) {
+    pm2.list((err2, list) => {
+      if (!err2) {
+        Object.entries(ports).forEach(([theme]) => {
+          if (!list.find(el => el.name === theme)) {
+            process.exit(1);
+          }
+        });
+        process.exit(0);
+      } else {
+        console.log('pm2 list error:', err2);
+        process.exit(1);
+      }
+    });
+  } else {
+    console.log('pm2 connection error:', err1);
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

K8s uses a liveness and readiness probes to check if a pod is available and ready to accept requests. Due to the implemented pm2 process manager a new liveness and readiness probe is needed.

## What Is the New Behavior?

New scripts for liveness and readiness probes are added to project, which can be used in k8s deployments.
The readiness probe checks if at least one process is available for each theme.
The liveness probe checks for each theme, that at least one process with status 'online' or 'launching' exists. 

The healthcheck should not be used for liveness and readiness probes and should not check, if the ICM is available.

## Does this PR Introduce a Breaking Change?

[ x ] No

## Other Information


[AB#65808](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65808)