### PR TITLE
fix: address countryCode and mainDivision fields behavior

### DIFF
--- a/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -46,11 +46,17 @@ export class FormlyAddressFormComponent implements OnInit, OnChanges {
   }
 
   handleCountryChange(model: { countryCode: string }) {
+    // extract old and new countryCode
     const prevCountryCode = this.countryCode;
     this.countryCode = model.countryCode;
+
     if (model.countryCode !== prevCountryCode) {
       const configuration = this.afcProvider.getConfiguration(model.countryCode, this.businessCustomer, this.shortForm);
-      this.addressForm = new FormGroup({});
+
+      // assign new form, model and fields
+      this.addressForm = new FormGroup({
+        countryCode: new FormControl(''),
+      });
       this.addressModel = {
         countryCode: model.countryCode,
         ...configuration.getModel(this.addressModel),
@@ -61,6 +67,7 @@ export class FormlyAddressFormComponent implements OnInit, OnChanges {
 
       this.addressModel.countryCode = model.countryCode;
       this.addressForm.updateValueAndValidity();
+      this.addressForm.get('countryCode').markAsDirty();
 
       this.parentForm?.setControl('address', this.addressForm);
     }

--- a/src/app/shared/formly-address-forms/configurations/default/address-form-default.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/default/address-form-default.configuration.ts
@@ -30,7 +30,6 @@ export class AddressFormDefaultConfiguration extends AddressFormConfiguration {
       'addressLine2',
       'postalCode',
       'city',
-      'mainDivisionCode',
       'phoneHome'
     );
   }

--- a/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
@@ -28,7 +28,6 @@ export class AddressFormUSConfiguration extends AddressFormConfiguration {
       'lastName',
       'addressLine1',
       'addressLine2',
-      'mainDivisionCode',
       'postalCode',
       'city',
       'phoneHome'


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Before, there was a bug that allowed you to submit an invalid address form when changing the country after already having selected a state/province. This is now fixed.
In addition, the country field didn't show a checkmark after selection.

## What Is the New Behavior?
The mainDivisionCode is now correctly reset after a country switch.
The country field now correctly displays a checkmark when a valid value is selected.


## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#65836](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65836)