### PR TITLE
fix: remove type: text from registration password fields

### DIFF
--- a/src/app/core/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/core/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -251,7 +251,6 @@ export class RegistrationFormConfigurationService {
             key: 'password',
             type: 'ish-password-field',
             templateOptions: {
-              type: 'text',
               postWrappers: [{ wrapper: 'description', index: -1 }],
               required: true,
               label: 'account.register.password.label',
@@ -266,7 +265,6 @@ export class RegistrationFormConfigurationService {
             key: 'passwordConfirmation',
             type: 'ish-password-field',
             templateOptions: {
-              type: 'text',
               required: true,
               label: 'account.register.password_confirmation.label',
 

--- a/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
+++ b/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
@@ -67,7 +67,6 @@ export class AccountProfileEmailComponent implements OnInit {
       {
         key: 'currentPassword',
         type: 'ish-password-field',
-
         templateOptions: {
           hideRequiredMarker: true,
           required: true,


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Registration password fields were of the wrong type


## What Is the New Behavior?

Registration password fields are now correctly hidden.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#65840](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65840)