### PR TITLE
chore: create own lint rule for deprecation

### DIFF
--- a/src/app/shared/forms/components/checkbox/checkbox.component.spec.ts
+++ b/src/app/shared/forms/components/checkbox/checkbox.component.spec.ts
@@ -8,6 +8,7 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { CheckboxComponent } from './checkbox.component';
 
+// tslint:disable ish-deprecation
 describe('Checkbox Component', () => {
   let component: CheckboxComponent;
   let fixture: ComponentFixture<CheckboxComponent>;

--- a/src/app/shared/forms/components/checkbox/checkbox.component.ts
+++ b/src/app/shared/forms/components/checkbox/checkbox.component.ts
@@ -3,6 +3,8 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { FormElementComponent } from 'ish-shared/forms/components/form-element/form-element.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/input-birthday/input-birthday.component.spec.ts
+++ b/src/app/shared/forms/components/input-birthday/input-birthday.component.spec.ts
@@ -8,6 +8,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { InputBirthdayComponent } from './input-birthday.component';
 
+// tslint:disable ish-deprecation
+
 describe('Input Birthday Component', () => {
   let component: InputBirthdayComponent;
   let fixture: ComponentFixture<InputBirthdayComponent>;

--- a/src/app/shared/forms/components/input-birthday/input-birthday.component.ts
+++ b/src/app/shared/forms/components/input-birthday/input-birthday.component.ts
@@ -6,6 +6,8 @@ import { takeUntil } from 'rxjs/operators';
 
 import { FormElementComponent } from 'ish-shared/forms/components/form-element/form-element.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/input/input.component.spec.ts
+++ b/src/app/shared/forms/components/input/input.component.spec.ts
@@ -8,6 +8,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { InputComponent } from './input.component';
 
+// tslint:disable ish-deprecation
+
 describe('Input Component', () => {
   let component: InputComponent;
   let fixture: ComponentFixture<InputComponent>;

--- a/src/app/shared/forms/components/input/input.component.ts
+++ b/src/app/shared/forms/components/input/input.component.ts
@@ -3,6 +3,8 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { FormElementComponent } from 'ish-shared/forms/components/form-element/form-element.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/select-address/select-address.component.spec.ts
+++ b/src/app/shared/forms/components/select-address/select-address.component.spec.ts
@@ -10,6 +10,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { SelectAddressComponent } from './select-address.component';
 
+// tslint:disable ish-deprecation
+
 describe('Select Address Component', () => {
   let component: SelectAddressComponent;
   let fixture: ComponentFixture<SelectAddressComponent>;

--- a/src/app/shared/forms/components/select-address/select-address.component.ts
+++ b/src/app/shared/forms/components/select-address/select-address.component.ts
@@ -3,6 +3,8 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } f
 import { Address } from 'ish-core/models/address/address.model';
 import { SelectComponent, SelectOption } from 'ish-shared/forms/components/select/select.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  * Select box for the given addresses.

--- a/src/app/shared/forms/components/select-country/select-country.component.spec.ts
+++ b/src/app/shared/forms/components/select-country/select-country.component.spec.ts
@@ -9,6 +9,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { SelectCountryComponent } from './select-country.component';
 
+// tslint:disable ish-deprecation
+
 describe('Select Country Component', () => {
   let component: SelectCountryComponent;
   let fixture: ComponentFixture<SelectCountryComponent>;

--- a/src/app/shared/forms/components/select-country/select-country.component.ts
+++ b/src/app/shared/forms/components/select-country/select-country.component.ts
@@ -3,6 +3,8 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } f
 import { Country } from 'ish-core/models/country/country.model';
 import { SelectComponent, SelectOption } from 'ish-shared/forms/components/select/select.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/select-region/select-region.component.spec.ts
+++ b/src/app/shared/forms/components/select-region/select-region.component.spec.ts
@@ -9,6 +9,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { SelectRegionComponent } from './select-region.component';
 
+// tslint:disable ish-deprecation
+
 describe('Select Region Component', () => {
   let component: SelectRegionComponent;
   let fixture: ComponentFixture<SelectRegionComponent>;

--- a/src/app/shared/forms/components/select-region/select-region.component.ts
+++ b/src/app/shared/forms/components/select-region/select-region.component.ts
@@ -3,6 +3,8 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } f
 import { Region } from 'ish-core/models/region/region.model';
 import { SelectComponent, SelectOption } from 'ish-shared/forms/components/select/select.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/select-title/select-title.component.spec.ts
+++ b/src/app/shared/forms/components/select-title/select-title.component.spec.ts
@@ -9,6 +9,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { SelectTitleComponent } from './select-title.component';
 
+// tslint:disable ish-deprecation
+
 describe('Select Title Component', () => {
   let component: SelectTitleComponent;
   let fixture: ComponentFixture<SelectTitleComponent>;

--- a/src/app/shared/forms/components/select-title/select-title.component.ts
+++ b/src/app/shared/forms/components/select-title/select-title.component.ts
@@ -3,6 +3,8 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { SelectComponent, SelectOption } from 'ish-shared/forms/components/select/select.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/select/select.component.spec.ts
+++ b/src/app/shared/forms/components/select/select.component.spec.ts
@@ -8,6 +8,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { SelectComponent, SelectOption } from './select.component';
 
+// tslint:disable ish-deprecation
+
 describe('Select Component', () => {
   let component: SelectComponent;
   let fixture: ComponentFixture<SelectComponent>;

--- a/src/app/shared/forms/components/select/select.component.ts
+++ b/src/app/shared/forms/components/select/select.component.ts
@@ -8,6 +8,8 @@ export interface SelectOption {
   label: string;
 }
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  */

--- a/src/app/shared/forms/components/textarea/textarea.component.spec.ts
+++ b/src/app/shared/forms/components/textarea/textarea.component.spec.ts
@@ -8,6 +8,8 @@ import { ShowFormFeedbackDirective } from 'ish-shared/forms/directives/show-form
 
 import { TextareaComponent } from './textarea.component';
 
+// tslint:disable ish-deprecation
+
 describe('Textarea Component', () => {
   let component: TextareaComponent;
   let fixture: ComponentFixture<TextareaComponent>;

--- a/src/app/shared/forms/components/textarea/textarea.component.ts
+++ b/src/app/shared/forms/components/textarea/textarea.component.ts
@@ -5,6 +5,8 @@ import { takeUntil } from 'rxjs/operators';
 
 import { FormElementComponent } from 'ish-shared/forms/components/form-element/form-element.component';
 
+// tslint:disable ish-deprecation
+
 /**
  * @deprecated use formly instead
  *

--- a/src/app/shared/forms/forms.module.ts
+++ b/src/app/shared/forms/forms.module.ts
@@ -22,6 +22,7 @@ import { ShowFormFeedbackDirective } from './directives/show-form-feedback.direc
 
 const exportedComponents = [FormControlFeedbackComponent, ShowFormFeedbackDirective];
 
+// tslint:disable ish-deprecation
 const deprecatedExportedComponents = [
   CheckboxComponent,
   InputBirthdayComponent,
@@ -33,6 +34,8 @@ const deprecatedExportedComponents = [
   SelectTitleComponent,
   TextareaComponent,
 ];
+
+// tslint:enable ish-deprecation
 
 @NgModule({
   imports: [

--- a/tslint-rules/src/ishDeprecationRule.ts
+++ b/tslint-rules/src/ishDeprecationRule.ts
@@ -1,0 +1,237 @@
+import * as Lint from 'tslint';
+import {
+  getDeclarationOfBindingElement,
+  getJsDoc,
+  isBindingElement,
+  isCallExpression,
+  isIdentifier,
+  isNewExpression,
+  isPropertyAccessExpression,
+  isPropertyAssignment,
+  isReassignmentTarget,
+  isShorthandPropertyAssignment,
+  isSymbolFlagSet,
+  isTaggedTemplateExpression,
+  isVariableDeclaration,
+  isVariableDeclarationList,
+} from 'tsutils';
+import * as ts from 'typescript';
+
+// tslint:disable
+export class Rule extends Lint.Rules.TypedRule {
+  /* tslint:disable:object-literal-sort-keys */
+  static metadata: Lint.IRuleMetadata = {
+    ruleName: 'ish-deprecation',
+    description: 'Warns when deprecated APIs are used.',
+    descriptionDetails: Lint.Utils.dedent`Any usage of an identifier
+          with the @deprecated JSDoc annotation will trigger a warning.
+          See http://usejsdoc.org/tags-deprecated.html`,
+    rationale: 'Deprecated APIs should be avoided, and usage updated.',
+    optionsDescription: '',
+    options: null,
+    optionExamples: [true],
+    type: 'maintainability',
+    typescriptOnly: false,
+    requiresTypeInfo: true,
+  };
+  /* tslint:enable:object-literal-sort-keys */
+
+  static FAILURE_STRING(name: string, message: string) {
+    return `${name} is deprecated${message === '' ? '.' : `: ${message.trim()}`}`;
+  }
+
+  applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
+  }
+}
+
+function walk(ctx: Lint.WalkContext, tc: ts.TypeChecker) {
+  return ts.forEachChild(ctx.sourceFile, function cb(node): void {
+    if (isIdentifier(node)) {
+      if (!isDeclaration(node)) {
+        const deprecation = getDeprecation(node, tc);
+        if (deprecation !== undefined) {
+          ctx.addFailureAtNode(node, Rule.FAILURE_STRING(node.text, deprecation));
+        }
+      }
+    } else {
+      switch (node.kind) {
+        case ts.SyntaxKind.ImportDeclaration:
+        case ts.SyntaxKind.ImportEqualsDeclaration:
+        case ts.SyntaxKind.ExportDeclaration:
+        case ts.SyntaxKind.ExportAssignment:
+          return;
+      }
+      return ts.forEachChild(node, cb);
+    }
+  });
+}
+
+function isDeclaration(identifier: ts.Identifier): boolean {
+  const parent = identifier.parent;
+  switch (parent.kind) {
+    case ts.SyntaxKind.ClassDeclaration:
+    case ts.SyntaxKind.ClassExpression:
+    case ts.SyntaxKind.InterfaceDeclaration:
+    case ts.SyntaxKind.TypeParameter:
+    case ts.SyntaxKind.FunctionExpression:
+    case ts.SyntaxKind.FunctionDeclaration:
+    case ts.SyntaxKind.LabeledStatement:
+    case ts.SyntaxKind.JsxAttribute:
+    case ts.SyntaxKind.MethodDeclaration:
+    case ts.SyntaxKind.MethodSignature:
+    case ts.SyntaxKind.PropertySignature:
+    case ts.SyntaxKind.TypeAliasDeclaration:
+    case ts.SyntaxKind.GetAccessor:
+    case ts.SyntaxKind.SetAccessor:
+    case ts.SyntaxKind.EnumDeclaration:
+    case ts.SyntaxKind.ModuleDeclaration:
+      return true;
+    case ts.SyntaxKind.VariableDeclaration:
+    case ts.SyntaxKind.Parameter:
+    case ts.SyntaxKind.PropertyDeclaration:
+    case ts.SyntaxKind.EnumMember:
+    case ts.SyntaxKind.ImportEqualsDeclaration:
+      return (parent as ts.NamedDeclaration).name === identifier;
+    case ts.SyntaxKind.PropertyAssignment:
+      return (
+        (parent as ts.PropertyAssignment).name === identifier &&
+        !isReassignmentTarget(identifier.parent.parent as ts.ObjectLiteralExpression)
+      );
+    case ts.SyntaxKind.BindingElement:
+      // return true for `b` in `const {a: b} = obj"`
+      return (
+        (parent as ts.BindingElement).name === identifier && (parent as ts.BindingElement).propertyName !== undefined
+      );
+    default:
+      return false;
+  }
+}
+
+function getCallExpresion(node: ts.Expression): ts.CallLikeExpression | undefined {
+  let parent = node.parent;
+  if (isPropertyAccessExpression(parent) && parent.name === node) {
+    node = parent;
+    parent = node.parent;
+  }
+  return isTaggedTemplateExpression(parent) ||
+    ((isCallExpression(parent) || isNewExpression(parent)) && parent.expression === node)
+    ? parent
+    : undefined;
+}
+
+function getDeprecation(node: ts.Identifier, tc: ts.TypeChecker): string | undefined {
+  const callExpression = getCallExpresion(node);
+  if (callExpression !== undefined) {
+    const result = getSignatureDeprecation(tc.getResolvedSignature(callExpression));
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  let symbol: ts.Symbol | undefined;
+  const parent = node.parent;
+  if (parent.kind === ts.SyntaxKind.BindingElement) {
+    symbol = tc.getTypeAtLocation(parent.parent).getProperty(node.text);
+  } else if (
+    (isPropertyAssignment(parent) && parent.name === node) ||
+    (isShorthandPropertyAssignment(parent) && parent.name === node && isReassignmentTarget(node))
+  ) {
+    symbol = tc.getPropertySymbolOfDestructuringAssignment(node);
+  } else {
+    symbol = tc.getSymbolAtLocation(node);
+  }
+
+  if (symbol !== undefined && isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
+    symbol = tc.getAliasedSymbol(symbol);
+  }
+  if (
+    symbol === undefined ||
+    // if this is a CallExpression and the declaration is a function or method,
+    // stop here to avoid collecting JsDoc of all overload signatures
+    (callExpression !== undefined && isFunctionOrMethod(symbol.declarations))
+  ) {
+    return undefined;
+  }
+  return getSymbolDeprecation(symbol);
+}
+
+function findDeprecationTag(tags: ts.JSDocTagInfo[]): string | undefined {
+  for (const tag of tags) {
+    if (tag.name === 'deprecated') {
+      return tag.text === undefined ? '' : tag.text[0]?.text;
+    }
+  }
+  return undefined;
+}
+
+function getSymbolDeprecation(symbol: ts.Symbol): string | undefined {
+  if (symbol.getJsDocTags !== undefined) {
+    return findDeprecationTag(symbol.getJsDocTags());
+  }
+  // for compatibility with typescript@<2.3.0
+  return getDeprecationFromDeclarations(symbol.declarations);
+}
+
+function getSignatureDeprecation(signature?: ts.Signature): string | undefined {
+  if (signature === undefined) {
+    return undefined;
+  }
+  if (signature.getJsDocTags !== undefined) {
+    return findDeprecationTag(signature.getJsDocTags());
+  }
+
+  // for compatibility with typescript@<2.3.0
+  return signature.declaration === undefined ? undefined : getDeprecationFromDeclaration(signature.declaration);
+}
+
+function getDeprecationFromDeclarations(declarations?: ts.Declaration[]): string | undefined {
+  if (declarations === undefined) {
+    return undefined;
+  }
+  let declaration: ts.Node;
+  for (declaration of declarations) {
+    if (isBindingElement(declaration)) {
+      declaration = getDeclarationOfBindingElement(declaration);
+    }
+    if (isVariableDeclaration(declaration)) {
+      declaration = declaration.parent;
+    }
+    if (isVariableDeclarationList(declaration)) {
+      declaration = declaration.parent;
+    }
+    const result = getDeprecationFromDeclaration(declaration);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
+}
+
+function getDeprecationFromDeclaration(declaration: ts.Node): string | undefined {
+  for (const comment of getJsDoc(declaration)) {
+    if (comment.tags === undefined) {
+      continue;
+    }
+    for (const tag of comment.tags) {
+      if (tag.tagName.text === 'deprecated') {
+        return '';
+      }
+    }
+  }
+  return undefined;
+}
+
+function isFunctionOrMethod(declarations?: ts.Declaration[]) {
+  if (declarations === undefined || declarations.length === 0) {
+    return false;
+  }
+  switch (declarations[0].kind) {
+    case ts.SyntaxKind.MethodDeclaration:
+    case ts.SyntaxKind.FunctionDeclaration:
+    case ts.SyntaxKind.FunctionExpression:
+    case ts.SyntaxKind.MethodSignature:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -36,7 +36,7 @@
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
-    "deprecation": {
+    "ish-deprecation": {
       "severity": "warning"
     },
     "eofline": true,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The deprecation tslint rule is buggy.

## What Is the New Behavior?

Because tslint is deprecated, I copied the rule into a local rule, fixed it and disabled it where appropriate.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
