### PR TITLE
fix: insert none default theme at the end of active themes

### DIFF
--- a/schematics/customization/add/index.js
+++ b/schematics/customization/add/index.js
@@ -51,7 +51,7 @@ const packageJson = parse(fs.readFileSync('./package.json', { encoding: 'UTF-8' 
 if (setDefault) {
   packageJson.config['active-themes'] = theme;
 } else {
-  packageJson.config['active-themes'] = `${theme},${packageJson.config['active-themes']}`;
+  packageJson.config['active-themes'] = `${packageJson.config['active-themes']},${theme}`;
 }
 fs.writeFileSync('./package.json', stringify(packageJson, null, 2));
 execSync('npx prettier --write package.json');


### PR DESCRIPTION
## PR Type
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

**Intro**
When executing customization schematic to add a new customization theme like so:
```zsh
node schematics/customization/add customer
```
The resulting process changes a bunch of files. One of which is the list of active-themes in `package.json` file. That list is also used for generating `dist/ecosystem.yml` and `dist/ecosystem-ports.js` files which are important for operating multiple themed PWAs in one container.

**Problem**
SSR requests without a theme parameter end up at the process behind port 4200. This is the first element of that active-themes list in `package.json`.  Every time you want to fallback to a theme > 1, you have to make sure that NGinx places a theme parameter (via `MULTI_CHANNEL` configuration) to the SSR request. Which opens up the necessity to adapt that `MULTI_CHANNEL` configuration and place theme parameters.

## What Is the New Behavior?

Don't make a new customer theme implicitly the new default unless you tell the schematic to do so via
```zsh
node schematics/customization/add --default customer
```

[AB#65924](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65924)