### PR TITLE
refactor: add items to addItemsToBasketSuccess action

### DIFF
--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -335,9 +335,9 @@ export class ProductContextFacade extends RxState<ProductContext> {
   }
 
   addToBasket() {
-    const childContexts = this.get('children') || this.get('parts');
-    if (childContexts && !ProductHelper.isProductBundle(this.get('product'))) {
-      childContexts
+    const items: SkuQuantityType[] = this.get('children') || this.get('parts');
+    if (items && !ProductHelper.isProductBundle(this.get('product'))) {
+      items
         .filter(x => !!x && !!x.quantity)
         .forEach(child => {
           this.shoppingFacade.addProductToBasket(child.sku, child.quantity);

--- a/src/app/core/models/product/product.helper.ts
+++ b/src/app/core/models/product/product.helper.ts
@@ -17,6 +17,7 @@ import {
 export interface SkuQuantityType {
   sku: string;
   quantity: number;
+  unit?: string;
 }
 
 export enum ProductCompletenessLevel {

--- a/src/app/core/store/customer/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.spec.ts
@@ -139,7 +139,7 @@ describe('Basket Items Effects', () => {
 
       const items = [{ sku: 'SKU', quantity: 1, unit: 'pcs.' }];
       const action = addItemsToBasket({ items });
-      const completion = addItemsToBasketSuccess({ info: undefined });
+      const completion = addItemsToBasketSuccess({ info: undefined, items });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
 
@@ -187,7 +187,7 @@ describe('Basket Items Effects', () => {
 
   describe('loadBasketAfterAddItemsToBasket$', () => {
     it('should map to action of type LoadBasket if AddItemsToBasketSuccess action triggered', () => {
-      const action = addItemsToBasketSuccess({ info: undefined });
+      const action = addItemsToBasketSuccess({ info: undefined, items: [] });
       const completion = loadBasket();
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-c', { c: completion });

--- a/src/app/core/store/customer/basket/basket-items.effects.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.ts
@@ -85,17 +85,17 @@ export class BasketItemsEffects {
       ofType(addItemsToBasket),
       mapToPayload(),
       withLatestFrom(this.store.pipe(select(getCurrentBasketId))),
-      concatMap(([payload, basketId]) => {
+      concatMap(([{ items }, basketId]) => {
         if (basketId) {
-          return this.basketService.addItemsToBasket(payload.items).pipe(
-            map(info => addItemsToBasketSuccess({ info })),
+          return this.basketService.addItemsToBasket(items).pipe(
+            map(info => addItemsToBasketSuccess({ info, items })),
             mapErrorToAction(addItemsToBasketFail)
           );
         } else {
           return this.basketService.createBasket().pipe(
             switchMap(() =>
-              this.basketService.addItemsToBasket(payload.items).pipe(
-                map(info => addItemsToBasketSuccess({ info })),
+              this.basketService.addItemsToBasket(items).pipe(
+                map(info => addItemsToBasketSuccess({ info, items })),
                 mapErrorToAction(addItemsToBasketFail)
               )
             )

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -9,6 +9,7 @@ import { Basket } from 'ish-core/models/basket/basket.model';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
 import { PaymentMethod } from 'ish-core/models/payment-method/payment-method.model';
+import { SkuQuantityType } from 'ish-core/models/product/product.helper';
 import { ShippingMethod } from 'ish-core/models/shipping-method/shipping-method.model';
 import { BasketUpdateType } from 'ish-core/services/basket/basket.service';
 import { httpError, payload } from 'ish-core/utils/ngrx-creators';
@@ -77,7 +78,7 @@ export const addItemsToBasketFail = createAction('[Basket API] Add Items To Bask
 
 export const addItemsToBasketSuccess = createAction(
   '[Basket API] Add Items To Basket Success',
-  payload<{ info: BasketInfo[] }>()
+  payload<{ info: BasketInfo[]; items: SkuQuantityType[] }>()
 );
 
 export const mergeBasketFail = createAction('[Basket API] Merge two baskets Fail', httpError());

--- a/src/app/core/store/customer/basket/basket.selectors.spec.ts
+++ b/src/app/core/store/customer/basket/basket.selectors.spec.ts
@@ -272,14 +272,14 @@ describe('Basket Selectors', () => {
 
   describe('loading last time and info when a product has been added to basket', () => {
     beforeEach(() => {
-      store$.dispatch(addItemsToBasketSuccess({ info: [{ message: 'info' } as BasketInfo] }));
+      store$.dispatch(addItemsToBasketSuccess({ info: [{ message: 'info' } as BasketInfo], items: [] }));
     });
 
     it('should get the last time when a product was added', () => {
       const firstTimeAdded = new Date(getBasketLastTimeProductAdded(store$.state));
 
       expect(firstTimeAdded).toBeDate();
-      store$.dispatch(addItemsToBasketSuccess({ info: undefined }));
+      store$.dispatch(addItemsToBasketSuccess({ info: undefined, items: [] }));
       expect(getBasketLastTimeProductAdded(store$.state)).not.toEqual(firstTimeAdded);
     });
 

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -220,6 +220,7 @@ describe('Customer Store', () => {
               items: [{"sku":"test","quantity":1,"unit":"pcs."}]
             [Basket API] Add Items To Basket Success:
               info: undefined
+              items: [{"sku":"test","quantity":1,"unit":"pcs."}]
             [Products Internal] Load Product:
               sku: "test"
             [Basket Internal] Load Basket


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

If projects don't want to use the mini-cart but instead use toasts for displaying add-to-cart success feedback, they can't use the `addItemsToBasketSuccess` out of the box because it does not include the added items.

## What Is the New Behavior?

`items` are also included in `addItemsToBasketSuccess`

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#65942](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/65942)