### PR TITLE
chore: limit jest load globally to 75%

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   preset: 'jest-preset-angular',
   testRunner: 'jest-jasmine2',
+  maxWorkers: '75%', // keep some cpu for moving the mouse
   roots: ['src', 'projects'],
   setupFilesAfterEnv: ['<rootDir>/src/setupJest.ts'],
   transformIgnorePatterns: [`node_modules/(?!${esModules.join('|')})`],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "spell-check-localizations": "cspell lint --no-summary --no-progress \"src/assets/i18n/{de_DE,en_US,fr_FR}.json\"",
     "clean": "git clean -xdf -e \"*environment.local.ts\" -e \"*environment.development.ts\" -e \"*node_modules\"",
     "postclean": "npm ci",
-    "check": "npm-run-all \"lint -- --fix\" format compile build:multi \"test -- --maxWorkers=50%\" dead-code clean-localizations",
+    "check": "npm-run-all \"lint -- --fix\" format compile build:multi test dead-code clean-localizations",
     "clean-check": "npm-run-all clean check",
     "changelog": "npx -p conventional-changelog-cli conventional-changelog -n intershop-changelog.js -i CHANGELOG.md -s",
     "3rd-party-licenses": "npm ci && npx license-checker --csv --out 3rd-party-licenses.txt --customPath templates/3rd-party-licenses_format.json",
@@ -183,7 +183,7 @@
     ],
     "*.ts": [
       "tslint --project tsconfig.json --fix",
-      "jest --ci --bail --findRelatedTests --maxWorkers=50%"
+      "jest --ci --bail --findRelatedTests"
     ],
     "src/assets/i18n/*.json": [
       "sort-json --indent-size=2"


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

Whenever `jest` can occupy all CPUs of the developer's machine, it will! 

## What Is the New Behavior?

No more computer freezes.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#66030](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/66030)