### PR TITLE
fix spaces in quickorder form

### DIFF
--- a/src/app/extensions/quickorder/shared/quickorder-repeat-form/quickorder-repeat-form.component.html
+++ b/src/app/extensions/quickorder/shared/quickorder-repeat-form/quickorder-repeat-form.component.html
@@ -6,11 +6,11 @@
 >
   <formly-field class="col-6" [field]="field"></formly-field>
   <ish-quickorder-repeat-form-quantity
-    class="col-3 col-sm-2 py-2"
+    class="col-3 col-sm-2 quickorder-line-item"
     [model]="model[i]"
     [skuControl]="field.formControl"
   ></ish-quickorder-repeat-form-quantity>
-  <div class="col-3 col-sm-2 d-flex pt-2">
+  <div class="col-3 col-sm-2 d-flex quickorder-line-item">
     <a class="btn btn-tool" (click)="remove(i)" title="{{ 'quickorder.page.remove.row' | translate }}">
       <fa-icon [icon]="['fas', 'trash-alt']"></fa-icon>
     </a>

--- a/src/styles/global/line-item.scss
+++ b/src/styles/global/line-item.scss
@@ -10,3 +10,8 @@
   display: inline-block;
   margin-bottom: $space-default * 0.5;
 }
+
+.quickorder-line-item {
+  padding-top: $space-default * 0.5;
+  padding-left: 0;
+}


### PR DESCRIPTION
<!--<br />## PR Checklist<br />Please check if your PR fulfills the following requirements:<br /><br />[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md<br />[ ] Tests for the changes have been added (for bug fixes / features)<br />[ ] Docs have been added / updated (for bug fixes / features)<br />[ ] Visual changes have been approved by VD / IAD (if applicable)<br />--><br /><br />## PR Type<br /><br /><!--<br />What kind of change does this PR introduce?<br />Please check the one that applies to this PR using "x".<br />--><br /><br />[x] Bugfix<br />[ ] Feature<br />[ ] Code style update (formatting, local variables)<br />[ ] Refactoring (no functional changes, no API changes)<br />[ ] Build-related changes<br />[ ] CI-related changes<br />[ ] Documentation content changes<br />[ ] Application / infrastructure changes<br />[ ] Other: <!--Please describe.--><br /><br />## What Is the Current Behavior?<br />Heading of quickorder form table isn't in line to the quantity fields. Between form elements is to much space.<br /><br />## What Is the New Behavior?<br />The form elements stand closer together, so the quantity field is in line with its heading.<br /><br />## Does this PR Introduce a Breaking Change?<br />[ ] Yes<br />[x] No<br /><br />## Other Information<br />

[AB#66041](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/66041)