### PR TITLE
fix: server build with component styles

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -143,7 +143,10 @@
             "outputPath": "dist/server",
             "main": "server.ts",
             "optimization": true,
-            "tsConfig": "tsconfig.server.json"
+            "tsConfig": "tsconfig.server.json",
+            "stylePreprocessorOptions": {
+              "includePaths": ["src/styles/themes/default"]
+            }
           },
           "defaultConfiguration": "default,production",
           "configurations": {

--- a/e2e/cypress/integration/specs/system/cookie-consent.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/cookie-consent.b2c.e2e-spec.ts
@@ -4,6 +4,7 @@ import { HomePage } from '../../pages/home.page';
 describe('Cookie Consent', () => {
   describe('starting at home page', () => {
     before(() => {
+      cy.clearCookie('cookieConsent');
       HomePage.navigateTo();
     });
 

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -45,6 +45,7 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
 // reset cookies for each spec
 before(() => {
   cy.clearCookie('apiToken');
+  cy.setCookie('cookieConsent', JSON.stringify({ enabledOptions: ['required', 'functional', 'tracking'], version: 1 }));
 });
 
 beforeEach(() => {

--- a/src/styles/components/footer/footer.scss
+++ b/src/styles/components/footer/footer.scss
@@ -1,6 +1,8 @@
 //
 // FOOTER
 
+/* purgecss start ignore */
+
 footer {
   clear: both;
   color: $text-color-secondary;
@@ -194,3 +196,5 @@ footer {
     }
   }
 }
+
+/* purgecss end ignore */

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -228,7 +228,7 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
     logger.log('setting up purgecss CSS minification');
     config.plugins.push(
       new purgecssPlugin({
-        paths: glob.sync('./{src,projects}/**/*', { nodir: true }),
+        paths: glob.sync('./**/src/app/**/*', { nodir: true }),
         safelist: {
           standard: [/(p|m)(l|r|x|y|t|b)?-[0-5]/],
           greedy: [


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When using component styles with imports in them, the build breaks using the new approach.
- purgeCSS tries to minify unrelevant themes
- the server build fails because the style import root is not set correctly

## What Is the New Behavior?

Fixed

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#66091](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/66091)