### PR TITLE
fix: propagate extra arguments in build:multi script

### DIFF
--- a/scripts/build-multi-pwa.js
+++ b/scripts/build-multi-pwa.js
@@ -8,19 +8,20 @@ const configurations = (process.env.npm_config_active_themes || process.env.npm_
 
 const builds = [];
 
-if (process.argv.length === 2 || process.argv[2] === 'client')
+const processArgs = process.argv.slice(2);
+const extraArgs = processArgs.filter(a => a !== 'client' && a !== 'server').join(' ');
+
+if (processArgs.includes('client') || !processArgs.includes('server'))
   builds.push(
-    ...configurations.map(
-      ({ theme }) =>
-        `build client --configuration=${theme},production -- --output-path=dist/${theme}/browser --progress=false`
+    ...configurations.map(({ theme }) =>
+      `build client --configuration=${theme},production -- --output-path=dist/${theme}/browser --progress=false ${extraArgs}`.trim()
     )
   );
 
-if (process.argv.length === 2 || process.argv[2] === 'server')
+if (processArgs.includes('server') || !processArgs.includes('client'))
   builds.push(
-    ...configurations.map(
-      ({ theme }) =>
-        `build server --configuration=${theme},production -- --output-path=dist/${theme}/server --progress=false`
+    ...configurations.map(({ theme }) =>
+      `build server --configuration=${theme},production -- --output-path=dist/${theme}/server --progress=false ${extraArgs}`.trim()
     )
   );
 
@@ -32,7 +33,7 @@ if (parallel) {
 
 const result = cp.spawnSync(
   path.join('node_modules', '.bin', 'npm-run-all' + (process.platform === 'win32' ? '.cmd' : '')),
-  [...parallel, ...builds],
+  ['--silent', ...parallel, ...builds],
   {
     stdio: 'inherit',
   }

--- a/scripts/build-pwa.js
+++ b/scripts/build-pwa.js
@@ -15,10 +15,10 @@ if (configuration) {
   configString = '-c ' + configuration;
 }
 
-const client = process.argv[2] !== 'server';
-const server = process.argv[2] !== 'client';
-const partial = (!client && server) || (client && !server);
-const remainingArgs = process.argv.slice(partial ? 3 : 2);
+const processArgs = process.argv.slice(2);
+const client = processArgs.includes('client') || !processArgs.includes('server');
+const server = processArgs.includes('server') || !processArgs.includes('client');
+const remainingArgs = processArgs.filter(a => a !== 'client' && a !== 'server');
 
 if (client) {
   execSync(`npm run ng -- build ${configString} ${remainingArgs.join(' ')}`, {


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The `DEPLOY_URL` functionality (#630) is broken with the multi-config build (#775) because extra arguments are not properly propagated.

## What Is the New Behavior?

Fixed

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#66096](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/66096)