### PR TITLE
fix: THEME variable should be string

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -15,4 +15,4 @@ declare var NGRX_RUNTIME_CHECKS: boolean;
 
 declare var PWA_VERSION: string;
 
-declare var THEME: boolean;
+declare var THEME: string;


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

`THEME` variable is typed as `boolean`.

## What Is the New Behavior?

`THEME` variable is typed as `string`.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#66169](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/66169)