### PR TITLE
feat: add virtual theme "all" for always overriding files

### DIFF
--- a/docs/guides/customizations.md
+++ b/docs/guides/customizations.md
@@ -94,6 +94,26 @@ Then this overridden component template will be swapped in.
 
 This also works for multiple configurations: `product-detail.component.foo.bar.baz.html` will be active for configurations `foo`, `bar` and `baz`, but not for `foobar`.
 
+There is also a virtual theme `all` that can be used to always override a specific file.
+However, the `all` theme cannot be used in combination with other themes.
+If a theme specific override is available next to an override for `all`, the specific override will be chosen.
+
+As an example, imagine the following files/overrides exist:
+
+```txt
+  my.component.html
+  my.component.all.html
+  my.component.foo.html
+  my.component.bar.baz.html
+```
+
+- In a build for theme `foo`, the file `my.component.foo.html` will be swapped in.
+- In a build for theme `bar`, the file `my.component.bar.baz.html` will be swapped in.
+- In a build for theme `foobar`, the file `my.component.all.html` will be swapped in.
+- The file `my.component.html` won't be used for any builds.
+
+##### Schematic Support
+
 You can use the `override` schematic to introduce custom theme overrides:
 
 ![override](./customizations-ng-g-override-schematic.gif)

--- a/docs/guides/multiple-themes.md
+++ b/docs/guides/multiple-themes.md
@@ -27,3 +27,7 @@ This configures the `<brand>` theme as the only active theme in the `package.jso
 Besides that, all necessary configurations in `angular.json`, `tslint.json` and `override/schema.json` are made and a new `src/styles/themes/<brand>` folder and `environment.<brand>.ts` is created that should be used for further project development.
 
 > **NOTE:** If only one theme is active, PM2 will run the theme-specific SSR process in cluster mode on the default port (see [Building Multiple Themes](../guides/ssr-startup.md#building-multiple-themes)).
+
+# Further References
+
+- [Guide - Customization - Theme Specific Overrides](./customizations.md#theme-specific-overrides)

--- a/schematics/src/helpers/override/schema.json
+++ b/schematics/src/helpers/override/schema.json
@@ -27,7 +27,7 @@
     },
     "theme": {
       "type": "string",
-      "enum": ["default", "blue"],
+      "enum": ["default", "blue", "all"],
       "x-prompt": "For which theme?"
     },
     "ts": {

--- a/tslint.json
+++ b/tslint.json
@@ -572,7 +572,7 @@
         "warnUnmatched": false,
         "reusePatterns": {
           "name": "[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*",
-          "theme": "(?:\\.(?:default|blue))*"
+          "theme": "(?:(?:\\.(?:default|blue))*|\\.all)"
         },
         "pathPatterns": [
           "^.*/src/environments/environment(\\.\\w+)?\\.ts$",


### PR DESCRIPTION
## PR Type

[x] Feature
[x] Build-related changes

## What Is the Current Behavior?

Currently it's not possible to _always_ override a file for every theme. All themes have to be added to the filename.

## What Is the New Behavior?

By using the virtual theme "all", a file is always switched in if no theme-specific override is defined.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#66222](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/66222)