### PR TITLE
feat: add option for only building specific themes in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV TESTING=${testing}
 
 # ^ this part above is copied to Dockerfile_noSSR and should be kept in sync
 
+ARG activeThemes=
+RUN if [ ! -z "${activeThemes}" ]; then npm config set intershop-pwa:active-themes="${activeThemes}"; fi
 RUN npm run build:multi client -- --deploy-url=DEPLOY_URL_PLACEHOLDER
 COPY tsconfig.server.json server.ts /workspace/
 RUN npm run build:multi server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       # dockerfile: Dockerfile_noSSR
       args:
         serviceWorker: 'false'
+        # activeThemes: default
+        # activeThemes: blue
     environment:
       - LOGGING=on
       - ICM_BASE_URL


### PR DESCRIPTION
## PR Type

[x] Feature
[x] Build-related changes

## What Is the Current Behavior?

Docker build performs multi-theme build for all active themes in `package.json`.

## What Is the New Behavior?

Docker build also takes active themes as an argument for overriding active themes in `package.json`.
Useful for locally speeding up builds in `docker-compose.yml`.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#69390](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69390)