### PR TITLE
feat: add version method for inspecting version information

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -89,3 +89,9 @@ import 'zone.js'; // Included with Angular CLI.
 (window as any).global = window;
 
 global.Buffer = global.Buffer || require('buffer').Buffer;
+
+(global as any).version = () => ({
+  displayVersion: JSON.parse(document.querySelector('#intershop-pwa-state')?.textContent?.replace(/&q;/g, '"') || '{}')
+    .displayVersion,
+  pwaVersion: document.querySelector('meta[property="pwa-version"]')?.getAttribute('content'),
+});


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the New Behavior?

Convenience method `version()` as a global polyfill, that can be used to inspect the versions of a deployed PWA.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

From the demo server:
![image](https://user-images.githubusercontent.com/23452927/131563946-3d3eae27-4b03-4e09-93cd-286b7937cc62.png)

It looks like the GitHub CI pipeline does not set a displayVersion 🤔 

[AB#69394](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69394)