### PR TITLE
fix: enable cxml punchout with unclean user state

### DIFF
--- a/src/app/core/guards/identity-provider-logout.guard.ts
+++ b/src/app/core/guards/identity-provider-logout.guard.ts
@@ -15,7 +15,7 @@ export class IdentityProviderLogoutGuard implements CanActivate {
     private accountFacade: AccountFacade
   ) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+  canActivate() {
     return this.roleToggleService.hasRole(['APP_B2B_CXML_USER', 'APP_B2B_OCI_USER']).pipe(
       take(1),
       switchMap(isPunchout => {

--- a/src/app/core/guards/identity-provider-logout.guard.ts
+++ b/src/app/core/guards/identity-provider-logout.guard.ts
@@ -23,7 +23,7 @@ export class IdentityProviderLogoutGuard implements CanActivate {
           this.accountFacade.logoutUser();
           return of(false);
         }
-        const logoutReturn$ = this.identityProviderFactory.getInstance().triggerLogout(route, state);
+        const logoutReturn$ = this.identityProviderFactory.getInstance().triggerLogout();
         return isObservable(logoutReturn$) || isPromise(logoutReturn$) ? logoutReturn$ : of(logoutReturn$);
       })
     );

--- a/src/app/core/guards/identity-provider-logout.guard.ts
+++ b/src/app/core/guards/identity-provider-logout.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+import { CanActivate } from '@angular/router';
 import { isObservable, of } from 'rxjs';
 import { switchMap, take } from 'rxjs/operators';
 

--- a/src/app/core/identity-provider/auth0.identity-provider.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.ts
@@ -220,17 +220,20 @@ export class Auth0IdentityProvider implements IdentityProvider {
 
   triggerLogout(): TriggerReturnType {
     if (this.oauthService.hasValidIdToken()) {
-      this.oauthService.revokeTokenAndLogout(
-        {
-          client_id: this.oauthService.clientId,
-          returnTo: this.oauthService.postLogoutRedirectUri,
-        },
-        true
-      );
-      return this.router.parseUrl('/loading');
-    } else {
+      if (this.oauthService.discoveryDocumentLoaded) {
+        this.oauthService.revokeTokenAndLogout(
+          {
+            client_id: this.oauthService.clientId,
+            returnTo: this.oauthService.postLogoutRedirectUri,
+          },
+          true
+        );
+        return this.router.parseUrl('/loading');
+      }
+      this.oauthService.logOut(true);
       return false;
     }
+    return false;
   }
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -39,7 +39,7 @@ export interface IdentityProvider<ConfigType = never> {
   /**
    * Route guard for logout
    */
-  triggerLogout(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
+  triggerLogout(route?: ActivatedRouteSnapshot, state?: RouterStateSnapshot): TriggerReturnType;
 
   /**
    * Interceptor for all API requests directed to the ICM

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -37,9 +37,9 @@ export interface IdentityProvider<ConfigType = never> {
   triggerInvite?(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): TriggerReturnType;
 
   /**
-   * Route guard for logout
+   * Logout method (can be used by route guard or otherwise)
    */
-  triggerLogout(route?: ActivatedRouteSnapshot, state?: RouterStateSnapshot): TriggerReturnType;
+  triggerLogout(): TriggerReturnType;
 
   /**
    * Interceptor for all API requests directed to the ICM

--- a/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
+++ b/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
@@ -7,6 +7,7 @@ import { catchError, concatMap, delay, first, mapTo, switchMap, take, tap } from
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 import { whenTruthy } from 'ish-core/utils/operators';
@@ -23,6 +24,7 @@ export class PunchoutPageGuard implements CanActivate {
     private apiTokenService: ApiTokenService,
     private cookiesService: CookiesService,
     private punchoutService: PunchoutService,
+    private identityProvider: IdentityProviderFactory,
     @Inject(PLATFORM_ID) private platformId: string
   ) {}
 
@@ -48,6 +50,7 @@ export class PunchoutPageGuard implements CanActivate {
 
     // initiate the punchout user login with the access-token (cXML) or the given credentials (OCI)
     if (route.queryParamMap.has('access-token')) {
+      this.identityProvider.getInstance().triggerLogout();
       this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
     } else {
       this.accountFacade.loginUser({

--- a/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
+++ b/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
@@ -48,9 +48,9 @@ export class PunchoutPageGuard implements CanActivate {
       return this.router.parseUrl('/loading');
     }
 
+    this.identityProvider.getInstance().triggerLogout();
     // initiate the punchout user login with the access-token (cXML) or the given credentials (OCI)
     if (route.queryParamMap.has('access-token')) {
-      this.identityProvider.getInstance().triggerLogout();
       this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
     } else {
       this.accountFacade.loginUser({


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

If you are logged into the PWA, there will some kind of persistent user state saved to your browser, depending on the identity provider. Especially with SSO this can lead to all kinds of problems if you are logged into the PWA and then try to do cxml punchout in the same browser.
This PR will attempt to fix this behaviour so that cxml punchout works even if the user forgot to log out of the regular PWA or has some other uncleaned state in their browser.

## What Is the New Behavior?

Punchout will work regardless of persistent user state.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#69525](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69525)