### PR TITLE
fix: use get instead of value in global variables

### DIFF
--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -47,15 +47,15 @@ beforeEach(() => {
 afterEach(() => jest.clearAllTimers());
 
 Object.defineProperty(global, 'PRODUCTION_MODE', {
-  value: () => false,
+  get: () => false,
 });
 
 Object.defineProperty(global, 'NGRX_RUNTIME_CHECKS', {
-  value: () => true,
+  get: () => true,
 });
 
 Object.defineProperty(global, 'THEME', {
-  value: () => 'default',
+  get: () => 'default',
 });
 
 Object.defineProperty(document.body.style, 'transform', {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when you add a unit test that uses toMatchInlineSnapshot and one of the 3 simple variables is being tested (PRODUCTION_MODE, NGRX_RUNTIME_CHECKS and THEME), the result for these variables will be the whole function (eg: for THEME, function () { return 'default'; }).

## What Is the New Behavior?

The snapshot will have only the intended value (eg: default for THEME).

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
