### PR TITLE
fix: noSSR PWA Docker container does not support deep links

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -34,13 +34,9 @@ http {
         listen  [::]:4200;
         server_name  localhost;
 
-        location ~* /.*index.html {
-            root   /usr/share/nginx/html;
-            try_files $uri $uri/ /index.html;
-        }
-
         location / {
             root   /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html;
 
             if ($request_method = OPTIONS) {
                 return 204;


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

After the latest changes to the noSSR PWA Docker container the container only worked for the '/' route but not for any other route anymore, e.g. '/home'. Such routes return a 404 error from nginx.

![image](https://user-images.githubusercontent.com/50741106/133217123-c7c9a716-a5d3-4df5-92a4-33e5febe67f9.png)

## What Is the New Behavior?

Reverted to the former location matching in nginx to restore previously working noSSR container routing.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#69756](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69756)