### PR TITLE
feat: customizable nginx cache duration

### DIFF
--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -80,10 +80,13 @@ A file named `<feature>.conf` is included if the environment variable `<feature>
 The feature is disabled otherwise and an optional file `<feature>-off.conf` is included in the configuration.
 The feature name must be all word-characters (letters, numbers and underscore).
 
-### Disabling Cache
+### Cache
 
 If the cache feature is switched off, all caching for pre-rendered pages is disabled.
 If the cache should also be disabled for static resources, the page speed feature has to be switched off as well as it caches optimized images individually.
+
+The cache duration for pre-rendered pages can be customized using `CACHE_DURATION_NGINX_OK` (for successful responses) and `CACHE_DURATION_NGINX_NF` (for 404 responses).
+The value supplied must be in the `time` format that is supported by [nginx proxy_cache_valid](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)
 
 # Further References
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -23,7 +23,16 @@ COPY --from=buildstep /usr/local/nginx /usr/local/nginx
 COPY --from=nginx/nginx-prometheus-exporter:0.9.0 /usr/bin/nginx-prometheus-exporter /nginx-prometheus-exporter
 COPY --from=configstep / /
 RUN chmod 777 /gomplate
-ENV NPSC_ENABLE_FILTERS=in_place_optimize_for_browser,prioritize_critical_css,inline_preview_images,lazyload_images,rewrite_images,rewrite_css,remove_comments,move_css_to_head,move_css_above_scripts,collapse_whitespace,combine_javascript,extend_cache NPSC_JsPreserveURLs=off NPSC_ImagePreserveURLs=on NPSC_ForceCaching=off CACHE=on COMPRESSION=on PAGESPEED=on DEVICE_DETECTION=on
+ENV NPSC_ENABLE_FILTERS=in_place_optimize_for_browser,prioritize_critical_css,inline_preview_images,lazyload_images,rewrite_images,rewrite_css,remove_comments,move_css_to_head,move_css_above_scripts,collapse_whitespace,combine_javascript,extend_cache
+ENV NPSC_JsPreserveURLs=off
+ENV NPSC_ImagePreserveURLs=on
+ENV NPSC_ForceCaching=off
+ENV CACHE=on
+ENV COMPRESSION=on
+ENV PAGESPEED=on
+ENV DEVICE_DETECTION=on
+ENV CACHE_DURATION_NGINX_OK=10m
+ENV CACHE_DURATION_NGINX_NF=60m
 
 EXPOSE 80 443 9113
 

--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -26,8 +26,8 @@
 
         add_header X-Cache-Status $upstream_cache_status;
         proxy_ignore_headers Cache-Control;
-        proxy_cache_valid 200 302 10m;
-        proxy_cache_valid 404     60m;
+        proxy_cache_valid 200 302 {{ getenv "CACHE_DURATION_NGINX_OK" }};
+        proxy_cache_valid 404     {{ getenv "CACHE_DURATION_NGINX_NF" }};
 
         add_header X-icm-channel {{ $channel }} always;
         add_header X-icm-default-lang {{ $lang }} always;


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Cache duration of pre-rendered pages in nginx is hard-coded to 10 minutes for successful pages and 60 minutes for 404 pages and cannot be configured individually for different environments.

## What Is the New Behavior?

Introduced two new environment variables for nginx container for customization.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#69867](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69867)