### PR TITLE
feat: helper for never forgetting npm install on branch change

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,8 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if git diff-tree -r --name-only --no-commit-id $1 $2 | grep -q package.json
+then
+  git clean -xdf src/**/lazy-* projects/**/lazy-*
+  npm install
+fi


### PR DESCRIPTION

## PR Type

[x] Other: Convenience

## What Is the Current Behavior?

Sometimes you forget to `npm install` when changing branches

## What Is the New Behavior?

A `post-checkout` hook detects `package.json` changes and performs the `npm install` automagically 🧙 

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#69936](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69936)