### PR TITLE
fix: use translate get instead of instant for product-image component

### DIFF
--- a/src/app/shared/components/product/product-image/product-image.component.spec.ts
+++ b/src/app/shared/components/product/product-image/product-image.component.spec.ts
@@ -55,7 +55,7 @@ describe('Product Image Component', () => {
     fixture.detectChanges();
     expect(element.querySelector('img')?.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
-        "alt": " product photo",
+        "alt": "product photo",
         "class": "product-image",
         "itemprop": "image",
         "src": "/assets/img/not_available.png",
@@ -80,7 +80,7 @@ describe('Product Image Component', () => {
     fixture.detectChanges();
     expect(element.querySelector('img')?.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
-        "alt": " product photo",
+        "alt": "product photo",
         "class": "product-image",
         "data-type": "S",
         "data-view": "front",
@@ -107,41 +107,41 @@ describe('Product Image Component', () => {
     );
 
     fixture.detectChanges();
-    expect(element.querySelector('img').getAttribute('src')).toBe('/assets/img/not_available.png');
+    expect(element.querySelector('img').getAttribute('src')).toMatchInlineSnapshot(`"/assets/img/not_available.png"`);
   });
 
   describe('image alt attribute', () => {
     it('should render if altText set as input parameter', () => {
       component.altText = 'test';
       fixture.detectChanges();
-      expect(element.querySelector('img').getAttribute('alt')).toBe('test');
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"test"`);
     });
 
     it('should render default text if product information is still undefined', () => {
       when(context.select('product')).thenReturn(of(undefined));
       fixture.detectChanges();
-      expect(element.querySelector('img').getAttribute('alt')).toBe(' product photo');
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"product photo"`);
     });
 
     it('should show product name when product name available', () => {
       when(context.select('product')).thenReturn(of({ name: 'Lenco', sku: '1234' } as ProductView));
 
       fixture.detectChanges();
-      expect(element.querySelector('img').getAttribute('alt')).toBe('Lenco product photo');
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"Lenco product photo"`);
     });
 
     it('should show product sku when product name not available', () => {
       when(context.select('product')).thenReturn(of({ sku: '1234' } as ProductView));
 
       fixture.detectChanges();
-      expect(element.querySelector('img').getAttribute('alt')).toBe('1234 product photo');
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"1234 product photo"`);
     });
 
     it('should append imageView when image view is available and altText parameter not set', () => {
       component.imageView = 'front';
 
       fixture.detectChanges();
-      expect(element.querySelector('img').getAttribute('alt')).toContain('front S');
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"product photo front S"`);
     });
   });
 

--- a/src/app/shared/components/product/product-image/product-image.component.ts
+++ b/src/app/shared/components/product/product-image/product-image.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { QueryParamsHandling } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable, ReplaySubject, combineLatest } from 'rxjs';
+import { Observable, ReplaySubject, combineLatest, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
@@ -55,16 +55,11 @@ export class ProductImageComponent implements OnInit {
       this.context.getProductImage$(this.imageType, this.imageView),
       this.showImage$,
     ]).pipe(map(([i]) => i));
-    this.defaultAltText$ = this.context
-      .select('product')
-      .pipe(map(product => [product?.name || product?.sku || '', this.buildAdditionalAltText()].join(' ')));
-  }
 
-  private buildAdditionalAltText(): string {
-    return `${this.translateService.instant('product.image.text.alttext')}${this.buildAltTextForGivenImageView()}`;
-  }
-
-  private buildAltTextForGivenImageView(): string {
-    return this.imageView ? ` ${this.imageView} ${this.imageType}` : '';
+    this.defaultAltText$ = combineLatest([
+      this.context.select('product').pipe(map(product => product?.name || product?.sku || '')),
+      this.translateService.get('product.image.text.alttext'),
+      of(this.imageView && `${this.imageView} ${this.imageType}`),
+    ]).pipe(map(parts => parts.filter(x => !!x).join(' ')));
   }
 }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Occasionally the console output contains the error `missing translation in en_US: product.image.text.alttext`. This happens because the `product-image` component accesses this translation with `TranslateService.instant` when translations are not yet loaded correctly.

## What Is the New Behavior?

Refactored to use `TranslateService.get`

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#69899](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69899)