### PR TITLE
perf: prevent compiling translations with very large values

### DIFF
--- a/docs/concepts/localization.md
+++ b/docs/concepts/localization.md
@@ -83,6 +83,8 @@ The PWA uses an [ICU Message Format](https://unicode-org.github.io/icu/userguide
 
 Have a look at the spec for [PWATranslateCompiler](../../src/app/core/utils/translate/pwa-translate-compiler.spec.ts) for an overview of supported methods.
 
+> :warning: Translations with large values (> 1000 characters) will not be compiled to improve performance. We recommend using CMS components instead. If you _really_ need to increase this limit, adapt the `MAX_COMPILATION_LENGTH` variable of [PWATranslateCompiler](../../src/app/core/utils/translate/pwa-translate-compiler.ts).
+
 ### Localization with Formatted Dates
 
 The date pipe is used as formatter in texts with dates.

--- a/src/app/core/utils/translate/pwa-translate-compiler.ts
+++ b/src/app/core/utils/translate/pwa-translate-compiler.ts
@@ -7,6 +7,8 @@ import { Translations } from './translations.type';
 export class PWATranslateCompiler implements TranslateCompiler {
   constructor(private injector: Injector) {}
 
+  private static MAX_COMPILATION_LENGTH = 1000;
+
   /**
    * regular expression for grabbing everything in the form:
    * {{<variable>, plural/select, <case>...<case>}}
@@ -114,7 +116,7 @@ export class PWATranslateCompiler implements TranslateCompiler {
   }
 
   private sanityCheck(key: string, value: string | Function): boolean {
-    const sane = typeof value !== 'string' || value.length <= 1000;
+    const sane = typeof value !== 'string' || value.length <= PWATranslateCompiler.MAX_COMPILATION_LENGTH;
     if (isDevMode() && !sane) {
       console.warn(
         'Not compiling translation with key',

--- a/src/app/core/utils/translate/pwa-translate-compiler.ts
+++ b/src/app/core/utils/translate/pwa-translate-compiler.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, isDevMode } from '@angular/core';
 import { TranslateCompiler, TranslateService } from '@ngx-translate/core';
 
 import { Translations } from './translations.type';
@@ -113,10 +113,22 @@ export class PWATranslateCompiler implements TranslateCompiler {
     return template;
   }
 
+  private sanityCheck(key: string, value: string | Function): boolean {
+    const sane = typeof value !== 'string' || value.length <= 1000;
+    if (isDevMode() && !sane) {
+      console.warn(
+        'Not compiling translation with key',
+        key,
+        'as it is too big! - Use CMS! - This is a development mode only warning and can be ignored if the behavior is intended.'
+      );
+    }
+    return sane;
+  }
+
   compileTranslations(translations: Translations): Translations {
     return Object.entries(translations)
       .map<[string, string | Function]>(([key, value]) => {
-        if (this.checkIfCompileNeeded(value)) {
+        if (this.sanityCheck(key, value) && this.checkIfCompileNeeded(value)) {
           return [key, this.compile(value as string)];
         }
         return [key, value];


### PR DESCRIPTION
## PR Type

[x] Other: Performance Improvement

## What Is the Current Behavior?

The PWA Translate Compiler compiles translation keys regardless of length, but if huge values are used (i.e. for injecting large quantities of HTML), the regular expressions evaluation becomes costly and blocks rendering.

## What Is the New Behavior?

- Large translation values (>1000 characters) are not compiled.
- A development warning is printed in the console.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#69904](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69904)