### PR TITLE
perf: cache compiled translations in PWA process

### DIFF
--- a/src/app/core/utils/translate/pwa-translate-compiler.ts
+++ b/src/app/core/utils/translate/pwa-translate-compiler.ts
@@ -3,6 +3,8 @@ import { TranslateCompiler, TranslateService } from '@ngx-translate/core';
 
 import { Translations } from './translations.type';
 
+const cache: Record<string, Function> = {};
+
 @Injectable()
 export class PWATranslateCompiler implements TranslateCompiler {
   constructor(private injector: Injector) {}
@@ -65,49 +67,58 @@ export class PWATranslateCompiler implements TranslateCompiler {
     return template?.replace(PWATranslateCompiler.SIMPLE_VARIABLE_REGEX, (_, repl) => args?.[repl]?.toString() ?? '');
   }
 
+  private doCompile(template: string): Function {
+    if (PWATranslateCompiler.PLURAL_REGEX.test(template)) {
+      const match = PWATranslateCompiler.PLURAL_REGEX.exec(template);
+      const variable = match[2];
+      const cases = match[4];
+
+      // construct map for looking up case templates for incoming values
+      const casesMap: Record<string, string> = {};
+      let defaultCase: string;
+      for (let cm: RegExpExecArray; (cm = PWATranslateCompiler.CASE_REGEX.exec(cases)); ) {
+        const c = cm[1];
+        if (c.startsWith('=')) {
+          casesMap[c.substring(1)] = cm[2];
+        } else if (c === 'other') {
+          defaultCase = cm[2];
+        }
+      }
+
+      return (args: Record<string, unknown>) => {
+        const value = args?.[variable] ?? '';
+        const caseTemplate = casesMap[value?.toString()] ?? defaultCase;
+        const caseOutput = caseTemplate?.replace(/#/, value?.toString());
+        const result = `${match[1]}${caseOutput}${match[5]}`;
+
+        return this.recurse(result, args);
+      };
+    } else if (PWATranslateCompiler.TRANSLATE_REGEX.test(template)) {
+      const match = PWATranslateCompiler.TRANSLATE_REGEX.exec(template);
+      const variable = match[2];
+      const key = match[3].split(',')[0].trim();
+      const rename = match[3].split(',')?.[1]?.trim();
+
+      return (args: Record<string, unknown>) => {
+        if (rename) {
+          args[rename] = args[variable];
+        }
+        const delegate = this.injector.get(TranslateService).instant(key, args);
+        const result = `${match[1]}${delegate}${match[4]}`;
+
+        return this.recurse(result, args);
+      };
+    } else {
+      return (args: Record<string, unknown>) => this.recurse(template, args);
+    }
+  }
+
   compile(template: string): string | Function {
     if (this.checkIfCompileNeeded(template)) {
-      if (PWATranslateCompiler.PLURAL_REGEX.test(template)) {
-        const match = PWATranslateCompiler.PLURAL_REGEX.exec(template);
-        const variable = match[2];
-        const cases = match[4];
-
-        // construct map for looking up case templates for incoming values
-        const casesMap: Record<string, string> = {};
-        let defaultCase: string;
-        for (let cm: RegExpExecArray; (cm = PWATranslateCompiler.CASE_REGEX.exec(cases)); ) {
-          const c = cm[1];
-          if (c.startsWith('=')) {
-            casesMap[c.substring(1)] = cm[2];
-          } else if (c === 'other') {
-            defaultCase = cm[2];
-          }
-        }
-
-        return (args: Record<string, unknown>) => {
-          const value = args?.[variable] ?? '';
-          const caseTemplate = casesMap[value?.toString()] ?? defaultCase;
-          const caseOutput = caseTemplate?.replace(/#/, value?.toString());
-          const result = `${match[1]}${caseOutput}${match[5]}`;
-
-          return this.recurse(result, args);
-        };
-      } else if (PWATranslateCompiler.TRANSLATE_REGEX.test(template)) {
-        const match = PWATranslateCompiler.TRANSLATE_REGEX.exec(template);
-        const variable = match[2];
-        const key = match[3].split(',')[0].trim();
-        const rename = match[3].split(',')?.[1]?.trim();
-
-        return (args: Record<string, unknown>) => {
-          if (rename) {
-            args[rename] = args[variable];
-          }
-          const delegate = this.injector.get(TranslateService).instant(key, args);
-          const result = `${match[1]}${delegate}${match[4]}`;
-
-          return this.recurse(result, args);
-        };
+      if (!cache[template]) {
+        cache[template] = this.doCompile(template);
       }
+      return cache[template];
     }
 
     return template;


### PR DESCRIPTION
## PR Type

[x] Other: Performance Improvement

## What Is the Current Behavior?

Translate Compiles are re-done for every value when the translations are initialized. Especially in the SSR process caching can improve performance.

## What Is the New Behavior?

Once compiled, translation templates are cached and reused.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#69905](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69905)