### PR TITLE
chore: switch from extension to vscode setting for bracket pair colorization

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
     // general
     "eamodio.gitlens",
     "vscode-icons-team.vscode-icons",
-    "coenraads.bracket-pair-colorizer",
     "vincaslt.highlight-matching-tag",
     "msjsdiag.debugger-for-chrome",
     // code assist

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "git.rebaseWhenSync": true,
   "git.autoStash": true,
   "tslint.alwaysShowRuleFailuresAsWarnings": true,
+  "editor.bracketPairColorization.enabled": true,
 
   // file type specific settings
   "[handlebars]": {


### PR DESCRIPTION
## PR Type

[x] Other: IDE setting

## What Is the Current Behavior?

Plugin used for bracket pair colorization: https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer

## What Is the New Behavior?

VSCode setting: https://www.youtube.com/watch?v=elNuPq3GFXg

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#69907](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69907)