### PR TITLE
fix: restrict product-quantity input to numbers (browser dependend)

### DIFF
--- a/src/app/shared/components/product/product-quantity/product-quantity.component.html
+++ b/src/app/shared/components/product/product-quantity/product-quantity.component.html
@@ -20,8 +20,6 @@
         [step]="step$ | async"
         (change)="change($event.target)"
         (keyup)="change($event.target)"
-        (input)="input($event)"
-        (paste)="paste($event)"
       />
     </ng-template>
     <ng-template ngSwitchDefault>
@@ -60,8 +58,6 @@
           [step]="step$ | async"
           (change)="change($event.target)"
           (keyup)="change($event.target)"
-          (input)="input($event)"
-          (paste)="paste($event)"
         />
       </div>
     </ng-template>

--- a/src/app/shared/components/product/product-quantity/product-quantity.component.html
+++ b/src/app/shared/components/product/product-quantity/product-quantity.component.html
@@ -13,12 +13,15 @@
         [id]="id"
         data-testing-id="quantity"
         type="number"
+        pattern="[0-9]*"
         [value]="quantity$ | async"
         [min]="min$ | async"
         [max]="max$ | async"
         [step]="step$ | async"
         (change)="change($event.target)"
         (keyup)="change($event.target)"
+        (input)="input($event)"
+        (paste)="paste($event)"
       />
     </ng-template>
     <ng-template ngSwitchDefault>
@@ -50,12 +53,15 @@
           [id]="id"
           data-testing-id="quantity"
           type="number"
+          pattern="[0-9]*"
           [value]="quantity$ | async"
           [min]="min$ | async"
           [max]="max$ | async"
           [step]="step$ | async"
           (change)="change($event.target)"
           (keyup)="change($event.target)"
+          (input)="input($event)"
+          (paste)="paste($event)"
         />
       </div>
     </ng-template>

--- a/src/app/shared/components/product/product-quantity/product-quantity.component.spec.ts
+++ b/src/app/shared/components/product/product-quantity/product-quantity.component.spec.ts
@@ -59,6 +59,7 @@ describe('Product Quantity Component', () => {
       <input
         class="form-control text-center"
         data-testing-id="quantity"
+        pattern="[0-9]*"
         type="number"
         id="ASDF"
         min="2"
@@ -81,6 +82,7 @@ describe('Product Quantity Component', () => {
       <input
         class="form-control"
         data-testing-id="quantity"
+        pattern="[0-9]*"
         type="number"
         id="ASDF"
         min="2"

--- a/src/app/shared/components/product/product-quantity/product-quantity.component.ts
+++ b/src/app/shared/components/product/product-quantity/product-quantity.component.ts
@@ -49,7 +49,7 @@ export class ProductQuantityComponent implements OnInit {
   }
 
   private setValue(value: number) {
-    this.context.set('quantity', () => value);
+    this.context.set('quantity', () => Math.abs(value));
   }
 
   private setNextValue(value: number) {

--- a/src/app/shared/components/product/product-quantity/product-quantity.component.ts
+++ b/src/app/shared/components/product/product-quantity/product-quantity.component.ts
@@ -49,7 +49,7 @@ export class ProductQuantityComponent implements OnInit {
   }
 
   private setValue(value: number) {
-    this.context.set('quantity', () => Math.abs(value));
+    this.context.set('quantity', () => value);
   }
 
   private setNextValue(value: number) {
@@ -69,5 +69,21 @@ export class ProductQuantityComponent implements OnInit {
 
   change(target: EventTarget) {
     this.setValue(Number.parseInt((target as HTMLDataElement).value, 10));
+  }
+
+  input(event: Event) {
+    const inputEvent = event as InputEvent;
+    const inputData = inputEvent.data;
+    const inputField = inputEvent.target as HTMLInputElement;
+    const allowed = /^[^0-9]*$/;
+    if (inputData !== null && allowed.test(inputData)) {
+      inputField.value = `${this.context.get('quantity')}`;
+    }
+  }
+
+  paste(event: Event) {
+    const clipboardData = (event as ClipboardEvent).clipboardData.getData('text');
+    const allowed = /^[0-9]*$/;
+    return allowed.test(clipboardData);
   }
 }

--- a/src/app/shared/components/product/product-quantity/product-quantity.component.ts
+++ b/src/app/shared/components/product/product-quantity/product-quantity.component.ts
@@ -70,20 +70,4 @@ export class ProductQuantityComponent implements OnInit {
   change(target: EventTarget) {
     this.setValue(Number.parseInt((target as HTMLDataElement).value, 10));
   }
-
-  input(event: Event) {
-    const inputEvent = event as InputEvent;
-    const inputData = inputEvent.data;
-    const inputField = inputEvent.target as HTMLInputElement;
-    const allowed = /^[^0-9]*$/;
-    if (inputData !== null && allowed.test(inputData)) {
-      inputField.value = `${this.context.get('quantity')}`;
-    }
-  }
-
-  paste(event: Event) {
-    const clipboardData = (event as ClipboardEvent).clipboardData.getData('text');
-    const allowed = /^[0-9]*$/;
-    return allowed.test(clipboardData);
-  }
 }


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When you enter negative numbers as product quantity, the form will display a warning and not set the value.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What Is the New Behavior?
~~When you enter negative numbers as product quantity, they get inverted to their positive counterparts and the value can be set. This prevents negative numbers from being used in the first place as this doesn't make sense for quantity values.~~

Depending on the browser (Chromium based works, others not) the added input pattern `[0-9]*` prevents the adding of invalid characters (letters etc.) but not '-'. But this is handled via validation error.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

~~Possible solution to #849~~