### PR TITLE
fix: filter with special characters

### DIFF
--- a/src/app/core/utils/url-form-params.ts
+++ b/src/app/core/utils/url-form-params.ts
@@ -32,7 +32,7 @@ export function stringToFormParams(object: string, separator = ','): URLFormPara
         .filter(val => val && val.includes('='))
         .map(val => {
           const [key, values] = val.split('=');
-          return { key, value: values.split(separator).map(decodeURIComponent) };
+          return { key: decodeURIComponent(key), value: values.split(separator).map(decodeURIComponent) };
         })
         .reduce((acc, val) => ({ ...acc, [val.key]: val.value }), {})
     : {};

--- a/src/app/core/utils/url-form-params.ts
+++ b/src/app/core/utils/url-form-params.ts
@@ -21,7 +21,7 @@ export function appendFormParamsToHttpParams(
   return object
     ? Object.entries(object)
         .filter(([, value]) => Array.isArray(value) && value.length)
-        .reduce((p, [key, val]) => p.set(decodeURI(key), val.map(decodeURI).join(separator)), params)
+        .reduce((p, [key, val]) => p.set(decodeURIComponent(key), val.map(decodeURIComponent).join(separator)), params)
     : params;
 }
 

--- a/src/app/core/utils/url-form-params.ts
+++ b/src/app/core/utils/url-form-params.ts
@@ -21,7 +21,7 @@ export function appendFormParamsToHttpParams(
   return object
     ? Object.entries(object)
         .filter(([, value]) => Array.isArray(value) && value.length)
-        .reduce((p, [key, val]) => p.set(decodeURIComponent(key), val.map(decodeURIComponent).join(separator)), params)
+        .reduce((p, [key, val]) => p.set(key, val.join(separator)), params)
     : params;
 }
 
@@ -32,7 +32,7 @@ export function stringToFormParams(object: string, separator = ','): URLFormPara
         .filter(val => val && val.includes('='))
         .map(val => {
           const [key, values] = val.split('=');
-          return { key, value: values.split(separator) };
+          return { key, value: values.split(separator).map(decodeURIComponent) };
         })
         .reduce((acc, val) => ({ ...acc, [val.key]: val.value }), {})
     : {};


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When applying search filter with characters like "&" or "/" leads to false encodet parameters in the rest request.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What Is the New Behavior?
When applying search filter with special characters, parameters are encodet properly.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No

## Other Information
The change from decodeURI to decodeURIComponent works for the filters, but wasn't tested enough and might lead to unexpected behavior elsewhere.