### PR TITLE
feat: SSR-only ICM call cache interceptor

### DIFF
--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -49,6 +49,7 @@ Make sure to use them as written in the table below.
 | **SSR Specific**    | PORT                  | number               | Port for running the application                                                             |
 |                     | SSL                   | any                  | Enables SSL/TLS                                                                              |
 |                     | CONCURRENCY_SSR       | number \| max        | concurrency for SSR instances per theme (default: 2)                                         |
+|                     | CACHE_ICM_CALLS       | recommended \| JSON  | enable caching for ICM calls, see [Local ICM Cache](#local-icm-cache) (default: disabled)    |
 | **General**         | ICM_BASE_URL          | string               | Sets the base URL for the ICM                                                                |
 |                     | ICM_CHANNEL           | string               | Overrides the default channel                                                                |
 |                     | ICM_APPLICATION       | string               | Overrides the default application                                                            |
@@ -74,6 +75,25 @@ Therefore be prepared for security questions when first accessing the site.
 
 Our image build process is expecting files `server.crt` and `server.key` in folder `dist`.
 Extension `crt` is the certificate and `key` represents the private key.
+
+## Local ICM Cache
+
+As there are multiple calls that are always common for any SSR requests (like retrieving `/configurations`, `/localizations` and category trees), those calls can be cached for a short time inside the PWA SSR process and be reused for multiple pre-renders.
+Set `CACHE_ICM_CALLS=recommended` to setup basic short-time caching for the aforementioned calls.
+
+You can further customize the caching by supplying a JSON structure to the `CACHE_ICM_CALLS` environment variable of the PWA SSR process:
+
+```json
+{
+  "/configurations": "20m",
+  "/variations": "2h",
+  ".*": "2m"
+}
+```
+
+This example will cache `/configurations` for 20 Minutes, product variations for 2 hours and everything else for 2 Minutes.
+
+This feature can also be used to benchmark the SSR render performance locally by caching all ICM calls.
 
 # Further References
 

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -7,6 +7,7 @@ import { META_REDUCERS } from '@ngrx/store';
 import { configurationMeta } from 'ish-core/configurations/configuration.meta';
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
 import { COOKIE_CONSENT_VERSION, DISPLAY_VERSION } from 'ish-core/configurations/state-keys';
+import { UniversalCacheInterceptor } from 'ish-core/interceptors/universal-cache.interceptor';
 import { UniversalLogInterceptor } from 'ish-core/interceptors/universal-log.interceptor';
 import { UniversalMockInterceptor } from 'ish-core/interceptors/universal-mock.interceptor';
 
@@ -31,6 +32,7 @@ export class UniversalErrorHandler implements ErrorHandler {
   imports: [AppModule, ServerModule, ServerTransferStateModule],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: UniversalMockInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: UniversalCacheInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UniversalLogInterceptor, multi: true },
     { provide: ErrorHandler, useClass: UniversalErrorHandler },
     { provide: META_REDUCERS, useValue: configurationMeta, multi: true },

--- a/src/app/core/interceptors/universal-cache.interceptor.ts
+++ b/src/app/core/interceptors/universal-cache.interceptor.ts
@@ -1,0 +1,74 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
+import { Injectable, NgZone } from '@angular/core';
+import { memoize, once } from 'lodash-es';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+import { parseTimeToSeconds } from 'ish-core/utils/functions';
+
+const CACHE_CONFIG = process.env.CACHE_ICM_CALLS;
+
+const config: () => Record<string, string> = once(() => {
+  if (CACHE_CONFIG) {
+    if (/recommended/i.test(CACHE_CONFIG)) {
+      return {
+        '/configurations': '5m',
+        '/categories.*view=tree': '5m',
+        '/localizations': '10m',
+      };
+    }
+    try {
+      return JSON.parse(CACHE_CONFIG);
+    } catch (err) {
+      console.error('ERROR parsing CACHE_ICM_CALLS:', err.message);
+      return {};
+    }
+  }
+  return {};
+});
+
+const cacheTime = memoize((url): number => {
+  const rule = Object.keys(config()).find(re => new RegExp(re, 'gi').test(url));
+  if (rule) {
+    const timeString = config()[rule];
+    try {
+      return parseTimeToSeconds(timeString);
+    } catch (err) {
+      console.error('ERROR setting up CACHE_ICM_CALLS:', err.message);
+    }
+  }
+  return 0;
+});
+
+const cache: Record<string, HttpResponse<unknown>> = {};
+
+@Injectable()
+export class UniversalCacheInterceptor implements HttpInterceptor {
+  constructor(private zone: NgZone) {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const seconds = cacheTime(req.urlWithParams);
+    if (CACHE_CONFIG && seconds && req.method === 'GET') {
+      const cached = cache[req.urlWithParams];
+      if (cached) {
+        return of(cached);
+      } else {
+        const cacheFn = (r: HttpEvent<unknown>) => {
+          if (r instanceof HttpResponse) {
+            cache[req.urlWithParams] = r;
+
+            // schedule deletion
+            this.zone.runOutsideAngular(() => {
+              setTimeout(() => {
+                delete cache[req.urlWithParams];
+              }, seconds * 1000);
+            });
+          }
+          return r;
+        };
+        return next.handle(req).pipe(tap(cacheFn));
+      }
+    }
+    return next.handle(req);
+  }
+}

--- a/src/app/core/utils/functions.spec.ts
+++ b/src/app/core/utils/functions.spec.ts
@@ -1,4 +1,4 @@
-import { arraySlices, isArrayEqual, mergeDeep, omit } from './functions';
+import { arraySlices, isArrayEqual, mergeDeep, omit, parseTimeToSeconds } from './functions';
 
 describe('Functions', () => {
   describe('arraySlices', () => {
@@ -141,6 +141,37 @@ describe('Functions', () => {
       ${[obj]}     | ${[obj]}     | ${true}
     `('should return $isEqual when comparing $array1 and $array2', ({ array1, array2, isEqual }) => {
       expect(isArrayEqual(array1, array2)).toEqual(isEqual);
+    });
+  });
+
+  describe('parseTimeToSeconds', () => {
+    it.each`
+      str     | seconds
+      ${'1'}  | ${1}
+      ${'5'}  | ${5}
+      ${'1s'} | ${1}
+      ${'5s'} | ${5}
+      ${'1m'} | ${1 * 60}
+      ${'5m'} | ${5 * 60}
+      ${'1h'} | ${1 * 60 * 60}
+      ${'5h'} | ${5 * 60 * 60}
+      ${'1d'} | ${1 * 60 * 60 * 24}
+      ${'5d'} | ${5 * 60 * 60 * 24}
+      ${'1S'} | ${1}
+      ${'5S'} | ${5}
+      ${'1M'} | ${1 * 60}
+      ${'5M'} | ${5 * 60}
+      ${'1H'} | ${1 * 60 * 60}
+      ${'5H'} | ${5 * 60 * 60}
+      ${'1D'} | ${1 * 60 * 60 * 24}
+      ${'5D'} | ${5 * 60 * 60 * 24}
+    `('should parse $str to $seconds seconds', ({ str, seconds }) => {
+      expect(parseTimeToSeconds(str)).toEqual(seconds);
+    });
+
+    it('should throw if value does not match format', () => {
+      expect(() => parseTimeToSeconds('20x')).toThrowErrorMatchingInlineSnapshot(`"Cannot parse \\"20x\\" as time."`);
+      expect(() => parseTimeToSeconds('asdf')).toThrowErrorMatchingInlineSnapshot(`"Cannot parse \\"asdf\\" as time."`);
     });
   });
 });

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -55,3 +55,13 @@ export function omit<T>(from: T, ...keys: (keyof T | string)[]) {
 export function isArrayEqual<T>(a1: T[], a2: T[]): boolean {
   return (!a1 && !a2) || (a1?.length === a2?.length && a1?.every((el, idx) => a2?.[idx] === el));
 }
+
+export function parseTimeToSeconds(timeString: string): number {
+  const match = /^([0-9]+)(s|m|h|d)?$/.exec(timeString.toLowerCase());
+  if (!match) {
+    throw new Error(`Cannot parse "${timeString}" as time.`);
+  }
+
+  const [, time, unit] = match;
+  return +time * (unit === 'd' ? 24 * 60 * 60 : unit === 'h' ? 60 * 60 : unit === 'm' ? 60 : 1);
+}


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Repeated calls to the same endpoints on every SSR render:
```
/INTERSHOP/rest/WFS/inSPIRED-inTRONICS-Site/rest;loc=en_US/configurations
/INTERSHOP/rest/WFS/inSPIRED-inTRONICS-Site/rest;loc=en_US/localizations?searchKeys=pwa-
```

## What Is the New Behavior?

Introduced `CACHE_ICM_CALLS` environment property to activate SSR-only short-time caching.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Alternative solution (less intrusive) to #867 

[AB#70117](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70117)