### PR TITLE
perf: restrict NgRx state transfer filtering to two levels

### DIFF
--- a/docs/concepts/state-management.md
+++ b/docs/concepts/state-management.md
@@ -221,6 +221,14 @@ In selectors, the data can be linked to views to be easily usable by components.
 
 see: [NgRx: Normalizing state](https://medium.com/@timdeschryver/ngrx-normalizing-state-d3960a86a3aa)
 
+## State Transfer
+
+The server side application in a typical deployment setup makes necessary REST API calls to pre-render a page for an incoming URL.
+The accumulated NgRx state is then passed to the client side via state transfer using Angular's [TransferState](https://angular.io/api/platform-browser/TransferState).
+If certain slices of the state should not be passed to the client, you can put an underscore (`_`) in front of the name.
+For reasons of performance, this filtering is limited to a depth of two levels.
+This means feature stores can exclude reducers (in their respective `X-store.module.ts`) and core store slices can exclude properties (in their respective `X.reducer.ts`).
+
 # Further References
 
 - [@rx-angular/state][rx-angular-state]

--- a/src/app/core/configurations/ngrx-state-transfer.spec.ts
+++ b/src/app/core/configurations/ngrx-state-transfer.spec.ts
@@ -15,7 +15,7 @@ describe('Ngrx State Transfer', () => {
         c: 'C',
       };
 
-      expect(filterState(input)).toEqual(output);
+      expect(filterState(input, 2)).toEqual(output);
     });
 
     it('should omit keys starting with underscore when copying state (advanced)', () => {
@@ -34,10 +34,10 @@ describe('Ngrx State Transfer', () => {
         },
       };
 
-      expect(filterState(input)).toEqual(output);
+      expect(filterState(input, 2)).toEqual(output);
     });
 
-    it('should omit keys starting with underscore when copying state (complex)', () => {
+    it('should omit keys starting with underscore for the first two levels when copying state (complex)', () => {
       const input = {
         a: 'A',
         _b: 'B',
@@ -60,15 +60,16 @@ describe('Ngrx State Transfer', () => {
           x: 'X',
           z: {
             a: ['A'],
+            _b: 'B',
           },
         },
       };
 
-      expect(filterState(input)).toEqual(output);
+      expect(filterState(input, 2)).toEqual(output);
     });
 
     it('should be able to handle empty states', () => {
-      expect(filterState({})).toBeEmpty();
+      expect(filterState({}, 2)).toBeEmpty();
     });
 
     it('should be able to handle undefined values', () => {
@@ -87,7 +88,7 @@ describe('Ngrx State Transfer', () => {
         },
       };
 
-      expect(filterState(input)).toEqual(output);
+      expect(filterState(input, 2)).toEqual(output);
     });
 
     it('should be able to handle array values', () => {
@@ -106,7 +107,7 @@ describe('Ngrx State Transfer', () => {
         },
       };
 
-      expect(filterState(input)).toEqual(output);
+      expect(filterState(input, 2)).toEqual(output);
     });
   });
 });

--- a/src/app/core/configurations/ngrx-state-transfer.ts
+++ b/src/app/core/configurations/ngrx-state-transfer.ts
@@ -31,11 +31,11 @@ export function ngrxStateTransferMeta(reducer: ActionReducer<CoreState>): Action
 }
 
 // tslint:disable-next-line: no-any - generic store can only be used as any
-export function filterState(store: any): object {
-  if (store && typeof store === 'object' && !(store instanceof Array)) {
+export function filterState(store: any, maxLevel: number): object {
+  if (maxLevel > 0 && store && typeof store === 'object' && !(store instanceof Array)) {
     return Object.keys(store)
       .filter(k => !k.startsWith('_'))
-      .map(k => ({ [k]: filterState(store[k]) }))
+      .map(k => ({ [k]: filterState(store[k], maxLevel - 1) }))
       .reduce((acc, val) => ({ ...acc, ...val }), {});
   } else {
     return store;
@@ -59,9 +59,14 @@ export function ngrxStateTransfer(transferState: TransferState, store: Store, ac
       // server
       transferState.onSerialize(NGRX_STATE_SK, () => {
         let state;
-        store.pipe(take(1), map(filterState)).subscribe((saveState: object) => {
-          state = saveState;
-        });
+        store
+          .pipe(
+            take(1),
+            map(s => filterState(s, 2))
+          )
+          .subscribe((saveState: object) => {
+            state = saveState;
+          });
 
         return state;
       });


### PR DESCRIPTION
## PR Type

[x] Other: Performance Improvement

## What Is the Current Behavior?

The state transfer is filtering out slices of the state starting with underscore before passing the NgRx state to the client. When there are a lot of entries in the store (i.e. when using server translations like https://pwa-ish-demo.test.intershop.com/INTERSHOP/rest/WFS/inSPIRED-inTRONICS-Site/rest;loc=en_US/localizations?searchKeys=pwa-) this process takes some time on every SSR render.

## What Is the New Behavior?

- Filtering is restricted to two levels
- Documentation for excluding properties with underscore

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#70157](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70157)