### PR TITLE
chore: remove deprecated "Debugger for Chrome" as recommended extension and clean up launch configurations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
     "eamodio.gitlens",
     "vscode-icons-team.vscode-icons",
     "vincaslt.highlight-matching-tag",
-    "msjsdiag.debugger-for-chrome",
     // code assist
     "visualstudioexptteam.vscodeintellicode",
     "cyrilletuzi.angular-schematics",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,8 +2,15 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Launch localhost (Chrome)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:4200/",
+      "webRoot": "${workspaceRoot}"
+    },
+    {
+      "name": "Jest Tests",
       "type": "node",
-      "name": "vscode-jest-tests",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
       "args": ["--runInBand"],
@@ -12,28 +19,14 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
+      "name": "Clean up Localizations",
       "type": "node",
-      "name": "clean-up-localizations",
       "request": "launch",
       "program": "${workspaceFolder}/scripts/clean-up-localizations",
       "args": [],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
-    },
-    {
-      "type": "chrome",
-      "request": "launch",
-      "name": "Launch Chrome with ng serve",
-      "url": "http://localhost:4200/#",
-      "webRoot": "${workspaceRoot}"
-    },
-    {
-      "type": "chrome",
-      "request": "launch",
-      "name": "Launch Chrome with debug",
-      "url": "http://localhost:9876/debug.html",
-      "webRoot": "${workspaceRoot}"
     }
   ]
 }


### PR DESCRIPTION
## PR Type

[x] Other: VS Code extension cleanup

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#70179](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70179)