### PR TITLE
chore: update swiper 6 to 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8845,11 +8845,11 @@
       }
     },
     "dom7": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-3.0.0.tgz",
-      "integrity": "sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.0.tgz",
+      "integrity": "sha512-xOJ0LAHFwktyj8Xljz4R2wzRI+Y9mR0plkMP0WlqtwqAkqn/vbdAyRifiW/w8mXe17LGktntcAwsQ5fKVDBNYg==",
       "requires": {
-        "ssr-window": "^3.0.0-alpha.1"
+        "ssr-window": "^4.0.0"
       }
     },
     "domelementtype": {
@@ -20477,9 +20477,9 @@
       }
     },
     "ssr-window": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-3.0.0.tgz",
-      "integrity": "sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.0.tgz",
+      "integrity": "sha512-qCg6wJNeGNTVcPK2KFNfwtHU1gA3UZDZdxogu+Ys5+Ue5PMOENxUb7sscpAWWo4mWOBkJRCwQ50IlyA7qZ0hxw=="
     },
     "ssri": {
       "version": "8.0.1",
@@ -21397,12 +21397,12 @@
       }
     },
     "swiper": {
-      "version": "6.8.4",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-6.8.4.tgz",
-      "integrity": "sha512-O+buF9Q+sMA0H7luMS8R59hCaJKlpo8PXhQ6ZYu6Rn2v9OsFd4d1jmrv14QvxtQpKAvL/ZiovEeANI/uDGet7g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.0.7.tgz",
+      "integrity": "sha512-oCpbG0zdBUFKMGlVlcRjtIQCJhAh5Y1+yX9wSYkhC6W92OExETtLXuWdNUiBnXQbWCx3n7nfFD7mxaCnWWDjPA==",
       "requires": {
-        "dom7": "^3.0.0",
-        "ssr-window": "^3.0.0"
+        "dom7": "^4.0.0",
+        "ssr-window": "^4.0.0"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ngx-infinite-scroll": "^10.0.1",
     "ngx-toastr": "^14.1.3",
     "rxjs": "~6.6.7",
-    "swiper": "^6.8.4",
+    "swiper": "^7.0.7",
     "tslib": "^2.3.1",
     "typeface-roboto": "1.1.13",
     "typeface-roboto-condensed": "1.1.13",

--- a/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
-import { SwiperOptions } from 'swiper';
-import SwiperCore, { Navigation, Pagination } from 'swiper/core';
+import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
 import { ProductContextDisplayProperties } from 'ish-core/facades/product-context.facade';

--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -13,7 +13,7 @@
   </div>
   <div *ngIf="getImageViewIDs$('L') | async as largeImages" class="col-12 col-lg-9 product-detail-img clearfix">
     <div class="product-image-container">
-      <swiper #carousel [navigation]="true" [(index)]="activeSlide">
+      <swiper #carousel [navigation]="true">
         <ng-container *ngFor="let imageView of largeImages">
           <ng-template swiperSlide>
             <ish-product-image imageType="L" [imageView]="imageView"></ish-product-image>

--- a/src/app/pages/product/product-images/product-images.component.spec.ts
+++ b/src/app/pages/product/product-images/product-images.component.spec.ts
@@ -83,7 +83,6 @@ describe('Product Images Component', () => {
     fixture = TestBed.createComponent(ProductImagesComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
-    component.activeSlide = 0;
   });
 
   it('should be created', () => {
@@ -111,7 +110,6 @@ describe('Product Images Component', () => {
     (element.getElementsByClassName('product-thumb-set')[1] as HTMLElement).click();
     fixture.detectChanges();
     expect(element.getElementsByClassName('product-thumb-set')[1].getAttribute('class')).toContain('active');
-    expect(component.activeSlide).toEqual(1);
   });
 
   it('should render product image component on component', () => {

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -27,8 +27,6 @@ SwiperCore.use([Navigation]);
 export class ProductImagesComponent implements OnInit {
   @ViewChild('carousel') carousel: SwiperComponent;
 
-  activeSlide = 0;
-
   product$: Observable<ProductView>;
 
   constructor(private context: ProductContextFacade) {}
@@ -49,7 +47,7 @@ export class ProductImagesComponent implements OnInit {
    * @param slideIndex The slide index to set the active slide
    */
   setActiveSlide(slideIndex: number) {
-    this.carousel.setIndex(slideIndex);
+    this.carousel?.swiperRef?.slideTo(slideIndex);
   }
 
   /**
@@ -58,6 +56,6 @@ export class ProductImagesComponent implements OnInit {
    * @returns True if the given slide index is the active slide, false otherwise
    */
   isActiveSlide(slideIndex: number): boolean {
-    return this.activeSlide === slideIndex;
+    return this.carousel?.swiperRef?.activeIndex === slideIndex;
   }
 }

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import SwiperCore, { Navigation } from 'swiper';
 import { SwiperComponent } from 'swiper/angular';
-import SwiperCore, { Navigation } from 'swiper/core';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -1,8 +1,7 @@
 import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges } from '@angular/core';
 import { Observable, combineLatest, of } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { SwiperOptions } from 'swiper';
-import SwiperCore, { Navigation, Pagination } from 'swiper/core';
+import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges } from '@angular/core';
-import { SwiperOptions } from 'swiper';
-import SwiperCore, { Navigation, Pagination } from 'swiper/core';
+import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
 import {
   LARGE_BREAKPOINT_WIDTH,

--- a/src/styles/global/swiper.scss
+++ b/src/styles/global/swiper.scss
@@ -1,4 +1,4 @@
-.swiper-container {
+.swiper {
   padding-bottom: 20px;
 
   .swiper-pagination {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -17,8 +17,8 @@
 @import '~ngx-toastr/toastr-bs4-alert';
 
 // import Swiper default theme
-@import '~swiper/swiper';
-@import '~swiper/components/pagination/pagination.scss';
+@import '~swiper/scss';
+@import '~swiper/scss/pagination';
 
 //
 // STYLING COMPATIBILITY LAYER


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[x] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently Swiper 6 (old) is used


## What Is the New Behavior?

Now Swiper 7 (latest) is used

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
- With the new version 7, Swiper is now a pure ESM package and some APIs were deprectated.
- Updating to version 7 breaks some tests which needs to be fixed (this might be due to the new ESM structure)