### PR TITLE
fix: repair chunk output file names for differential loading

### DIFF
--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -151,9 +151,6 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
       }
     });
 
-    // set chunk file names with name instead of id
-    config.output.chunkFilename = '[name].[chunkhash:20].js';
-
     // splitChunks not available for SSR build
     if (config.optimization.splitChunks) {
       logger.log('optimizing chunk splitting');


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Files for differential loading are not correct: 
- add `> 0.5%` as an only rule to `.browserslistrc`
- `npm run build client`
- observe overlapping filenames for lazy differential loading chunks:
```
Initial Chunk Files                             | Names                   |      Size
vendor-es5.6bfd51788ebdd6c8e837.js              | vendor                  | 844.88 kB
vendor-es2015.6bfd51788ebdd6c8e837.js           | vendor                  | 720.08 kB
...
                                                | Initial ES5 Total       |   1.58 MB
                                                | Initial ES2015 Total    |   1.32 MB

Lazy Chunk Files                                | Names                   |      Size
common.5d231b554730def6758e.js                  | common                  | 648.54 kB
common.5d231b554730def6758e.js                  | common                  | 605.59 kB
...
requisition-management.3219190aab4f64752ee3.js  | requisition-management  |  58.96 kB
organization-management.5bb87a710ce316cefa02.js | organization-management |  57.11 kB
requisition-management.3219190aab4f64752ee3.js  | requisition-management  |  55.08 kB
organization-management.5bb87a710ce316cefa02.js | organization-management |  51.88 kB
...
```

## What Is the New Behavior?

Suffix is added correctly:
```
Initial Chunk Files                                    | Names                   |      Size
vendor-es5.6bfd51788ebdd6c8e837.js                     | vendor                  | 844.88 kB
vendor-es2015.6bfd51788ebdd6c8e837.js                  | vendor                  | 720.07 kB
...
                                                       | Initial ES5 Total       |   1.58 MB
                                                       | Initial ES2015 Total    |   1.32 MB

Lazy Chunk Files                                       | Names                   |      Size
common-es5.28e04bf8291415cab4d3.js                     | common                  | 648.54 kB
common-es2015.28e04bf8291415cab4d3.js                  | common                  | 605.59 kB
...
requisition-management-es5.3219190aab4f64752ee3.js     | requisition-management  |  58.96 kB
organization-management-es5.5bb87a710ce316cefa02.js    | organization-management |  57.11 kB
requisition-management-es2015.3219190aab4f64752ee3.js  | requisition-management  |  55.08 kB
organization-management-es2015.5bb87a710ce316cefa02.js | organization-management |  51.88 kB
...
```

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

- `output.chunkFilename` was introduced after an Angular (Webpack 5) upgrade, because the chunks did not contain names of the chunks, just numbers. Now it seems the Angular CLI uses a proper name scheme.

[AB#70223](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70223)