### PR TITLE
fix: file error message doesnt overlap button

### DIFF
--- a/src/app/extensions/quickorder/shared/quickorder-csv-form/quickorder-csv-form.component.html
+++ b/src/app/extensions/quickorder/shared/quickorder-csv-form/quickorder-csv-form.component.html
@@ -1,5 +1,5 @@
 <div class="row mt-4">
-  <div class="col-md-6">
+  <div class="col-md-12">
     <h3>{{ 'quickorder.page.csv.title' | translate }}</h3>
     <p>{{ 'quickorder.page.csv.subtitle' | translate }}</p>
     <form [formGroup]="csvForm" (ngSubmit)="addCsvToCart()">

--- a/src/app/extensions/quickorder/shared/quickorder-csv-form/quickorder-csv-form.component.html
+++ b/src/app/extensions/quickorder/shared/quickorder-csv-form/quickorder-csv-form.component.html
@@ -13,7 +13,7 @@
           accept=".csv"
           (change)="uploadListener($event.target)"
         />
-        <div [ngSwitch]="status" class="position-absolute">
+        <div [ngSwitch]="status">
           <small *ngSwitchCase="'IncorrectInput'" class="has-error"
             ><span class="validation-message">{{ 'quickorder.page.csv.file.invalid.input' | translate }}</span></small
           >


### PR DESCRIPTION
<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Quickorder file message overlaps button due to it being wrapped inside a div with absolute position.

Issue Number: Closes #827

## What Is the New Behavior?
Message doesn't overlap button anymore

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
Absolute positioning in parent div caused the overlaping. Since there is no use in having absolute positioning here it was simply removed from the div.