### PR TITLE
refactor: remove b64u library and use native methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5400,11 +5400,6 @@
         "ast-types-flow": "0.0.7"
       }
     },
-    "b64u": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/b64u/-/b64u-3.0.0.tgz",
-      "integrity": "sha512-EBzvQ9RbYl9ZFTVswkTsHrFzRiwp6e56M2MoxRHcGU00d14XWefkoEsVLOrNJw8WHnWUTM/QvbsC3VtNHwls5w=="
-    },
     "babel-jest": {
       "version": "27.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "angular-oauth2-oidc": "^12.1.0",
     "angular2-uuid": "^1.1.1",
     "angulartics2": "^10.0.0",
-    "b64u": "^3.0.0",
     "bootstrap": "^4.6.0",
     "core-js": "^3.17.3",
     "express": "^4.17.1",

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -1,7 +1,6 @@
 import { HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import b64u from 'b64u';
 import { pick } from 'lodash-es';
 import { Observable, combineLatest, of, throwError } from 'rxjs';
 import { concatMap, first, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
@@ -55,7 +54,7 @@ export class UserService {
   signInUser(loginCredentials: Credentials): Observable<CustomerUserType> {
     const headers = new HttpHeaders().set(
       ApiService.AUTHORIZATION_HEADER_KEY,
-      'BASIC ' + b64u.toBase64(b64u.encode(`${loginCredentials.login}:${loginCredentials.password}`))
+      'BASIC ' + window.btoa(`${loginCredentials.login}:${loginCredentials.password}`)
     );
 
     return this.fetchCustomer({ headers });
@@ -168,7 +167,7 @@ export class UserService {
     const headers = credentials
       ? new HttpHeaders().set(
           ApiService.AUTHORIZATION_HEADER_KEY,
-          'BASIC ' + b64u.toBase64(b64u.encode(`${credentials.login}:${credentials.password}`))
+          'BASIC ' + window.btoa(`${credentials.login}:${credentials.password}`)
         )
       : undefined;
 

--- a/src/app/pages/checkout-payment/payment-cybersource-creditcard/payment-cybersource-creditcard.component.spec.ts
+++ b/src/app/pages/checkout-payment/payment-cybersource-creditcard/payment-cybersource-creditcard.component.spec.ts
@@ -3,7 +3,6 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
-import b64u from 'b64u';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { anything, spy, verify } from 'ts-mockito';
 
@@ -68,7 +67,7 @@ describe('Payment Cybersource Creditcard Component', () => {
       iat: 'test',
       jti: 'test',
     };
-    const payload = b64u.encode(JSON.stringify(payloadjson));
+    const payload = window.btoa(JSON.stringify(payloadjson));
 
     component.cyberSourceCreditCardForm.controls.expirationMonth.setValue('11');
     component.cyberSourceCreditCardForm.controls.expirationYear.setValue('2022');
@@ -90,7 +89,7 @@ describe('Payment Cybersource Creditcard Component', () => {
       iat: 'test',
       jti: 'test',
     };
-    const payload = b64u.encode(JSON.stringify(payloadjson));
+    const payload = window.btoa(JSON.stringify(payloadjson));
 
     component.expirationMonthVal = '11';
     component.expirationYearVal = '2022';

--- a/src/app/pages/checkout-payment/payment-cybersource-creditcard/payment-cybersource-creditcard.component.ts
+++ b/src/app/pages/checkout-payment/payment-cybersource-creditcard/payment-cybersource-creditcard.component.ts
@@ -10,7 +10,6 @@ import {
   Output,
 } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import b64u from 'b64u';
 import { range } from 'lodash-es';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -184,7 +183,7 @@ export class PaymentCybersourceCreditcardComponent implements OnChanges, OnDestr
         exp: string;
         iat: string;
         jti: string;
-      } = JSON.parse(b64u.decode(tokenSplit[1]));
+      } = JSON.parse(window.atob(tokenSplit[1]));
 
       this.submit.emit({
         parameters: [

--- a/tslint.json
+++ b/tslint.json
@@ -257,14 +257,6 @@
       {
         "name": ["spyOn"],
         "message": "Use ts-mockito instead!"
-      },
-      {
-        "name": ["atob"],
-        "message": "This is not available in universal mode. Use https://github.com/jacobwgillespie/b64u"
-      },
-      {
-        "name": ["btoa"],
-        "message": "This is not available in universal mode. Use https://github.com/jacobwgillespie/b64u"
       }
     ],
     "ban-specific-imports": {


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

[`b64u`](https://www.npmjs.com/package/b64u) library is used for base64 encoding and decoding. This was primarily used for handling the old ICM filter API responses on SSR, as there are no native methods available.

## What Is the New Behavior?

- `b64u` is removed
- remaining implementations (logging in, card payment) are refactored to use the native methods, as they don't happen on SSR

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

If base64 functionality is again required on SSR, the use of a polyfill like [btoa-polyfill](https://www.npmjs.com/package/@kfiros/btoa-polyfill) should be preferred.

