### PR TITLE
refactor: retrieve many variations parallel in chunks

### DIFF
--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -117,18 +117,21 @@ describe('Products Service', () => {
   });
 
   it("should get all product variations data when 'getProductVariations' is called and more than 50 variations exist", done => {
-    when(apiServiceMock.get(`products/${productSku}/variations`)).thenReturn(
-      of({ elements: [], amount: 50, total: 56 })
-    );
-    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenReturn(
-      of({ elements: [], amount: 6, total: 56 })
-    );
+    const total = 156;
+    when(apiServiceMock.get(`products/${productSku}/variations`)).thenReturn(of({ elements: [], amount: 40, total }));
+    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenReturn(of({ elements: [], total }));
     productsService.getProductVariations(productSku).subscribe(() => {
       verify(apiServiceMock.get(`products/${productSku}/variations`)).once();
-      verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).once();
-      const [, args] = capture<string, AvailableOptions>(apiServiceMock.get).last();
-      expect(args.params).toBeTruthy();
-      expect(args.params.toString()).toMatchInlineSnapshot(`"amount=6&offset=50"`);
+      verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).thrice();
+      expect(
+        capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(1)?.[1]?.params?.toString()
+      ).toMatchInlineSnapshot(`"amount=40&offset=40"`);
+      expect(
+        capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(2)?.[1]?.params?.toString()
+      ).toMatchInlineSnapshot(`"amount=40&offset=80"`);
+      expect(
+        capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(3)?.[1]?.params?.toString()
+      ).toMatchInlineSnapshot(`"amount=36&offset=120"`);
       done();
     });
   });


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

If a master product has many variations, there are two calls:
- the first call returns a maximum of 50 variations
- the second call fetches the remaining variations

If there are many variations, the second call can take a long time to be processed by the ICM REST API.

## What Is the New Behavior?

Additional variations are retrieved in batches in parallel.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#70409](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70409)