### PR TITLE
fix: disable inlineCriticalCss for Angular Universal engine

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -114,6 +114,7 @@ export function app() {
     ngExpressEngine({
       bootstrap: AppServerModule,
       providers: [{ provide: 'SSR_HYBRID', useValue: !!process.env.SSR_HYBRID }],
+      inlineCriticalCss: false,
     })
   );
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Although the deploy url replacement is working, an error message is logged. 

`Unable to locate stylesheet: /dist/default/browser/DEPLOY_URL_PLACEHOLDERstyles.eba20b5eb002a3942b77.css`

Issue Number: Closes #862 

## What Is the New Behavior?

The error message should not be there.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

This error message was caused by the inlineCritical option of the Angular Universal express-engine. It calls the `Critters:getCssAsset() `function, which is trying to resolve external assets on local path. (linked Github Issue)


