### PR TITLE
fix: respect ICM setting "Add Product Behavior" when adding basket items

### DIFF
--- a/src/app/core/store/customer/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.spec.ts
@@ -70,15 +70,17 @@ describe('Basket Items Effects', () => {
   });
 
   describe('addProductToBasket$', () => {
-    it('should accumulate AddProductToBasket to a single AddItemsToBasket action', () => {
+    it('should accumulate AddProductToBasket to a single action', () => {
       store$.dispatch(loadProductSuccess({ product: { sku: 'SKU1', packingUnit: 'pcs.' } as Product }));
       store$.dispatch(loadProductSuccess({ product: { sku: 'SKU2', packingUnit: 'pcs.' } as Product }));
       const action1 = addProductToBasket({ sku: 'SKU1', quantity: 1 });
       const action2 = addProductToBasket({ sku: 'SKU2', quantity: 1 });
       const completion = addItemsToBasket({
         items: [
-          { sku: 'SKU2', quantity: 2, unit: 'pcs.' },
-          { sku: 'SKU1', quantity: 2, unit: 'pcs.' },
+          { sku: 'SKU2', quantity: 1, unit: 'pcs.' },
+          { sku: 'SKU1', quantity: 1, unit: 'pcs.' },
+          { sku: 'SKU2', quantity: 1, unit: 'pcs.' },
+          { sku: 'SKU1', quantity: 1, unit: 'pcs.' },
         ],
       });
       actions$ = hot('        -b-a-b-a--|', { a: action1, b: action2 });

--- a/src/app/core/store/customer/basket/basket-items.effects.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.ts
@@ -12,8 +12,8 @@ import {
   map,
   mapTo,
   mergeMap,
-  reduce,
   switchMap,
+  toArray,
   window,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -53,30 +53,19 @@ export class BasketItemsEffects {
 
   /**
    * Add a product to the current basket.
-   * Triggers the internal AddItemsToBasket action that handles the actual adding of the product to the basket.
+   * Triggers the internal action that handles the actual adding of the product to the basket.
    */
   addProductToBasket$ = createEffect(() =>
     this.actions$.pipe(
       ofType(addProductToBasket),
       mapToPayload(),
+      // add unit
+      withLatestFrom(this.store.pipe(select(getProductEntities))),
+      map(([val, entities]) => ({ ...val, unit: entities[val.sku] && entities[val.sku].packingUnit })),
       // accumulate all actions
       window(this.actions$.pipe(ofType(addProductToBasket), debounceTime(1000))),
-      mergeMap(window$ =>
-        window$.pipe(
-          withLatestFrom(this.store.pipe(select(getProductEntities))),
-          // accumulate changes
-          reduce((acc, [val, entities]) => {
-            const element = acc.find(x => x.sku === val.sku);
-            if (element) {
-              element.quantity += val.quantity;
-            } else {
-              acc.push({ ...val, unit: entities[val.sku] && entities[val.sku].packingUnit });
-            }
-            return acc;
-          }, []),
-          map(items => addItemsToBasket({ items }))
-        )
-      )
+      mergeMap(window$ => window$.pipe(toArray())),
+      map(items => addItemsToBasket({ items }))
     )
   );
 


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The ICM Application setting `Shopping Cart & Checkout > Add Product Behavior` is not properly respected by the PWA

Steps to repeat:
BO:
- go to ICM BO
- manage B2B channel
- 'Applications' > select 'Progressive Web App' application
- tab 'Shopping Cart & Checkout' change 'Add Product Behavior' to 'Allow Repeats'

PWA:
- go to quickorder
- add multiple entries for one product
- add to cart

Expected:
- multiple entries in cart

Actual:
- one line item with quantities merged

## What Is the New Behavior?

- disabled the quantity merging in the PWA and let ICM handle it automatically

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#70421](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70421)