### PR TITLE
Add documentation to express the differences between pgid and spgid

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -48,9 +48,15 @@ export interface AvailableOptions {
   sendCurrency?: boolean;
   /** opt-out of sending locale matrix parameter by setting it to false */
   sendLocale?: boolean;
-  /** opt-in to sending pgid matrix parameter by setting it to true */
+  /**
+   * opt-in to sending pgid matrix parameter by setting it to true. As per Intershop Commerce REST api documentation ´pgid´ is the standard means
+   * to get and cache personalized content of supported REST resources (e.g. cms).
+   */
   sendPGID?: boolean;
-  /** opt-in to sending spgid matrix parameter by setting it to true */
+  /**
+   * opt-in to sending spgid matrix parameter by setting it to true. As per Intershop Commerce REST api documentation this is the special means
+   * to get and cache personalized content of the product and category API (1.x).
+   */
   sendSPGID?: boolean;
 }
 


### PR DESCRIPTION
## PR Type
[X] Documentation content changes

## What Is the Current Behavior?

For a PWA newbie It is hard to grasp the differences between these two lines:
```
this.apiService.get<ContentPageletEntryPointData>(`cms/includes/${includeId}`, { sendPGID: true })
this.apiService.get<ProductData>(`products/${sku}`, { sendSPGID: true })
```
Api service's options interface `AvailableOptions` has two characteristics for something that essentialy is the same thing, i.e. `sendPGID` and `sendSPGID`

## What Is the New Behavior?

Both options are still available, but we added documentation to the code to make the meaning more clear.
- `sendSPGID` is for product and category API only
- `sendPGID` is for all other API that supports personalization.

## Does this PR Introduce a Breaking Change?

[X] No

## Other Information


[AB#70583](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70583)