### PR TITLE
fix: dns resolve issue in ssr

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -56,7 +56,7 @@ export function app() {
     if (icmProtocol === 'https') {
       const https = require('https');
 
-      const [, icmHost, icmPort] = /^(.*?):?([0-9]+)?$/.exec(icmBase);
+      const [, icmHost, icmPort] = /^(.*?):?([0-9]+)?[\/]*$/.exec(icmBase);
 
       const options = {
         host: icmHost,


### PR DESCRIPTION
## PR Type

[X] Bugfix

## What Is the Current Behavior?

As described in issue #913 , syscall `getaddrinfo` is failing if ICM_BASE_URL contains a trailing `/` character

Issue Number: Closes #913

## What Is the New Behavior?

Unboxed icm-host variable contains no `/` slash at the end.

## Does this PR Introduce a Breaking Change?

[X] Yes
[ ] No

## Other Information


[AB#70774](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70774)