### PR TITLE
feat: punchout identity provider

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -166,6 +166,7 @@ Of course, the ICM server must supply appropriate REST resources to leverage fun
 | orderTemplates               | order templates feature                                                                                                    |
 | quickorder                   | quick order page and direct add to cart input                                                                              |
 | quoting                      | quoting feature                                                                                                            |
+| punchout                     | punchout feature                                                                                                           |
 | **B2C Features**             |                                                                                                                            |
 | guestCheckout                | allow unregistered guest checkout                                                                                          |
 | wishlists                    | wishlist product list feature                                                                                              |

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -41,7 +41,7 @@ nginx:
 Entries of the IP whitelist are added to the nginx config as [`allow`](http://nginx.org/en/docs/http/ngx_http_access_module.html) statements, which also supports IP ranges.
 Please refer to the linked nginx documentation on how to configure this.
 
-After activating basic authentication for your setup globally you can also selectively deactivate it per site.
+After globally activating basic authentication for your setup you can also disable it selectively per site.
 See [Multi-Site Configurations](../guides/multi-site-configurations.md#Examples) for examples on how to do that.
 
 ### Multi-Site
@@ -53,13 +53,13 @@ For more information on the multi-site syntax, refer to [Multi-Site Configuratio
 
 The configuration can be supplied simply by setting the environment variable `MULTI_CHANNEL`.
 Alternatively, the source can be supplied by setting `MULTI_CHANNEL_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources/).
-If no environment variables for multi-channel configuration are given, the configuration will fall back to the content of [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), which can also be customized.
+If no environment variables for multi-channel configuration are provided, the configuration will fall back to the content of [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), which can also be customized.
 
 > :warning: Multi-Channel configuration with context paths does not work in conjunction with [service workers](../concepts/progressive-web-app.md#service-worker)
 
 An extended list of examples can be found in the [Multi-Site Configurations](../guides/multi-site-configurations.md#Syntax) guide.
 
-### Ignore parameters during caching
+### Ignore Parameters During Caching
 
 Often, nginx receives requests from advertising networks or various user agents that append unused query parameters when making a request, for example `gclid` or `utm_source`. <br>
 These parameters can lead to inefficient caching because even if the same URL is requested multiple times, if it is accessed with different query parameters, the cached version will not be used.
@@ -70,9 +70,9 @@ As with multi-site handling above, the configuration can be supplied simply by s
 Alternatively, the source can be supplied by setting `CACHING_IGNORE_PARAMS_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources/).
 Be aware that the supplied list of parameters must be declared under a `params` property.
 
-If no environment variables for ignoring parameters are given, the configuration will fall back to the content of [`nginx/caching-ignore-params.yaml`](../../nginx/caching-ignore-params.yaml), which can also be customized.
+If no environment variables for ignoring parameters are provided, the configuration will fall back to the content of [`nginx/caching-ignore-params.yaml`](../../nginx/caching-ignore-params.yaml), which can also be customized.
 
-### Access ICM sitemap
+### Access ICM Sitemap
 
 Please refer to [this](https://support.intershop.com/kb/index.php/Display/23D962#ConceptXMLSitemaps-XMLSitemapsandIntershopPWAxml_sitemap_pwa) Intershop knowledge base article on how to configure ICM to generate PWA sitemap files.
 
@@ -80,9 +80,9 @@ Please refer to [this](https://support.intershop.com/kb/index.php/Display/23D962
 http://pwa/sitemap_pwa.xml
 ```
 
-To make above sitemap index file available under your deployment you need to add environment variable `ICM_BASE_URL` in your nginx container.
+To make above sitemap index file available under your deployment you need to add the environment variable `ICM_BASE_URL` to your nginx container.
 Let `ICM_BASE_URL` point to your ICM backend installation, e.g. `https://pwa-ish-demo.test.intershop.com`.
-When the container is started it'll process cache-ignore and multi-channel templates as well as sitemap proxy rules like this:
+When the container is started it will process cache-ignore and multi-channel templates as well as sitemap proxy rules like this:
 
 ```yaml
 location /sitemap_ {
@@ -93,11 +93,11 @@ proxy_pass https://pwa-ish-demo.test.intershop.com/INTERSHOP/static/WFS/inSPIRED
 The process will utilize your [Multi-Site Configuration](../guides/multi-site-configurations.md#Syntax).
 Be sure to include `application` if you deviate from standard `rest` application.
 
-### Override identity providers by path
+### Override Identity Providers by Path
 
 The PWA can be configured with multiple identity providers.
 In some use cases a specific identity provider must be selected, when a certain route is requested.
-A punchout user eg. should be logged in by the punchout identity provider by requesting a punchout route.
+For example, a punchout user should be logged in by the punchout identity provider requesting a punchout route.
 For all other possible routes the default identity provider must be selected.
 This can be done by setting only the environment variable `OVERRIDE_IDENTITY_PROVIDER`.
 
@@ -110,10 +110,10 @@ nginx:
           type: PUNCHOUT
 ```
 
-This setting will generate for all given domains rewrite rules for the url paths.
+This setting will generate rewrite rules for the URL paths for all given domains.
 Alternatively, the source can be supplied by setting `OVERRIDE_IDENTITY_PROVIDERS_SOURCE` in any supported format by gomplate.
 
-If no environment variable is set, this feature will be disabled.
+If no environment variable is set, this feature is disabled.
 
 ### Other
 
@@ -132,9 +132,9 @@ Built-in features can be enabled and disabled:
 ## Features
 
 New features can be supplied in the folder `nginx/features`.
-A file named `<feature>.conf` is included if the environment variable `<feature>` is set to `on`, `1`, `true` or `yes` (checked case in-sensitive).
+A file named `<feature>.conf` is included if the environment variable `<feature>` is set to `on`, `1`, `true` or `yes` (case in-sensitive).
 The feature is disabled otherwise and an optional file `<feature>-off.conf` is included in the configuration.
-The feature name must be all word-characters (letters, numbers and underscore).
+The feature name must only contain word characters (letters, numbers and underscore).
 
 ### Cache
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -93,6 +93,28 @@ proxy_pass https://pwa-ish-demo.test.intershop.com/INTERSHOP/static/WFS/inSPIRED
 The process will utilize your [Multi-Site Configuration](../guides/multi-site-configurations.md#Syntax).
 Be sure to include `application` if you deviate from standard `rest` application.
 
+### Override identity providers by path
+
+The PWA can be configured with multiple identity providers.
+In some use cases a specific identity provider must be selected, when a certain route is requested.
+A punchout user eg. should be logged in by the punchout identity provider by requesting a punchout route.
+For all other possible routes the default identity provider must be selected.
+This can be done by setting only the environment variable `OVERRIDE_IDENTITY_PROVIDER`.
+
+```yaml
+nginx:
+  environment:
+    OVERRIDE_IDENTITY_PROVIDERS: |
+      .+:
+        - path: /b2b/punchout
+          type: PUNCHOUT
+```
+
+This setting will generate for all given domains rewrite rules for the url paths.
+Alternatively, the source can be supplied by setting `OVERRIDE_IDENTITY_PROVIDERS_SOURCE` in any supported format by gomplate.
+
+If no environment variable is set, this feature will be disabled.
+
 ### Other
 
 The page speed configuration can also be overridden:

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -7,6 +7,8 @@ set -e
 
 [ -z "$ICM_BASE_URL" ] && echo "ICM_BASE_URL is not set. Cannot use sitemap proxy feature."
 
+[ -z "$OVERRIDE_IDENTITY_PROVIDERS" ] && echo "OVERRIDE_IDENTITY_PROVIDER is not set. Cannot use override identity provider feature."
+
 [ -f "/etc/nginx/conf.d/default.conf" ] && rm /etc/nginx/conf.d/default.conf
 
 if [ -n "$BASIC_AUTH" ]
@@ -26,6 +28,14 @@ then
   fi
 fi
 
+if [ -z "$OVERRIDE_IDENTITY_PROVIDERS_SOURCE" ]
+then
+  if [ -n "$OVERRIDE_IDENTITY_PROVIDERS" ]
+  then
+    OVERRIDE_IDENTITY_PROVIDERS_SOURCE="env:///OVERRIDE_IDENTITY_PROVIDERS?type=application/yaml"
+  fi
+fi
+
 if [ -z "$CACHING_IGNORE_PARAMS_SOURCE"]
 then
   if [ -z "$CACHING_IGNORE_PARAMS"]
@@ -36,7 +46,7 @@ then
   fi
 fi
 
-/gomplate -d "domains=$MULTI_CHANNEL_SOURCE" -d "cachingIgnoreParams=$CACHING_IGNORE_PARAMS_SOURCE" -d 'ipwhitelist=env:///BASIC_AUTH_IP_WHITELIST?type=application/yaml' --input-dir="/etc/nginx/templates" --output-map='/etc/nginx/conf.d/{{ .in | strings.ReplaceAll ".conf.tmpl" ".conf" }}'
+/gomplate -d "domains=$MULTI_CHANNEL_SOURCE" -d "overrideIdentityProviders=$OVERRIDE_IDENTITY_PROVIDERS_SOURCE" -d "cachingIgnoreParams=$CACHING_IGNORE_PARAMS_SOURCE" -d 'ipwhitelist=env:///BASIC_AUTH_IP_WHITELIST?type=application/yaml' --input-dir="/etc/nginx/templates" --output-map='/etc/nginx/conf.d/{{ .in | strings.ReplaceAll ".conf.tmpl" ".conf" }}'
 
 # Generate Pagespeed config based on environment variables
 env | grep NPSC_ | sed -e 's/^NPSC_//g' -e "s/\([A-Z_]*\)=/\L\1=/g" -e "s/_\([a-zA-Z]\)/\u\1/g" -e "s/^\([a-zA-Z]\)/\u\1/g" -e 's/=.*$//' -e 's/\=/ /' -e 's/^/\pagespeed /' > /tmp/pagespeed-prefix.txt

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -3,7 +3,7 @@
 {{ define "LOCATION_TEMPLATE" }}
         {{- $channel := .channel }}
         {{- $application := "" }}{{ if (has . "application") }}{{ $application = join ( slice ";application" .application ) "=" }}{{ end }}
-        {{- $identityProvider := "" }}{{ if (has . "identityProvider") }}{{ $identityProvider = join ( slice ";identityProvider" .identityProvider ) "=" }}{{ end }}
+        {{- $identityProvider := "" }}{{ if (has . "identityProvider") }}{{ $identityProvider = .identityProvider }}{{ end }}
         {{- $lang := "default" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
         {{- $currency := "" }}{{ if (has . "currency") }}{{ $currency = join ( slice ";currency" .currency ) "=" }}{{ end }}
         {{- $features := "" }}{{ if (has . "features") }}{{ $features = join ( slice ";features" .features ) "=" }}{{ end }}
@@ -42,7 +42,11 @@
         rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang={{ $lang }}';
         rewrite '^(?!.*;currency=.*)(.*)$' '$1;currency={{ $currency }}';
 
-        set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $identityProvider }}{{ $features }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
+      {{ if $identityProvider }}
+        rewrite '^(?!.*;identityProvider=.*)(.*)$' '$1;identityProvider={{ $identityProvider }}';
+      {{ end }}
+
+        set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $features }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
 
         rewrite '^(.*)$' '$1$default_rewrite_params' break;
 
@@ -51,6 +55,11 @@
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
 {{- end }}
+
+{{- define "OVERRIDE_IDENTITY_PROVIDER_TEMPLATE" }}
+    {{- $identityProvider := join ( slice ";identityProvider" .type ) "=" }}
+    rewrite '^((.*){{ .path }})$' '$1{{$identityProvider}}';
+{{- end}}
 
 {{- range $domain, $mapping := (ds "domains") }}
 server {
@@ -72,6 +81,16 @@ server {
    set $c_uri $args;
 
    include /etc/nginx/conf.d/cache-blacklist.conf;
+
+  {{- if getenv "OVERRIDE_IDENTITY_PROVIDERS" }}
+    {{- range $domainOverride, $identyProviderOverride := (ds "overrideIdentityProviders") }}
+      {{ if eq $domain $domainOverride }}
+        {{- range $identyProviderOverride }}
+          {{- tmpl.Exec "OVERRIDE_IDENTITY_PROVIDER_TEMPLATE" . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 
   {{ if getenv "DEBUG" | strings.ToLower | regexp.Match "on|1|true|yes" }}
     error_log /dev/stdout notice;

--- a/src/app/core/guards/identity-provider-logout.guard.ts
+++ b/src/app/core/guards/identity-provider-logout.guard.ts
@@ -1,32 +1,16 @@
 import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';
 import { isObservable, of } from 'rxjs';
-import { switchMap, take } from 'rxjs/operators';
 
-import { AccountFacade } from 'ish-core/facades/account.facade';
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { RoleToggleService } from 'ish-core/utils/role-toggle/role-toggle.service';
 
 @Injectable({ providedIn: 'root' })
 export class IdentityProviderLogoutGuard implements CanActivate {
-  constructor(
-    private identityProviderFactory: IdentityProviderFactory,
-    private roleToggleService: RoleToggleService,
-    private accountFacade: AccountFacade
-  ) {}
+  constructor(private identityProviderFactory: IdentityProviderFactory) {}
 
   canActivate() {
-    return this.roleToggleService.hasRole(['APP_B2B_CXML_USER', 'APP_B2B_OCI_USER']).pipe(
-      take(1),
-      switchMap(isPunchout => {
-        if (isPunchout) {
-          this.accountFacade.logoutUser();
-          return of(false);
-        }
-        const logoutReturn$ = this.identityProviderFactory.getInstance().triggerLogout();
-        return isObservable(logoutReturn$) || isPromise(logoutReturn$) ? logoutReturn$ : of(logoutReturn$);
-      })
-    );
+    const logoutReturn$ = this.identityProviderFactory.getInstance().triggerLogout();
+    return isObservable(logoutReturn$) || isPromise(logoutReturn$) ? logoutReturn$ : of(logoutReturn$);
   }
 }
 

--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -5,6 +5,8 @@ import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { NgModuleWithProviders } from 'ng-mocks';
 import { noop } from 'rxjs';
 
+import { PunchoutIdentityProviderModule } from '../extensions/punchout/identity-provider/punchout-identity-provider.module';
+
 import { Auth0IdentityProvider } from './identity-provider/auth0.identity-provider';
 import { ICMIdentityProvider } from './identity-provider/icm.identity-provider';
 import { IDENTITY_PROVIDER_IMPLEMENTOR, IdentityProviderFactory } from './identity-provider/identity-provider.factory';
@@ -21,7 +23,7 @@ export function storageFactory(platformId: string): OAuthStorage {
 }
 
 @NgModule({
-  imports: [OAuthModule.forRoot({ resourceServer: { sendAccessToken: false } })],
+  imports: [OAuthModule.forRoot({ resourceServer: { sendAccessToken: false } }), PunchoutIdentityProviderModule],
   providers: [
     { provide: OAuthStorage, useFactory: storageFactory, deps: [PLATFORM_ID] },
     {

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -4,15 +4,21 @@ import { Store, select } from '@ngrx/store';
 import { noop } from 'rxjs';
 import { first } from 'rxjs/operators';
 
+import { FeatureToggleService } from 'ish-core/feature-toggle.module';
 import { getIdentityProvider } from 'ish-core/store/core/configuration';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 import { IdentityProvider } from './identity-provider.interface';
 
-export const IDENTITY_PROVIDER_IMPLEMENTOR = new InjectionToken<{
+interface IdentityProviderImplementor {
   type: string;
   implementor: Type<IdentityProvider<unknown>>;
-}>('identityProviderImplementor');
+  feature?: string;
+}
+
+export const IDENTITY_PROVIDER_IMPLEMENTOR = new InjectionToken<IdentityProviderImplementor>(
+  'identityProviderImplementor'
+);
 
 @Injectable({ providedIn: 'root' })
 export class IdentityProviderFactory {
@@ -22,11 +28,17 @@ export class IdentityProviderFactory {
     type?: string;
   };
 
-  constructor(private store: Store, private injector: Injector, @Inject(PLATFORM_ID) platformId: string) {
+  constructor(
+    private store: Store,
+    private injector: Injector,
+    private featureToggleService: FeatureToggleService,
+    @Inject(PLATFORM_ID) platformId: string
+  ) {
     if (isPlatformBrowser(platformId)) {
       this.store.pipe(select(getIdentityProvider), whenTruthy(), first()).subscribe(config => {
         const provider = this.injector
-          .get<{ type: string; implementor: Type<IdentityProvider<unknown>> }[]>(IDENTITY_PROVIDER_IMPLEMENTOR, [])
+          .get<IdentityProviderImplementor[]>(IDENTITY_PROVIDER_IMPLEMENTOR, [])
+          .filter(p => (p.feature ? this.featureToggleService.enabled(p.feature) : true))
           .find(p => p.type === config?.type);
 
         if (!provider) {

--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -113,6 +113,22 @@ describe('Basket Effects', () => {
 
       expect(effects.loadBasket$).toBeObservable(expected$);
     });
+
+    describe('with basket-id in session storage', () => {
+      beforeEach(() => {
+        window.sessionStorage.clear();
+      });
+
+      it('should map to action of type LoadBasketWithId', () => {
+        window.sessionStorage.setItem('basket-id', 'BID');
+        const action = loadBasket();
+        const completion = loadBasketWithId({ basketId: 'BID' });
+        actions$ = hot('-a-a-a', { a: action });
+        const expected$ = cold('-c-c-c', { c: completion });
+
+        expect(effects.loadBasket$).toBeObservable(expected$);
+      });
+    });
   });
 
   describe('loadBasketWithId$', () => {

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
@@ -63,7 +64,8 @@ export class BasketEffects {
     private basketService: BasketService,
     private apiTokenService: ApiTokenService,
     private router: Router,
-    private store: Store
+    private store: Store,
+    @Inject(PLATFORM_ID) private platformId: string
   ) {}
 
   /**
@@ -73,10 +75,12 @@ export class BasketEffects {
     this.actions$.pipe(
       ofType(loadBasket),
       mergeMap(() =>
-        this.basketService.getBasket().pipe(
-          map(basket => loadBasketSuccess({ basket })),
-          mapErrorToAction(loadBasketFail)
-        )
+        isPlatformBrowser(this.platformId) && window.sessionStorage.getItem('basket-id')
+          ? of(loadBasketWithId({ basketId: window.sessionStorage.getItem('basket-id') }))
+          : this.basketService.getBasket().pipe(
+              map(basket => loadBasketSuccess({ basket })),
+              mapErrorToAction(loadBasketFail)
+            )
       )
     )
   );

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.module.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+
+import { IDENTITY_PROVIDER_IMPLEMENTOR } from 'ish-core/identity-provider/identity-provider.factory';
+
+import { PunchoutIdentityProvider } from './punchout-identity-provider';
+
+@NgModule({
+  providers: [
+    {
+      provide: IDENTITY_PROVIDER_IMPLEMENTOR,
+      multi: true,
+      useValue: {
+        type: 'PUNCHOUT',
+        implementor: PunchoutIdentityProvider,
+        feature: 'punchout',
+      },
+    },
+  ],
+})
+export class PunchoutIdentityProviderModule {}

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.spec.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.spec.ts
@@ -1,0 +1,356 @@
+import { Component } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Params, Router, UrlTree, convertToParamMap } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { EMPTY, Observable, Subject, noop, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+import { anyString, anything, capture, instance, mock, resetCalls, spy, verify, when } from 'ts-mockito';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { ApiService } from 'ish-core/services/api/api.service';
+import { selectQueryParam } from 'ish-core/store/core/router';
+import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
+import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
+import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
+
+import { PunchoutSession } from '../models/punchout-session/punchout-session.model';
+import { PunchoutService } from '../services/punchout/punchout.service';
+
+import { PunchoutIdentityProvider } from './punchout-identity-provider';
+
+@Component({ template: 'dummy' })
+class DummyComponent {}
+
+type ApiTokenCookieType = 'user' | 'basket' | 'order';
+
+function getSnapshot(queryParams: Params): ActivatedRouteSnapshot {
+  return {
+    queryParamMap: convertToParamMap(queryParams),
+  } as ActivatedRouteSnapshot;
+}
+
+describe('Punchout Identity Provider', () => {
+  const punchoutService = mock(PunchoutService);
+  const apiService = mock(ApiService);
+  const apiTokenService = mock(ApiTokenService);
+  const appFacade = mock(AppFacade);
+  const accountFacade = mock(AccountFacade);
+  const checkoutFacade = mock(CheckoutFacade);
+  const cookiesService = mock(CookiesService);
+
+  let punchoutIdentityProvider: PunchoutIdentityProvider;
+  let store$: MockStore;
+  let storeSpy$: MockStore;
+  let router: Router;
+  let cookieVanishes$: Subject<ApiTokenCookieType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [DummyComponent],
+      imports: [
+        RouterTestingModule.withRoutes([
+          { path: 'home', component: DummyComponent },
+          { path: 'logout', component: DummyComponent },
+          { path: 'error', component: DummyComponent },
+        ]),
+      ],
+      providers: [
+        { provide: ApiService, useFactory: () => instance(apiService) },
+        { provide: ApiTokenService, useFactory: () => instance(apiTokenService) },
+        { provide: PunchoutService, useFactory: () => instance(punchoutService) },
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
+        { provide: AccountFacade, useFactory: () => instance(accountFacade) },
+        { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
+        { provide: CookiesService, useFactory: () => instance(cookiesService) },
+        provideMockStore(),
+      ],
+    }).compileComponents();
+
+    punchoutIdentityProvider = TestBed.inject(PunchoutIdentityProvider);
+    router = TestBed.inject(Router);
+    store$ = TestBed.inject(MockStore);
+    storeSpy$ = spy(store$);
+  });
+
+  beforeEach(() => {
+    cookieVanishes$ = new Subject<ApiTokenCookieType>();
+    when(apiTokenService.restore$(anything())).thenReturn(of(true));
+    when(checkoutFacade.basket$).thenReturn(EMPTY);
+    when(apiTokenService.cookieVanishes$).thenReturn(cookieVanishes$);
+
+    resetCalls(apiService);
+    resetCalls(apiTokenService);
+    resetCalls(punchoutService);
+    resetCalls(appFacade);
+    resetCalls(accountFacade);
+    resetCalls(checkoutFacade);
+    resetCalls(cookiesService);
+
+    window.sessionStorage.clear();
+  });
+
+  describe('init', () => {
+    it('should restore apiToken on startup', () => {
+      punchoutIdentityProvider.init();
+      verify(apiTokenService.restore$(anything())).once();
+      verify(apiTokenService.removeApiToken()).never();
+    });
+
+    it('should add basket-id to session storage, when basket is available', () => {
+      when(checkoutFacade.basket$).thenReturn(of(BasketMockData.getBasket()));
+      punchoutIdentityProvider.init();
+      expect(window.sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
+    });
+  });
+
+  describe('triggerLogout', () => {
+    beforeEach(() => {
+      when(checkoutFacade.basket$).thenReturn(of(BasketMockData.getBasket()));
+      store$.overrideSelector(selectQueryParam(anything()), undefined);
+      punchoutIdentityProvider.init();
+    });
+
+    it('should remove api token and basket-id on logout', () => {
+      expect(window.sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
+
+      punchoutIdentityProvider.triggerLogout();
+
+      expect(window.sessionStorage.getItem('basket-id')).toBeNull();
+      expect(capture(storeSpy$.dispatch).first()).toMatchInlineSnapshot(`[User] Logout User`);
+      verify(apiTokenService.removeApiToken()).once();
+    });
+
+    it('should return to home page per default on subscribe', done => {
+      const routerSpy = spy(router);
+
+      const logoutTrigger$ = punchoutIdentityProvider.triggerLogout() as Observable<UrlTree>;
+
+      logoutTrigger$.subscribe(() => {
+        verify(routerSpy.parseUrl('/home')).once();
+        done();
+      });
+    });
+  });
+  describe('triggerLogin', () => {
+    let routerSpy: Router;
+    let queryParams = {};
+
+    beforeEach(() => {
+      routerSpy = spy(router);
+      punchoutIdentityProvider.init();
+      when(accountFacade.userError$).thenReturn(EMPTY);
+      when(accountFacade.isLoggedIn$).thenReturn(EMPTY);
+    });
+
+    it('should throw an business error without query params on login', () => {
+      const result$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams));
+
+      verify(appFacade.setBusinessError('punchout.error.missing.parameters')).once();
+      expect(result$).toBeFalsy();
+    });
+
+    describe('with access-token', () => {
+      const accessToken = 'login-access-token';
+
+      beforeEach(() => {
+        queryParams = { sid: 'sid', 'access-token': accessToken };
+      });
+
+      it('should trigger loginUserWithToken method on login', () => {
+        punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams));
+        verify(accountFacade.loginUserWithToken(accessToken)).once();
+      });
+    });
+
+    describe('with username and password', () => {
+      const username = 'username';
+      const password = 'password';
+
+      beforeEach(() => {
+        queryParams = { HOOK_URL: 'url', USERNAME: username, PASSWORD: password };
+      });
+
+      it('should trigger loginUser method on login', () => {
+        punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams));
+        verify(accountFacade.loginUser(anything())).once();
+      });
+    });
+    describe('race', () => {
+      describe('isLoggedIn$ emits first', () => {
+        beforeEach(() => {
+          // userError$ first
+          when(accountFacade.userError$).thenReturn(EMPTY.pipe(delay(Infinity)));
+          when(accountFacade.isLoggedIn$).thenReturn(of(true));
+        });
+
+        describe('with cxmlPunchoutUser', () => {
+          beforeEach(() => {
+            queryParams = { sid: 'sid', 'access-token': 'accessToken' };
+
+            when(punchoutService.getCxmlPunchoutSession(anything())).thenReturn(
+              of({ returnURL: 'home', basketId: 'basket-id' } as PunchoutSession)
+            );
+          });
+
+          it('should set cookies, load basket basket and return to homepage', fakeAsync(() => {
+            const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+              boolean | UrlTree
+            >;
+            login$.subscribe(() => {
+              verify(cookiesService.put('punchout_SID', 'sid', anything())).once();
+              verify(cookiesService.put('punchout_ReturnURL', 'home', anything())).once();
+              verify(cookiesService.put('punchout_BasketID', 'basket-id', anything())).once();
+            });
+
+            tick(500);
+            verify(checkoutFacade.loadBasketWithId('basket-id')).once();
+            verify(routerSpy.parseUrl('/home')).once();
+          }));
+        });
+
+        describe('with oci punchout user', () => {
+          beforeEach(() => {
+            queryParams = { HOOK_URL: 'url', USERNAME: 'username', PASSWORD: 'password' };
+          });
+
+          it('should set cookie and create basket on login', done => {
+            const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+              boolean | UrlTree
+            >;
+            login$.subscribe(() => {
+              verify(cookiesService.put('punchout_HookURL', 'url', anything())).once();
+              verify(checkoutFacade.createBasket()).once();
+              verify(routerSpy.parseUrl('/home')).once();
+              done();
+            });
+          });
+
+          it('should reload basket when basket is saved in session storage', done => {
+            window.sessionStorage.setItem('basket-id', 'basket-id');
+            const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+              boolean | UrlTree
+            >;
+            login$.subscribe(() => {
+              verify(checkoutFacade.loadBasketWithId('basket-id')).once();
+              done();
+            });
+          });
+
+          describe('requests product details', () => {
+            const productId = 'product-123';
+            beforeEach(() => {
+              queryParams = { ...queryParams, FUNCTION: 'DETAIL', PRODUCTID: productId };
+            });
+
+            it('should route to product details page', done => {
+              const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+                boolean | UrlTree
+              >;
+              login$.subscribe(() => {
+                verify(routerSpy.parseUrl(`/product/${productId}`)).once();
+                done();
+              });
+            });
+          });
+
+          describe('requests validation of product', () => {
+            const productId = 'product-123';
+            beforeEach(() => {
+              queryParams = { ...queryParams, FUNCTION: 'VALIDATE', PRODUCTID: productId };
+              when(punchoutService.getOciPunchoutProductData(anyString(), anyString())).thenReturn(of([]));
+            });
+
+            it('should get product data and submit data to oci punchout system', done => {
+              const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+                boolean | UrlTree
+              >;
+              login$.subscribe(() => {
+                verify(punchoutService.getOciPunchoutProductData(productId, '1')).once();
+                verify(punchoutService.submitOciPunchoutData(anything())).once();
+                done();
+              });
+            });
+
+            it('should set quantity of requested punchout product data when value is available', done => {
+              queryParams = { ...queryParams, QUANTITY: '42' };
+              const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+                boolean | UrlTree
+              >;
+              login$.subscribe(() => {
+                verify(punchoutService.getOciPunchoutProductData(productId, '42')).once();
+                verify(punchoutService.submitOciPunchoutData(anything())).once();
+                done();
+              });
+            });
+          });
+
+          describe('requests background requests', () => {
+            const search = 'product-123';
+            beforeEach(() => {
+              queryParams = { ...queryParams, FUNCTION: 'BACKGROUND_SEARCH', SEARCHSTRING: search };
+              when(punchoutService.getOciPunchoutSearchData(anyString())).thenReturn(of([]));
+            });
+
+            it('should get punchout product data from search and create form without submit', done => {
+              const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+                boolean | UrlTree
+              >;
+              login$.subscribe(() => {
+                verify(punchoutService.getOciPunchoutSearchData(search)).once();
+                verify(punchoutService.submitOciPunchoutData(anything(), false)).once();
+                done();
+              });
+            });
+          });
+        });
+
+        describe('throws error after successful authentication', () => {
+          const error = {
+            message: 'cXML punchout session error',
+          } as Error;
+
+          beforeEach(() => {
+            queryParams = { sid: 'sid', 'access-token': 'accessToken' };
+            when(punchoutService.getCxmlPunchoutSession(anyString())).thenThrow(error);
+            when(accountFacade.userLoading$).thenReturn(of(false));
+          });
+
+          it('should logout user, remove api token and route to error page', fakeAsync(() => {
+            const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+              boolean | UrlTree
+            >;
+            login$.subscribe(noop);
+            tick(0);
+            verify(accountFacade.logoutUser()).once();
+            verify(apiTokenService.removeApiToken()).once();
+            verify(appFacade.setBusinessError(error.toString()));
+            verify(routerSpy.parseUrl('/error')).once();
+          }));
+        });
+      });
+
+      describe('userError$ emits first', () => {
+        beforeEach(() => {
+          when(accountFacade.userError$).thenReturn(of(makeHttpError({ message: 'userError' })));
+          when(accountFacade.isLoggedIn$).thenReturn(EMPTY.pipe(delay(Infinity)));
+          queryParams = { sid: 'sid', 'access-token': 'accessToken' };
+        });
+
+        it('should set business error and return to error page', done => {
+          const login$ = punchoutIdentityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<
+            boolean | UrlTree
+          >;
+          login$.subscribe(() => {
+            verify(appFacade.setBusinessError(anything())).once();
+            verify(routerSpy.parseUrl('/error')).once();
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
@@ -1,0 +1,204 @@
+import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { Store, select } from '@ngrx/store';
+import { Observable, noop, of, race, throwError } from 'rxjs';
+import { catchError, concatMap, delay, first, map, mapTo, switchMap, take, tap } from 'rxjs/operators';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { IdentityProvider, TriggerReturnType } from 'ish-core/identity-provider/identity-provider.interface';
+import { selectQueryParam } from 'ish-core/store/core/router';
+import { logoutUser } from 'ish-core/store/customer/user';
+import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
+import { whenTruthy } from 'ish-core/utils/operators';
+
+import { PunchoutService } from '../services/punchout/punchout.service';
+
+@Injectable({ providedIn: 'root' })
+export class PunchoutIdentityProvider implements IdentityProvider {
+  constructor(
+    protected router: Router,
+    protected store: Store,
+    protected apiTokenService: ApiTokenService,
+    private appFacade: AppFacade,
+    private accountFacade: AccountFacade,
+    private punchoutService: PunchoutService,
+    private cookiesService: CookiesService,
+    private checkoutFacade: CheckoutFacade
+  ) {}
+
+  getCapabilities() {
+    return {
+      editPassword: true,
+      editEmail: true,
+      editProfile: true,
+    };
+  }
+
+  init() {
+    this.apiTokenService.restore$(['user', 'order']).subscribe(noop);
+    this.apiTokenService.cookieVanishes$.subscribe(type => {
+      if (type === 'user') {
+        this.store.dispatch(logoutUser());
+      }
+    });
+
+    this.checkoutFacade.basket$.pipe(whenTruthy(), first()).subscribe(basketView => {
+      window.sessionStorage.setItem('basket-id', basketView.id);
+    });
+  }
+
+  triggerLogin(route: ActivatedRouteSnapshot): TriggerReturnType {
+    // check for required start parameters before doing anything with the punchout route
+    // 'sid', 'access-token' (cXML) or 'HOOK_URL', 'USERNAME', 'PASSWORD' (OCI)
+    if (
+      !(
+        (route.queryParamMap.has('sid') && route.queryParamMap.has('access-token')) ||
+        (route.queryParamMap.has('HOOK_URL') &&
+          route.queryParamMap.has('USERNAME') &&
+          route.queryParamMap.has('PASSWORD'))
+      )
+    ) {
+      this.appFacade.setBusinessError('punchout.error.missing.parameters');
+      return false;
+    }
+
+    // initiate the punchout user login with the access-token (cXML) or the given credentials (OCI)
+    if (route.queryParamMap.has('access-token')) {
+      this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
+    } else {
+      this.accountFacade.loginUser({
+        login: route.queryParamMap.get('USERNAME'),
+        password: route.queryParamMap.get('PASSWORD'),
+      });
+    }
+    return race(
+      // throw an error if a user login error occurs
+      this.accountFacade.userError$.pipe(
+        whenTruthy(),
+        take(1),
+        // tslint:disable-next-line: no-unnecessary-callback-wrapper
+        concatMap(userError => throwError(userError))
+      ),
+
+      // handle the punchout functions once the punchout user is logged in
+      this.accountFacade.isLoggedIn$.pipe(
+        whenTruthy(),
+        take(1),
+        switchMap(() => {
+          // handle cXML punchout with sid
+          if (route.queryParamMap.get('sid')) {
+            // fetch sid session information (basketId, returnURL, operation, ...)
+            return this.punchoutService.getCxmlPunchoutSession(route.queryParamMap.get('sid')).pipe(
+              // persist cXML session information (sid, returnURL, basketId) in cookies for later basket transfer
+              tap(data => {
+                this.cookiesService.put('punchout_SID', route.queryParamMap.get('sid'), {
+                  sameSite: 'None',
+                  secure: true,
+                });
+                this.cookiesService.put('punchout_ReturnURL', data.returnURL, {
+                  sameSite: 'None',
+                  secure: true,
+                });
+                this.cookiesService.put('punchout_BasketID', data.basketId, {
+                  sameSite: 'None',
+                  secure: true,
+                });
+              }),
+              // use the basketId basket for the current PWA session (instead of default current basket)
+              // TODO: if load basket error (currently no error page) -> logout and do not use default 'current' basket
+              // TODO: if loadBasketWithId is faster then the initial loading of the 'current' basket after login the wrong 'current' basket might be used (the additional delay is the current work around)
+              delay(500),
+              tap(data => this.checkoutFacade.loadBasketWithId(data.basketId)),
+              mapTo(this.router.parseUrl('/home'))
+            );
+
+            // handle OCI punchout with HOOK_URL
+          } else if (route.queryParamMap.get('HOOK_URL')) {
+            // save HOOK_URL to cookie for later basket transfer
+            this.cookiesService.put('punchout_HookURL', route.queryParamMap.get('HOOK_URL'), {
+              sameSite: 'None',
+              secure: true,
+            });
+
+            const basketId = window.sessionStorage.getItem('basket-id');
+            if (!basketId) {
+              // create a new basket for every punchout session to avoid basket conflicts for concurrent punchout sessions
+              this.checkoutFacade.createBasket();
+            } else {
+              this.checkoutFacade.loadBasketWithId(basketId);
+            }
+
+            // Product Details
+            if (route.queryParamMap.get('FUNCTION') === 'DETAIL' && route.queryParamMap.get('PRODUCTID')) {
+              return of(this.router.parseUrl(`/product/${route.queryParamMap.get('PRODUCTID')}`));
+
+              // Validation of Products
+            } else if (route.queryParamMap.get('FUNCTION') === 'VALIDATE' && route.queryParamMap.get('PRODUCTID')) {
+              return this.punchoutService
+                .getOciPunchoutProductData(
+                  route.queryParamMap.get('PRODUCTID'),
+                  route.queryParamMap.get('QUANTITY') || '1'
+                )
+                .pipe(
+                  tap(data => this.punchoutService.submitOciPunchoutData(data)),
+                  mapTo(false)
+                );
+
+              // Background Search
+            } else if (
+              route.queryParamMap.get('FUNCTION') === 'BACKGROUND_SEARCH' &&
+              route.queryParamMap.get('SEARCHSTRING')
+            ) {
+              return this.punchoutService.getOciPunchoutSearchData(route.queryParamMap.get('SEARCHSTRING')).pipe(
+                tap(data => this.punchoutService.submitOciPunchoutData(data, false)),
+                mapTo(false)
+              );
+
+              // Login
+            } else {
+              return of(this.router.parseUrl('/home'));
+            }
+          }
+        }),
+        // punchout error after successful authentication (needs to logout)
+        catchError(error =>
+          this.accountFacade.userLoading$.pipe(
+            first(loading => !loading),
+            delay(0),
+            switchMap(() => {
+              this.accountFacade.logoutUser();
+              this.apiTokenService.removeApiToken();
+              this.appFacade.setBusinessError(error);
+              return of(this.router.parseUrl('/error'));
+            })
+          )
+        )
+      )
+    ).pipe(
+      // general punchout error handling (parameter missing, authentication error)
+      catchError(error => {
+        this.appFacade.setBusinessError(error);
+        return of(this.router.parseUrl('/error'));
+      })
+    );
+  }
+
+  triggerLogout(): TriggerReturnType {
+    window.sessionStorage.removeItem('basket-id');
+    this.store.dispatch(logoutUser());
+    this.apiTokenService.removeApiToken();
+    return this.store.pipe(
+      select(selectQueryParam('returnUrl')),
+      map(returnUrl => returnUrl || '/home'),
+      map(returnUrl => this.router.parseUrl(returnUrl))
+    );
+  }
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return this.apiTokenService.intercept(req, next);
+  }
+}

--- a/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
+++ b/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
@@ -1,168 +1,17 @@
 import { isPlatformServer } from '@angular/common';
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
-import { of, race, throwError } from 'rxjs';
-import { catchError, concatMap, delay, first, mapTo, switchMap, take, tap } from 'rxjs/operators';
-
-import { AccountFacade } from 'ish-core/facades/account.facade';
-import { AppFacade } from 'ish-core/facades/app.facade';
-import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
-import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
-import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
-import { whenTruthy } from 'ish-core/utils/operators';
-
-import { PunchoutService } from '../../services/punchout/punchout.service';
 
 @Injectable()
 export class PunchoutPageGuard implements CanActivate {
-  constructor(
-    private router: Router,
-    private appFacade: AppFacade,
-    private accountFacade: AccountFacade,
-    private checkoutFacade: CheckoutFacade,
-    private apiTokenService: ApiTokenService,
-    private cookiesService: CookiesService,
-    private punchoutService: PunchoutService,
-    private identityProvider: IdentityProviderFactory,
-    @Inject(PLATFORM_ID) private platformId: string
-  ) {}
+  constructor(private router: Router, @Inject(PLATFORM_ID) private platformId: string) {}
 
   canActivate(route: ActivatedRouteSnapshot) {
-    // check for required start parameters before doing anything with the punchout route
-    // 'sid', 'access-token' (cXML) or 'HOOK_URL', 'USERNAME', 'PASSWORD' (OCI)
-    if (
-      !(
-        (route.queryParamMap.has('sid') && route.queryParamMap.has('access-token')) ||
-        (route.queryParamMap.has('HOOK_URL') &&
-          route.queryParamMap.has('USERNAME') &&
-          route.queryParamMap.has('PASSWORD'))
-      )
-    ) {
-      this.appFacade.setBusinessError('punchout.error.missing.parameters');
-      return false;
-    }
-
     // prevent any punchout handling on the server and instead show loading
     if (isPlatformServer(this.platformId)) {
       return this.router.parseUrl('/loading');
     }
 
-    this.identityProvider.getInstance().triggerLogout();
-    // initiate the punchout user login with the access-token (cXML) or the given credentials (OCI)
-    if (route.queryParamMap.has('access-token')) {
-      this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
-    } else {
-      this.accountFacade.loginUser({
-        login: route.queryParamMap.get('USERNAME'),
-        password: route.queryParamMap.get('PASSWORD'),
-      });
-    }
-
-    return race(
-      // throw an error if a user login error occurs
-      this.accountFacade.userError$.pipe(
-        whenTruthy(),
-        take(1),
-        // tslint:disable-next-line: no-unnecessary-callback-wrapper
-        concatMap(userError => throwError(userError))
-      ),
-
-      // handle the punchout functions once the punchout user is logged in
-      this.accountFacade.isLoggedIn$.pipe(
-        whenTruthy(),
-        take(1),
-        switchMap(() => {
-          // handle cXML punchout with sid
-          if (route.queryParamMap.get('sid')) {
-            // fetch sid session information (basketId, returnURL, operation, ...)
-            return this.punchoutService.getCxmlPunchoutSession(route.queryParamMap.get('sid')).pipe(
-              // persist cXML session information (sid, returnURL, basketId) in cookies for later basket transfer
-              tap(data => {
-                this.cookiesService.put('punchout_SID', route.queryParamMap.get('sid'), {
-                  sameSite: 'None',
-                  secure: true,
-                });
-                this.cookiesService.put('punchout_ReturnURL', data.returnURL, {
-                  sameSite: 'None',
-                  secure: true,
-                });
-                this.cookiesService.put('punchout_BasketID', data.basketId, {
-                  sameSite: 'None',
-                  secure: true,
-                });
-              }),
-              // use the basketId basket for the current PWA session (instead of default current basket)
-              // TODO: if load basket error (currently no error page) -> logout and do not use default 'current' basket
-              // TODO: if loadBasketWithId is faster then the initial loading of the 'current' basket after login the wrong 'current' basket might be used (the additional delay is the current work around)
-              delay(500),
-              tap(data => this.checkoutFacade.loadBasketWithId(data.basketId)),
-              mapTo(this.router.parseUrl('/home'))
-            );
-
-            // handle OCI punchout with HOOK_URL
-          } else if (route.queryParamMap.get('HOOK_URL')) {
-            // save HOOK_URL to cookie for later basket transfer
-            this.cookiesService.put('punchout_HookURL', route.queryParamMap.get('HOOK_URL'), {
-              sameSite: 'None',
-              secure: true,
-            });
-
-            // create a new basket for every punchout session to avoid basket conflicts for concurrent punchout sessions
-            this.checkoutFacade.createBasket();
-
-            // Product Details
-            if (route.queryParamMap.get('FUNCTION') === 'DETAIL' && route.queryParamMap.get('PRODUCTID')) {
-              return of(this.router.parseUrl(`/product/${route.queryParamMap.get('PRODUCTID')}`));
-
-              // Validation of Products
-            } else if (route.queryParamMap.get('FUNCTION') === 'VALIDATE' && route.queryParamMap.get('PRODUCTID')) {
-              return this.punchoutService
-                .getOciPunchoutProductData(
-                  route.queryParamMap.get('PRODUCTID'),
-                  route.queryParamMap.get('QUANTITY') || '1'
-                )
-                .pipe(
-                  tap(data => this.punchoutService.submitOciPunchoutData(data)),
-                  mapTo(false)
-                );
-
-              // Background Search
-            } else if (
-              route.queryParamMap.get('FUNCTION') === 'BACKGROUND_SEARCH' &&
-              route.queryParamMap.get('SEARCHSTRING')
-            ) {
-              return this.punchoutService.getOciPunchoutSearchData(route.queryParamMap.get('SEARCHSTRING')).pipe(
-                tap(data => this.punchoutService.submitOciPunchoutData(data, false)),
-                mapTo(false)
-              );
-
-              // Login
-            } else {
-              return of(this.router.parseUrl('/home'));
-            }
-          }
-        }),
-        // punchout error after successful authentication (needs to logout)
-        catchError(error =>
-          this.accountFacade.userLoading$.pipe(
-            first(loading => !loading),
-            delay(0),
-            switchMap(() => {
-              this.accountFacade.logoutUser();
-              this.apiTokenService.removeApiToken();
-              this.appFacade.setBusinessError(error);
-              return of(this.router.parseUrl('/error'));
-            })
-          )
-        )
-      )
-    ).pipe(
-      // general punchout error handling (parameter missing, authentication error)
-      catchError(error => {
-        this.appFacade.setBusinessError(error);
-        return of(this.router.parseUrl('/error'));
-      })
-    );
+    return this.router.createUrlTree(['/login'], { queryParams: route.queryParams });
   }
 }

--- a/src/app/extensions/punchout/store/punchout-functions/punchout-functions.effects.ts
+++ b/src/app/extensions/punchout/store/punchout-functions/punchout-functions.effects.ts
@@ -28,6 +28,15 @@ export class PunchoutFunctionsEffects {
     )
   );
 
+  removeBasketFromSessionsStorageAfterSuccessfulTransfer$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(transferPunchoutBasketSuccess),
+        map(() => window.sessionStorage.removeItem('basket-id'))
+      ),
+    { dispatch: false }
+  );
+
   displayPunchoutErrorMessage$ = createEffect(() =>
     this.actions$.pipe(
       ofType(transferPunchoutBasketFail),

--- a/tslint.json
+++ b/tslint.json
@@ -615,7 +615,7 @@
           "^.*/src/app/shared/formly/(components|wrappers|types|extensions|utils|dev)/.*$",
           "^.*/src/app/pages/<name>/formly/.*$",
           // identity providers
-          "^.*/src/app/core/identity-provider/.*$",
+          "^.*(/src/app/core|/src/app/extensions/<name>)/identity-provider/.*$",
           // aggregation modules
           "^.*/src/app/(shell|shared)/\\1\\.module(<theme>)?\\.ts$",
           "^.*/src/app/extensions/(<name>)/\\1\\.module(<theme>)?\\.ts$",
@@ -729,6 +729,10 @@
           {
             "name": "^([A-Z].*)ComponentModule$",
             "file": ".*/<kebab>\\.component(<theme>)?\\.ts$"
+          },
+          {
+            "name": "^([A-Z].*)IdentityProviderModule$",
+            "file": ".*/(<kebab>|identity-provider)/<kebab>-identity-provider\\.module(<theme>)?\\.ts$"
           },
           {
             "name": "^(.*)Module$",


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

OCI Punchout Sessions gets lost after Reload.

Issue Number: Closes #

## What Is the New Behavior?

OCI Punchout Sessions is available after Reload. Therefore is the punchout guard refactored to a new identity provider, which saves the actual basketId to the session storage. Furthermore it is possible to override the actual identity provider on specific routes. 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#70891](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70891)