### PR TITLE
fix: make ICM sitemap files available via nginx

### DIFF
--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -155,6 +155,7 @@ blocklist
 safelisting
 walkthrough
 mergeable
+gclid
 
 foo
 foos

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -72,6 +72,27 @@ Be aware that the supplied list of parameters must be declared under a `params` 
 
 If no environment variables for ignoring parameters are given, the configuration will fall back to the content of [`nginx/caching-ignore-params.yaml`](../../nginx/caching-ignore-params.yaml), which can also be customized.
 
+### Access ICM sitemap
+
+Please refer to [this](https://support.intershop.com/kb/index.php/Display/23D962#ConceptXMLSitemaps-XMLSitemapsandIntershopPWAxml_sitemap_pwa) Intershop knowledge base article on how to configure ICM to generate PWA sitemap files.
+
+```
+http://pwa/sitemap_pwa.xml
+```
+
+To make above sitemap index file available under your deployment you need to add environment variable `ICM_BASE_URL` in your nginx container.
+Let `ICM_BASE_URL` point to your ICM backend installation, e.g. `https://pwa-ish-demo.test.intershop.com`.
+When the container is started it'll process cache-ignore and multi-channel templates as well as sitemap proxy rules like this:
+
+```yaml
+location /sitemap_ {
+proxy_pass https://pwa-ish-demo.test.intershop.com/INTERSHOP/static/WFS/inSPIRED-inTRONICS-Site/rest/inSPIRED-inTRONICS/en_US/sitemaps/pwa/sitemap_;
+}
+```
+
+The process will utilize your [Multi-Site Configuration](../guides/multi-site-configurations.md#Syntax).
+Be sure to include `application` if you deviate from standard `rest` application.
+
 ### Other
 
 The page speed configuration can also be overridden:

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -5,6 +5,8 @@ set -e
 
 [ -z "$UPSTREAM_PWA" ] && echo "UPSTREAM_PWA is not set" && exit 1
 
+[ -z "$ICM_BASE_URL" ] && echo "ICM_BASE_URL is not set. Cannot use sitemap proxy feature."
+
 [ -f "/etc/nginx/conf.d/default.conf" ] && rm /etc/nginx/conf.d/default.conf
 
 if [ -n "$BASIC_AUTH" ]

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -146,6 +146,11 @@ server {
   {{- end -}}
   {{- end }}
 
+{{- if (getenv "ICM_BASE_URL") }}
+    # we have the ICM_BASE_URL so we can include sitemap locations
+    #
+    include /etc/nginx/conf.d/sitemap.conf;
+{{- end }}
     # redirect server error pages to the static page /50x.html
     #
     error_page 500 502 503 504 /50x.html;

--- a/nginx/templates/sitemap.conf.tmpl
+++ b/nginx/templates/sitemap.conf.tmpl
@@ -1,0 +1,26 @@
+{{ define "LOCATION_TEMPLATE_SITEMAP" }}
+        {{- $channel := .channel }}
+        {{- $application := "rest" }}{{ if (has . "application") }}{{ $application = .application }}{{ end }}
+        {{- $lang := "en_US" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
+       proxy_pass {{ getenv "ICM_BASE_URL" }}/INTERSHOP/static/WFS/{{ $channel }}/{{ $application }}/{{ $channel | strings.ReplaceAll "-Site" "" }}/{{ $lang }}/sitemaps/pwa/sitemap_;
+{{- end }}
+{{- range $domain, $mapping := (ds "domains") }}
+{{ if (has $mapping "channel") }}
+    location /sitemap_ {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_SITEMAP" $mapping }}
+    }
+  {{- else -}}
+    {{ range $mapping }}
+    location {{ .baseHref }}{{if not ( .baseHref | strings.HasSuffix "/")}}/{{end}}sitemap_ {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_SITEMAP" . }}
+    }
+{{ end }}
+  {{- if (has ($mapping | jsonpath "$..baseHref") "/") }}
+  {{- else }}
+    {{ $first := index $mapping 0 -}}
+    location /sitemap_ {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_SITEMAP" $first }}
+    }
+  {{- end -}}
+{{- end }}
+{{ end }}


### PR DESCRIPTION
## PR Type
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

It is not easy to access PWA sitemaps generated in Intershop Commerce Management within your PWA deployment

## What Is the New Behavior?

Make sitemap files available using `INTERSHOP/static` url theme. Together with nginx proxy capabilites it is easy to include this in your PWA deployment.

**Please note:** This solution only works if ICM places the resulting sitemap into the necessary folder.
This: `server/share/sites/inSPIRED-inTRONICS-Site/units/inSPIRED-inTRONICS/syndication/sitemaps/pwa/sitemap_pwa.xml`
VS that: `server/share/sites/inSPIRED-inTRONICS-Site/1/units/inSPIRED-inTRONICS/static/en_US/sitemaps/pwa/sitemap_pwa.xml`
Changes on ICM to fulfill that are done currently. I document the versions when available.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information
If you are reading this information in the nginx standard out logging:
```
ICM_BASE_URL is not set. Cannot use sitemap proxy feature.
```
it means that the prerequisite of this fix is not met. Please refer to `docs/guides/nginx-startup.md`

[AB#70908](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70908)