### PR TITLE
fix: use newest Bootstrap release 4.6.1 with own divide() function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5952,9 +5952,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "angular-oauth2-oidc": "^12.1.0",
     "angular2-uuid": "^1.1.1",
     "angulartics2": "^10.0.0",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^4.6.1",
     "core-js": "^3.18.3",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.2",

--- a/src/styles/components/header/language-switch.scss
+++ b/src/styles/components/header/language-switch.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 .language-switch {
   margin-left: ($space-default * 2);
   font-family: $font-family-bold;
@@ -32,7 +30,7 @@
 
     .language-switch-container {
       z-index: 9999;
-      padding: math.div($space-default * 2, 3) $space-default;
+      padding: divide($space-default * 2, 3) $space-default;
       background: $color-inverse;
       box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.2);
 

--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -1,7 +1,5 @@
 /*********** SEARCH CONTAINER **********/
 
-@use 'sass:math';
-
 .search-container {
   position: relative;
 
@@ -182,7 +180,7 @@
 
     .btn-search {
       @include media-breakpoint-down(md) {
-        right: math.div($space-default * 2, 3);
+        right: divide($space-default * 2, 3);
         margin-right: 0;
       }
     }

--- a/src/styles/components/header/user-information-mobile.scss
+++ b/src/styles/components/header/user-information-mobile.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 .user-info-box {
   padding-bottom: 10px;
   //overflow: hidden;
@@ -28,7 +26,7 @@
     padding-bottom: 0;
 
     ul {
-      padding: math.div($space-default * 2, 3);
+      padding: divide($space-default * 2, 3);
       margin-bottom: 0;
 
       li a {

--- a/src/styles/global/buttons.scss
+++ b/src/styles/global/buttons.scss
@@ -1,8 +1,6 @@
 //
 // BUTTONS
 
-@use 'sass:math';
-
 .btn {
   font-family: $font-family-bold;
   text-transform: uppercase;
@@ -56,10 +54,10 @@
 // multiple buttons margin handling (use "button-group" in case the buttons are not direct siblings)
 .button-group .btn,
 .btn:not(:only-child) {
-  margin-bottom: math.div($space-default, 3);
+  margin-bottom: divide($space-default, 3);
 
   &:not(.float-right) {
-    margin-right: math.div($space-default, 3);
+    margin-right: divide($space-default, 3);
 
     @media (max-width: $screen-xs-max) {
       margin-right: 0;
@@ -67,7 +65,7 @@
   }
 
   &.float-right {
-    margin-left: math.div($space-default, 3);
+    margin-left: divide($space-default, 3);
 
     @media (max-width: $screen-xs-max) {
       margin-left: 0;

--- a/src/styles/global/forms/forms.scss
+++ b/src/styles/global/forms/forms.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 .form-check {
   height: auto;
   padding-bottom: 0;
@@ -9,7 +7,7 @@
 
 .has-feedback {
   .form-control[type='number'] {
-    padding: $grid-gutter-width * 0.2 math.div($grid-gutter-width, 2.5);
+    padding: $grid-gutter-width * 0.2 divide($grid-gutter-width, 2.5);
   }
 
   .form-control[type='number'] + * .form-control-feedback {
@@ -129,7 +127,7 @@ input.form-check-input {
         .icon-checked {
           position: absolute;
           right: 15px;
-          padding-top: math.div($space-default, 6);
+          padding-top: divide($space-default, 6);
         }
       }
     }

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -1,8 +1,6 @@
 //
 // LAYOUT
 // contains layout and presentation classes for the global page structure (header, footer, global navigation, ...)
-@use 'sass:math';
-
 .main-container {
   background: $color-inverse;
 }
@@ -43,7 +41,7 @@ h4,
 .h4 h5,
 .h5 h6,
 .h6 {
-  margin-top: math.div($space-default * 2, 3);
+  margin-top: divide($space-default * 2, 3);
   margin-bottom: $space-default;
   font-family: $font-family-regular;
 }
@@ -155,7 +153,7 @@ img {
 
 // Help Text
 .form-text {
-  margin: math.div($space-default, 3) 0 $space-default * 0.5;
+  margin: divide($space-default, 3) 0 $space-default * 0.5;
   color: $text-color-quarternary;
 }
 

--- a/src/styles/global/icons.scss
+++ b/src/styles/global/icons.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 .ng-fa-icon {
   line-height: 1;
 }
@@ -10,7 +8,7 @@
   }
 
   & ~ .btn-tool {
-    margin-left: math.div($space-default * 2, 3);
+    margin-left: divide($space-default * 2, 3);
   }
 }
 
@@ -26,7 +24,7 @@
 
       & ~ .btn-tool {
         margin-top: 7.5px;
-        margin-left: math.div($space-default * 2, 3);
+        margin-left: divide($space-default * 2, 3);
       }
     }
   }

--- a/src/styles/global/panel.scss
+++ b/src/styles/global/panel.scss
@@ -1,8 +1,6 @@
 //
 // PANEL
 // TODO: reimplement as cards? https://getbootstrap.com/docs/4.0/migration/#components
-@use 'sass:math';
-
 .panel {
   margin-bottom: ($space-default * 2);
   background-color: $color-inverse;
@@ -167,7 +165,7 @@
       padding: 0;
 
       h4 {
-        padding: math.div($grid-gutter-width, 3) $grid-gutter-width * 0.5;
+        padding: divide($grid-gutter-width, 3) $grid-gutter-width * 0.5;
       }
 
       a {

--- a/src/styles/global/share-tools.scss
+++ b/src/styles/global/share-tools.scss
@@ -1,8 +1,6 @@
 //
 // SHARE TOOLS
 
-@use 'sass:math';
-
 .share-tools {
   display: flex;
   justify-content: flex-end;
@@ -13,7 +11,7 @@
   > li {
     max-width: 50px;
     height: 27px;
-    padding: 0 math.div($space-default * 2, 3);
+    padding: 0 divide($space-default * 2, 3);
     margin: 0;
     overflow: hidden;
     font-size: 18px;

--- a/src/styles/global/tables.scss
+++ b/src/styles/global/tables.scss
@@ -1,6 +1,4 @@
 // SPECIFIC TABLE MIXINS
-@use 'sass:math';
-
 @mixin list-header-mixin() {
   border-top: 0;
   border-bottom: 1px solid $border-color-default;
@@ -287,7 +285,7 @@
 table.mobile-optimized,
 table.mobile-optimized.table-lg {
   @include media-breakpoint-only(xs) {
-    margin-bottom: math.div($space-default, 3);
+    margin-bottom: divide($space-default, 3);
 
     thead {
       display: none;
@@ -296,7 +294,7 @@ table.mobile-optimized.table-lg {
     tr {
       float: left;
       width: 100%;
-      padding-bottom: math.div($space-default * 2, 3);
+      padding-bottom: divide($space-default * 2, 3);
       margin-bottom: $space-default;
       border-bottom: 1px solid $border-color-lighter;
 
@@ -306,7 +304,7 @@ table.mobile-optimized.table-lg {
         float: left;
         width: 100%;
         padding: 0;
-        margin-bottom: math.div($space-default, 3);
+        margin-bottom: divide($space-default, 3);
         clear: both;
         border: none;
 

--- a/src/styles/pages/account/account-navigation.scss
+++ b/src/styles/pages/account/account-navigation.scss
@@ -1,11 +1,9 @@
 //
 // ACCOUNT NAVIGATION
 
-@use 'sass:math';
-
 .account-navigation {
   li {
-    padding: math.div($space-default * 2, 3) math.div($space-default * 2, 3) ($space-default * 0.5);
+    padding: divide($space-default * 2, 3) divide($space-default * 2, 3) ($space-default * 0.5);
     background: $color-tertiary;
     border: $border-width-default solid $border-color-lighter;
     border-width: 0 1px 1px 1px;

--- a/src/styles/pages/category/filter-panel.scss
+++ b/src/styles/pages/category/filter-panel.scss
@@ -2,8 +2,6 @@
 
 /* FILTER PANEL */
 
-@use 'sass:math';
-
 .category-panel h3 {
   text-transform: uppercase;
 }
@@ -103,13 +101,13 @@
           display: inline-block;
           width: 15px;
           height: 15px;
-          margin-right: math.div($space-default, 3);
+          margin-right: divide($space-default, 3);
           background-color: $color-tertiary;
           border: 1px solid $border-color-light;
         }
 
         &.filter-count {
-          margin-left: math.div($space-default, 3);
+          margin-left: divide($space-default, 3);
         }
       }
     }
@@ -139,7 +137,7 @@
           display: inline-block;
           width: 15px;
           height: 15px;
-          margin-right: math.div($space-default, 3);
+          margin-right: divide($space-default, 3);
           background-color: $color-corporate;
           border: 1px solid $border-color-default;
         }

--- a/src/styles/pages/category/filter-row.scss
+++ b/src/styles/pages/category/filter-row.scss
@@ -1,10 +1,8 @@
 /**************** CATEGORY FILTER ROW ******************/
 
-@use 'sass:math';
-
 .filters-row {
   z-index: 99999;
-  padding: math.div($space-default * 2, 3) 0;
+  padding: divide($space-default * 2, 3) 0;
   margin: $space-default 0;
   background-color: $color-tertiary;
 
@@ -65,7 +63,7 @@
 
     label {
       float: right;
-      margin-right: math.div($space-default * 2, 3);
+      margin-right: divide($space-default * 2, 3);
       margin-bottom: 0;
       font-weight: normal;
       line-height: $input-height;
@@ -116,7 +114,7 @@
     white-space: nowrap;
 
     .form-control-feedback {
-      padding-left: math.div($space-default, 6);
+      padding-left: divide($space-default, 6);
       font-size: $font-size-base * 0.8;
       color: $text-color-corporate;
     }

--- a/src/styles/pages/category/product-list.scss
+++ b/src/styles/pages/category/product-list.scss
@@ -1,8 +1,6 @@
 //
 // PRODUCT LIST
 
-@use 'sass:math';
-
 .product-list {
   position: relative;
   padding: 0;
@@ -30,7 +28,7 @@
         }
 
         .form-group {
-          margin-bottom: math.div($space-default, 3);
+          margin-bottom: divide($space-default, 3);
 
           label {
             padding-bottom: 0;
@@ -332,12 +330,12 @@
 .product-variation {
   &.read-only {
     label {
-      padding-right: math.div($space-default, 3);
+      padding-right: divide($space-default, 3);
       margin-bottom: 0;
     }
 
     &:last-of-type {
-      margin-bottom: math.div($space-default * 2, 3);
+      margin-bottom: divide($space-default * 2, 3);
     }
   }
 }

--- a/src/styles/pages/checkout/shopping-cart.scss
+++ b/src/styles/pages/checkout/shopping-cart.scss
@@ -1,7 +1,5 @@
 /************* SHOPPING CART LAYOUT ***************/
 
-@use 'sass:math';
-
 .cart-header {
   .share-tools {
     margin-top: $space-default;
@@ -251,13 +249,13 @@
 
 .pli-description {
   ul {
-    padding-left: math.div($space-default, 3) * 4;
+    padding-left: divide($space-default, 3) * 4;
     list-style-position: outside;
   }
 
   .btn-tool {
     display: inline-block;
-    padding: 0 math.div($space-default, 3);
+    padding: 0 divide($space-default, 3);
     margin-top: ($space-default);
     margin-bottom: 0;
 
@@ -270,7 +268,7 @@
     dt {
       float: left;
       width: auto;
-      padding-right: math.div($space-default, 6);
+      padding-right: divide($space-default, 6);
     }
 
     dd {

--- a/src/styles/pages/content-pages/page-content.scss
+++ b/src/styles/pages/content-pages/page-content.scss
@@ -1,7 +1,3 @@
-//
-
-@use 'sass:math';
-
 .content-page {
   padding: $space-default 0 $space-default 0;
 }
@@ -72,7 +68,7 @@ ol {
 
     li {
       padding-top: 0;
-      padding-bottom: math.div($space-default, 3);
+      padding-bottom: divide($space-default, 3);
       font-family: $font-family-regular;
       font-size: $font-size-lg;
       text-decoration: none;

--- a/src/styles/pages/homepage/homepage.scss
+++ b/src/styles/pages/homepage/homepage.scss
@@ -1,8 +1,6 @@
 //
 // HOMEPAGE
 
-@use 'sass:math';
-
 .homepage {
   header {
     margin-bottom: 0;
@@ -58,7 +56,7 @@
   margin-top: $space-default;
 
   p {
-    margin-bottom: math.div($space-default, 3);
+    margin-bottom: divide($space-default, 3);
     font-family: $font-family-condensedbold;
     font-size: $font-size-lg;
     text-transform: uppercase;

--- a/src/styles/pages/productdetail/product-images.scss
+++ b/src/styles/pages/productdetail/product-images.scss
@@ -1,8 +1,6 @@
 //
 // PRODUCT IMAGES
 
-@use 'sass:math';
-
 .product-detail-img {
   .carousel {
     float: left;
@@ -67,7 +65,7 @@
 
 .product-thumb-set {
   float: left;
-  padding: math.div($space-default, 3);
+  padding: divide($space-default, 3);
   margin-bottom: $space-default;
   cursor: pointer;
   border: 1px solid $border-color-lighter;

--- a/src/styles/pages/productdetail/product-info.scss
+++ b/src/styles/pages/productdetail/product-info.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 .product-title {
   font-family: $font-family-condensedbold;
   font-size: 16px;
@@ -16,7 +14,7 @@ a.product-title {
   color: $text-color-quarternary;
 
   label {
-    padding-right: math.div($space-default, 3);
+    padding-right: divide($space-default, 3);
   }
 }
 
@@ -83,7 +81,7 @@ a.product-title {
 
     &.read-only {
       label {
-        padding-right: math.div($space-default, 3);
+        padding-right: divide($space-default, 3);
       }
     }
 
@@ -95,7 +93,7 @@ a.product-title {
 
   .product-variation {
     .form-group {
-      margin-bottom: math.div($space-default, 3);
+      margin-bottom: divide($space-default, 3);
 
       label {
         padding-top: 0;
@@ -192,11 +190,11 @@ a.product-title {
 }
 
 .product-end-of-live-status {
-  padding-bottom: math.div($space-default, 3);
+  padding-bottom: divide($space-default, 3);
 }
 
 .product-lifecycle-status {
-  padding-bottom: math.div($space-default, 3);
+  padding-bottom: divide($space-default, 3);
   color: $text-color-special;
 
   span {

--- a/src/styles/pages/productdetail/productdetail.scss
+++ b/src/styles/pages/productdetail/productdetail.scss
@@ -1,8 +1,6 @@
 //
 // PRODUCT DETAILS
 
-@use 'sass:math';
-
 .product-page {
   padding: $space-default 0 $space-default 0;
 }
@@ -46,7 +44,7 @@
   margin-bottom: ($space-default * 3);
 
   @media (max-width: $screen-sm-max) {
-    margin-top: math.div($space-default, 3);
+    margin-top: divide($space-default, 3);
     margin-bottom: ($space-default);
   }
 
@@ -83,7 +81,7 @@
   margin: $space-default 0;
 
   .panel-heading {
-    padding: math.div($space-default, 3) 0;
+    padding: divide($space-default, 3) 0;
 
     a {
       color: $text-color-quarternary;
@@ -124,7 +122,7 @@
   }
 
   .product-warranty-list {
-    margin-top: math.div($space-default, 3);
+    margin-top: divide($space-default, 3);
   }
 }
 


### PR DESCRIPTION
* remove `@use 'sass:math';` and replace `math.div();`
* cleanup after temporary changes from #751

closes: #759

BREAKING CHANGE: We no longer use `@use 'sass:math';` and `math.div();` in our `.scss` files but instead switched to the new Bootstrap default way using `divide()`. This is more a note to check your styling customizations for possible adaptions. Both ways should still work together and adaptions are not required.

## PR Type

[x] Bugfix

## Other Information


[AB#70931](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/70931)