### PR TITLE
feat: allow translations to be loaded from an external source

### DIFF
--- a/docs/concepts/localization.md
+++ b/docs/concepts/localization.md
@@ -260,6 +260,12 @@ This has to fit to your PWA environment.
 This allows to enable easy filtering.
 The prefixes will be removed when the translations are loaded into the PWA.
 
+## External Localization Sources
+
+The Intershop PWA can be configured to use an external source for loading translations in JSON format.
+This configuration can be done via environment variables `TRANSLATE_LOADER_URL` and `TRANSLATE_LOADER_FORMAT` or via Angular CLI environment files with properties `translateLoaderUrl` and `translateLoaderFormat`.
+Please refer to the documentation in [`environment.model.ts`](../../src/environments/environment.model.ts) for format replacement options.
+
 ## Localization File Clean Up Process
 
 Localization files require constant maintenance to keep them up to date.

--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -44,30 +44,32 @@ If the format is _switch_, the property is switched on by supplying `on`, `1`, `
 All parameters are **case sensitive**.
 Make sure to use them as written in the table below.
 
-|                     | parameter             | format               | comment                                                                                      |
-| ------------------- | --------------------- | -------------------- | -------------------------------------------------------------------------------------------- |
-| **SSR Specific**    | PORT                  | number               | Port for running the application                                                             |
-|                     | SSL                   | any                  | Enables SSL/TLS                                                                              |
-|                     | CONCURRENCY_SSR       | number \| max        | concurrency for SSR instances per theme (default: 2)                                         |
-|                     | CACHE_ICM_CALLS       | recommended \| JSON  | enable caching for ICM calls, see [Local ICM Cache](#local-icm-cache) (default: disabled)    |
-| **General**         | ICM_BASE_URL          | string               | Sets the base URL for the ICM                                                                |
-|                     | ICM_CHANNEL           | string               | Overrides the default channel                                                                |
-|                     | ICM_APPLICATION       | string               | Overrides the default application                                                            |
-|                     | FEATURES              | comma-separated list | Overrides active features                                                                    |
-|                     | THEME                 | string               | Overrides the default theme                                                                  |
-|                     | MULTI_SITE_LOCALE_MAP | JSON \| false        | Used to map locales to [url modification parameters](../guides/multi-site-configurations.md) |
-|                     | DEPLOY_URL            | string               | Set a [Deploy URL][concept-deploy-url] (default `/`)                                         |
-| **Debug** :warning: | TRUST_ICM             | any                  | Use this if ICM is deployed with an insecure certificate                                     |
-|                     | LOGGING               | switch               | Enables extra log output                                                                     |
-|                     | SOURCE_MAPS           | switch               | Exposes source maps if activated                                                             |
-| **Hybrid Approach** | SSR_HYBRID            | any                  | Enables running PWA and ICM in [Hybrid Mode][concept-hybrid]                                 |
-|                     | PROXY_ICM             | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)                                 |
-| **Third party**     | GTM_TOKEN             | string               | Token for Google Tag Manager                                                                 |
-|                     | GMA_KEY               | string               | API key for Google Maps                                                                      |
-|                     | SENTRY_DSN            | string               | Sentry DSN URL for using Sentry Error Monitor                                                |
-|                     | PROMETHEUS            | switch               | Exposes Prometheus metrics                                                                   |
-|                     | ICM_IDENTITY_PROVIDER | string               | ID of Identity Provider for [SSO][concept-sso]                                               |
-|                     | IDENTITY_PROVIDERS    | JSON                 | Configuration of Identity Providers for [SSO][concept-sso]                                   |
+|                     | parameter               | format               | comment                                                                                      |
+| ------------------- | ----------------------- | -------------------- | -------------------------------------------------------------------------------------------- |
+| **SSR Specific**    | PORT                    | number               | Port for running the application                                                             |
+|                     | SSL                     | any                  | Enables SSL/TLS                                                                              |
+|                     | CONCURRENCY_SSR         | number \| max        | concurrency for SSR instances per theme (default: 2)                                         |
+|                     | CACHE_ICM_CALLS         | recommended \| JSON  | enable caching for ICM calls, see [Local ICM Cache](#local-icm-cache) (default: disabled)    |
+| **General**         | ICM_BASE_URL            | string               | Sets the base URL for the ICM                                                                |
+|                     | ICM_CHANNEL             | string               | Overrides the default channel                                                                |
+|                     | ICM_APPLICATION         | string               | Overrides the default application                                                            |
+|                     | FEATURES                | comma-separated list | Overrides active features                                                                    |
+|                     | THEME                   | string               | Overrides the default theme                                                                  |
+|                     | MULTI_SITE_LOCALE_MAP   | JSON \| false        | Used to map locales to [url modification parameters](../guides/multi-site-configurations.md) |
+|                     | DEPLOY_URL              | string               | Set a [Deploy URL][concept-deploy-url] (default `/`)                                         |
+|                     | TRANSLATE_LOADER_URL    | string               | Set an alternate source for loading translations                                             |
+|                     | TRANSLATE_LOADER_FORMAT | string               | File template for loading translations                                                       |
+| **Debug** :warning: | TRUST_ICM               | any                  | Use this if ICM is deployed with an insecure certificate                                     |
+|                     | LOGGING                 | switch               | Enables extra log output                                                                     |
+|                     | SOURCE_MAPS             | switch               | Exposes source maps if activated                                                             |
+| **Hybrid Approach** | SSR_HYBRID              | any                  | Enables running PWA and ICM in [Hybrid Mode][concept-hybrid]                                 |
+|                     | PROXY_ICM               | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)                                 |
+| **Third party**     | GTM_TOKEN               | string               | Token for Google Tag Manager                                                                 |
+|                     | GMA_KEY                 | string               | API key for Google Maps                                                                      |
+|                     | SENTRY_DSN              | string               | Sentry DSN URL for using Sentry Error Monitor                                                |
+|                     | PROMETHEUS              | switch               | Exposes Prometheus metrics                                                                   |
+|                     | ICM_IDENTITY_PROVIDER   | string               | ID of Identity Provider for [SSO][concept-sso]                                               |
+|                     | IDENTITY_PROVIDERS      | JSON                 | Configuration of Identity Providers for [SSO][concept-sso]                                   |
 
 ## Running with https
 

--- a/src/app/core/configurations/injection-keys.ts
+++ b/src/app/core/configurations/injection-keys.ts
@@ -73,6 +73,14 @@ export const THEME_COLOR = new InjectionToken<string>('themeColor', {
   factory: () => environment.themeColor,
 });
 
+export const TRANSLATE_LOADER_URL = new InjectionToken<string>('translateLoaderUrl', {
+  factory: () => environment.translateLoaderUrl,
+});
+
+export const TRANSLATE_LOADER_FORMAT = new InjectionToken<string>('translateLoaderFormat', {
+  factory: () => environment.translateLoaderFormat,
+});
+
 /*
  * global definition of the Bootstrap grid system breakpoint widths
  */

--- a/src/app/core/internationalization.module.ts
+++ b/src/app/core/internationalization.module.ts
@@ -1,8 +1,9 @@
-import { registerLocaleData } from '@angular/common';
+import { isPlatformServer, registerLocaleData } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 import localeDe from '@angular/common/locales/de';
 import localeFr from '@angular/common/locales/fr';
-import { Inject, LOCALE_ID, NgModule } from '@angular/core';
-import { TransferState } from '@angular/platform-browser';
+import { Inject, LOCALE_ID, NgModule, PLATFORM_ID, isDevMode } from '@angular/core';
+import { TransferState, makeStateKey } from '@angular/platform-browser';
 import {
   MissingTranslationHandler,
   TranslateCompiler,
@@ -11,7 +12,10 @@ import {
   TranslateService,
 } from '@ngx-translate/core';
 
+import { TRANSLATE_LOADER_FORMAT, TRANSLATE_LOADER_URL } from './configurations/injection-keys';
 import { SSR_LOCALE } from './configurations/state-keys';
+import { LocalizationsService } from './services/localizations/localizations.service';
+import { ExternalTranslateLoader } from './utils/translate/external-translate-loader';
 import {
   FALLBACK_LANG,
   FallbackMissingTranslationHandler,
@@ -20,10 +24,55 @@ import { ICMTranslateLoader } from './utils/translate/icm-translate-loader';
 import { PWATranslateCompiler } from './utils/translate/pwa-translate-compiler';
 import { TranslationGenerator } from './utils/translate/translations-generator';
 
+const TRANSLATE_LOADER_URL_SK = makeStateKey<string>('translateLoaderUrl');
+
+const TRANSLATE_LOADER_FORMAT_SK = makeStateKey<string>('translateLoaderFormat');
+
+export function translateLoaderFactory(
+  transferState: TransferState,
+  platformId: string,
+  localizations: LocalizationsService,
+  http: HttpClient,
+  translateLoaderUrl: string,
+  translateLoaderFormat: string
+) {
+  if (isPlatformServer(platformId) || isDevMode()) {
+    const url = (typeof process !== 'undefined' && process.env.TRANSLATE_LOADER_URL) || translateLoaderUrl;
+    if (url) {
+      transferState.set(TRANSLATE_LOADER_URL_SK, url);
+    }
+    const format = (typeof process !== 'undefined' && process.env.TRANSLATE_LOADER_FORMAT) || translateLoaderFormat;
+    if (format) {
+      transferState.set(TRANSLATE_LOADER_FORMAT_SK, format);
+    }
+  }
+
+  if (transferState.hasKey(TRANSLATE_LOADER_URL_SK)) {
+    let url = transferState.get(TRANSLATE_LOADER_URL_SK, '/TRANSLATE_LOADER_URL');
+    let format = transferState.get(TRANSLATE_LOADER_FORMAT_SK, ExternalTranslateLoader.DEFAULT_FORMAT);
+    return new ExternalTranslateLoader(http, url, format);
+  }
+
+  return new ICMTranslateLoader(transferState, platformId, localizations);
+}
+
 @NgModule({
   imports: [
     TranslateModule.forRoot({
-      loader: { provide: TranslateLoader, useClass: ICMTranslateLoader },
+      loader: {
+        provide: TranslateLoader,
+        useFactory: translateLoaderFactory,
+        /* eslint-disable @angular-eslint/sort-ngmodule-metadata-arrays */
+        deps: [
+          TransferState,
+          PLATFORM_ID,
+          LocalizationsService,
+          HttpClient,
+          TRANSLATE_LOADER_URL,
+          TRANSLATE_LOADER_FORMAT,
+        ],
+        /* eslint-enable @angular-eslint/sort-ngmodule-metadata-arrays */
+      },
       missingTranslationHandler: { provide: MissingTranslationHandler, useClass: FallbackMissingTranslationHandler },
       useDefaultLang: false,
       compiler: { provide: TranslateCompiler, useClass: PWATranslateCompiler },

--- a/src/app/core/utils/translate/external-translate-loader.spec.ts
+++ b/src/app/core/utils/translate/external-translate-loader.spec.ts
@@ -1,0 +1,64 @@
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+
+import { ExternalTranslateLoader } from './external-translate-loader';
+
+describe('External Translate Loader', () => {
+  let http: HttpClient;
+  let loader: ExternalTranslateLoader;
+
+  describe('with standard format', () => {
+    beforeEach(() => {
+      http = mock(HttpClient);
+      when(http.get(anything())).thenReturn(of({}));
+
+      loader = new ExternalTranslateLoader(instance(http), 'http://example.com');
+    });
+
+    it('should be created', () => {
+      expect(http).toBeTruthy();
+      expect(loader).toBeTruthy();
+    });
+
+    it.each<string | jest.DoneCallback>(['en_US', 'en-us', 'EN-US'])(
+      'should load translations for %s',
+      (lang: string, done: jest.DoneCallback) => {
+        loader.getTranslation(lang).subscribe(() => {
+          verify(http.get(anything())).once();
+          const [query] = capture(http.get).last();
+          expect(query).toEqual('http://example.com/en_US.json');
+
+          done();
+        });
+      }
+    );
+  });
+
+  describe('with special format', () => {
+    beforeEach(() => {
+      http = mock(HttpClient);
+      when(http.get(anything())).thenReturn(of({}));
+
+      loader = new ExternalTranslateLoader(instance(http), 'http://example.com', '$language-$country-$theme');
+    });
+
+    it('should be created', () => {
+      expect(http).toBeTruthy();
+      expect(loader).toBeTruthy();
+    });
+
+    it.each<string | jest.DoneCallback>(['en_US', 'en-us', 'EN-US'])(
+      'should load translations for %s',
+      (lang: string, done: jest.DoneCallback) => {
+        loader.getTranslation(lang).subscribe(() => {
+          verify(http.get(anything())).once();
+          const [query] = capture(http.get).last();
+          expect(query).toEqual('http://example.com/en-us-default');
+
+          done();
+        });
+      }
+    );
+  });
+});

--- a/src/app/core/utils/translate/external-translate-loader.ts
+++ b/src/app/core/utils/translate/external-translate-loader.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { memoize } from 'lodash-es';
+import { shareReplay } from 'rxjs/operators';
+
+export class ExternalTranslateLoader extends TranslateHttpLoader {
+  static DEFAULT_FORMAT = '$language_$COUNTRY.json';
+
+  constructor(http: HttpClient, url: string, private format: string = ExternalTranslateLoader.DEFAULT_FORMAT) {
+    super(http, !url.endsWith('/') ? `${url}/` : url, '');
+  }
+
+  private retrieveTranslation = memoize(lang => super.getTranslation(lang).pipe(shareReplay(1)));
+
+  private interpolate = memoize((lang: string) => {
+    const [language, country] = lang.split(/[^a-zA-Z0-9]/g);
+
+    return this.format
+      .replace('$language', language?.toLowerCase())
+      .replace('$LANGUAGE', language?.toUpperCase())
+      .replace('$country', country?.toLowerCase())
+      .replace('$COUNTRY', country?.toUpperCase())
+      .replace('$theme', THEME.toLowerCase())
+      .replace('$THEME', THEME.toUpperCase());
+  });
+
+  getTranslation(lang: string) {
+    return this.retrieveTranslation(this.interpolate(lang));
+  }
+}

--- a/src/app/core/utils/translate/icm-translate-loader.ts
+++ b/src/app/core/utils/translate/icm-translate-loader.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Inject, PLATFORM_ID } from '@angular/core';
 import { TransferState, makeStateKey } from '@angular/platform-browser';
 import { TranslateLoader } from '@ngx-translate/core';
 import { memoize } from 'lodash-es';
@@ -10,7 +10,6 @@ import { LocalizationsService } from 'ish-core/services/localizations/localizati
 
 import { Translations } from './translations.type';
 
-@Injectable()
 export class ICMTranslateLoader implements TranslateLoader {
   constructor(
     private transferState: TransferState,

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -112,6 +112,25 @@ export interface Environment {
       | Auth0Config;
   };
 
+  /**
+   * URL for loading translations from an external resource
+   */
+  translateLoaderUrl?: string;
+
+  /**
+   * format for requesting translations from the external resource
+   * default is `$language_$COUNTRY.json`
+   *
+   * possible replacements in this format:
+   * - `$language`: language code in lower case
+   * - `$LANGUAGE`: language code in upper case
+   * - `$country`: country code in lower case
+   * - `$COUNTRY`: country code in upper case
+   * - `$theme`: theme in lower case
+   * - `$THEME`: theme in upper case
+   */
+  translateLoaderFormat?: string;
+
   // enable and configure data persistence for specific stores (compare, recently, tacton)
   dataRetention: DataRetentionPolicy;
 


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Translation cannot be loaded from an external source.
ICM translation management has some limitations:
- Translations can't be shared between locales of brands (depending on the channel setup)

## What Is the New Behavior?

An external translation source can be defined.

### For testing:

1. start external translation source: `npx http-server src/assets/i18n --cors`
2. set `translateLoaderUrl: 'http://localhost:8080'` in `environment.development.ts`
3. play around with `translateLoaderFormat: '$language_$COUNTRY.json'` in `environment.development.ts`

## Does this PR Introduce a Breaking Change?

[ ] Yes
[ ] No

## Other Information

[AB#71316](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/71316)