### PR TITLE
fix: allow + sign in email addresses

### DIFF
--- a/src/app/shared/forms/validators/special-validators.ts
+++ b/src/app/shared/forms/validators/special-validators.ts
@@ -57,7 +57,7 @@ export class SpecialValidators {
      * - no IPs allowed for login emails
      * - only some special characters allowed
      */
-    return /^([\w\-\~]+\.)*[\w\-\~]+@(([\w][\w\-]*)?[\w]\.)+[a-zA-Z]{2,}$/.test(control.value)
+    return /^([\w\-\~\+]+\.)*[\w\-\~\+]+@(([\w][\w\-]*)?[\w]\.)+[a-zA-Z]{2,}$/.test(control.value)
       ? undefined
       : { email: { valid: false } };
   }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?
Currently, email addresses like `diverdori+6@<randomemailaddressprovider>.com` are not supported.
`+` is a common sign in email.

## What Is the New Behavior?
With this fix email addresses like `diverdori+6@<randomemailaddressprovider>.com` are supported.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#71504](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/71504)