### PR TITLE
fix: display a default promotionname if promotionmessaging disabled

### DIFF
--- a/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
+++ b/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
@@ -9,7 +9,6 @@
       <ng-container *ngFor="let rebate of totals.valueRebates">
         <dt *ngIf="rebate?.promotionId" class="col-6">
           <ish-basket-promotion [rebate]="rebate"></ish-basket-promotion>
-          <ng-template #default>{{ 'checkout.widget.promotion.discount' | translate }}</ng-template>
         </dt>
         <dd class="col-6">{{ invert(rebate.amount) | ishPrice }}</dd>
       </ng-container>
@@ -27,7 +26,6 @@
       <ng-container *ngFor="let rebate of totals.shippingRebates">
         <dt class="col-6">
           <ish-basket-promotion [rebate]="rebate"></ish-basket-promotion>
-          <ng-template #default>{{ 'checkout.widget.promotion.discount' | translate }}</ng-template>
         </dt>
         <dd class="col-6">{{ invert(rebate.amount) | ishPrice }}</dd>
       </ng-container>

--- a/src/app/shared/components/basket/basket-promotion/basket-promotion.component.html
+++ b/src/app/shared/components/basket/basket-promotion/basket-promotion.component.html
@@ -1,9 +1,10 @@
-<ng-container *ngIf="promotion$ | async as promotion"
-  ><div *ngIf="promotion && !promotion.disableMessages">
+<ng-container *ngIf="promotion$ | async as promotion">
+  <ng-container *ngIf="promotion && !promotion.disableMessages; else fallback">
     <div class="promotion-title" [ishServerHtml]="promotion.title"></div>
     <div class="promotion-details-and-remove-links">
       <ish-promotion-details [promotion]="promotion"></ish-promotion-details>
       <ish-promotion-remove [code]="rebate.code"></ish-promotion-remove>
     </div>
-  </div>
+  </ng-container>
+  <ng-template #fallback>{{ 'checkout.widget.promotion.discount' | translate }}</ng-template>
 </ng-container>

--- a/src/app/shared/components/basket/basket-promotion/basket-promotion.component.spec.ts
+++ b/src/app/shared/components/basket/basket-promotion/basket-promotion.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
@@ -26,6 +27,7 @@ describe('Basket Promotion Component', () => {
     when(appFacade.icmBaseUrl).thenReturn('example.org');
 
     await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
       declarations: [
         BasketPromotionComponent,
         MockComponent(PromotionDetailsComponent),
@@ -65,12 +67,10 @@ describe('Basket Promotion Component', () => {
     fixture.detectChanges();
 
     expect(element).toMatchInlineSnapshot(`
-      <div>
         <div class="promotion-title" ng-reflect-ish-server-html="MyPromotionTitle"></div>
         <div class="promotion-details-and-remove-links">
           <ish-promotion-details></ish-promotion-details><ish-promotion-remove></ish-promotion-remove>
         </div>
-      </div>
     `);
   });
 
@@ -89,6 +89,6 @@ describe('Basket Promotion Component', () => {
     component.ngOnChanges();
     fixture.detectChanges();
 
-    expect(element).toMatchInlineSnapshot(`N/A`);
+    expect(element).toMatchInlineSnapshot(`checkout.widget.promotion.discount`);
   });
 });


### PR DESCRIPTION
## PR Type

[x] Bugfix


## What Is the Current Behavior?

In the order/basket cost summary there is no default text, if a promotion discount has been applied and promotion messages are disabled. A user only sees that the price was reduced but might be confused why. 


## What Is the New Behavior?

Now, a localizable default value is displayed.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#71599](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/71599)