### PR TITLE
fix: remove wrongly used component CSS class from 'img' tag

### DIFF
--- a/src/app/shared/cms/components/cms-image-enhanced/cms-image-enhanced.component.html
+++ b/src/app/shared/cms/components/cms-image-enhanced/cms-image-enhanced.component.html
@@ -36,7 +36,6 @@
       <img
         [src]="pagelet.stringParam('Image')"
         [attr.alt]="pagelet.stringParam('AlternateText')"
-        [ngClass]="pagelet.stringParam('CSSClass')"
         class="enhanced-image"
       />
     </picture>


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

`CMSImageEnhancedComponent` applies the pagelet configuration paramter `CSS Class` to the component `div` and the `img` tag. This duplication is not intended and can lead to unexpected styling effects.

## What Is the New Behavior?

The `CSS Class` configuration parameter is only applied to the component `div`.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

[AB#71848](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/71848)