### PR TITLE
fix: Query parameters are duplicated during multi-site nginx rewrite

### DIFF
--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -185,7 +185,7 @@ server {
         auth_basic off;
         {{ $first := index $mapping 0 -}}
         rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" permanent;
-        rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri" permanent;
+        rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri?" permanent;
     }
     location ^~ /sitemap_ {
         {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $first }}


### PR DESCRIPTION
## PR Type

[x] Bugfix


## What Is the Current Behavior?

Query parameters are duplicated at rewrite.

Issue Number: Closes #929

## What Is the New Behavior?

Query parameters are not duplicated at rewrite.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information

solution: http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite


[AB#71880](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/71880)