### PR TITLE
Scrolling to error message

### DIFF
--- a/src/app/core/directives.module.ts
+++ b/src/app/core/directives.module.ts
@@ -5,6 +5,7 @@ import { IdentityProviderCapabilityDirective } from './directives/identity-provi
 import { IntersectionObserverDirective } from './directives/intersection-observer.directive';
 import { ProductContextAccessDirective } from './directives/product-context-access.directive';
 import { ProductContextDirective } from './directives/product-context.directive';
+import { ScrollDirective } from './directives/scroll.directive';
 import { ServerHtmlDirective } from './directives/server-html.directive';
 
 @NgModule({
@@ -14,6 +15,7 @@ import { ServerHtmlDirective } from './directives/server-html.directive';
     IntersectionObserverDirective,
     ProductContextAccessDirective,
     ProductContextDirective,
+    ScrollDirective,
     ServerHtmlDirective,
   ],
   exports: [
@@ -22,6 +24,7 @@ import { ServerHtmlDirective } from './directives/server-html.directive';
     IntersectionObserverDirective,
     ProductContextAccessDirective,
     ProductContextDirective,
+    ScrollDirective,
     ServerHtmlDirective,
   ],
 })

--- a/src/app/core/directives/scroll.directive.ts
+++ b/src/app/core/directives/scroll.directive.ts
@@ -1,0 +1,120 @@
+import { Directive, ElementRef, Input, OnChanges } from '@angular/core';
+
+/**
+ * Structural directive.
+ * Used on an element, the elements parent will scroll to it, when the given value is true
+ *
+ * @example
+ * <div [ishScroll]="true" [scrollDuration]="500">
+ *   Parent will scroll smoothly to this element within 500 milliseconds
+ * </div>
+ * or
+ * <div [ishScroll]="true">
+ *   Parent will scroll to this element instantly
+ * </div>
+ * or
+ * <div [ishScroll]="false">
+ *   Parent will not scroll to this element
+ * </div>
+ */
+@Directive({
+  selector: '[ishScroll]',
+})
+export class ScrollDirective implements OnChanges {
+  constructor(private el: ElementRef) {}
+
+  /**
+   * Wether or not scrolling should happen
+   */
+  @Input() ishScroll: boolean;
+
+  /**
+   * Sets the duration for the scrolling in milliseconds.
+   * If set to 0 scrolling happens instantly.
+   */
+  @Input() scrollDuration = 0;
+
+  /**
+   * Sets the scroll container
+   * This values uses the elements parent node by default.
+   *
+   * @usageNotes
+   * Set it to "root" to use the window, "parent" to use the elements parent (default)
+   * or pass in any HTMLElement that is a parent to the element.
+   */
+  @Input() scrollContainer: 'parent' | 'root' | HTMLElement = 'root';
+
+  /**
+   * Sets spacing above the element in pixel.
+   * If set, scrolling will target given amount of pixel above the element.
+   * Set to 0 by default
+   */
+  @Input() scrollSpacing = 0;
+
+  ngOnChanges() {
+    if (this.ishScroll) {
+      this.scroll();
+    }
+  }
+
+  private scroll() {
+    const target: HTMLElement = this.el.nativeElement;
+    const scrollContainer =
+      this.scrollContainer === 'parent'
+        ? target.parentElement
+        : this.scrollContainer === 'root'
+        ? document.documentElement
+        : this.scrollContainer;
+
+    // calculate the offset from target to scrollContainer
+    let offset = target.offsetTop;
+    let tempTarget = target.offsetParent as HTMLElement;
+    while (!tempTarget.isSameNode(scrollContainer) && !tempTarget.isSameNode(document.body)) {
+      offset += tempTarget.offsetTop;
+      tempTarget = tempTarget.offsetParent as HTMLElement;
+    }
+    offset -= this.scrollSpacing;
+
+    // scroll instantly if no duration is set
+    if (!this.scrollDuration) {
+      scrollContainer.scrollTop = offset;
+      return;
+    }
+
+    // set values for animation
+    let startTime: number;
+    const initialScrollPosition = scrollContainer.scrollTop;
+    const scrollDifference = offset - initialScrollPosition;
+
+    const step = (timestamp: number) => {
+      // set start time at the beginning
+      if (!startTime) {
+        startTime = timestamp;
+      }
+
+      // get time passed
+      const passed = timestamp - startTime;
+
+      // exit animation when duration is reached or calculated difference is smaller than 0.5 pixel
+      if (passed >= this.scrollDuration || Math.abs(scrollContainer.scrollTop - offset) <= 0.5) {
+        scrollContainer.scrollTop = offset;
+        return;
+      }
+
+      // current progress of the animation based on timing
+      const progress = passed / this.scrollDuration;
+
+      // cubic ease-in-out function
+      const ease = (x: number) => (x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2);
+
+      // set new scroll value based on current time progression
+      scrollContainer.scrollTop = initialScrollPosition + scrollDifference * ease(progress);
+
+      // request next animation frame
+      requestAnimationFrame(step);
+    };
+
+    // start animation by requesting animation frame
+    requestAnimationFrame(step);
+  }
+}

--- a/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.html
+++ b/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.html
@@ -1,8 +1,11 @@
 <!-- error messages -->
 <div
-  *ngFor="let message of errorMessages$ | async"
+  *ngFor="let message of errorMessages$ | async; let first = first"
   class="alert alert-danger"
   role="alert"
+  [ishScroll]="first"
+  [scrollDuration]="scrollDuration"
+  [scrollSpacing]="scrollSpacing"
   data-testing-id="validation-error-message"
 >
   {{ message }}
@@ -10,15 +13,25 @@
 
 <!-- info messages -->
 <div
-  *ngFor="let message of infoMessages$ | async"
+  *ngFor="let message of infoMessages$ | async; let first = first"
   class="alert alert-info"
   role="alert"
+  [ishScroll]="first"
+  [scrollDuration]="scrollDuration"
+  [scrollSpacing]="scrollSpacing"
   data-testing-id="validation-info-message"
 >
   {{ message }}
 </div>
 
-<div *ngIf="hasGeneralBasketError$ | async" class="alert alert-danger" data-testing-id="general-validation-message">
+<div
+  *ngIf="hasGeneralBasketError$ | async"
+  class="alert alert-danger"
+  [ishScroll]="true"
+  [scrollDuration]="scrollDuration"
+  [scrollSpacing]="scrollSpacing"
+  data-testing-id="general-validation-message"
+>
   {{ 'basket.validation.general.error' | translate }}
 </div>
 
@@ -28,6 +41,9 @@
     *ngIf="undeliverableItems.length"
     class="alert alert-box"
     role="alert"
+    [ishScroll]="true"
+    [scrollDuration]="scrollDuration"
+    [scrollSpacing]="scrollSpacing"
     data-testing-id="undeliverable-items-message"
   >
     <div class="alert-box-header">
@@ -49,7 +65,14 @@
 
 <!-- removed items messages -->
 <ng-container *ngIf="removedItems$ | async as removedItems">
-  <div *ngIf="removedItems.length" class="alert alert-danger" data-testing-id="validation-removed-message">
+  <div
+    *ngIf="removedItems.length"
+    class="alert alert-danger"
+    [ishScroll]="true"
+    [scrollDuration]="scrollDuration"
+    [scrollSpacing]="scrollSpacing"
+    data-testing-id="validation-removed-message"
+  >
     {{ 'shopping_cart.adjusted_items.warnung' | translate }}
   </div>
   <ish-basket-validation-products [items]="removedItems"></ish-basket-validation-products>

--- a/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.spec.ts
+++ b/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anyString, instance, mock, verify, when } from 'ts-mockito';
 
+import { ScrollDirective } from 'ish-core/directives/scroll.directive';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { BasketValidationResultType } from 'ish-core/models/basket-validation/basket-validation.model';
 import { BasketValidationItemsComponent } from 'ish-shared/components/basket/basket-validation-items/basket-validation-items.component';
@@ -26,6 +27,7 @@ describe('Basket Validation Results Component', () => {
         BasketValidationResultsComponent,
         MockComponent(BasketValidationItemsComponent),
         MockComponent(BasketValidationProductsComponent),
+        MockDirective(ScrollDirective),
       ],
       imports: [TranslateModule.forRoot()],
       providers: [{ provide: CheckoutFacade, useFactory: () => instance(checkoutFacadeMock) }],

--- a/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.ts
+++ b/src/app/shared/components/basket/basket-validation-results/basket-validation-results.component.ts
@@ -31,6 +31,10 @@ export class BasketValidationResultsComponent implements OnInit, OnDestroy {
 
   itemHasBeenRemoved = false;
 
+  // default values to controll scrolling behavior
+  scrollDuration = 500;
+  scrollSpacing = 64;
+
   private destroy$ = new Subject<void>();
 
   constructor(private checkoutFacade: CheckoutFacade) {}


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On checkout error message doesn't get scrolled to
Issue Number: Closes #848 

## What Is the New Behavior?
When the checkout has some errors, the browser will scroll to it

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
Uses Scrolling Directive developed for #911 

[AB#71917](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/71917)