### PR TITLE
fix: add quote to cart in case no cart exists

### DIFF
--- a/src/app/extensions/quoting/services/quoting/quoting.service.spec.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.spec.ts
@@ -156,15 +156,15 @@ describe('Quoting Service', () => {
 
   describe('addQuoteToBasket', () => {
     beforeEach(() => {
-      when(apiService.post(anything(), anything(), anything())).thenReturn(of({}));
+      when(apiService.post(anything(), anything())).thenReturn(of({}));
     });
 
     it('should use basket API for adding quotes to basket', done => {
-      quotingService.addQuoteToBasket('quoteID').subscribe(
+      quotingService.addQuoteToBasket('basketId', 'quoteID').subscribe(
         () => {
-          verify(apiService.post(anything(), anything(), anything())).once();
+          verify(apiService.post(anything(), anything())).once();
           const [path, body] = capture(apiService.post).last();
-          expect(path).toMatchInlineSnapshot(`"baskets/current/items"`);
+          expect(path).toMatchInlineSnapshot(`"baskets/basketId/items"`);
           expect(body).toMatchInlineSnapshot(`
             Object {
               "quoteID": "quoteID",

--- a/src/app/extensions/quoting/services/quoting/quoting.service.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.ts
@@ -6,7 +6,6 @@ import { concatMap, defaultIfEmpty, expand, filter, last, map, mapTo, take } fro
 
 import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
-import { BasketService } from 'ish-core/services/basket/basket.service';
 
 import { QuoteRequestUpdate } from '../../models/quote-request-update/quote-request-update.model';
 import { QuotingHelper } from '../../models/quoting/quoting.helper';
@@ -22,11 +21,7 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class QuotingService {
-  constructor(
-    private apiService: ApiService,
-    private basketService: BasketService,
-    private quoteMapper: QuotingMapper
-  ) {}
+  constructor(private apiService: ApiService, private quoteMapper: QuotingMapper) {}
 
   getQuotes() {
     return forkJoin([
@@ -100,8 +95,9 @@ export class QuotingService {
       .pipe(map(data => this.quoteMapper.fromData(data, 'Quote')));
   }
 
-  addQuoteToBasket(quoteID: string) {
-    return this.basketService.currentBasketEndpoint().post('items', { quoteID }).pipe(mapTo(quoteID));
+  addQuoteToBasket(basketId: string, quoteID: string) {
+    // ToDo: remove parameter basketId and delegate addQuoteToBasket to the basket service if the basket REST api 1.0 provides this functionality, see #70533
+    return this.apiService.post(`baskets/${basketId}/items`, { quoteID }).pipe(mapTo(quoteID));
   }
 
   createQuoteRequestFromQuote(quoteID: string) {

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
@@ -180,7 +180,7 @@ describe('Quoting Effects', () => {
 
   describe('addQuoteToBasket$', () => {
     beforeEach(() => {
-      when(quotingService.addQuoteToBasket(anything())).thenReturn(of(''));
+      when(quotingService.addQuoteToBasket(anything(), anything())).thenReturn(of(''));
     });
 
     describe('with basket', () => {
@@ -192,7 +192,7 @@ describe('Quoting Effects', () => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
         effects.addQuoteToBasket$.subscribe(() => {
-          verify(quotingService.addQuoteToBasket('quoteID')).once();
+          verify(quotingService.addQuoteToBasket('basketID', 'quoteID')).once();
           verify(basketService.createBasket()).never();
           done();
         });
@@ -209,7 +209,7 @@ describe('Quoting Effects', () => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
         effects.addQuoteToBasket$.subscribe(() => {
-          verify(quotingService.addQuoteToBasket('quoteID')).once();
+          verify(quotingService.addQuoteToBasket('basketID', 'quoteID')).once();
           verify(basketService.createBasket()).once();
           done();
         });

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.ts
@@ -115,15 +115,15 @@ export class QuotingEffects {
     this.actions$.pipe(
       ofType(addQuoteToBasket),
       mapToPayloadProperty('id'),
-      concatMap(id =>
+      concatMap(quoteId =>
         this.store.pipe(
           select(getCurrentBasketId),
           first(),
           switchMap(basketId =>
             !basketId ? this.basketService.createBasket().pipe(map(basket => basket.id)) : of(basketId)
           ),
-          concatMap(() => this.quotingService.addQuoteToBasket(id)),
-          mergeMapTo([updateBasket({ update: { calculated: true } }), addQuoteToBasketSuccess({ id })]),
+          concatMap(basketId => this.quotingService.addQuoteToBasket(basketId, quoteId)),
+          mergeMapTo([updateBasket({ update: { calculated: true } }), addQuoteToBasketSuccess({ id: quoteId })]),
           mapErrorToAction(loadQuotingFail)
         )
       )


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user has no cart and he tries to add a quote to cart he gets only a cart-not-found-error message.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #947 

## What Is the New Behavior?
If the user has no cart a new cart will be automatically created before the quote is added to cart.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
