### PR TITLE
refactor: move localization keep patterns where they are needed

### DIFF
--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Find Unused TestBed declarations
         run: |
           npx ts-node scripts/cleanup-testbed
-          git diff --exit-code --raw -p --stat
+          npm run check-no-changes

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -47,16 +47,13 @@ jobs:
           npm i
 
       - name: Code Formatting
-        run: npm run format
-
-      - name: Check No Changes from Formatting
-        run: git diff --exit-code --raw -p --stat
+        run: npx npm-run-all format check-no-changes
 
       - name: .dockerignore Sync
-        run: npm run update-dockerignore
+        run: npx npm-run-all update-dockerignore check-no-changes
 
-      - name: Check No Changes from .dockerignore Sync
-        run: git diff --exit-code --raw -p --stat
+      - name: Clean Localizations
+        run: npx npm-run-all clean-localizations check-no-changes
 
       - name: Compile Angular
         run: npm run build client
@@ -126,7 +123,7 @@ jobs:
       - name: Find Unused TestBed declarations
         run: |
           npx ts-node scripts/cleanup-testbed origin/develop
-          git diff --exit-code --raw -p --stat
+          npm run check-no-changes
 
   Schematics:
     needs: [Quality, Jest]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,10 +35,7 @@ jobs:
         run: node docs/check-documentation-overview
 
       - name: Run Formatting
-        run: npm run format
-
-      - name: Check No Changes
-        run: git diff --exit-code --raw -p --stat
+        run: npx npm-run-all format check-no-changes
 
       - name: Check Dead Links For Changed Files
         if: github.ref != 'refs/heads/develop'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm run check
 
       - name: Check No Changes
-        run: git diff --exit-code --raw -p --stat
+        run: npm run check-no-changes
 
   Local:
     needs: [CancelPrevious]

--- a/docs/concepts/localization.md
+++ b/docs/concepts/localization.md
@@ -262,12 +262,27 @@ Localization keys that are not available in these files - meaning they have no t
 
 Not explicitly used localization keys, such as dynamic created keys or error keys from REST calls, are handled separately.
 Their patterns are searched in all the localization keys of the default localization file and all matches will be included in the new cleaned up file.
-Therefore additional patterns have to be added for additional keys used in this way.
+
+Global patterns can be added to the [`clean-up-localizations` script](../../scripts/clean-up-localizations.js);
 
 ```javascript
-// regular expression for patterns of not explicitly used localization keys (dynamic created keys, error keys from REST calls)
-// ADDITIONAL PATTERNS HAVE TO BE ADDED HERE
-const regEx = /account\.login\..*\.message|.*\.error\..*/i;
+// ADDITIONAL GLOBAL PATTERNS HAVE TO BE ADDED HERE
+const regExps = [/.*\.error.*/i];
+```
+
+Localization patterns can also be defined where they are used.
+Add a comment with the keyword `keep-localization-pattern:` to the code to register a specific pattern for preservation.
+
+Javascript
+
+```javascript
+// keep-localization-pattern: ^account\.costcenter\.budget\.period\.value.*
+```
+
+HTML
+
+```html
+<!-- keep-localization-pattern: ^account\.login\..*\.message$ -->
 ```
 
 The clean up script is integrated in the full check run (`npm run check`) and will also be performed in continuous integration on the whole code base.

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -13,6 +13,9 @@ The recently viewed products functionality was moved into an extension.
 The already existing `recently` feature toggle works as before but the recently viewed component integration changed from `<ish-recently-viewed *ishFeature="'recently'"></ish-recently-viewed>` to `<ish-lazy-recently-viewed></ish-lazy-recently-viewed>`.
 This was already changed for the product detail page and the basket page but needs to be done for any customized usage of the recently viewed component.
 
+The `clean-localizations` functionality was changed so that `keep-localization-pattern` can be defined where they are used and do no longer need to be added directly to the [`clean-up-localizations` script](../../scripts/clean-up-localizations.js).
+It might be useful to move custom patterns according to the changes done for the standard code (for more information see [Localization File Clean Up Process](../concepts/localization.md#localization-file-clean-up-process)).
+
 ## 1.4 to 2.0
 
 Since [TSLint has been deprecated](https://blog.palantir.com/tslint-in-2019-1a144c2317a9) for a while now and Angular removed the TSLint support we had to migrate our project from TSLint to ESLint as well.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "postclean": "npm ci",
     "check": "npm-run-all \"lint -- --fix\" format compile build:multi test dead-code clean-localizations",
     "clean-check": "npm-run-all clean check",
+    "check-no-changes": "git diff --exit-code --raw -p --stat",
     "changelog": "npx -p conventional-changelog-cli conventional-changelog -n intershop-changelog.js -i CHANGELOG.md -s",
     "3rd-party-licenses": "npm ci && npx license-checker --csv --out 3rd-party-licenses.txt --customPath templates/3rd-party-licenses_format.json",
     "3rd-party-licenses:summary": "npx license-checker --summary",

--- a/projects/organization-management/src/app/components/user-budget-form/user-budget-form.component.ts
+++ b/projects/organization-management/src/app/components/user-budget-form/user-budget-form.component.ts
@@ -133,6 +133,7 @@ export class UserBudgetFormComponent implements OnInit, OnDestroy {
                   fieldClass: 'col-12 label-empty',
                   options: this.periods.map(period => ({
                     value: period,
+                    // keep-localization-pattern: ^account\.user\.new\.budget\.period\.value.*
                     label: `account.user.new.budget.period.value.${period}`,
                   })),
                 },

--- a/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.html
+++ b/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.html
@@ -1,5 +1,9 @@
 <h1>{{ 'account.costcenter.details.buyers.heading' | translate }}</h1>
 
+<!--
+    in ICM versions lower than 7.10.38 the cost center admin is not allowed to read the list of users for the customer
+    keep-localization-pattern: ^subject.has.no.permission.assigned$
+  -->
 <ish-error-message [error]="error$ | async"></ish-error-message>
 
 <ng-container *ngIf="buyers$ | async as buyers; else emptyList">

--- a/projects/requisition-management/src/app/store/requisitions/requisitions.effects.ts
+++ b/projects/requisition-management/src/app/store/requisitions/requisitions.effects.ts
@@ -82,6 +82,7 @@ export class RequisitionsEffects {
               from(this.router.navigate([`/account/requisitions/approver`])).pipe(
                 concatMap(() => {
                   let messageAction;
+                  // keep-localization-pattern: ^approval\.order_.*\.text$
                   switch (requisition.approval?.statusCode) {
                     case 'APPROVED':
                     case 'REJECTED':

--- a/scripts/clean-up-localizations.js
+++ b/scripts/clean-up-localizations.js
@@ -6,19 +6,34 @@ const { execSync } = require('child_process');
 const localizationFile_default = 'src/assets/i18n/en_US.json';
 
 // regular expression for patterns of not explicitly used localization keys (dynamic created keys, error keys from REST calls)
-// ADDITIONAL PATTERNS HAVE TO BE ADDED HERE
-const regExps = [
-  /^account\.login\..*\.message/i,
-  /^subject.*/i,
-  /.*budget.period..*/i,
-  /.*\.error.*/i,
-  /^locale\..*/i,
-  /^approval\.order_.*\.text/i,
-];
+// ADDITIONAL GLOBAL PATTERNS HAVE TO BE ADDED HERE
+const regExps = [/.*\.error.*/i];
 
 // store localizations from default localization file in an object
 const localizations_default = JSON.parse(fs.readFileSync(localizationFile_default, 'utf8'));
 console.log('Clean up file', localizationFile_default, 'as default localization file');
+
+// go through directory recursively and find files to be searched
+const filesToBeSearched = glob.sync('{src,projects}/**/!(*.spec).{ts,html}');
+
+console.log('\nKeep-patterns:');
+regExps.forEach(regex => {
+  console.log('global', regex);
+});
+
+// collect annotated patterns to keep
+filesToBeSearched.forEach(filePath => {
+  const fileContent = fs.readFileSync(filePath, { encoding: 'utf-8' });
+  if (fileContent.includes('keep-localization-pattern:')) {
+    const regex = /keep-localization-pattern:(.*)/g;
+    for (let match; (match = regex.exec(fileContent)); ) {
+      keeper = match[1].replace('-->', '').replace('*/', '').trim();
+      const regex = new RegExp(keeper);
+      console.log(filePath, regex);
+      regExps.push(regex);
+    }
+  }
+});
 
 // add not explicitly used localization keys with their localization values
 const localizationsFound = {};
@@ -29,14 +44,11 @@ Object.keys(localizations_default)
     delete localizations_default[localizationKey];
   });
 
-// go through directory recursively and find files to be searched
-const filesToBeSearched = glob.sync('{src,projects}/**/!(*.spec).{ts,html}');
-
 const regex = _.memoize(key => new RegExp(`[^.-]\\b${key.replace(/[.]/g, '\\$&')}\\b[^.-]`));
 
 // add used localization keys with their localization values
 filesToBeSearched.forEach(filePath => {
-  const fileContent = fs.readFileSync(filePath);
+  const fileContent = fs.readFileSync(filePath, { encoding: 'utf-8' });
   for (const localizationKey in localizations_default) {
     if (regex(localizationKey).test(fileContent)) {
       // store found localizations

--- a/src/app/pages/registration/registration-page.component.ts
+++ b/src/app/pages/registration/registration-page.component.ts
@@ -62,6 +62,7 @@ export class RegistrationPageComponent implements OnInit {
       this.submitted = true;
       return;
     }
+    // keep-localization-pattern: ^customer\..*\.error$
     this.registrationFormConfiguration.submitRegistrationForm(this.form, this.registrationConfig, this.model);
   }
 

--- a/src/app/shared/components/login/login-modal/login-modal.component.html
+++ b/src/app/shared/components/login/login-modal/login-modal.component.html
@@ -15,6 +15,7 @@
   <div class="modal-body">
     <div data-testing-id="account-login-page">
       <p *ngIf="loginMessageKey" class="alert alert-info">
+        <!-- keep-localization-pattern: ^account\.login\..*\.message$ -->
         {{ 'account.login.' + loginMessageKey + '.message' | translate }}
       </p>
 

--- a/src/app/shared/forms/utils/forms.service.ts
+++ b/src/app/shared/forms/utils/forms.service.ts
@@ -48,6 +48,7 @@ export class FormsService {
 
     return periods.map(period => ({
       value: period,
+      // keep-localization-pattern: ^account\.costcenter\.budget\.period\.value.*
       label: `account.costcenter.budget.period.value.${period}`,
     }));
   }

--- a/src/app/shell/header/language-switch/language-switch.component.html
+++ b/src/app/shell/header/language-switch/language-switch.component.html
@@ -1,3 +1,4 @@
+<!-- keep-localization-pattern: ^locale\..*\.(long|short)$ -->
 <div
   *ngIf="locale$ | async as locale"
   class="language-switch"


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Localization keep patterns are managed in the cleanup script.

## What Is the New Behavior?

Localization keep patterns are managed where they are defined. (with an annotation)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Hi @SGrueber @suschneider @MaxKless 😃 

I think the `.error.` keep pattern in the `scripts/clean-up-localizations.js` is outdated. I see that all of the error feedback regarding payments comes from the API, there should be no need to keep those translation keys in the PWA (also because we now fetch specific keys directly from the ICM). Regarding anything not payment related? I'm not sure...

Please check if my assumption is correct.

In projects every uselessly translated localization is money 🤑 





[AB#72086](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/72086)