### PR TITLE
fix: support the character sequence 'sku' in product SKUs

### DIFF
--- a/src/app/core/routing/product/product.route.ts
+++ b/src/app/core/routing/product/product.route.ts
@@ -30,7 +30,7 @@ function generateProductSlug(product: ProductView) {
   return slug;
 }
 
-const productRouteFormat = new RegExp('^/(.*)?sku(.*?)(-cat(.*))?$');
+const productRouteFormat = new RegExp('^/(.*-)?sku(.*?)(-cat(.*))?$');
 
 export function matchProductRoute(segments: UrlSegment[]): UrlMatchResult {
   // compatibility to old routes


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The current `product.route` matcher results in an error page if the products SKU contains the character sequence `sku` e.g. `glaskugel_1`.

Example product detail URL:  `http://localhost:4200/Acer/Glaskugel-skuglaskugel_1-catComputers.897.897_Acer`

Results in a wrong REST API call for the product details: `https://pwa-ish-demo.test.intershop.com/INTERSHOP/rest/WFS/inSPIRED-inTRONICS_Business-Site/rest;loc=en_US;cur=USD/products/gel_1?allImages=true`

skugla**sku**_gel_1_

## What Is the New Behavior?

Routes with product SKUs containing the character sequence `sku` work as expected.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No

## Other Information
