### PR TITLE
fix: include healthcheck.js in docker compile scripts

### DIFF
--- a/src/ssr/server-scripts/healthcheck.js
+++ b/src/ssr/server-scripts/healthcheck.js
@@ -21,7 +21,7 @@ const errFunc = function (err) {
   process.exit(1);
 };
 
-let ports = require('./ecosystem-ports').ports;
+let ports = require('./ecosystem-ports.json');
 
 if (process.env.ACTIVE_THEMES) {
   const active = process.env.ACTIVE_THEMES.split(',');


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Issue Number: Closes #968

## What Is the New Behavior?

`healthcheck.js` moved to docker scripts for compilation.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information
