### PR TITLE
fix: lazily resolve translate service in translate compiler

### DIFF
--- a/src/app/core/utils/translate/pwa-translate-compiler.ts
+++ b/src/app/core/utils/translate/pwa-translate-compiler.ts
@@ -54,7 +54,7 @@ export class PWATranslateCompiler implements TranslateCompiler {
   private translate: () => TranslateService;
 
   constructor(injector: Injector) {
-    // set cyclic dependency
+    // cache TranslateService reference to avoid repeated calls to injector
     this.translate = once(() => injector.get(TranslateService));
   }
 


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

`translate` functionality of [`PWATranslateCompiler`](https://github.com/intershop/intershop-pwa/blob/892a1ef31a4442a0bda2a17ac889eaca8ed5e5c4/src/app/core/utils/translate/pwa-translate-compiler.spec.ts#L167) breaks on SSR after the first SSR prerender.

Steps to reproduce:
- add a translation key using the `translate` functionality:
  ```
  "test.translate.key": "Welcome to {{ translate, seo.defaults.description }}",
  ```
- use this key on some page:
  ```html
  {{ 'test.translate.key' | translate }}
  ```
- start SSR: `npm run start`
- trigger an SSR render for that page multiple times

-> it will work properly the first time, but for every subsequent prerender the following errors are displayed in the console:
```
ERROR Error Injector has already been destroyed. at R3Injector.assertNotDestroyed (/home/dh/workspace/intershop-pwa/dist/b2b/server/main.js:1:1357692)
```

## What Is the New Behavior?

- translate service is lazily fetched from the injector once and reused every time.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#72606](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/72606)