### PR TITLE
fix: stringify SSR error if possible

### DIFF
--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -22,8 +22,14 @@ export class UniversalErrorHandler implements ErrorHandler {
       console.error('ERROR', error.message);
     } else if (error instanceof Error) {
       console.error('ERROR', error.name, error.message, error.stack?.split('\n')?.[1]?.trim());
+    } else if (typeof error === 'object') {
+      try {
+        console.error('ERROR', JSON.stringify(error));
+      } catch (_) {
+        console.error('ERROR (cannot stringify)', error);
+      }
     } else {
-      console.error('ERROR', error?.toString());
+      console.error('ERROR', error);
     }
   }
 }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Steps to reproduce:
- start SSR with wrong configuration and logging enabled: (linux) `LOGGING=true ICM_CHANNEL=blubb npm run start`
- trigger render for any SSR page
-> observe log output:
```
ERROR [object Object]
ERROR [object Object]
...
```

## What Is the New Behavior?

Output is stringified using JSON.stringify if possible.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#72609](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/72609)