### PR TITLE
chore: pm2 logging adaptions for Intershop CaaS

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -10,7 +10,7 @@ import { AppServerModule, ICM_WEB_URL, HYBRID_MAPPING_TABLE, environment, APP_BA
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import { getDeployURLFromEnv, setDeployUrlInFile } from './src/ssr/deploy-url';
 
-const PM2 = process.env.pm_id;
+const PM2 = process.env.pm_id && process.env.name ? `${process.env.pm_id} ${process.env.name}` : undefined;
 
 if (PM2) {
   const logOriginal = console.log;

--- a/server.ts
+++ b/server.ts
@@ -10,6 +10,28 @@ import { AppServerModule, ICM_WEB_URL, HYBRID_MAPPING_TABLE, environment, APP_BA
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import { getDeployURLFromEnv, setDeployUrlInFile } from './src/ssr/deploy-url';
 
+const PM2 = process.env.pm_id;
+
+if (PM2) {
+  const logOriginal = console.log;
+
+  console.log = (...args: unknown[]) => {
+    logOriginal(PM2, ...args);
+  };
+
+  const warnOriginal = console.warn;
+
+  console.warn = (...args: unknown[]) => {
+    warnOriginal(PM2, ...args);
+  };
+
+  const errorOriginal = console.error;
+
+  console.error = (...args: unknown[]) => {
+    errorOriginal(PM2, ...args);
+  };
+}
+
 const PORT = process.env.PORT || 4200;
 
 const DEPLOY_URL = getDeployURLFromEnv();
@@ -122,8 +144,14 @@ export function app() {
   server.set('views', BROWSER_FOLDER);
 
   if (logging) {
+    const morgan = require('morgan');
+    // see https://github.com/expressjs/morgan#predefined-formats
+    let logFormat = morgan.tiny;
+    if (PM2) {
+      logFormat = `${PM2} ${logFormat}`;
+    }
     server.use(
-      require('morgan')('tiny', {
+      morgan(logFormat, {
         skip: (req: express.Request) => req.originalUrl.startsWith('/INTERSHOP/static'),
       })
     );

--- a/src/ssr/server-scripts/build-ecosystem.js
+++ b/src/ssr/server-scripts/build-ecosystem.js
@@ -18,7 +18,6 @@ if (Object.keys(ports).length === 1) {
     name: distributor
     instances: ${process.env.CONCURRENCY_DISTRIBUTOR || 'max'}
     exec_mode: cluster
-    time: true
   `;
 }
 
@@ -26,7 +25,6 @@ if (/^(on|1|true|yes)$/i.test(process.env.PROMETHEUS)) {
   content += `
   - script: dist/prometheus.js
     name: prometheus
-    time: true
 `;
 }
 
@@ -36,7 +34,6 @@ Object.entries(ports).forEach(([theme, port]) => {
     name: ${theme}
     instances: ${process.env.CONCURRENCY_SSR || 2}
     exec_mode: cluster
-    time: true
     max_memory_restart: ${process.env.SSR_MAX_MEM || '400M'}
     env:
       BROWSER_FOLDER: dist/${theme}/browser


### PR DESCRIPTION
## PR Type

[x] Other: Logging optimization

## What Is the Current Behavior?

- Log output is prepended with timestamps for stdout but not stderr by pm2. If run in an Intershop CaaS environment, datadog will also provide timestamps
- Multiple PWA instances running in parallel inside the container are not easily distinguishable 

## What Is the New Behavior?

- timestamps removed
- pm2 process ids prepended

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#72619](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/72619)