### PR TITLE
deps: update cypress from 7.x to 9.x

### DIFF
--- a/e2e/cypress/integration/pages/meta-data.module.ts
+++ b/e2e/cypress/integration/pages/meta-data.module.ts
@@ -57,7 +57,8 @@ export class MetaDataModule {
     if (expected.description) {
       this.meta('description').should(this.checkStrategy(expected.description), expected.description);
       this.meta('og:description').should(this.checkStrategy(expected.description), expected.description);
-      this.meta('description').then(description => {
+
+      (this.meta('description') as Cypress.Chainable<unknown>).then(description => {
         this.meta('og:description').should('equal', description);
       });
     }

--- a/e2e/open-cypress.js
+++ b/e2e/open-cypress.js
@@ -8,10 +8,10 @@ if (process.env.ICM_BASE_URL) {
 } else if (fs.existsSync('../src/environments/environment.development.ts')) {
   console.log('using ICM_BASE_URL from environment.development.ts');
   const data = fs.readFileSync('../src/environments/environment.development.ts', 'UTF-8');
-
-  const regex = /^ *icmBaseURL: '(.*?)',/m;
-  icmBaseUrl = data.match(regex)[1];
-} else {
+  const regex = /^ *icmBaseURL: '(.*?)'/m;
+  icmBaseUrl = data.match(regex) ? data.match(regex)[1] : undefined;
+}
+if (!icmBaseUrl) {
   console.error(
     'Did not find a valid ICM_BASE_URL. Setup a environment.development.ts or supply it via environment variable.'
   );

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,10 +13,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "cypress": "^7.0.0",
-    "cypress-failed-log": "^2.0.0",
+    "cypress": "^9.0.0",
+    "cypress-failed-log": "^2.9.2",
     "cypress-log-to-output": "^1.1.2",
     "har-validator": "^5.1.5",
-    "typescript": "*"
+    "typescript": "^4.5.4"
   }
 }


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Other: Cypress update

## What Is the Current Behavior?
Cypress 7.x is used to execute e2e tests.

## What Is the New Behavior?
Cypress is updated to the latest version 9.x.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No

## Other Information


[AB#72819](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/72819)