### PR TITLE
fix: remove console.log from schematic

### DIFF
--- a/schematics/src/eslint-rule/factory.ts
+++ b/schematics/src/eslint-rule/factory.ts
@@ -11,13 +11,9 @@ import { createTsMorphProject } from '../utils/ts-morph';
 // per file.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function eslintRule(options: any): Rule {
-  // extract properties
-  const ruleName = options.name;
-
   // update options
   options.path = '/eslint-rules/';
 
-  console.log('eslint-rule schematic', ruleName);
   return async _ => {
     const operations: Rule[] = [];
 


### PR DESCRIPTION
Remove a leftover console.log statement from eslint rule schematic.

[AB#73586](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/73586)