### PR TITLE
refactor: add dynamic punchout type to punchout service

### DIFF
--- a/src/app/extensions/punchout/services/punchout/punchout.service.ts
+++ b/src/app/extensions/punchout/services/punchout/punchout.service.ts
@@ -30,7 +30,7 @@ export class PunchoutService {
   });
 
   private getResourceType(punchoutType: PunchoutType): string {
-    return punchoutType === 'oci' ? 'oci5' : 'cxml1.2';
+    return punchoutType === 'oci' ? 'oci5' : punchoutType === 'cxml' ? 'cxml1.2' : punchoutType;
   }
 
   /**


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

If a new punchout type want to be added all request of this new type will call the "cxml" rest url. 

## What Is the New Behavior?

New punchout types will use its name for the rest call. You can add new types, when the rest url is the same.

## Does this PR Introduce a Breaking Change?

[x] No - only the fallback to `cxml1.2` no longer works


## Other Information


[AB#73848](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/73848)