### PR TITLE
fix: fix missing space on caching ignore (entrypoint.sh)

### DIFF
--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -36,9 +36,9 @@ then
   fi
 fi
 
-if [ -z "$CACHING_IGNORE_PARAMS_SOURCE"]
+if [ -z "$CACHING_IGNORE_PARAMS_SOURCE" ]
 then
-  if [ -z "$CACHING_IGNORE_PARAMS"]
+  if [ -z "$CACHING_IGNORE_PARAMS" ]
   then
     CACHING_IGNORE_PARAMS_SOURCE="./caching-ignore-params.yaml"
   else


### PR DESCRIPTION
## PR Type
[x] Bugfix[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When starting nginx container with `CACHING_IGNORE_PARAMS_SOURCE` environment variable set. You get to see this.
```
entrypoint.sh: 39: [: missing ]
```

## What Is the New Behavior?

No error is printed

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#73908](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/73908)