### PR TITLE
test: adapt search e2e test to the slightly changed solr search behavior

### DIFF
--- a/e2e/cypress/integration/specs/checkout/checkout-cost-center-multiple.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/checkout-cost-center-multiple.b2b.e2e-spec.ts
@@ -11,7 +11,7 @@ const _ = {
     login: 'jlink@test.intershop.de',
     password: sensibleDefaults.password,
   },
-  sku: '201807181',
+  sku: '201807199',
 };
 
 describe('Shopping User B2B', () => {

--- a/e2e/cypress/integration/specs/shopping/search-products.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/shopping/search-products.b2b.e2e-spec.ts
@@ -6,7 +6,7 @@ import { SearchResultPage } from '../../pages/shopping/search-result.page';
 const _ = {
   suggestTerm: 'bel',
   suggestItemText: 'Belkin',
-  searchTerm: 'belkin n',
+  searchTerm: 'belkin n300',
   product: '10802812',
 };
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,10 +13,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "cypress": "^9.0.0",
+    "cypress": "^9.4.1",
     "cypress-failed-log": "^2.9.2",
     "cypress-log-to-output": "^1.1.2",
     "har-validator": "^5.1.5",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7943,9 +7943,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
-      "integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.0",
     "@types/lodash-es": "^4.17.5",
-    "@types/node": "^17.0.13",
+    "@types/node": "^14.18.10",
     "@types/webpack": "^5.28.0",
     "@typescript-eslint/eslint-plugin": "5.10.1",
     "@typescript-eslint/parser": "5.10.1",


### PR DESCRIPTION
## PR Type

[x] Other: e2e test fix

## What Is the Current Behavior?
The search products b2b e2e test fails after solr has been updated to a new version.

## What Is the New Behavior?
The search term in the test has been adapted and it returns the right search result now.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#73925](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/73925)