### PR TITLE
fix: payment redirect respects baseHref

### DIFF
--- a/src/app/core/services/order/order.service.spec.ts
+++ b/src/app/core/services/order/order.service.spec.ts
@@ -1,3 +1,4 @@
+import { APP_BASE_HREF } from '@angular/common';
 import { HttpHeaders } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -31,6 +32,7 @@ describe('Order Service', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: ApiService, useFactory: () => instance(apiService) },
+        { provide: APP_BASE_HREF, useFactory: () => '/' },
         provideMockStore({ selectors: [{ selector: getCurrentLocale, value: 'en_US' }] }),
       ],
     });

--- a/src/app/core/services/order/order.service.ts
+++ b/src/app/core/services/order/order.service.ts
@@ -1,5 +1,6 @@
+import { APP_BASE_HREF } from '@angular/common';
 import { HttpHeaders, HttpParams } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { EMPTY, Observable, of, throwError } from 'rxjs';
 import { catchError, concatMap, map, mapTo, withLatestFrom } from 'rxjs/operators';
@@ -26,7 +27,7 @@ type OrderIncludeType =
  */
 @Injectable({ providedIn: 'root' })
 export class OrderService {
-  constructor(private apiService: ApiService, private store: Store) {}
+  constructor(private apiService: ApiService, private store: Store, @Inject(APP_BASE_HREF) private baseHref: string) {}
 
   private orderHeaders = new HttpHeaders({
     'content-type': 'application/json',
@@ -86,13 +87,13 @@ export class OrderService {
    * @returns               The (updated) order.
    */
   private sendRedirectUrlsIfRequired(order: Order, lang: string): Observable<Order> {
-    const loc = location.origin;
     if (
       order.orderCreation &&
       order.orderCreation.status === 'STOPPED' &&
       order.orderCreation.stopAction.type === 'Workflow' &&
       order.orderCreation.stopAction.exitReason === 'redirect_urls_required'
     ) {
+      const loc = `${location.origin}${this.baseHref}`;
       const body = {
         orderCreation: {
           redirect: {

--- a/src/app/core/services/payment/payment.service.spec.ts
+++ b/src/app/core/services/payment/payment.service.spec.ts
@@ -1,3 +1,4 @@
+import { APP_BASE_HREF } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
@@ -76,6 +77,7 @@ describe('Payment Service', () => {
       providers: [
         { provide: ApiService, useFactory: () => instance(apiService) },
         { provide: AppFacade, useFactory: () => instance(appFacade) },
+        { provide: APP_BASE_HREF, useFactory: () => '/' },
         provideMockStore({
           selectors: [
             { selector: getCurrentLocale, value: 'en_US' },

--- a/src/app/core/services/payment/payment.service.ts
+++ b/src/app/core/services/payment/payment.service.ts
@@ -1,5 +1,6 @@
+import { APP_BASE_HREF } from '@angular/common';
 import { HttpHeaders, HttpParams } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable, of, throwError } from 'rxjs';
 import { concatMap, first, map, mapTo, withLatestFrom } from 'rxjs/operators';
@@ -30,7 +31,8 @@ export class PaymentService {
     private apiService: ApiService,
     private basketService: BasketService,
     private store: Store,
-    private appFacade: AppFacade
+    private appFacade: AppFacade,
+    @Inject(APP_BASE_HREF) private baseHref: string
   ) {}
 
   private basketHeaders = new HttpHeaders({
@@ -97,11 +99,11 @@ export class PaymentService {
     paymentInstrument: string,
     lang: string
   ): Observable<string> {
-    const loc = location.origin;
     if (!pm || !pm.capabilities || !pm.capabilities.some(data => ['RedirectBeforeCheckout'].includes(data))) {
       return of(paymentInstrument);
       // send redirect urls if there is a redirect required
     } else {
+      const loc = `${location.origin}${this.baseHref}`;
       const redirect = {
         successUrl: `${loc}/checkout/review;lang=${lang}?redirect=success`,
         cancelUrl: `${loc}/checkout/payment;lang=${lang}?redirect=cancel`,


### PR DESCRIPTION
<!--<br />## PR Checklist<br />Please check if your PR fulfills the following requirements:<br /><br />[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md<br />[ ] Tests for the changes have been added (for bug fixes / features)<br />[ ] Docs have been added / updated (for bug fixes / features)<br />[ ] Visual changes have been approved by VD / IAD (if applicable)<br />--><br /><br />## PR Type<br /><br /><!--<br />What kind of change does this PR introduce?<br />Please check the one that applies to this PR using "x".<br />--><br /><br />[x] Bugfix<br />[ ] Feature<br />[ ] Code style update (formatting, local variables)<br />[ ] Refactoring (no functional changes, no API changes)<br />[ ] Build-related changes<br />[ ] CI-related changes<br />[ ] Documentation content changes<br />[ ] Application / infrastructure changes<br />[ ] Other: <!--Please describe.--><br /><br />## What Is the Current Behavior?<br /><br />Currently, when using a multisite configuration, the payment redirect link will not contain the baseHref and often return to a wrongly configured PWA.<br /><br />Issue Number: Closes #912<br /><br />## What Is the New Behavior?<br />Now, the baseHref is respected and the payments will redirect to a correct PWA.<br /><br />## Does this PR Introduce a Breaking Change?<br /><br /><!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --><br /><br />[ ] Yes<br />[x] No<br /><br />## Other Information<br />

[AB#74216](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74216)