### PR TITLE
fix: include all theme in allowed overrides

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -376,7 +376,7 @@
             "warnUnmatched": false,
             "reusePatterns": {
               "name": "[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*",
-              "theme": "(?:\\.(?:b2b|b2c))*"
+              "theme": "(?:(?:\\.(?:b2b|b2c))*|\\.all)"
             },
             "pathPatterns": [
               "^.*/src/environments/environment(\\.\\w+)?\\.ts$",


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

A change from 9b595d1812690ef0d00e96ec3022c6301f58533a was lost in the tslint to eslint migration

## What Is the New Behavior?

Included again

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

[AB#74359](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74359)