### PR TITLE
feat: support personalized product prices

### DIFF
--- a/src/app/core/models/product-prices/product-prices.interface.ts
+++ b/src/app/core/models/product-prices/product-prices.interface.ts
@@ -1,0 +1,14 @@
+import { PriceItemData } from 'ish-core/models/price-item/price-item.interface';
+
+export interface ProductPriceDetailsData {
+  sku: string;
+  prices: {
+    SalePrice: ProductPriceItemData[];
+    ListPrice: ProductPriceItemData[];
+  };
+}
+
+export interface ProductPriceItemData extends PriceItemData {
+  minQuantity: { value: number };
+  priceQuantity: { value: number };
+}

--- a/src/app/core/models/product-prices/product-prices.mapper.spec.ts
+++ b/src/app/core/models/product-prices/product-prices.mapper.spec.ts
@@ -1,0 +1,102 @@
+import { ProductPricesMapper } from './product-prices.mapper';
+
+describe('Product Prices Mapper', () => {
+  describe('fromData', () => {
+    it('should map product price data to client object with prices for minQuantity=1', () => {
+      expect(
+        ProductPricesMapper.fromData({
+          sku: 'abc',
+          prices: {
+            SalePrice: [
+              {
+                gross: { value: 2, currency: 'USD' },
+                net: { value: 1, currency: 'USD' },
+                minQuantity: { value: 1 },
+                priceQuantity: { value: 1 },
+              },
+
+              {
+                gross: { value: 1.5, currency: 'USD' },
+                net: { value: 0.5, currency: 'USD' },
+                minQuantity: { value: 2 },
+                priceQuantity: { value: 1 },
+              },
+            ],
+
+            ListPrice: [
+              {
+                gross: { value: 2, currency: 'USD' },
+                net: { value: 1, currency: 'USD' },
+                minQuantity: { value: 1 },
+                priceQuantity: { value: 1 },
+              },
+            ],
+          },
+        })
+      ).toMatchInlineSnapshot(`
+        Object {
+          "prices": Object {
+            "listPrice": Object {
+              "currency": "USD",
+              "gross": 2,
+              "net": 1,
+              "type": "PriceItem",
+            },
+            "salePrice": Object {
+              "currency": "USD",
+              "gross": 2,
+              "net": 1,
+              "type": "PriceItem",
+            },
+          },
+          "sku": "abc",
+        }
+      `);
+    });
+
+    it('should set ListPrice as SalePrice when SalePrice doesnt contain price with minQuantity=1', () => {
+      expect(
+        ProductPricesMapper.fromData({
+          sku: 'abc',
+          prices: {
+            SalePrice: [
+              {
+                gross: { value: 1, currency: 'USD' },
+                net: { value: 0.5, currency: 'USD' },
+                minQuantity: { value: 2 },
+                priceQuantity: { value: 1 },
+              },
+            ],
+
+            ListPrice: [
+              {
+                gross: { value: 2, currency: 'USD' },
+                net: { value: 1, currency: 'USD' },
+                minQuantity: { value: 1 },
+                priceQuantity: { value: 1 },
+              },
+            ],
+          },
+        })
+      ).toMatchInlineSnapshot(`
+        Object {
+          "prices": Object {
+            "listPrice": Object {
+              "currency": "USD",
+              "gross": 2,
+              "net": 1,
+              "type": "PriceItem",
+            },
+            "salePrice": Object {
+              "currency": "USD",
+              "gross": 2,
+              "net": 1,
+              "type": "PriceItem",
+            },
+          },
+          "sku": "abc",
+        }
+      `);
+    });
+  });
+});

--- a/src/app/core/models/product-prices/product-prices.mapper.ts
+++ b/src/app/core/models/product-prices/product-prices.mapper.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+
+import { PriceItemMapper } from 'ish-core/models/price-item/price-item.mapper';
+import { PriceItem } from 'ish-core/models/price-item/price-item.model';
+
+import { ProductPriceDetailsData, ProductPriceItemData } from './product-prices.interface';
+import { ProductPriceDetails } from './product-prices.model';
+
+// get ProductPriceItem for a single product from a set of possible prices
+function getSinglePrice(prices: ProductPriceItemData[]): PriceItem {
+  if (prices?.length !== 0) {
+    const singlePrice = prices?.find(price => price?.minQuantity?.value === 1);
+    if (singlePrice) {
+      return PriceItemMapper.fromPriceItem(singlePrice);
+    }
+  }
+  return;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ProductPricesMapper {
+  static fromData(data: ProductPriceDetailsData): ProductPriceDetails {
+    return {
+      sku: data?.sku,
+      prices: {
+        salePrice: getSinglePrice(data?.prices?.SalePrice) ?? getSinglePrice(data?.prices?.ListPrice),
+        listPrice: getSinglePrice(data?.prices?.ListPrice),
+      },
+    };
+  }
+}

--- a/src/app/core/models/product-prices/product-prices.model.ts
+++ b/src/app/core/models/product-prices/product-prices.model.ts
@@ -1,0 +1,9 @@
+import { PriceItem } from 'ish-core/models/price-item/price-item.model';
+
+export interface ProductPriceDetails {
+  sku: string;
+  prices: {
+    salePrice: PriceItem;
+    listPrice: PriceItem;
+  };
+}

--- a/src/app/core/models/product-view/product-view.model.spec.ts
+++ b/src/app/core/models/product-view/product-view.model.spec.ts
@@ -1,21 +1,22 @@
 import { Category } from 'ish-core/models/category/category.model';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { Product } from 'ish-core/models/product/product.model';
 
 import { createProductView } from './product-view.model';
 
 describe('Product View Model', () => {
   it('should return undefined on falsy input', () => {
-    expect(createProductView(undefined)).toBeUndefined();
+    expect(createProductView(undefined, undefined, undefined)).toBeUndefined();
   });
 
   it('should return product without defaultCategory() if the product default category is not in the category tree', () => {
-    const view = createProductView({ defaultCategoryId: 'some' } as Product);
+    const view = createProductView({ defaultCategoryId: 'some' } as Product, undefined, undefined);
     expect(view).toBeTruthy();
     expect(view.defaultCategory).toBeUndefined();
   });
 
   it('should return product if the product default category is empty', () => {
-    const view = createProductView({ sku: 'some' } as Product);
+    const view = createProductView({ sku: 'some' } as Product, undefined, undefined);
     expect(view).toBeTruthy();
     expect(view).toHaveProperty('sku', 'some');
   });
@@ -27,11 +28,26 @@ describe('Product View Model', () => {
       categoryPath: ['123'],
     } as Category;
 
-    const view = createProductView({ sku: 'some', defaultCategoryId: '123' } as Product, category);
+    const productPrice = { sku: 'some', prices: { salePrice: { gross: 1, currency: 'EUR' } } } as ProductPriceDetails;
+    const productPriceType = 'gross';
+
+    const view = createProductView(
+      { sku: 'some', defaultCategoryId: '123' } as Product,
+      productPrice,
+      productPriceType,
+      category
+    );
 
     expect(view).toBeTruthy();
     expect(view.sku).toEqual('some');
     expect(view.defaultCategory).toHaveProperty('uniqueId', '123');
     expect(view.defaultCategory).toHaveProperty('name', 'test');
+    expect(view.salePrice).toMatchInlineSnapshot(`
+      Object {
+        "currency": "EUR",
+        "type": "Money",
+        "value": 1,
+      }
+    `);
   });
 });

--- a/src/app/core/models/product-view/product-view.model.ts
+++ b/src/app/core/models/product-view/product-view.model.ts
@@ -1,4 +1,7 @@
 import { Category } from 'ish-core/models/category/category.model';
+import { PriceItemHelper } from 'ish-core/models/price-item/price-item.helper';
+import { Price } from 'ish-core/models/price/price.model';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { Product, VariationProduct, VariationProductMaster } from 'ish-core/models/product/product.model';
 
 export type ProductView = Partial<SimpleProductView> &
@@ -7,6 +10,8 @@ export type ProductView = Partial<SimpleProductView> &
 
 interface SimpleProductView extends Product {
   defaultCategory: Category;
+  listPrice: Price;
+  salePrice: Price;
 }
 
 interface VariationProductView extends VariationProduct, SimpleProductView {
@@ -21,20 +26,34 @@ interface VariationProductMasterView extends VariationProductMaster, SimpleProdu
   defaultVariationSKU: string;
 }
 
-export function createProductView(product: Product, defaultCategory?: Category): SimpleProductView {
-  return product && { ...product, defaultCategory };
+export function createProductView(
+  product: Product,
+  productPrice: ProductPriceDetails,
+  priceDisplayType: 'gross' | 'net',
+  defaultCategory?: Category
+): SimpleProductView {
+  return (
+    product && {
+      ...product,
+      defaultCategory,
+      salePrice: PriceItemHelper.selectType(productPrice?.prices?.salePrice, priceDisplayType),
+      listPrice: PriceItemHelper.selectType(productPrice?.prices?.listPrice, priceDisplayType),
+    }
+  );
 }
 
 export function createVariationProductMasterView(
   product: VariationProductMaster,
   defaultVariationSKU: string,
   variations: VariationProduct[],
+  productPrice: ProductPriceDetails,
+  priceDisplayType: 'gross' | 'net',
   defaultCategory?: Category
 ): VariationProductMasterView {
   return (
     product &&
     variations?.length && {
-      ...createProductView(product, defaultCategory),
+      ...createProductView(product, productPrice, priceDisplayType, defaultCategory),
       type: 'VariationProductMaster',
       defaultVariationSKU,
       variations,
@@ -46,13 +65,15 @@ export function createVariationProductView(
   product: VariationProduct,
   variations: VariationProduct[],
   productMaster: VariationProductMaster,
+  productPrice: ProductPriceDetails,
+  priceDisplayType: 'gross' | 'net',
   defaultCategory?: Category
 ): VariationProductView {
   return (
     product &&
     productMaster &&
     variations?.length && {
-      ...createProductView(product, defaultCategory),
+      ...createProductView(product, productPrice, priceDisplayType, defaultCategory),
       type: 'VariationProduct',
       variations,
       productMaster,

--- a/src/app/core/models/product/__snapshots__/product.mapper.spec.ts.snap
+++ b/src/app/core/models/product/__snapshots__/product.mapper.spec.ts.snap
@@ -39,11 +39,6 @@ Object {
       "viewID": "front",
     },
   ],
-  "listPrice": Object {
-    "currency": "USD",
-    "type": "Money",
-    "value": 132.24,
-  },
   "longDescription": undefined,
   "manufacturer": "Kodak",
   "maxOrderQuantity": undefined,
@@ -54,11 +49,6 @@ Object {
   "readyForShipmentMax": undefined,
   "readyForShipmentMin": undefined,
   "roundedAverageRating": 0,
-  "salePrice": Object {
-    "currency": "USD",
-    "type": "Money",
-    "value": 132.24,
-  },
   "shortDescription": "EasyShare M552, 14MP, 6.858 cm (2.7 \\") LCD, 4x, 28mm, HD 720p, Black",
   "sku": "7912057",
   "stepOrderQuantity": undefined,

--- a/src/app/core/models/product/product.helper.spec.ts
+++ b/src/app/core/models/product/product.helper.spec.ts
@@ -2,6 +2,7 @@ import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 
 import { ProductDataStub } from './product.interface';
 import { Product, ProductCompletenessLevel, ProductHelper } from './product.model';
@@ -187,48 +188,64 @@ describe('Product Helper', () => {
 
   describe('calculatePriceRange()', () => {
     it('should return empty object when no products are supplied', () => {
-      expect(ProductHelper.calculatePriceRange(undefined)).toBeEmpty();
-      expect(ProductHelper.calculatePriceRange([])).toBeEmpty();
+      expect(ProductHelper.calculatePriceRange(undefined, undefined, undefined)).toBeEmpty();
+      expect(ProductHelper.calculatePriceRange([], [], undefined)).toBeEmpty();
     });
 
     it('should return the single object if only one element is supplied', () => {
-      const product = { salePrice: { value: 1 } } as Product;
-      expect(ProductHelper.calculatePriceRange([product])).toEqual(product);
+      const product = { sku: '1' } as Product;
+      const productPrice = {
+        sku: '1',
+        prices: { salePrice: { gross: 1, currency: 'EUR' } },
+      } as ProductPriceDetails;
+      expect(ProductHelper.calculatePriceRange([product], [productPrice], 'gross')).toEqual(productPrice);
     });
 
     it('should calculate a range when multiple elements are supplied', () => {
-      const product1 = {
-        salePrice: { value: 1, currency: 'EUR' },
-        listPrice: { value: 2, currency: 'EUR' },
-      } as Product;
-      const product2 = {
-        salePrice: { value: 3, currency: 'EUR' },
-        listPrice: { value: 4, currency: 'EUR' },
-      } as Product;
-      const product3 = {
-        salePrice: { value: 5, currency: 'EUR' },
-        listPrice: { value: 6, currency: 'EUR' },
-      } as Product;
-      expect(ProductHelper.calculatePriceRange([product1, product2, product3])).toMatchInlineSnapshot(`
+      const product1 = { sku: '1' } as Product;
+      const productPrice1 = {
+        sku: '1',
+        prices: { salePrice: { gross: 1, currency: 'EUR' }, listPrice: { gross: 2, currency: 'EUR' } },
+      } as ProductPriceDetails;
+
+      const product2 = { sku: '2' } as Product;
+      const productPrice2 = {
+        sku: '2',
+        prices: { salePrice: { gross: 3, currency: 'EUR' }, listPrice: { gross: 4, currency: 'EUR' } },
+      } as ProductPriceDetails;
+
+      const product3 = { sku: '3' } as Product;
+      const productPrice3 = {
+        sku: '3',
+        prices: { salePrice: { gross: 5, currency: 'EUR' }, listPrice: { gross: 6, currency: 'EUR' } },
+      } as ProductPriceDetails;
+
+      expect(
+        ProductHelper.calculatePriceRange(
+          [product1, product2, product3],
+          [productPrice1, productPrice2, productPrice3],
+          'gross'
+        )
+      ).toMatchInlineSnapshot(`
         Object {
           "minListPrice": Object {
             "currency": "EUR",
-            "type": undefined,
+            "type": "Money",
             "value": 2,
           },
           "minSalePrice": Object {
             "currency": "EUR",
-            "type": undefined,
+            "type": "Money",
             "value": 1,
           },
           "summedUpListPrice": Object {
             "currency": "EUR",
-            "type": undefined,
+            "type": "Money",
             "value": 12,
           },
           "summedUpSalePrice": Object {
             "currency": "EUR",
-            "type": undefined,
+            "type": "Money",
             "value": 9,
           },
         }

--- a/src/app/core/models/product/product.mapper.spec.ts
+++ b/src/app/core/models/product/product.mapper.spec.ts
@@ -188,14 +188,6 @@ describe('Product Mapper', () => {
         attributes: [
           { name: 'sku', value: '7912057' },
           { name: 'image', value: '/assets/product_img/a.jpg' },
-          {
-            name: 'listPrice',
-            value: { currency: 'USD', type: 'Money', value: 132.24 },
-          },
-          {
-            name: 'salePrice',
-            value: { currency: 'USD', type: 'Money', value: 132.24 },
-          },
           { name: 'availability', value: true },
           { name: 'manufacturer', value: 'Kodak' },
           { name: 'minOrderQuantity', value: { value: 5 } },

--- a/src/app/core/models/product/product.mapper.ts
+++ b/src/app/core/models/product/product.mapper.ts
@@ -123,8 +123,6 @@ export class ProductMapper {
       shortDescription: data.description,
       name: data.title,
       sku,
-      listPrice: PriceMapper.fromData(retrieveStubAttributeValue(data, 'listPrice')),
-      salePrice: PriceMapper.fromData(retrieveStubAttributeValue(data, 'salePrice')),
       images: this.imageMapper.fromImages([
         {
           effectiveUrl: retrieveStubAttributeValue(data, 'image'),
@@ -188,8 +186,6 @@ export class ProductMapper {
       attributeGroups: data.attributeGroups,
       attachments: this.attachmentMapper.fromAttachments(data.attachments),
       images: this.imageMapper.fromImages(data.images),
-      listPrice: PriceMapper.fromData(data.listPrice),
-      salePrice: PriceMapper.fromData(data.salePrice),
       manufacturer: data.manufacturer,
       readyForShipmentMin: data.readyForShipmentMin,
       readyForShipmentMax: data.readyForShipmentMax,

--- a/src/app/core/models/product/product.model.ts
+++ b/src/app/core/models/product/product.model.ts
@@ -19,8 +19,6 @@ export interface Product {
   attributeGroups?: { [id: string]: AttributeGroup };
   attachments?: Attachment[];
   images: Image[];
-  listPrice: Price;
-  salePrice: Price;
   manufacturer: string;
   roundedAverageRating: number;
   readyForShipmentMin: number;

--- a/src/app/core/routing/product/product.route.spec.ts
+++ b/src/app/core/routing/product/product.route.spec.ts
@@ -61,7 +61,7 @@ describe('Product Route', () => {
 
   describe('without category', () => {
     describe('without product name', () => {
-      const product = createProductView({ sku: 'A' } as Product);
+      const product = createProductView({ sku: 'A' } as Product, undefined, undefined);
       it('should create simple link when just sku is supplied', () => {
         expect(generateProductUrl(product)).toMatchInlineSnapshot(`"/skuA"`);
       });
@@ -76,7 +76,7 @@ describe('Product Route', () => {
     });
 
     describe('with product name', () => {
-      const product = createProductView({ sku: 'A', name: 'some example name' } as Product);
+      const product = createProductView({ sku: 'A', name: 'some example name' } as Product, undefined, undefined);
 
       it('should include slug when product has a name', () => {
         expect(generateProductUrl(product)).toMatchInlineSnapshot(`"/some-example-name-skuA"`);
@@ -97,16 +97,20 @@ describe('Product Route', () => {
     });
 
     describe('variation product', () => {
-      const product = createProductView({
-        sku: 'A',
-        name: 'some example name',
-        type: 'VariationProduct',
-        variableVariationAttributes: [
-          { value: 'SSD - (HDD)' },
-          { value: 'Cobalt Blue & Yellow' },
-          { value: '500 r/min' },
-        ],
-      } as VariationProduct);
+      const product = createProductView(
+        {
+          sku: 'A',
+          name: 'some example name',
+          type: 'VariationProduct',
+          variableVariationAttributes: [
+            { value: 'SSD - (HDD)' },
+            { value: 'Cobalt Blue & Yellow' },
+            { value: '500 r/min' },
+          ],
+        } as VariationProduct,
+        undefined,
+        undefined
+      );
 
       it('should include attribute values in slug when product is a variation', () => {
         expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -121,7 +125,7 @@ describe('Product Route', () => {
 
     describe('as context', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, specials);
+        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(`"/Spezielles/skuA-catSpecials"`);
@@ -138,7 +142,12 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, specials);
+        const product = createProductView(
+          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
+          undefined,
+          undefined,
+          specials
+        );
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(
@@ -159,7 +168,7 @@ describe('Product Route', () => {
 
     describe('as default category', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, specials);
+        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(`"/Spezielles/skuA-catSpecials"`);
@@ -176,7 +185,12 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, specials);
+        const product = createProductView(
+          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
+          undefined,
+          undefined,
+          specials
+        );
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -202,7 +216,7 @@ describe('Product Route', () => {
 
     describe('as context', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, specials);
+        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(
@@ -221,7 +235,12 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, specials);
+        const product = createProductView(
+          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
+          undefined,
+          undefined,
+          specials
+        );
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(
@@ -242,7 +261,7 @@ describe('Product Route', () => {
 
     describe('as default category', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, limitedOffer);
+        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, limitedOffer);
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -261,7 +280,12 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, limitedOffer);
+        const product = createProductView(
+          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
+          undefined,
+          undefined,
+          limitedOffer
+        );
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -297,7 +321,7 @@ describe('Product Route', () => {
   describe('additional URL params', () => {
     it('should ignore additional URL params when supplied', () => {
       const category = createCategoryView(categoryTree([specials, topSeller, limitedOffer]), limitedOffer.uniqueId);
-      const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product);
+      const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, undefined, undefined);
 
       expect(matchProductRoute(wrap(`${generateProductUrl(product, category)};lang=de_DE`))).toMatchInlineSnapshot(`
         Object {

--- a/src/app/core/services/filter/filter.service.spec.ts
+++ b/src/app/core/services/filter/filter.service.spec.ts
@@ -113,7 +113,7 @@ describe('Filter Service', () => {
       const [resource, params] = capture(apiService.get).last();
       expect(resource).toMatchInlineSnapshot(`"products"`);
       expect((params as AvailableOptions)?.params?.toString()).toMatchInlineSnapshot(
-        `"amount=2&offset=0&attrs=sku,salePrice,listPrice,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet&attributeGroup=PRODUCT_LABEL_ATTRIBUTES&returnSortKeys=true&SearchParameter=b"`
+        `"amount=2&offset=0&attrs=sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet&attributeGroup=PRODUCT_LABEL_ATTRIBUTES&returnSortKeys=true&SearchParameter=b"`
       );
 
       done();

--- a/src/app/core/services/prices/prices.service.spec.ts
+++ b/src/app/core/services/prices/prices.service.spec.ts
@@ -1,0 +1,54 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+
+import { Customer } from 'ish-core/models/customer/customer.model';
+import { ProductPriceDetailsData } from 'ish-core/models/product-prices/product-prices.interface';
+import { ApiService, AvailableOptions } from 'ish-core/services/api/api.service';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
+
+import { PricesService } from './prices.service';
+
+describe('Prices Service', () => {
+  let apiServiceMock: ApiService;
+  let pricesService: PricesService;
+
+  beforeEach(() => {
+    apiServiceMock = mock(ApiService);
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ApiService, useFactory: () => instance(apiServiceMock) },
+        provideMockStore({
+          selectors: [
+            { selector: getLoggedInCustomer, value: { customerNo: 'customer', isBusinessCustomer: true } as Customer },
+          ],
+        }),
+      ],
+    });
+    pricesService = TestBed.inject(PricesService);
+  });
+
+  it('should be created', () => {
+    expect(pricesService).toBeTruthy();
+  });
+
+  describe('getProductPrices', () => {
+    beforeEach(() => {
+      when(apiServiceMock.get<{ data: ProductPriceDetailsData[] }>('productprices', anything())).thenReturn(
+        of({ data: [{ sku: 'abc' }, { sku: '123' }] as ProductPriceDetailsData[] })
+      );
+    });
+
+    it('should get product price data when "getProductPrices" is called', done => {
+      pricesService.getProductPrices(['abc', '123']).subscribe(priceDetails => {
+        expect(priceDetails).toHaveLength(2);
+        verify(apiServiceMock.get(`productprices`, anything())).once();
+        expect(
+          capture<string, AvailableOptions>(apiServiceMock.get).last()?.[1]?.params?.toString()
+        ).toMatchInlineSnapshot(`"sku=abc&sku=123&customerID=customer"`);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/core/services/prices/prices.service.ts
+++ b/src/app/core/services/prices/prices.service.ts
@@ -1,0 +1,44 @@
+import { HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
+import { Observable, throwError } from 'rxjs';
+import { map, switchMap, take, tap } from 'rxjs/operators';
+
+import { ProductPriceDetailsData } from 'ish-core/models/product-prices/product-prices.interface';
+import { ProductPricesMapper } from 'ish-core/models/product-prices/product-prices.mapper';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
+import { ApiService } from 'ish-core/services/api/api.service';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
+
+@Injectable({ providedIn: 'root' })
+export class PricesService {
+  private priceHeaders = new HttpHeaders({
+    Accept: 'application/vnd.intershop.pricing.v1+json',
+  });
+
+  constructor(private apiService: ApiService, private store: Store) {}
+
+  private currentCustomer$ = this.store.pipe(select(getLoggedInCustomer), take(1));
+
+  getProductPrices(skus: string[]): Observable<ProductPriceDetails[]> {
+    if (!skus || skus.length === 0) {
+      return throwError(() => new Error('getProductPrices() called without skus'));
+    }
+
+    let params = new HttpParams();
+    skus.map(sku => (params = params.append('sku', sku)));
+
+    return this.currentCustomer$.pipe(
+      tap(customer => {
+        if (customer?.customerNo) {
+          params = params.set('customerID', customer.customerNo);
+        }
+      }),
+      switchMap(() =>
+        this.apiService
+          .get<{ data: ProductPriceDetailsData[] }>(`productprices`, { headers: this.priceHeaders, params })
+          .pipe(map(element => element?.data?.map(prices => ProductPricesMapper.fromData(prices))))
+      )
+    );
+  }
+}

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -28,7 +28,7 @@ import { mapToProperty } from 'ish-core/utils/operators';
 @Injectable({ providedIn: 'root' })
 export class ProductsService {
   static STUB_ATTRS =
-    'sku,salePrice,listPrice,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet';
+    'sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet';
 
   constructor(private apiService: ApiService, private productMapper: ProductMapper, private appFacade: AppFacade) {}
 

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -9,7 +9,6 @@ import { Basket } from 'ish-core/models/basket/basket.model';
 import { Credentials } from 'ish-core/models/credentials/credentials.model';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
-import { Price } from 'ish-core/models/price/price.model';
 import { Product, ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { Promotion } from 'ish-core/models/promotion/promotion.model';
 import { User } from 'ish-core/models/user/user.model';
@@ -23,6 +22,7 @@ import { FilterService } from 'ish-core/services/filter/filter.service';
 import { OrderService } from 'ish-core/services/order/order.service';
 import { PaymentService } from 'ish-core/services/payment/payment.service';
 import { PersonalizationService } from 'ish-core/services/personalization/personalization.service';
+import { PricesService } from 'ish-core/services/prices/prices.service';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
@@ -65,8 +65,6 @@ describe('Customer Store', () => {
     minOrderQuantity: 1,
     attributes: [],
     images: [],
-    listPrice: {} as Price,
-    salePrice: {} as Price,
     manufacturer: 'test',
     readyForShipmentMin: 1,
     readyForShipmentMax: 1,
@@ -152,6 +150,9 @@ describe('Customer Store', () => {
     const orderServiceMock = mock(OrderService);
     const authorizationServiceMock = mock(AuthorizationService);
 
+    const productPriceServiceMock = mock(PricesService);
+    when(productPriceServiceMock.getProductPrices(anything())).thenReturn(of([]));
+
     TestBed.configureTestingModule({
       declarations: [DummyComponent],
       imports: [
@@ -180,6 +181,7 @@ describe('Customer Store', () => {
         { provide: OrderService, useFactory: () => instance(orderServiceMock) },
         { provide: PaymentService, useFactory: () => instance(mock(PaymentService)) },
         { provide: PersonalizationService, useFactory: () => instance(personalizationServiceMock) },
+        { provide: PricesService, useFactory: () => instance(productPriceServiceMock) },
         { provide: ProductsService, useFactory: () => instance(productsServiceMock) },
         { provide: PromotionsService, useFactory: () => instance(promotionsServiceMock) },
         { provide: SHOPPING_STORE_CONFIG, useValue: {} },

--- a/src/app/core/store/shopping/product-prices/index.ts
+++ b/src/app/core/store/shopping/product-prices/index.ts
@@ -1,0 +1,2 @@
+// API to access ngrx products state
+export * from './product-prices.actions';

--- a/src/app/core/store/shopping/product-prices/product-prices.actions.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.actions.ts
@@ -1,0 +1,14 @@
+import { createAction } from '@ngrx/store';
+
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
+import { payload } from 'ish-core/utils/ngrx-creators';
+
+export const loadProductPrices = createAction(
+  '[Product Price Internal] Load Product Prices',
+  payload<{ skus: string[] }>()
+);
+
+export const loadProductPricesSuccess = createAction(
+  '[Products API] Load Product Prices Success',
+  payload<{ prices: ProductPriceDetails[] }>()
+);

--- a/src/app/core/store/shopping/product-prices/product-prices.effects.spec.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.effects.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { cold, hot } from 'jest-marbles';
+import { Observable, of, throwError } from 'rxjs';
+import { anything, capture, instance, mock, when } from 'ts-mockito';
+
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
+import { PricesService } from 'ish-core/services/prices/prices.service';
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
+import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
+import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
+import { provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
+
+import { loadProductPrices, loadProductPricesSuccess } from '.';
+import { ProductPricesEffects } from './product-prices.effects';
+
+describe('Products Effects', () => {
+  let actions$: Observable<Action>;
+  let effects: ProductPricesEffects;
+  let pricesServiceMock: PricesService;
+
+  beforeEach(() => {
+    pricesServiceMock = mock(PricesService);
+    when(pricesServiceMock.getProductPrices(anything())).thenCall((skus: string[]) => {
+      if (skus.length === 0) {
+        return throwError(() => makeHttpError({ message: 'getProductPrices() called with invalid sku' }));
+      } else {
+        return of(
+          skus.map(sku => {
+            return { sku } as ProductPriceDetails;
+          })
+        );
+      }
+    });
+
+    TestBed.configureTestingModule({
+      imports: [
+        CoreStoreModule.forTesting(['serverConfig']),
+        CustomerStoreModule.forTesting('user'),
+        ShoppingStoreModule.forTesting('productPrices'),
+      ],
+      providers: [
+        { provide: PricesService, useFactory: () => instance(pricesServiceMock) },
+        ProductPricesEffects,
+        provideMockActions(() => actions$),
+        provideStoreSnapshots(),
+      ],
+    });
+
+    effects = TestBed.inject(ProductPricesEffects);
+  });
+
+  describe('loadProductPrices$', () => {
+    it('should call the getProductPrices service with skus for loadProductPrices action', done => {
+      const skus = ['P123'];
+      const action = loadProductPrices({ skus });
+      actions$ = of(action);
+
+      effects.loadProductPrices$.subscribe(() => {
+        const [skus, customerId] = capture(pricesServiceMock.getProductPrices).last();
+        expect(skus).toEqual(skus);
+        expect(customerId).toBeUndefined();
+        done();
+      });
+    });
+
+    it('should map multiple actions to type LoadProductSuccess', () => {
+      const action1 = loadProductPrices({ skus: ['a', 'b'] });
+      const action2 = loadProductPrices({ skus: ['b', 'c'] });
+      const action3 = loadProductPrices({ skus: ['a', 'c', 'd'] });
+
+      const completion = loadProductPricesSuccess({
+        prices: [
+          { sku: 'a' } as ProductPriceDetails,
+          { sku: 'b' } as ProductPriceDetails,
+          { sku: 'c' } as ProductPriceDetails,
+          { sku: 'd' } as ProductPriceDetails,
+        ],
+      });
+      actions$ = hot('        -a-b-a-c--|', { a: action1, b: action2, c: action3 });
+      const expected$ = cold('----------(c|)', { c: completion });
+
+      expect(effects.loadProductPrices$).toBeObservable(expected$);
+    });
+  });
+});

--- a/src/app/core/store/shopping/product-prices/product-prices.effects.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.effects.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { debounceTime, filter, map, mergeMap, toArray, window } from 'rxjs/operators';
+
+import { PricesService } from 'ish-core/services/prices/prices.service';
+import { mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
+
+import { loadProductPrices, loadProductPricesSuccess } from '.';
+
+@Injectable()
+export class ProductPricesEffects {
+  constructor(private actions$: Actions, private pricesService: PricesService) {}
+
+  loadProductPrices$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(loadProductPrices),
+      mapToPayloadProperty('skus'),
+      whenTruthy(),
+      window(this.actions$.pipe(ofType(loadProductPrices), debounceTime(500))),
+      mergeMap(window$ =>
+        window$.pipe(
+          toArray(),
+          filter(skuArrays => skuArrays.length !== 0), // array should have entries for following map operators
+          map(skuArrays => skuArrays.reduce((prev, cur) => prev.concat(cur))), // map two dimensional array list to one dimension
+          map(skus => Array.from(new Set(skus))) // remove duplicated entries from sku list
+        )
+      ),
+      mergeMap(skus =>
+        this.pricesService.getProductPrices(skus).pipe(map(prices => loadProductPricesSuccess({ prices })))
+      )
+    )
+  );
+}

--- a/src/app/core/store/shopping/product-prices/product-prices.reducer.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.reducer.ts
@@ -1,0 +1,21 @@
+import { EntityState, createEntityAdapter } from '@ngrx/entity';
+import { createReducer, on } from '@ngrx/store';
+
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
+
+import { loadProductPricesSuccess } from '.';
+
+export const productPriceAdapter = createEntityAdapter<ProductPriceDetails>({
+  selectId: product => product.sku,
+});
+
+export type ProductPricesState = EntityState<ProductPriceDetails>;
+
+const initialState: ProductPricesState = productPriceAdapter.getInitialState({});
+
+export const productPricesReducer = createReducer(
+  initialState,
+  on(loadProductPricesSuccess, (state, action) => {
+    return productPriceAdapter.upsertMany(action.payload.prices, state);
+  })
+);

--- a/src/app/core/store/shopping/product-prices/product-prices.selectors.spec.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.selectors.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed, fakeAsync } from '@angular/core/testing';
+
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
+import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
+import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
+
+import { loadProductPricesSuccess } from '.';
+import { getProductPrice } from './product-prices.selectors';
+
+describe('Product Price Selectors', () => {
+  let store$: StoreWithSnapshots;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CoreStoreModule.forTesting(['serverConfig']),
+        CustomerStoreModule.forTesting('user'),
+        ShoppingStoreModule.forTesting('productPrices'),
+      ],
+      providers: [provideStoreSnapshots()],
+    });
+
+    store$ = TestBed.inject(StoreWithSnapshots);
+  });
+
+  describe('with empty state', () => {
+    it('should not select any product price when used', () => {
+      expect(getProductPrice('sku')(store$.state)).toBeUndefined();
+    });
+  });
+
+  describe('with LoadProductPriceSuccess state', () => {
+    const priceDetails: ProductPriceDetails = { sku: 'sku' } as ProductPriceDetails;
+    beforeEach(() => {
+      store$.dispatch(loadProductPricesSuccess({ prices: [priceDetails] }));
+    });
+    it('should add the product price to the state', fakeAsync(() => {
+      expect(getProductPrice('sku')(store$.state)).toEqual(priceDetails);
+    }));
+  });
+});

--- a/src/app/core/store/shopping/product-prices/product-prices.selectors.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.selectors.ts
@@ -1,0 +1,18 @@
+import { Dictionary } from '@ngrx/entity';
+import { createSelector, createSelectorFactory, resultMemoize } from '@ngrx/store';
+import { isEqual } from 'lodash-es';
+
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
+import { ShoppingState, getShoppingState } from 'ish-core/store/shopping/shopping-store';
+
+import { productPriceAdapter } from './product-prices.reducer';
+
+const getProductPricesState = createSelector(getShoppingState, (state: ShoppingState) => state.productPrices);
+
+const { selectEntities } = productPriceAdapter.getSelectors(getProductPricesState);
+
+export const getProductPrice = (sku: string) =>
+  createSelectorFactory<object, ProductPriceDetails>(projector => resultMemoize(projector, isEqual))(
+    selectEntities,
+    (entities: Dictionary<ProductPriceDetails>) => entities[sku]
+  );

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -31,6 +31,7 @@ import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
 import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
+import { loadProductPrices } from 'ish-core/store/shopping/product-prices';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
 import {
   delayUntil,
@@ -107,6 +108,16 @@ export class ProductsEffects {
       withLatestFrom(this.store.pipe(select(getProductEntities))),
       filter(([{ sku, level }, entities]) => !ProductHelper.isSufficientlyLoaded(entities[sku], level)),
       map(([{ sku }]) => loadProduct({ sku }))
+    )
+  );
+
+  loadProductPricesAfterProductSuccess$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(loadProductSuccess),
+      mapToPayloadProperty('product'),
+      mapToProperty('sku'),
+      whenTruthy(),
+      map(sku => loadProductPrices({ skus: [sku] }))
     )
   );
 

--- a/src/app/core/store/shopping/products/products.selectors.spec.ts
+++ b/src/app/core/store/shopping/products/products.selectors.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Category } from 'ish-core/models/category/category.model';
 import { Product, ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { loadCategorySuccess } from 'ish-core/store/shopping/categories';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
@@ -46,9 +47,10 @@ describe('Products Selectors', () => {
     TestBed.configureTestingModule({
       declarations: [DummyComponent],
       imports: [
-        CoreStoreModule.forTesting(['router']),
+        CoreStoreModule.forTesting(['router', 'serverConfig']),
+        CustomerStoreModule.forTesting('user'),
         RouterTestingModule.withRoutes([{ path: '**', component: DummyComponent }]),
-        ShoppingStoreModule.forTesting('products', 'categories'),
+        ShoppingStoreModule.forTesting('products', 'categories', 'productPrices'),
       ],
       providers: [provideStoreSnapshots()],
     });
@@ -117,6 +119,8 @@ describe('Products Selectors', () => {
           Object {
             "defaultCategory": undefined,
             "failed": true,
+            "listPrice": undefined,
+            "salePrice": undefined,
             "sku": "invalid",
           }
         `);
@@ -324,6 +328,8 @@ describe('Products Selectors', () => {
           Object {
             "defaultCategory": undefined,
             "defaultVariationSKU": "VAR",
+            "listPrice": undefined,
+            "salePrice": undefined,
             "sku": "SKU",
             "type": "VariationProductMaster",
             "variations": Array [

--- a/src/app/core/store/shopping/products/products.selectors.ts
+++ b/src/app/core/store/shopping/products/products.selectors.ts
@@ -22,8 +22,10 @@ import {
 } from 'ish-core/models/product/product.model';
 import { generateCategoryUrl } from 'ish-core/routing/category/category.route';
 import { selectRouteParam } from 'ish-core/store/core/router';
+import { getPriceDisplayType } from 'ish-core/store/customer/user';
 import { getCategoryEntities, getSelectedCategory } from 'ish-core/store/shopping/categories';
 import { getAvailableFilter } from 'ish-core/store/shopping/filter';
+import { getProductPrice } from 'ish-core/store/shopping/product-prices/product-prices.selectors';
 import { getShoppingState } from 'ish-core/store/shopping/shopping-store';
 
 import { ProductsState, productAdapter } from './products.reducer';
@@ -97,12 +99,36 @@ export const getProduct = (sku: string) =>
     internalProductDefaultVariationSKU(sku),
     internalProductVariations(sku),
     internalProductMaster(sku),
-    (product, defaultCategory, defaultVariationSKU, variations, productMaster): ProductView =>
+    getProductPrice(sku),
+    getPriceDisplayType,
+    (
+      product,
+      defaultCategory,
+      defaultVariationSKU,
+      variations,
+      productMaster,
+      productPrice,
+      priceDisplayType
+    ): ProductView =>
       ProductHelper.isMasterProduct(product)
-        ? createVariationProductMasterView(product, defaultVariationSKU, variations, defaultCategory)
+        ? createVariationProductMasterView(
+            product,
+            defaultVariationSKU,
+            variations,
+            productPrice,
+            priceDisplayType,
+            defaultCategory
+          )
         : ProductHelper.isVariationProduct(product)
-        ? createVariationProductView(product, variations, productMaster, defaultCategory)
-        : createProductView(product, defaultCategory)
+        ? createVariationProductView(
+            product,
+            variations,
+            productMaster,
+            productPrice,
+            priceDisplayType,
+            defaultCategory
+          )
+        : createProductView(product, productPrice, priceDisplayType, defaultCategory)
   );
 
 export const getSelectedProduct = createSelectorFactory<object, ProductView>(projector =>

--- a/src/app/core/store/shopping/shopping-store.module.ts
+++ b/src/app/core/store/shopping/shopping-store.module.ts
@@ -16,6 +16,8 @@ import { FilterEffects } from './filter/filter.effects';
 import { filterReducer } from './filter/filter.reducer';
 import { ProductListingEffects } from './product-listing/product-listing.effects';
 import { productListingReducer } from './product-listing/product-listing.reducer';
+import { ProductPricesEffects } from './product-prices/product-prices.effects';
+import { productPricesReducer } from './product-prices/product-prices.reducer';
 import { ProductsEffects } from './products/products.effects';
 import { productsReducer } from './products/products.reducer';
 import { PromotionsEffects } from './promotions/promotions.effects';
@@ -32,6 +34,7 @@ const shoppingReducers: ActionReducerMap<ShoppingState> = {
   filter: filterReducer,
   promotions: promotionsReducer,
   productListing: productListingReducer,
+  productPrices: productPricesReducer,
 };
 
 const shoppingEffects = [
@@ -42,6 +45,7 @@ const shoppingEffects = [
   FilterEffects,
   PromotionsEffects,
   ProductListingEffects,
+  ProductPricesEffects,
 ];
 
 @Injectable()
@@ -49,7 +53,7 @@ export class DefaultShoppingStoreConfig implements StoreConfig<ShoppingState> {
   metaReducers = [
     dataRetentionMeta<ShoppingState>(this.dataRetention.compare, this.appBaseHref, 'shopping', '_compare'),
     resetSubStatesOnActionsMeta<ShoppingState>(
-      ['categories', 'products', 'search', 'filter'],
+      ['categories', 'products', 'search', 'filter', 'productPrices'],
       [personalizationStatusDetermined]
     ),
   ];

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -16,10 +16,12 @@ import { CategoriesService } from 'ish-core/services/categories/categories.servi
 import { ConfigurationService } from 'ish-core/services/configuration/configuration.service';
 import { CountryService } from 'ish-core/services/country/country.service';
 import { FilterService } from 'ish-core/services/filter/filter.service';
+import { PricesService } from 'ish-core/services/prices/prices.service';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
@@ -43,6 +45,7 @@ describe('Shopping Store', () => {
   let promotionsServiceMock: PromotionsService;
   let suggestServiceMock: SuggestService;
   let filterServiceMock: FilterService;
+  let priceServiceMock: PricesService;
 
   beforeEach(() => {
     @Component({ template: 'dummy' })
@@ -140,10 +143,14 @@ describe('Shopping Store', () => {
     when(filterServiceMock.getFilterForSearch(anything())).thenReturn(of({} as FilterNavigation));
     when(filterServiceMock.getFilterForCategory(anything())).thenReturn(of({} as FilterNavigation));
 
+    priceServiceMock = mock(PricesService);
+    when(priceServiceMock.getProductPrices(anything())).thenReturn(of([]));
+
     TestBed.configureTestingModule({
       declarations: [DummyComponent],
       imports: [
         CoreStoreModule.forTesting(['router', 'configuration', 'serverConfig'], true),
+        CustomerStoreModule.forTesting('user'),
         RouterTestingModule.withRoutes([
           {
             path: 'home',
@@ -181,6 +188,7 @@ describe('Shopping Store', () => {
       providers: [
         { provide: CategoriesService, useFactory: () => instance(categoriesServiceMock) },
         { provide: FilterService, useFactory: () => instance(filterServiceMock) },
+        { provide: PricesService, useFactory: () => instance(priceServiceMock) },
         { provide: ProductsService, useFactory: () => instance(productsServiceMock) },
         { provide: PromotionsService, useFactory: () => instance(promotionsServiceMock) },
         { provide: SHOPPING_STORE_CONFIG, useValue: {} },
@@ -316,6 +324,10 @@ describe('Shopping Store', () => {
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
+          [Product Price Internal] Load Product Prices:
+            skus: ["P2"]
+          [Products API] Load Product Prices Success:
+            prices: []
         `);
       }));
 
@@ -334,7 +346,11 @@ describe('Shopping Store', () => {
               sku: "P2"
             [Products API] Load Product Success:
               product: {"sku":"P2","name":"nP2"}
+            [Product Price Internal] Load Product Prices:
+              skus: ["P2"]
             @ngrx/router-store/navigated: /product/P2
+            [Products API] Load Product Prices Success:
+              prices: []
           `);
         }));
       });
@@ -459,6 +475,12 @@ describe('Shopping Store', () => {
           sortableAttributes: []
         [Filter API] Load Filter Success:
           filterNavigation: {}
+        [Product Price Internal] Load Product Prices:
+          skus: ["P1"]
+        [Product Price Internal] Load Product Prices:
+          skus: ["P2"]
+        [Products API] Load Product Prices Success:
+          prices: []
       `);
     }));
 
@@ -477,7 +499,11 @@ describe('Shopping Store', () => {
             sku: "P1"
           [Products API] Load Product Success:
             product: {"sku":"P1","name":"nP1"}
+          [Product Price Internal] Load Product Prices:
+            skus: ["P1"]
           @ngrx/router-store/navigated: /category/A.123.456/product/P1
+          [Products API] Load Product Prices Success:
+            prices: []
         `);
       }));
 
@@ -544,6 +570,10 @@ describe('Shopping Store', () => {
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
+          [Product Price Internal] Load Product Prices:
+            skus: ["P2"]
+          [Products API] Load Product Prices Success:
+            prices: []
         `);
       }));
 
@@ -584,11 +614,17 @@ describe('Shopping Store', () => {
               sortableAttributes: []
             [Filter API] Load Filter Success:
               filterNavigation: {}
+            [Product Price Internal] Load Product Prices:
+              skus: ["P1"]
+            [Product Price Internal] Load Product Prices:
+              skus: ["P2"]
             @ngrx/router-store/navigated: /category/A.123.456
             [Product Listing] Load More Products:
               id: {"type":"category","value":"A.123.456"}
             [Viewconf Internal] Set Breadcrumb Data:
               breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
+            [Products API] Load Product Prices Success:
+              prices: []
           `);
         }));
       });
@@ -657,7 +693,11 @@ describe('Shopping Store', () => {
           sku: "P1"
         [Products API] Load Product Success:
           product: {"sku":"P1","name":"nP1"}
+        [Product Price Internal] Load Product Prices:
+          skus: ["P1"]
         @ngrx/router-store/navigated: /category/A.123.456/product/P1
+        [Products API] Load Product Prices Success:
+          prices: []
       `);
     }));
 
@@ -709,11 +749,17 @@ describe('Shopping Store', () => {
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
+          [Product Price Internal] Load Product Prices:
+            skus: ["P1"]
+          [Product Price Internal] Load Product Prices:
+            skus: ["P2"]
           @ngrx/router-store/navigated: /category/A.123.456
           [Product Listing] Load More Products:
             id: {"type":"category","value":"A.123.456"}
           [Viewconf Internal] Set Breadcrumb Data:
             breadcrumbData: [{"text":"nA","link":"/nA-catA"},{"text":"nA123","link":"/nA...
+          [Products API] Load Product Prices Success:
+            prices: []
         `);
       }));
     });
@@ -771,7 +817,11 @@ describe('Shopping Store', () => {
           sku: "P1"
         [Products API] Load Product Success:
           product: {"sku":"P1","name":"nP1"}
+        [Product Price Internal] Load Product Prices:
+          skus: ["P1"]
         @ngrx/router-store/navigated: /product/P1
+        [Products API] Load Product Prices Success:
+          prices: []
       `);
     }));
 
@@ -919,6 +969,10 @@ describe('Shopping Store', () => {
           sortableAttributes: []
         [Filter API] Load Filter Success:
           filterNavigation: {}
+        [Product Price Internal] Load Product Prices:
+          skus: ["P2"]
+        [Products API] Load Product Prices Success:
+          prices: []
       `);
     }));
   });

--- a/src/app/core/store/shopping/shopping-store.ts
+++ b/src/app/core/store/shopping/shopping-store.ts
@@ -4,6 +4,7 @@ import { CategoriesState } from './categories/categories.reducer';
 import { CompareState } from './compare/compare.reducer';
 import { FilterState } from './filter/filter.reducer';
 import { ProductListingState } from './product-listing/product-listing.reducer';
+import { ProductPricesState } from './product-prices/product-prices.reducer';
 import { ProductsState } from './products/products.reducer';
 import { PromotionsState } from './promotions/promotions.reducer';
 import { SearchState } from './search/search.reducer';
@@ -16,6 +17,7 @@ export interface ShoppingState {
   filter: FilterState;
   promotions: PromotionsState;
   productListing: ProductListingState;
+  productPrices: ProductPricesState;
 }
 
 export const getShoppingState = createFeatureSelector<ShoppingState>('shopping');

--- a/src/app/extensions/recently/store/recently/recently.integration.spec.ts
+++ b/src/app/extensions/recently/store/recently/recently.integration.spec.ts
@@ -6,6 +6,7 @@ import { flatten } from 'lodash-es';
 
 import { Product, VariationProduct, VariationProductMaster } from 'ish-core/models/product/product.model';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { loadProductSuccess, loadProductVariationsSuccess } from 'ish-core/store/shopping/products';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
@@ -28,9 +29,10 @@ describe('Recently Selectors', () => {
       declarations: [DummyComponent],
       imports: [
         CoreStoreModule.forTesting(['router', 'configuration', 'serverConfig'], [RecentlyEffects]),
+        CustomerStoreModule.forTesting('user'),
         RecentlyStoreModule.forTesting('_recently'),
         RouterTestingModule.withRoutes([{ path: 'product/:sku', component: DummyComponent }]),
-        ShoppingStoreModule.forTesting('categories', 'products'),
+        ShoppingStoreModule.forTesting('categories', 'products', 'productPrices'),
       ],
       providers: [provideStoreSnapshots()],
     });

--- a/src/app/pages/compare/product-compare-list/product-compare-list.component.spec.ts
+++ b/src/app/pages/compare/product-compare-list/product-compare-list.component.spec.ts
@@ -9,6 +9,7 @@ import { FeatureToggleDirective } from 'ish-core/directives/feature-toggle.direc
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { AttributeToStringPipe } from 'ish-core/models/attribute/attribute.pipe';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { ProductView, createProductView } from 'ish-core/models/product-view/product-view.model';
 import { Product } from 'ish-core/models/product/product.model';
 import { ProductAddToBasketComponent } from 'ish-shared/components/product/product-add-to-basket/product-add-to-basket.component';
@@ -34,7 +35,7 @@ describe('Product Compare List Component', () => {
   let compareProduct2: ProductView;
 
   beforeEach(async () => {
-    compareProduct1 = createProductView({ sku: '111', available: true } as Product);
+    compareProduct1 = createProductView({ sku: '111', available: true } as Product, {} as ProductPriceDetails, 'gross');
     compareProduct1.attributes = [
       {
         name: 'Optical zoom',

--- a/src/app/pages/product/product-detail-actions/product-detail-actions.component.spec.ts
+++ b/src/app/pages/product/product-detail-actions/product-detail-actions.component.spec.ts
@@ -7,6 +7,7 @@ import { anyString, instance, mock, verify, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { createProductView } from 'ish-core/models/product-view/product-view.model';
 import { Product } from 'ish-core/models/product/product.model';
 
@@ -44,7 +45,7 @@ describe('Product Detail Actions Component', () => {
     translate.use('en');
 
     const product = { sku: 'sku', available: true } as Product;
-    when(context.select('product')).thenReturn(of(createProductView(product)));
+    when(context.select('product')).thenReturn(of(createProductView(product, {} as ProductPriceDetails, 'gross')));
     when(context.select('displayProperties', anyString())).thenReturn(of(true));
   });
 
@@ -81,7 +82,13 @@ describe('Product Detail Actions Component', () => {
 
     it('should not show "compare" link when product information is available and productMaster = true', () => {
       when(context.select('product')).thenReturn(
-        of(createProductView({ sku: 'SKU', type: 'VariationProductMaster' } as Product))
+        of(
+          createProductView(
+            { sku: 'SKU', type: 'VariationProductMaster' } as Product,
+            {} as ProductPriceDetails,
+            'gross'
+          )
+        )
       );
       fixture.detectChanges();
 

--- a/src/app/pages/product/product-page.component.spec.ts
+++ b/src/app/pages/product/product-page.component.spec.ts
@@ -75,7 +75,7 @@ describe('Product Page Component', () => {
   it('should display product page components when product is available', () => {
     const product = { sku: 'dummy', completenessLevel: ProductCompletenessLevel.Detail } as Product;
     const category = { uniqueId: 'A', categoryPath: ['A'] } as Category;
-    when(context.select('product')).thenReturn(of(createProductView(product, category)));
+    when(context.select('product')).thenReturn(of(createProductView(product, undefined, undefined, category)));
 
     fixture.detectChanges();
 

--- a/src/app/shared/components/product/product-price/product-price.component.ts
+++ b/src/app/shared/components/product/product-price/product-price.component.ts
@@ -4,7 +4,8 @@ import { map } from 'rxjs/operators';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { Price, PriceHelper } from 'ish-core/models/price/price.model';
-import { Product, ProductHelper } from 'ish-core/models/product/product.model';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { ProductHelper } from 'ish-core/models/product/product.model';
 
 @Component({
   selector: 'ish-product-price',
@@ -24,7 +25,7 @@ export class ProductPriceComponent implements OnInit {
       priceSavings: Price;
       lowerPrice: Price;
       upperPrice: Price;
-    } & Pick<Product, 'salePrice' | 'listPrice'>
+    } & Pick<ProductView, 'salePrice' | 'listPrice'>
   >;
 
   constructor(private context: ProductContextFacade) {}


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Product prices are fetched with the products REST resource.

## What Is the New Behavior?

The PWA uses the new productprice REST API to get the (personalized) product prices.
On Logout or Login all personalized prices are removed from store.

## Does this PR Introduce a Breaking Change?

[x] Yes

BREAKING CHANGES: Product prices are now fetched by separate `productprices` REST calls instead of using the information fetched with the products REST call.

## Other Information

[AB#74406](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74406)