### PR TITLE
feat: fetch and display personalized category and product data

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -20,6 +20,13 @@ TestBed configuration arrays are sorted again as of 2.1 This means a lot of (sma
 Simply run `ng lint --fix` in order to sort your arrays.
 If you have a lot of migration changes, you might be required to run it more than once.
 
+With the introduction of personalized REST calls for categories and products, data in the ngrx store runs the risk of not being up-to-date after a login or logout.
+To fix this, a new `resetSubStatesOnActionsMeta` meta-reducer was introduced to remove potentially invalid data from the store.
+If the removal of previous data from the store is not wanted this meta reducer should not be used in customized projects.
+In addition a mechanism was introduced to trigger such personalized REST calls after loading the PGID if necessary.
+This way of loading personalized data might need to be added to any custom implementations that potentially fetch personalized data.
+To get an idea of the necessary mechanism search for the usage of `useCombinedObservableOnAction` and `personalizationStatusDetermined` in the source code.
+
 ## 1.4 to 2.0
 
 Since [TSLint has been deprecated](https://blog.palantir.com/tslint-in-2019-1a144c2317a9) for a while now and Angular removed the TSLint support we had to migrate our project from TSLint to ESLint as well.

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { debounce, delay, filter, map, pairwise, switchMap, tap } from 'rxjs/operators';
+import { debounce, delay, filter, map, switchMap, tap } from 'rxjs/operators';
 
 import { ProductListingID } from 'ish-core/models/product-listing/product-listing.model';
 import { ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
@@ -99,18 +99,6 @@ export class ShoppingFacade {
       switchMap(plainSKU =>
         this.store.pipe(
           select(getProduct(plainSKU)),
-          pairwise(),
-          tap(([prev, curr]) => {
-            if (
-              ProductHelper.isReadyForDisplay(prev, completenessLevel) &&
-              !ProductHelper.isReadyForDisplay(curr, completenessLevel)
-            ) {
-              level === true
-                ? this.store.dispatch(loadProduct({ sku: plainSKU }))
-                : this.store.dispatch(loadProductIfNotLoaded({ sku: plainSKU, level }));
-            }
-          }),
-          map(([, curr]) => curr),
           filter(p => ProductHelper.isReadyForDisplay(p, completenessLevel))
         )
       )
@@ -220,13 +208,8 @@ export class ShoppingFacade {
   // PROMOTIONS
 
   promotion$(promotionId: string) {
-    return this.store.pipe(select(getPromotion(promotionId))).pipe(
-      tap(promo => {
-        if (!promo) {
-          this.store.dispatch(loadPromotion({ promoId: promotionId }));
-        }
-      })
-    );
+    this.store.dispatch(loadPromotion({ promoId: promotionId }));
+    return this.store.pipe(select(getPromotion(promotionId)));
   }
 
   promotions$(promotionIds: string[]) {

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { debounce, delay, filter, map, switchMap, tap } from 'rxjs/operators';
+import { debounce, filter, map, switchMap, tap } from 'rxjs/operators';
 
 import { ProductListingID } from 'ish-core/models/product-listing/product-listing.model';
 import { ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { addProductToBasket } from 'ish-core/store/customer/basket';
-import { getPGID } from 'ish-core/store/customer/user';
 import {
   getCategory,
   getCategoryIdByRefId,
@@ -66,20 +65,10 @@ export class ShoppingFacade {
   }
 
   navigationCategories$(uniqueId?: string) {
-    return uniqueId
-      ? this.store.pipe(select(getNavigationCategories(uniqueId)))
-      : this.store.pipe(select(getPGID)).pipe(
-          delay(0), // delay ensures the apiToken cookie is deleted before a cms request without a pgid is triggered
-          tap(() => {
-            this.store.dispatch(loadTopLevelCategories()); // fetch top level categories after pgid changes (login/logout)
-          }),
-          switchMap(() =>
-            this.store.pipe(
-              select(getNavigationCategories(uniqueId)),
-              filter(categories => !!categories?.length) // prevent to display an empty navigation bar after login/logout
-            )
-          )
-        );
+    if (!uniqueId) {
+      this.store.dispatch(loadTopLevelCategories());
+    }
+    return this.store.pipe(select(getNavigationCategories(uniqueId)));
   }
 
   // PRODUCT

--- a/src/app/core/identity-provider/icm.identity-provider.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.ts
@@ -41,8 +41,8 @@ export class ICMIdentityProvider implements IdentityProvider {
   }
 
   triggerLogout(): TriggerReturnType {
-    this.store.dispatch(logoutUser());
     this.apiTokenService.removeApiToken();
+    this.store.dispatch(logoutUser());
     return this.store.pipe(
       select(selectQueryParam('returnUrl')),
       map(returnUrl => returnUrl || '/home'),

--- a/src/app/core/services/categories/categories.service.spec.ts
+++ b/src/app/core/services/categories/categories.service.spec.ts
@@ -18,8 +18,10 @@ describe('Categories Service', () => {
     when(apiServiceMock.get('categories', anything())).thenReturn(
       of([{ categoryPath: [{ id: 'blubb' }] }] as CategoryData[])
     );
-    when(apiServiceMock.get('categories/dummyid')).thenReturn(of({ categoryPath: [{ id: 'blubb' }] } as CategoryData));
-    when(apiServiceMock.get('categories/dummyid/dummysubid')).thenReturn(
+    when(apiServiceMock.get('categories/dummyid', anything())).thenReturn(
+      of({ categoryPath: [{ id: 'blubb' }] } as CategoryData)
+    );
+    when(apiServiceMock.get('categories/dummyid/dummysubid', anything())).thenReturn(
       of({ categoryPath: [{ id: 'blubb' }] } as CategoryData)
     );
     TestBed.configureTestingModule({
@@ -62,7 +64,7 @@ describe('Categories Service', () => {
     it('should call underlying ApiService categories/id when asked to resolve a category by id', () => {
       categoriesService.getCategory('dummyid');
 
-      verify(apiServiceMock.get('categories/dummyid')).once();
+      verify(apiServiceMock.get('categories/dummyid', anything())).once();
     });
 
     it('should return error when called with undefined', done => {
@@ -91,7 +93,7 @@ describe('Categories Service', () => {
 
     it('should call underlying ApiService categories/id when asked to resolve a subcategory by id', () => {
       categoriesService.getCategory('dummyid/dummysubid');
-      verify(apiServiceMock.get('categories/dummyid/dummysubid')).once();
+      verify(apiServiceMock.get('categories/dummyid/dummysubid', anything())).once();
     });
   });
 });

--- a/src/app/core/services/categories/categories.service.ts
+++ b/src/app/core/services/categories/categories.service.ts
@@ -27,15 +27,17 @@ export class CategoriesService {
       return throwError(() => new Error('getCategory() called without categoryUniqueId'));
     }
 
-    return this.apiService.get<CategoryData>(`categories/${CategoryHelper.getCategoryPath(categoryUniqueId)}`).pipe(
-      map(element => this.categoryMapper.fromData(element)),
-      // bump up completeness level as it won't get any better than this
-      tap(
-        tree =>
-          (tree.nodes[tree.categoryRefs[categoryUniqueId] ?? categoryUniqueId].completenessLevel =
-            CategoryCompletenessLevel.Max)
-      )
-    );
+    return this.apiService
+      .get<CategoryData>(`categories/${CategoryHelper.getCategoryPath(categoryUniqueId)}`, { sendSPGID: true })
+      .pipe(
+        map(element => this.categoryMapper.fromData(element)),
+        // bump up completeness level as it won't get any better than this
+        tap(
+          tree =>
+            (tree.nodes[tree.categoryRefs[categoryUniqueId] ?? categoryUniqueId].completenessLevel =
+              CategoryCompletenessLevel.Max)
+        )
+      );
   }
 
   /**
@@ -50,7 +52,7 @@ export class CategoriesService {
       params = params.set('view', 'tree').set('limit', limit.toString()).set('omitHasOnlineProducts', 'true');
     }
 
-    return this.apiService.get('categories', { params }).pipe(
+    return this.apiService.get('categories', { sendSPGID: true, params }).pipe(
       unpackEnvelope<CategoryData>(),
       map(categoriesData =>
         categoriesData

--- a/src/app/core/services/filter/filter.service.spec.ts
+++ b/src/app/core/services/filter/filter.service.spec.ts
@@ -58,17 +58,20 @@ describe('Filter Service', () => {
   });
 
   it("should get Filter data when 'getFilterForCategory' is called", done => {
-    when(apiService.get(anything())).thenReturn(of(filterMock));
+    when(apiService.get(anything(), anything())).thenReturn(of(filterMock));
     filterService.getFilterForCategory('A.B').subscribe(data => {
       expect(data.filter).toHaveLength(1);
       expect(data.filter[0].facets).toHaveLength(2);
       expect(data.filter[0].facets[0].name).toEqual('a');
       expect(data.filter[0].facets[1].name).toEqual('b');
 
-      verify(apiService.get(anything())).once();
+      verify(apiService.get(anything(), anything())).once();
       expect(capture(apiService.get).last()).toMatchInlineSnapshot(`
         Array [
           "categories/A/B/productfilters",
+          Object {
+            "sendSPGID": true,
+          },
         ]
       `);
 

--- a/src/app/core/services/filter/filter.service.ts
+++ b/src/app/core/services/filter/filter.service.ts
@@ -30,19 +30,23 @@ export class FilterService {
   getFilterForCategory(categoryUniqueId: string): Observable<FilterNavigation> {
     const category = CategoryHelper.getCategoryPath(categoryUniqueId);
     return this.apiService
-      .get<FilterNavigationData>(`categories/${category}/productfilters`)
+      .get<FilterNavigationData>(`categories/${category}/productfilters`, { sendSPGID: true })
       .pipe(map(filter => this.filterNavigationMapper.fromData(filter)));
   }
 
   getFilterForSearch(searchTerm: string): Observable<FilterNavigation> {
     return this.apiService
-      .get<FilterNavigationData>(`productfilters`, { params: new HttpParams().set('searchTerm', searchTerm) })
+      .get<FilterNavigationData>(`productfilters`, {
+        sendSPGID: true,
+        params: new HttpParams().set('searchTerm', searchTerm),
+      })
       .pipe(map(filter => this.filterNavigationMapper.fromData(filter)));
   }
 
   getFilterForMaster(masterSKU: string): Observable<FilterNavigation> {
     return this.apiService
       .get<FilterNavigationData>(`productfilters`, {
+        sendSPGID: true,
         params: new HttpParams().set('MasterSKU', masterSKU),
       })
       .pipe(map(filter => this.filterNavigationMapper.fromData(filter)));

--- a/src/app/core/services/filter/filter.service.ts
+++ b/src/app/core/services/filter/filter.service.ts
@@ -88,7 +88,7 @@ export class FilterService {
         total: number;
         elements: ProductDataStub[];
         sortableAttributes: { [id: string]: SortableAttributesType };
-      }>(resource, { params })
+      }>(resource, { params, sendSPGID: true })
       .pipe(
         map(x => ({
           products: x.elements.map(stub => this.productMapper.fromStubData(stub)),

--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -127,11 +127,13 @@ describe('Products Service', () => {
 
   it("should get all product variations data when 'getProductVariations' is called and more than 50 variations exist", done => {
     const total = 156;
-    when(apiServiceMock.get(`products/${productSku}/variations`)).thenReturn(of({ elements: [], amount: 40, total }));
-    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenReturn(of({ elements: [], total }));
+    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenCall((_, opts) => {
+      return !opts.params ? of({ elements: [], amount: 40, total }) : of({ elements: [], total });
+    });
+
     productsService.getProductVariations(productSku).subscribe(() => {
-      verify(apiServiceMock.get(`products/${productSku}/variations`)).once();
-      verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).thrice();
+      verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).times(4);
+      expect(capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(0)?.[1]?.params).toBeUndefined();
       expect(
         capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(1)?.[1]?.params?.toString()
       ).toMatchInlineSnapshot(`"amount=40&offset=40"`);

--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -118,9 +118,9 @@ describe('Products Service', () => {
   });
 
   it("should get product variations data when 'getProductVariations' is called", done => {
-    when(apiServiceMock.get(`products/${productSku}/variations`)).thenReturn(of({ elements: [] }));
+    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenReturn(of({ elements: [] }));
     productsService.getProductVariations(productSku).subscribe(() => {
-      verify(apiServiceMock.get(`products/${productSku}/variations`)).once();
+      verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).once();
       done();
     });
   });
@@ -146,31 +146,31 @@ describe('Products Service', () => {
   });
 
   it("should get product bundles data when 'getProductBundles' is called", done => {
-    when(apiServiceMock.get(`products/${productSku}/bundles`)).thenReturn(of([]));
+    when(apiServiceMock.get(`products/${productSku}/bundles`, anything())).thenReturn(of([]));
     productsService.getProductBundles(productSku).subscribe(() => {
-      verify(apiServiceMock.get(`products/${productSku}/bundles`)).once();
+      verify(apiServiceMock.get(`products/${productSku}/bundles`, anything())).once();
       done();
     });
   });
 
   it("should get retail set parts data when 'getRetailSetParts' is called", done => {
-    when(apiServiceMock.get(`products/${productSku}/partOfRetailSet`)).thenReturn(of([]));
+    when(apiServiceMock.get(`products/${productSku}/partOfRetailSet`, anything())).thenReturn(of([]));
     productsService.getRetailSetParts(productSku).subscribe(() => {
-      verify(apiServiceMock.get(`products/${productSku}/partOfRetailSet`)).once();
+      verify(apiServiceMock.get(`products/${productSku}/partOfRetailSet`, anything())).once();
       done();
     });
   });
 
   it("should get product links data when 'getProductLinks' is called", done => {
-    when(apiServiceMock.get(`products/${productSku}/links`)).thenReturn(of([]));
+    when(apiServiceMock.get(`products/${productSku}/links`, anything())).thenReturn(of([]));
     productsService.getProductLinks(productSku).subscribe(() => {
-      verify(apiServiceMock.get(`products/${productSku}/links`)).once();
+      verify(apiServiceMock.get(`products/${productSku}/links`, anything())).once();
       done();
     });
   });
 
   it("should get map product links data when 'getProductLinks' is called", done => {
-    when(apiServiceMock.get(`products/${productSku}/links`)).thenReturn(
+    when(apiServiceMock.get(`products/${productSku}/links`, anything())).thenReturn(
       of({
         elements: [
           {

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -46,7 +46,7 @@ export class ProductsService {
     const params = new HttpParams().set('allImages', 'true');
 
     return this.apiService
-      .get<ProductData>(`products/${sku}`, { params })
+      .get<ProductData>(`products/${sku}`, { sendSPGID: true, params })
       .pipe(map(element => this.productMapper.fromData(element)));
   }
 
@@ -85,7 +85,7 @@ export class ProductsService {
         sortableAttributes: { [id: string]: SortableAttributesType };
         categoryUniqueId: string;
         total: number;
-      }>(`categories/${CategoryHelper.getCategoryPath(categoryUniqueId)}/products`, { params })
+      }>(`categories/${CategoryHelper.getCategoryPath(categoryUniqueId)}/products`, { sendSPGID: true, params })
       .pipe(
         map(response => ({
           products: response.elements.map((element: ProductDataStub) => this.productMapper.fromStubData(element)),
@@ -138,7 +138,7 @@ export class ProductsService {
         sortKeys: string[];
         sortableAttributes: { [id: string]: SortableAttributesType };
         total: number;
-      }>('products', { params })
+      }>('products', { sendSPGID: true, params })
       .pipe(
         map(response => ({
           products: response.elements.map(element => this.productMapper.fromStubData(element)),
@@ -182,7 +182,7 @@ export class ProductsService {
         elements: ProductDataStub[];
         sortableAttributes: { [id: string]: SortableAttributesType };
         total: number;
-      }>('products', { params })
+      }>('products', { sendSPGID: true, params })
       .pipe(
         map(response => ({
           products: response.elements.map(element => this.productMapper.fromStubData(element)) as Product[],
@@ -231,6 +231,7 @@ export class ProductsService {
                     .map(([offset, length]) =>
                       this.apiService
                         .get<{ elements: Link[] }>(`products/${sku}/variations`, {
+                          sendSPGID: true,
                           params: new HttpParams().set('amount', length).set('offset', offset),
                         })
                         .pipe(mapToProperty('elements'))

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -262,7 +262,7 @@ export class ProductsService {
       return throwError(() => new Error('getProductBundles() called without a sku'));
     }
 
-    return this.apiService.get(`products/${sku}/bundles`).pipe(
+    return this.apiService.get(`products/${sku}/bundles`, { sendSPGID: true }).pipe(
       unpackEnvelope<Link>(),
       map(links => ({
         stubs: links.map(link => this.productMapper.fromLink(link)),
@@ -279,7 +279,7 @@ export class ProductsService {
       return throwError(() => new Error('getRetailSetParts() called without a sku'));
     }
 
-    return this.apiService.get(`products/${sku}/partOfRetailSet`).pipe(
+    return this.apiService.get(`products/${sku}/partOfRetailSet`, { sendSPGID: true }).pipe(
       unpackEnvelope<Link>(),
       map(links => links.map(link => this.productMapper.fromRetailSetLink(link))),
       defaultIfEmpty([])
@@ -287,7 +287,7 @@ export class ProductsService {
   }
 
   getProductLinks(sku: string): Observable<ProductLinksDictionary> {
-    return this.apiService.get(`products/${sku}/links`).pipe(
+    return this.apiService.get(`products/${sku}/links`, { sendSPGID: true }).pipe(
       unpackEnvelope<{ linkType: string; categoryLinks: Link[]; productLinks: Link[] }>(),
       map(links =>
         links.reduce(

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -36,7 +36,7 @@ import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ng
 import { categoryTree } from 'ish-core/utils/dev/test-data-utils';
 
 import { addProductToBasket, loadBasketSuccess, startCheckout } from './basket';
-import { loginUser, waitForSPGIDComplete } from './user';
+import { loginUser, personalizationStatusDetermined } from './user';
 
 describe('Customer Store', () => {
   let store: StoreWithSnapshots;
@@ -204,7 +204,7 @@ describe('Customer Store', () => {
         })
       );
       store.dispatch(addProductToBasket({ sku: 'test', quantity: 1 }));
-      store.dispatch(waitForSPGIDComplete());
+      store.dispatch(personalizationStatusDetermined());
     });
 
     describe('and with basket', () => {
@@ -220,10 +220,10 @@ describe('Customer Store', () => {
         expect(store.actionsArray()).toMatchInlineSnapshot(`
           [User] Login User:
             credentials: {}
-          [User Internal] Set PGID:
+          [User Internal] Load PGID:
             customer: {"isBusinessCustomer":false,"customerNo":"test"}
             user: {"title":"","firstName":"test","lastName":"test","phoneHome"...
-          [User Internal] Set PGID Success:
+          [User API] Load PGID Success:
             pgid: "spgid"
           [User API] Login User Success:
             customer: {"isBusinessCustomer":false,"customerNo":"test"}

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { EMPTY, of } from 'rxjs';
@@ -205,32 +205,6 @@ describe('Customer Store', () => {
       );
       store.dispatch(addProductToBasket({ sku: 'test', quantity: 1 }));
       store.dispatch(waitForSPGIDComplete());
-    });
-
-    describe('and without basket', () => {
-      it('should initially load basket and basketItems on product add.', fakeAsync(() => {
-        tick(2000);
-
-        expect(store.actionsArray()).toMatchInlineSnapshot(`
-            [Products API] Load Product Success:
-              product: {"sku":"test","packingUnit":"pcs.","completenessLevel":2}
-            [Basket] Add Product:
-              sku: "test"
-              quantity: 1
-            [Basket Internal] Add Items To Basket:
-              items: [{"sku":"test","quantity":1,"unit":"pcs."}]
-            [Basket API] Add Items To Basket Success:
-              info: undefined
-              items: [{"sku":"test","quantity":1,"unit":"pcs."}]
-            [Products Internal] Load Product:
-              sku: "test"
-            [Basket Internal] Load Basket
-            [Products API] Load Product Success:
-              product: {"name":"test","shortDescription":"test","longDescription":"...
-            [Basket API] Load Basket Success:
-              basket: {"id":"test","lineItems":[1]}
-          `);
-      }));
     });
 
     describe('and with basket', () => {

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -148,10 +148,10 @@ describe('Customer Store', () => {
     when(userServiceMock.signInUser(anything())).thenReturn(of({ customer, user }));
 
     const personalizationServiceMock = mock(PersonalizationService);
-    when(personalizationServiceMock.getPGID()).thenReturn(of(''));
+    when(personalizationServiceMock.getPGID()).thenReturn(EMPTY);
 
     const apiTokenServiceMock = mock(ApiTokenService);
-    when(apiTokenServiceMock.hasApiToken()).thenReturn(false);
+    when(apiTokenServiceMock.hasApiTokenCookie()).thenReturn(false);
 
     const filterServiceMock = mock(FilterService);
     const orderServiceMock = mock(OrderService);

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -6,7 +6,6 @@ import { EMPTY, of } from 'rxjs';
 import { anyNumber, anything, instance, mock, when } from 'ts-mockito';
 
 import { Basket } from 'ish-core/models/basket/basket.model';
-import { Credentials } from 'ish-core/models/credentials/credentials.model';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
 import { Price } from 'ish-core/models/price/price.model';
@@ -29,7 +28,6 @@ import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { UserService } from 'ish-core/services/user/user.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
-import { loginUser } from 'ish-core/store/customer/user';
 import { UserEffects } from 'ish-core/store/customer/user/user.effects';
 import { loadProductSuccess } from 'ish-core/store/shopping/products';
 import { SHOPPING_STORE_CONFIG, ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
@@ -239,19 +237,6 @@ describe('Customer Store', () => {
         store.dispatch(loadBasketSuccess({ basket }));
 
         store.reset();
-      });
-      it('should merge basket on user login.', () => {
-        store.dispatch(loginUser({ credentials: {} as Credentials }));
-
-        expect(store.actionsArray()).toMatchInlineSnapshot(`
-          [User] Login User:
-            credentials: {}
-          [User API] Login User Success:
-            customer: {"isBusinessCustomer":false,"customerNo":"test"}
-            user: {"title":"","firstName":"test","lastName":"test","phoneHome"...
-          [Basket API] Merge two baskets Success:
-            basket: {"id":"test","lineItems":[1]}
-        `);
       });
 
       it('should go to checkout address page after starting checkout.', () => {

--- a/src/app/core/store/customer/user/user.actions.ts
+++ b/src/app/core/store/customer/user/user.actions.ts
@@ -73,6 +73,8 @@ export const setPGID = createAction('[User Internal] Set PGID', payload<Customer
 
 export const setPGIDSuccess = createAction('[User Internal] Set PGID Success', payload<{ pgid: string }>());
 
+export const waitForSPGIDComplete = createAction('[User Internal] Wait for SPGID Complete');
+
 export const loadUserCostCenters = createAction('[User] Load User Cost Centers');
 
 export const loadUserCostCentersFail = createAction('[User API] Load User Cost Centers Fail', httpError());

--- a/src/app/core/store/customer/user/user.actions.ts
+++ b/src/app/core/store/customer/user/user.actions.ts
@@ -69,11 +69,11 @@ export const userErrorReset = createAction('[User Internal] Reset User Error');
 
 export const loadUserByAPIToken = createAction('[User] Load User by API Token');
 
-export const setPGID = createAction('[User Internal] Set PGID', payload<CustomerUserType>());
+export const loadPGID = createAction('[User Internal] Load PGID', payload<CustomerUserType>());
 
-export const setPGIDSuccess = createAction('[User Internal] Set PGID Success', payload<{ pgid: string }>());
+export const loadPGIDSuccess = createAction('[User API] Load PGID Success', payload<{ pgid: string }>());
 
-export const waitForSPGIDComplete = createAction('[User Internal] Wait for SPGID Complete');
+export const personalizationStatusDetermined = createAction('[User Internal] Personalization Status Determined');
 
 export const loadUserCostCenters = createAction('[User] Load User Cost Centers');
 

--- a/src/app/core/store/customer/user/user.actions.ts
+++ b/src/app/core/store/customer/user/user.actions.ts
@@ -69,7 +69,9 @@ export const userErrorReset = createAction('[User Internal] Reset User Error');
 
 export const loadUserByAPIToken = createAction('[User] Load User by API Token');
 
-export const setPGID = createAction('[User Internal] Set PGID', payload<{ pgid: string }>());
+export const setPGID = createAction('[User Internal] Set PGID', payload<CustomerUserType>());
+
+export const setPGIDSuccess = createAction('[User Internal] Set PGID Success', payload<{ pgid: string }>());
 
 export const loadUserCostCenters = createAction('[User] Load User Cost Centers');
 

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -22,6 +22,7 @@ import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.modu
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
+import { setPGID } from '.';
 import {
   createUser,
   createUserFail,
@@ -141,9 +142,9 @@ describe('User Effects', () => {
       });
     });
 
-    it('should dispatch a LoginUserSuccess action on successful login', () => {
+    it('should dispatch a setPGID action on successful login', () => {
       const action = loginUser({ credentials: { login: 'dummy', password: 'dummy' } });
-      const completion = loginUserSuccess(loginResponseData);
+      const completion = setPGID(loginResponseData);
 
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-b', { b: completion });
@@ -260,11 +261,11 @@ describe('User Effects', () => {
       });
     });
 
-    it('should dispatch a LoginUserSuccess action on successful user creation', () => {
+    it('should dispatch a setPGID action on successful user creation', () => {
       const credentials: Credentials = { login: '1234', password: 'xxx' };
 
       const action = createUser({ credentials } as CustomerRegistrationType);
-      const completion = loginUserSuccess({} as CustomerUserType);
+      const completion = setPGID({} as CustomerUserType);
 
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-b', { b: completion });
@@ -509,7 +510,7 @@ describe('User Effects', () => {
   });
 
   describe('loadUserByAPIToken$', () => {
-    it('should call the user service on LoadUserByAPIToken action and load user on success', done => {
+    it('should call the user service on LoadUserByAPIToken action and set pgid on success', done => {
       when(userServiceMock.signInUserByToken()).thenReturn(
         of({ user: { email: 'test@intershop.de' } } as CustomerUserType)
       );
@@ -519,8 +520,8 @@ describe('User Effects', () => {
       effects.loadUserByAPIToken$.subscribe(action => {
         verify(userServiceMock.signInUserByToken()).once();
         expect(action).toMatchInlineSnapshot(`
-          [User API] Login User Success:
-            user: {"email":"test@intershop.de"}
+        [User Internal] Set PGID:
+          user: {"email":"test@intershop.de"}
         `);
         done();
       });

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -23,7 +23,7 @@ import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
-import { setPGID } from '.';
+import { loadPGID } from '.';
 import {
   createUser,
   createUserFail,
@@ -148,9 +148,9 @@ describe('User Effects', () => {
       });
     });
 
-    it('should dispatch a setPGID action on successful login', () => {
+    it('should dispatch a loadPGID action on successful login', () => {
       const action = loginUser({ credentials: { login: 'dummy', password: 'dummy' } });
-      const completion = setPGID(loginResponseData);
+      const completion = loadPGID(loginResponseData);
 
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-b', { b: completion });
@@ -267,11 +267,11 @@ describe('User Effects', () => {
       });
     });
 
-    it('should dispatch a setPGID action on successful user creation', () => {
+    it('should dispatch a loadPGID action on successful user creation', () => {
       const credentials: Credentials = { login: '1234', password: 'xxx' };
 
       const action = createUser({ credentials } as CustomerRegistrationType);
-      const completion = setPGID({} as CustomerUserType);
+      const completion = loadPGID({} as CustomerUserType);
 
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-b', { b: completion });
@@ -526,7 +526,7 @@ describe('User Effects', () => {
       effects.loadUserByAPIToken$.subscribe(action => {
         verify(userServiceMock.signInUserByToken()).once();
         expect(action).toMatchInlineSnapshot(`
-        [User Internal] Set PGID:
+        [User Internal] Load PGID:
           user: {"email":"test@intershop.de"}
         `);
         done();

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -19,6 +19,7 @@ import { UserService } from 'ish-core/services/user/user.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
+import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
@@ -64,6 +65,7 @@ describe('User Effects', () => {
   let store$: Store;
   let userServiceMock: UserService;
   let paymentServiceMock: PaymentService;
+  let apiTokenServiceMock: ApiTokenService;
   let router: Router;
   let location: Location;
 
@@ -96,6 +98,7 @@ describe('User Effects', () => {
     when(userServiceMock.getEligibleCostCenters()).thenReturn(of([]));
     when(paymentServiceMock.getUserPaymentMethods(anything())).thenReturn(of([]));
     when(paymentServiceMock.deleteUserPaymentInstrument(anyString(), anyString())).thenReturn(of(undefined));
+    when(apiTokenServiceMock.hasApiToken()).thenReturn(false);
 
     TestBed.configureTestingModule({
       declarations: [DummyComponent],
@@ -105,6 +108,7 @@ describe('User Effects', () => {
         RouterTestingModule.withRoutes([{ path: '**', component: DummyComponent }]),
       ],
       providers: [
+        { provide: ApiTokenService, useFactory: () => instance(apiTokenServiceMock) },
         { provide: PaymentService, useFactory: () => instance(paymentServiceMock) },
         { provide: PersonalizationService, useFactory: () => instance(mock(PersonalizationService)) },
         { provide: UserService, useFactory: () => instance(userServiceMock) },

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -100,7 +100,7 @@ describe('User Effects', () => {
     when(userServiceMock.getEligibleCostCenters()).thenReturn(of([]));
     when(paymentServiceMock.getUserPaymentMethods(anything())).thenReturn(of([]));
     when(paymentServiceMock.deleteUserPaymentInstrument(anyString(), anyString())).thenReturn(of(undefined));
-    when(apiTokenServiceMock.hasApiToken()).thenReturn(false);
+    when(apiTokenServiceMock.hasApiTokenCookie()).thenReturn(false);
 
     TestBed.configureTestingModule({
       declarations: [DummyComponent],

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -87,6 +87,8 @@ describe('User Effects', () => {
   beforeEach(() => {
     userServiceMock = mock(UserService);
     paymentServiceMock = mock(PaymentService);
+    apiTokenServiceMock = mock(ApiTokenService);
+
     when(userServiceMock.signInUser(anything())).thenReturn(of(loginResponseData));
     when(userServiceMock.signInUserByToken(anything())).thenReturn(of(loginResponseData));
     when(userServiceMock.createUser(anything())).thenReturn(of(undefined));

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -100,7 +100,7 @@ describe('User Effects', () => {
     when(userServiceMock.getEligibleCostCenters()).thenReturn(of([]));
     when(paymentServiceMock.getUserPaymentMethods(anything())).thenReturn(of([]));
     when(paymentServiceMock.deleteUserPaymentInstrument(anyString(), anyString())).thenReturn(of(undefined));
-    when(apiTokenServiceMock.hasApiTokenCookie()).thenReturn(false);
+    when(apiTokenServiceMock.hasUserApiTokenCookie()).thenReturn(false);
 
     TestBed.configureTestingModule({
       declarations: [DummyComponent],

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -246,11 +246,14 @@ export class UserEffects {
     )
   );
 
+  /**
+   * This effect emits the waitForSPGIDComplete action when the pgid is set or there is no apiToken cookie,
+   */
   waitForPGID$ = createEffect(() =>
     this.store$.pipe(
       select(getPGID),
       log('wait for pgid'),
-      map(pgid => !this.apiTokenService.hasApiToken() || pgid),
+      map(pgid => !this.apiTokenService.hasApiTokenCookie() || pgid),
       whenTruthy(),
       delay(100),
       map(() => waitForSPGIDComplete())

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -252,7 +252,7 @@ export class UserEffects {
       log('wait for pgid'),
       map(pgid => !this.apiTokenService.hasApiToken() || pgid),
       whenTruthy(),
-      delay(200),
+      delay(100),
       map(() => waitForSPGIDComplete())
     )
   );

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -247,12 +247,12 @@ export class UserEffects {
   );
 
   /**
-   * This effect emits the 'personalizationStatusDetermined' action once the PGID is fetched or there is no apiToken cookie,
+   * This effect emits the 'personalizationStatusDetermined' action once the PGID is fetched or there is no user apiToken cookie,
    */
   determinePersonalizationStatus$ = createEffect(() =>
     this.store$.pipe(
       select(getPGID),
-      map(pgid => !this.apiTokenService.hasApiTokenCookie() || pgid),
+      map(pgid => !this.apiTokenService.hasUserApiTokenCookie() || pgid),
       whenTruthy(),
       delay(100),
       map(() => personalizationStatusDetermined())

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -249,10 +249,10 @@ export class UserEffects {
   waitForPGID$ = createEffect(() =>
     this.store$.pipe(
       select(getPGID),
+      log('wait for pgid'),
       map(pgid => !this.apiTokenService.hasApiToken() || pgid),
       whenTruthy(),
-      delay(100),
-      log('wait for pgid'),
+      delay(200),
       map(() => waitForSPGIDComplete())
     )
   );

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -27,7 +27,6 @@ import { UserService } from 'ish-core/services/user/user.service';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { selectQueryParam, selectUrl } from 'ish-core/store/core/router';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
-import { log } from 'ish-core/utils/dev/operators';
 import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
 import { getPGID, waitForSPGIDComplete } from '.';
@@ -252,7 +251,6 @@ export class UserEffects {
   waitForPGID$ = createEffect(() =>
     this.store$.pipe(
       select(getPGID),
-      log('wait for pgid'),
       map(pgid => !this.apiTokenService.hasApiTokenCookie() || pgid),
       whenTruthy(),
       delay(100),

--- a/src/app/core/store/customer/user/user.reducer.ts
+++ b/src/app/core/store/customer/user/user.reducer.ts
@@ -30,7 +30,7 @@ import {
   requestPasswordReminderFail,
   requestPasswordReminderSuccess,
   resetPasswordReminder,
-  setPGID,
+  setPGIDSuccess,
   updateCustomer,
   updateCustomerFail,
   updateCustomerSuccess,
@@ -165,7 +165,7 @@ export const userReducer = createReducer(
       customer,
     };
   }),
-  on(setPGID, (state, action) => ({
+  on(setPGIDSuccess, (state, action) => ({
     ...state,
     pgid: action.payload.pgid,
   })),

--- a/src/app/core/store/customer/user/user.reducer.ts
+++ b/src/app/core/store/customer/user/user.reducer.ts
@@ -30,7 +30,7 @@ import {
   requestPasswordReminderFail,
   requestPasswordReminderSuccess,
   resetPasswordReminder,
-  setPGIDSuccess,
+  loadPGIDSuccess,
   updateCustomer,
   updateCustomerFail,
   updateCustomerSuccess,
@@ -165,7 +165,7 @@ export const userReducer = createReducer(
       customer,
     };
   }),
-  on(setPGIDSuccess, (state, action) => ({
+  on(loadPGIDSuccess, (state, action) => ({
     ...state,
     pgid: action.payload.pgid,
   })),

--- a/src/app/core/store/shopping/categories/categories.effects.spec.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.spec.ts
@@ -13,6 +13,7 @@ import { CategoryView } from 'ish-core/models/category-view/category-view.model'
 import { Category, CategoryCompletenessLevel, CategoryHelper } from 'ish-core/models/category/category.model';
 import { CategoriesService } from 'ish-core/services/categories/categories.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { categoryTree } from 'ish-core/utils/dev/test-data-utils';
@@ -93,6 +94,7 @@ describe('Categories Effects', () => {
         uniqueId: 'dummy',
         categoryRef: 'dummy@domain',
       } as CategoryView;
+      actions$ = of(waitForSPGIDComplete());
     });
     it('should trigger loadCategoryByRef when /categoryref/XXX is visited', done => {
       router.navigateByUrl('/categoryref/dummy@domain');
@@ -280,7 +282,7 @@ describe('Categories Effects', () => {
   describe('loadTopLevelCategories$', () => {
     it('should call the categoriesService for LoadTopLevelCategories action', done => {
       const action = loadTopLevelCategories();
-      actions$ = of(action);
+      actions$ = of(waitForSPGIDComplete(), action);
 
       effects.loadTopLevelCategories$.subscribe(() => {
         verify(categoriesServiceMock.getTopLevelCategories(anyNumber())).once();
@@ -296,8 +298,8 @@ describe('Categories Effects', () => {
     it('should map to action of type LoadCategorySuccess', () => {
       const action = loadTopLevelCategories();
       const completion = loadTopLevelCategoriesSuccess({ categories: TOP_LEVEL_CATEGORIES });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = hot('b-a-a-a', { a: action, b: waitForSPGIDComplete() });
+      const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadTopLevelCategories$).toBeObservable(expected$);
     });
@@ -310,8 +312,8 @@ describe('Categories Effects', () => {
       const completion = loadTopLevelCategoriesFail({
         error: makeHttpError({ message: 'invalid number' }),
       });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = hot('b-a-a-a', { a: action, b: waitForSPGIDComplete() });
+      const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadTopLevelCategories$).toBeObservable(expected$);
     });

--- a/src/app/core/store/shopping/categories/categories.effects.spec.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.spec.ts
@@ -13,7 +13,7 @@ import { CategoryView } from 'ish-core/models/category-view/category-view.model'
 import { Category, CategoryCompletenessLevel, CategoryHelper } from 'ish-core/models/category/category.model';
 import { CategoriesService } from 'ish-core/services/categories/categories.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { categoryTree } from 'ish-core/utils/dev/test-data-utils';
@@ -94,7 +94,7 @@ describe('Categories Effects', () => {
         uniqueId: 'dummy',
         categoryRef: 'dummy@domain',
       } as CategoryView;
-      actions$ = of(waitForSPGIDComplete());
+      actions$ = of(personalizationStatusDetermined());
     });
     it('should trigger loadCategoryByRef when /categoryref/XXX is visited', done => {
       router.navigateByUrl('/categoryref/dummy@domain');
@@ -282,7 +282,7 @@ describe('Categories Effects', () => {
   describe('loadTopLevelCategories$', () => {
     it('should call the categoriesService for LoadTopLevelCategories action', done => {
       const action = loadTopLevelCategories();
-      actions$ = of(waitForSPGIDComplete(), action);
+      actions$ = of(personalizationStatusDetermined(), action);
 
       effects.loadTopLevelCategories$.subscribe(() => {
         verify(categoriesServiceMock.getTopLevelCategories(anyNumber())).once();
@@ -298,7 +298,7 @@ describe('Categories Effects', () => {
     it('should map to action of type LoadCategorySuccess', () => {
       const action = loadTopLevelCategories();
       const completion = loadTopLevelCategoriesSuccess({ categories: TOP_LEVEL_CATEGORIES });
-      actions$ = hot('b-a-a-a', { a: action, b: waitForSPGIDComplete() });
+      actions$ = hot('b-a-a-a', { a: action, b: personalizationStatusDetermined() });
       const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadTopLevelCategories$).toBeObservable(expected$);
@@ -312,7 +312,7 @@ describe('Categories Effects', () => {
       const completion = loadTopLevelCategoriesFail({
         error: makeHttpError({ message: 'invalid number' }),
       });
-      actions$ = hot('b-a-a-a', { a: action, b: waitForSPGIDComplete() });
+      actions$ = hot('b-a-a-a', { a: action, b: personalizationStatusDetermined() });
       const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadTopLevelCategories$).toBeObservable(expected$);

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -11,9 +11,15 @@ import { ofCategoryUrl } from 'ish-core/routing/category/category.route';
 import { CategoriesService } from 'ish-core/services/categories/categories.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { loadMoreProducts } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
-import { mapErrorToAction, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
+import {
+  mapErrorToAction,
+  mapToPayloadProperty,
+  useCombinedObservableOnAction,
+  whenTruthy,
+} from 'ish-core/utils/operators';
 
 import {
   loadCategory,
@@ -46,8 +52,11 @@ export class CategoriesEffects {
    * when the requested {@link Category} is not available, yet
    */
   selectedCategory$ = createEffect(() =>
-    this.store.pipe(
-      select(selectRouteParam('categoryUniqueId')),
+    this.actions$.pipe(
+      useCombinedObservableOnAction(
+        this.store.pipe(select(selectRouteParam('categoryUniqueId'))),
+        waitForSPGIDComplete
+      ),
       whenTruthy(),
       withLatestFrom(this.store.pipe(select(getCategoryEntities))),
       filter(([id, entities]) => !CategoryHelper.isCategoryCompletelyLoaded(entities[id])),
@@ -60,8 +69,8 @@ export class CategoriesEffects {
    * when the requested ref in {@link getCategoryRefs} is not available, yet
    */
   selectedCategoryRef$ = createEffect(() =>
-    this.store.pipe(
-      select(selectRouteParam('categoryRefId')),
+    this.actions$.pipe(
+      useCombinedObservableOnAction(this.store.pipe(select(selectRouteParam('categoryRefId'))), waitForSPGIDComplete),
       whenTruthy(),
       withLatestFrom(this.store.pipe(select(getCategoryRefs)), this.store.pipe(select(getCategoryEntities))),
       filter(
@@ -90,7 +99,7 @@ export class CategoriesEffects {
 
   loadTopLevelCategories$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(loadTopLevelCategories),
+      useCombinedObservableOnAction(this.actions$.pipe(ofType(loadTopLevelCategories)), waitForSPGIDComplete),
       switchMap(() =>
         this.categoryService.getTopLevelCategories(this.mainNavigationMaxSubCategoriesDepth).pipe(
           map(categories => loadTopLevelCategoriesSuccess({ categories })),

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -11,7 +11,7 @@ import { ofCategoryUrl } from 'ish-core/routing/category/category.route';
 import { CategoriesService } from 'ish-core/services/categories/categories.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { loadMoreProducts } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
 import {
@@ -55,7 +55,7 @@ export class CategoriesEffects {
     this.actions$.pipe(
       useCombinedObservableOnAction(
         this.store.pipe(select(selectRouteParam('categoryUniqueId'))),
-        waitForSPGIDComplete
+        personalizationStatusDetermined
       ),
       whenTruthy(),
       withLatestFrom(this.store.pipe(select(getCategoryEntities))),
@@ -70,7 +70,10 @@ export class CategoriesEffects {
    */
   selectedCategoryRef$ = createEffect(() =>
     this.actions$.pipe(
-      useCombinedObservableOnAction(this.store.pipe(select(selectRouteParam('categoryRefId'))), waitForSPGIDComplete),
+      useCombinedObservableOnAction(
+        this.store.pipe(select(selectRouteParam('categoryRefId'))),
+        personalizationStatusDetermined
+      ),
       whenTruthy(),
       withLatestFrom(this.store.pipe(select(getCategoryRefs)), this.store.pipe(select(getCategoryEntities))),
       filter(
@@ -99,7 +102,10 @@ export class CategoriesEffects {
 
   loadTopLevelCategories$ = createEffect(() =>
     this.actions$.pipe(
-      useCombinedObservableOnAction(this.actions$.pipe(ofType(loadTopLevelCategories)), waitForSPGIDComplete),
+      useCombinedObservableOnAction(
+        this.actions$.pipe(ofType(loadTopLevelCategories)),
+        personalizationStatusDetermined
+      ),
       switchMap(() =>
         this.categoryService.getTopLevelCategories(this.mainNavigationMaxSubCategoriesDepth).pipe(
           map(categories => loadTopLevelCategoriesSuccess({ categories })),

--- a/src/app/core/store/shopping/products/products.effects.spec.ts
+++ b/src/app/core/store/shopping/products/products.effects.spec.ts
@@ -12,7 +12,7 @@ import { anyNumber, anyString, anything, capture, instance, mock, spy, verify, w
 import { Product, VariationProductMaster } from 'ish-core/models/product/product.model';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user/user.actions';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user/user.actions';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
@@ -90,11 +90,11 @@ describe('Products Effects', () => {
   });
 
   describe('loadProduct$', () => {
-    const waitAction = waitForSPGIDComplete();
+    const waitAction = personalizationStatusDetermined();
     it('should call the productsService for LoadProduct action', done => {
       const sku = 'P123';
       const action = loadProduct({ sku });
-      actions$ = merge(of(waitForSPGIDComplete()), of(action));
+      actions$ = merge(of(personalizationStatusDetermined()), of(action));
 
       effects.loadProduct$.subscribe(() => {
         verify(productsServiceMock.getProduct(sku)).once();
@@ -124,7 +124,7 @@ describe('Products Effects', () => {
 
     it('should map invalid request to action of type LoadProductFail - setTimeout', done => {
       actions$ = merge(
-        of(waitForSPGIDComplete()),
+        of(personalizationStatusDetermined()),
         new BehaviorSubject(loadProduct({ sku: 'invalid' })),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(1000)),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(2000))
@@ -160,7 +160,7 @@ describe('Products Effects', () => {
 
     it('should map invalid request to action of type LoadProductFail - fakeAsync', fakeAsync(() => {
       actions$ = merge(
-        of(waitForSPGIDComplete()),
+        of(personalizationStatusDetermined()),
         new BehaviorSubject(loadProduct({ sku: 'invalid' })),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(1000)),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(2000))

--- a/src/app/core/store/shopping/products/products.effects.spec.ts
+++ b/src/app/core/store/shopping/products/products.effects.spec.ts
@@ -12,6 +12,7 @@ import { anyNumber, anyString, anything, capture, instance, mock, spy, verify, w
 import { Product, VariationProductMaster } from 'ish-core/models/product/product.model';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user/user.actions';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
@@ -89,10 +90,11 @@ describe('Products Effects', () => {
   });
 
   describe('loadProduct$', () => {
+    const waitAction = waitForSPGIDComplete();
     it('should call the productsService for LoadProduct action', done => {
       const sku = 'P123';
       const action = loadProduct({ sku });
-      actions$ = of(action);
+      actions$ = merge(of(waitForSPGIDComplete()), of(action));
 
       effects.loadProduct$.subscribe(() => {
         verify(productsServiceMock.getProduct(sku)).once();
@@ -104,8 +106,8 @@ describe('Products Effects', () => {
       const sku = 'P123';
       const action = loadProduct({ sku });
       const completion = loadProductSuccess({ product: { sku } as Product });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = hot('b-a-a-a', { a: action, b: waitAction });
+      const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadProduct$).toBeObservable(expected$);
     });
@@ -114,14 +116,15 @@ describe('Products Effects', () => {
       const sku = 'invalid';
       const action = loadProduct({ sku });
       const completion = loadProductFail({ error: makeHttpError({ message: 'invalid' }), sku });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = hot('b-a-a-a', { a: action, b: waitAction });
+      const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadProduct$).toBeObservable(expected$);
     });
 
     it('should map invalid request to action of type LoadProductFail - setTimeout', done => {
       actions$ = merge(
+        of(waitForSPGIDComplete()),
         new BehaviorSubject(loadProduct({ sku: 'invalid' })),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(1000)),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(2000))
@@ -157,6 +160,7 @@ describe('Products Effects', () => {
 
     it('should map invalid request to action of type LoadProductFail - fakeAsync', fakeAsync(() => {
       actions$ = merge(
+        of(waitForSPGIDComplete()),
         new BehaviorSubject(loadProduct({ sku: 'invalid' })),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(1000)),
         of(loadProduct({ sku: 'invalid' })).pipe(delay(2000))

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -28,7 +28,7 @@ import { ofProductUrl } from 'ish-core/routing/product/product.route';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
@@ -83,7 +83,7 @@ export class ProductsEffects {
   loadProduct$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadProduct),
-      delayUntil(this.actions$.pipe(ofType(waitForSPGIDComplete))),
+      delayUntil(this.actions$.pipe(ofType(personalizationStatusDetermined))),
       mapToPayloadProperty('sku'),
       groupBy(identity),
       mergeMap(group$ =>

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -29,6 +29,7 @@ import { ofProductUrl } from 'ish-core/routing/product/product.route';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
@@ -37,6 +38,7 @@ import {
   mapToPayload,
   mapToPayloadProperty,
   mapToProperty,
+  useCombinedObservableOnAction,
   whenTruthy,
 } from 'ish-core/utils/operators';
 
@@ -227,7 +229,7 @@ export class ProductsEffects {
    */
   loadProductVariations$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(loadProductVariationsIfNotLoaded),
+      useCombinedObservableOnAction(this.actions$.pipe(ofType(loadProductVariationsIfNotLoaded)), waitForSPGIDComplete),
       mapToPayloadProperty('sku'),
       groupBy(identity),
       mergeMap(group$ =>

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -28,10 +28,12 @@ import { ofProductUrl } from 'ish-core/routing/product/product.route';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
 import {
+  delayUntil,
   mapErrorToAction,
   mapToPayload,
   mapToPayloadProperty,
@@ -81,6 +83,7 @@ export class ProductsEffects {
   loadProduct$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadProduct),
+      delayUntil(this.actions$.pipe(ofType(waitForSPGIDComplete))),
       mapToPayloadProperty('sku'),
       groupBy(identity),
       mergeMap(group$ =>

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -8,7 +8,6 @@ import { combineLatest, from, identity } from 'rxjs';
 import {
   concatMap,
   distinct,
-  distinctUntilChanged,
   exhaustMap,
   filter,
   first,
@@ -29,7 +28,6 @@ import { ofProductUrl } from 'ish-core/routing/product/product.route';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { loadCategory } from 'ish-core/store/shopping/categories';
 import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
@@ -38,7 +36,6 @@ import {
   mapToPayload,
   mapToPayloadProperty,
   mapToProperty,
-  useCombinedObservableOnAction,
   whenTruthy,
 } from 'ish-core/utils/operators';
 
@@ -229,7 +226,7 @@ export class ProductsEffects {
    */
   loadProductVariations$ = createEffect(() =>
     this.actions$.pipe(
-      useCombinedObservableOnAction(this.actions$.pipe(ofType(loadProductVariationsIfNotLoaded)), waitForSPGIDComplete),
+      ofType(loadProductVariationsIfNotLoaded),
       mapToPayloadProperty('sku'),
       groupBy(identity),
       mergeMap(group$ =>
@@ -293,7 +290,6 @@ export class ProductsEffects {
       filter(p => !ProductHelper.isFailedLoading(p)),
       mapToProperty('defaultCategoryId'),
       whenTruthy(),
-      distinctUntilChanged(),
       map(categoryId => loadCategory({ categoryId }))
     )
   );

--- a/src/app/core/store/shopping/promotions/promotions.effects.spec.ts
+++ b/src/app/core/store/shopping/promotions/promotions.effects.spec.ts
@@ -50,23 +50,23 @@ describe('Promotions Effects', () => {
       });
     });
 
-    it('should map to action of type LoadPromotionSuccess', () => {
+    it('should map to action of type LoadPromotionSuccess only once', () => {
       const id = 'P123';
       const promoId = 'P123';
       const action = loadPromotion({ promoId });
       const completion = loadPromotionSuccess({ promotion: { id } as Promotion });
       actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c-', { c: completion });
+      const expected$ = cold('-c-----', { c: completion });
 
       expect(effects.loadPromotion$).toBeObservable(expected$);
     });
 
-    it('should map invalid request to action of type LoadPromotionFail', () => {
+    it('should map invalid request to action of type LoadPromotionFail only once', () => {
       const promoId = 'invalid';
       const action = loadPromotion({ promoId });
       const completion = loadPromotionFail({ error: makeHttpError({ message: 'invalid' }), promoId });
       actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c-', { c: completion });
+      const expected$ = cold('-c-----', { c: completion });
 
       expect(effects.loadPromotion$).toBeObservable(expected$);
     });

--- a/src/app/core/store/shopping/promotions/promotions.effects.spec.ts
+++ b/src/app/core/store/shopping/promotions/promotions.effects.spec.ts
@@ -50,23 +50,23 @@ describe('Promotions Effects', () => {
       });
     });
 
-    it('should map to action of type LoadPromotionSuccess only once', () => {
+    it('should map to action of type LoadPromotionSuccess', () => {
       const id = 'P123';
       const promoId = 'P123';
       const action = loadPromotion({ promoId });
       const completion = loadPromotionSuccess({ promotion: { id } as Promotion });
       actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c----', { c: completion });
+      const expected$ = cold('-c-c-c-', { c: completion });
 
       expect(effects.loadPromotion$).toBeObservable(expected$);
     });
 
-    it('should map invalid request to action of type LoadPromotionFail only once', () => {
+    it('should map invalid request to action of type LoadPromotionFail', () => {
       const promoId = 'invalid';
       const action = loadPromotion({ promoId });
       const completion = loadPromotionFail({ error: makeHttpError({ message: 'invalid' }), promoId });
       actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c----', { c: completion });
+      const expected$ = cold('-c-c-c-', { c: completion });
 
       expect(effects.loadPromotion$).toBeObservable(expected$);
     });

--- a/src/app/core/store/shopping/promotions/promotions.effects.ts
+++ b/src/app/core/store/shopping/promotions/promotions.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { distinct, map, mergeMap } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
@@ -15,8 +15,6 @@ export class PromotionsEffects {
     this.actions$.pipe(
       ofType(loadPromotion),
       mapToPayloadProperty('promoId'),
-      // trigger the promotion REST call only once for each distinct promotion id (per application session)
-      distinct(),
       mergeMap(
         promoId =>
           this.promotionsService.getPromotion(promoId).pipe(

--- a/src/app/core/store/shopping/promotions/promotions.effects.ts
+++ b/src/app/core/store/shopping/promotions/promotions.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { map, mergeMap } from 'rxjs/operators';
+import { distinct, map, mergeMap } from 'rxjs/operators';
 
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
@@ -15,6 +15,8 @@ export class PromotionsEffects {
     this.actions$.pipe(
       ofType(loadPromotion),
       mapToPayloadProperty('promoId'),
+      // trigger the promotion REST call only once for each distinct promotion id (per application session)
+      distinct(),
       mergeMap(
         promoId =>
           this.promotionsService.getPromotion(promoId).pipe(

--- a/src/app/core/store/shopping/search/search.effects.spec.ts
+++ b/src/app/core/store/shopping/search/search.effects.spec.ts
@@ -10,7 +10,7 @@ import { SuggestTerm } from 'ish-core/models/suggest-term/suggest-term.model';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { loadMoreProducts, setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
 import { ProductListingEffects } from 'ish-core/store/shopping/product-listing/product-listing.effects';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
@@ -78,7 +78,7 @@ describe('Search Effects', () => {
     httpStatusCodeService = spy(TestBed.inject(HttpStatusCodeService));
 
     store$.dispatch(setProductListingPageSize({ itemsPerPage: 12 }));
-    store$.dispatch(waitForSPGIDComplete());
+    store$.dispatch(personalizationStatusDetermined());
   });
 
   describe('triggerSearch$', () => {

--- a/src/app/core/store/shopping/search/search.effects.spec.ts
+++ b/src/app/core/store/shopping/search/search.effects.spec.ts
@@ -10,6 +10,7 @@ import { SuggestTerm } from 'ish-core/models/suggest-term/suggest-term.model';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { loadMoreProducts, setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
 import { ProductListingEffects } from 'ish-core/store/shopping/product-listing/product-listing.effects';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
@@ -77,20 +78,25 @@ describe('Search Effects', () => {
     httpStatusCodeService = spy(TestBed.inject(HttpStatusCodeService));
 
     store$.dispatch(setProductListingPageSize({ itemsPerPage: 12 }));
+    store$.dispatch(waitForSPGIDComplete());
   });
 
   describe('triggerSearch$', () => {
-    it('should trigger action if search URL is matched', done => {
+    it('should trigger actions if search URL is matched', fakeAsync(() => {
       router.navigateByUrl('/search/dummy');
 
-      effects.triggerSearch$.subscribe(data => {
-        expect(data).toMatchInlineSnapshot(`
-          [Product Listing] Load More Products:
-            id: {"type":"search","value":"dummy"}
-        `);
-        done();
-      });
-    });
+      tick(200);
+
+      expect(store$.actionsArray(/Load More Products/)).toMatchInlineSnapshot(`
+        [Product Listing] Load More Products:
+          id: {"type":"search","value":"dummy"}
+        [Product Listing Internal] Load More Products For Params:
+          id: {"type":"search","value":"dummy"}
+          filters: undefined
+          sorting: undefined
+          page: undefined
+      `);
+    }));
   });
 
   describe('suggestSearch$', () => {

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -30,6 +30,7 @@ import {
   setProductListingPages,
 } from 'ish-core/store/shopping/product-listing';
 import { loadProductSuccess } from 'ish-core/store/shopping/products';
+import { log } from 'ish-core/utils/dev/operators';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
 import {
   mapErrorToAction,
@@ -67,8 +68,10 @@ export class SearchEffects {
       ofUrl(/^\/search.*/),
       withLatestFrom(this.store.pipe(select(selectRouteParam('searchTerm')))),
       map(([, searchTerm]) => searchTerm),
+      log('before wt'),
       whenTruthy(),
-      map(searchTerm => loadMoreProducts({ id: { type: 'search', value: searchTerm } }))
+      map(searchTerm => loadMoreProducts({ id: { type: 'search', value: searchTerm } })),
+      log('after wt')
     )
   );
 

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -23,7 +23,7 @@ import { ProductsService } from 'ish-core/services/products/products.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { ofUrl, selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import {
   getProductListingItemsPerPage,
   loadMoreProducts,
@@ -61,7 +61,10 @@ export class SearchEffects {
     this.store.pipe(
       sample(
         this.actions$.pipe(
-          useCombinedObservableOnAction(this.actions$.pipe(ofType(routerNavigatedAction)), waitForSPGIDComplete)
+          useCombinedObservableOnAction(
+            this.actions$.pipe(ofType(routerNavigatedAction)),
+            personalizationStatusDetermined
+          )
         )
       ),
       ofUrl(/^\/search.*/),

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -23,6 +23,7 @@ import { ProductsService } from 'ish-core/services/products/products.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { ofUrl, selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import {
   getProductListingItemsPerPage,
   loadMoreProducts,
@@ -30,7 +31,13 @@ import {
 } from 'ish-core/store/shopping/product-listing';
 import { loadProductSuccess } from 'ish-core/store/shopping/products';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
-import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
+import {
+  mapErrorToAction,
+  mapToPayload,
+  mapToPayloadProperty,
+  useCombinedObservableOnAction,
+  whenTruthy,
+} from 'ish-core/utils/operators';
 
 import { searchProducts, searchProductsFail, suggestSearch, suggestSearchSuccess } from './search.actions';
 
@@ -52,7 +59,11 @@ export class SearchEffects {
    */
   triggerSearch$ = createEffect(() =>
     this.store.pipe(
-      sample(this.actions$.pipe(ofType(routerNavigatedAction))),
+      sample(
+        this.actions$.pipe(
+          useCombinedObservableOnAction(this.actions$.pipe(ofType(routerNavigatedAction)), waitForSPGIDComplete)
+        )
+      ),
       ofUrl(/^\/search.*/),
       withLatestFrom(this.store.pipe(select(selectRouteParam('searchTerm')))),
       map(([, searchTerm]) => searchTerm),

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -30,7 +30,6 @@ import {
   setProductListingPages,
 } from 'ish-core/store/shopping/product-listing';
 import { loadProductSuccess } from 'ish-core/store/shopping/products';
-import { log } from 'ish-core/utils/dev/operators';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
 import {
   mapErrorToAction,
@@ -68,10 +67,8 @@ export class SearchEffects {
       ofUrl(/^\/search.*/),
       withLatestFrom(this.store.pipe(select(selectRouteParam('searchTerm')))),
       map(([, searchTerm]) => searchTerm),
-      log('before wt'),
       whenTruthy(),
-      map(searchTerm => loadMoreProducts({ id: { type: 'search', value: searchTerm } })),
-      log('after wt')
+      map(searchTerm => loadMoreProducts({ id: { type: 'search', value: searchTerm } }))
     )
   );
 

--- a/src/app/core/store/shopping/shopping-store.module.ts
+++ b/src/app/core/store/shopping/shopping-store.module.ts
@@ -5,7 +5,7 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user/user.actions';
+import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user';
 import { DataRetentionPolicy, dataRetentionMeta, resetSubStatesOnActionsMeta } from 'ish-core/utils/meta-reducers';
 
 import { CategoriesEffects } from './categories/categories.effects';

--- a/src/app/core/store/shopping/shopping-store.module.ts
+++ b/src/app/core/store/shopping/shopping-store.module.ts
@@ -5,7 +5,7 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { DataRetentionPolicy, dataRetentionMeta, resetSubStatesOnActionsMeta } from 'ish-core/utils/meta-reducers';
 
 import { CategoriesEffects } from './categories/categories.effects';
@@ -48,10 +48,7 @@ const shoppingEffects = [
 export class DefaultShoppingStoreConfig implements StoreConfig<ShoppingState> {
   metaReducers = [
     dataRetentionMeta<ShoppingState>(this.dataRetention.compare, this.appBaseHref, 'shopping', '_compare'),
-    resetSubStatesOnActionsMeta<ShoppingState>(
-      ['categories', 'products', 'search', 'filter'],
-      [logoutUser, loginUserSuccess]
-    ),
+    resetSubStatesOnActionsMeta<ShoppingState>(['categories', 'products', 'search', 'filter'], [waitForSPGIDComplete]),
   ];
 
   constructor(

--- a/src/app/core/store/shopping/shopping-store.module.ts
+++ b/src/app/core/store/shopping/shopping-store.module.ts
@@ -5,7 +5,7 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { DataRetentionPolicy, dataRetentionMeta, resetSubStatesOnActionsMeta } from 'ish-core/utils/meta-reducers';
 
 import { CategoriesEffects } from './categories/categories.effects';
@@ -48,7 +48,10 @@ const shoppingEffects = [
 export class DefaultShoppingStoreConfig implements StoreConfig<ShoppingState> {
   metaReducers = [
     dataRetentionMeta<ShoppingState>(this.dataRetention.compare, this.appBaseHref, 'shopping', '_compare'),
-    resetSubStatesOnActionsMeta<ShoppingState>(['categories', 'products', 'search', 'filter'], [waitForSPGIDComplete]),
+    resetSubStatesOnActionsMeta<ShoppingState>(
+      ['categories', 'products', 'search', 'filter'],
+      [personalizationStatusDetermined]
+    ),
   ];
 
   constructor(

--- a/src/app/core/store/shopping/shopping-store.module.ts
+++ b/src/app/core/store/shopping/shopping-store.module.ts
@@ -5,7 +5,8 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { DataRetentionPolicy, dataRetentionMeta, resetPersonalizedShoppingMeta } from 'ish-core/utils/meta-reducers';
+import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user/user.actions';
+import { DataRetentionPolicy, dataRetentionMeta, resetSubStatesOnActionsMeta } from 'ish-core/utils/meta-reducers';
 
 import { CategoriesEffects } from './categories/categories.effects';
 import { categoriesReducer } from './categories/categories.reducer';
@@ -47,7 +48,10 @@ const shoppingEffects = [
 export class DefaultShoppingStoreConfig implements StoreConfig<ShoppingState> {
   metaReducers = [
     dataRetentionMeta<ShoppingState>(this.dataRetention.compare, this.appBaseHref, 'shopping', '_compare'),
-    resetPersonalizedShoppingMeta,
+    resetSubStatesOnActionsMeta<ShoppingState>(
+      ['categories', 'products', 'search', 'filter'],
+      [logoutUser, loginUserSuccess]
+    ),
   ];
 
   constructor(

--- a/src/app/core/store/shopping/shopping-store.module.ts
+++ b/src/app/core/store/shopping/shopping-store.module.ts
@@ -5,7 +5,7 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { DataRetentionPolicy, dataRetentionMeta } from 'ish-core/utils/meta-reducers';
+import { DataRetentionPolicy, dataRetentionMeta, resetPersonalizedShoppingMeta } from 'ish-core/utils/meta-reducers';
 
 import { CategoriesEffects } from './categories/categories.effects';
 import { categoriesReducer } from './categories/categories.reducer';
@@ -47,6 +47,7 @@ const shoppingEffects = [
 export class DefaultShoppingStoreConfig implements StoreConfig<ShoppingState> {
   metaReducers = [
     dataRetentionMeta<ShoppingState>(this.dataRetention.compare, this.appBaseHref, 'shopping', '_compare'),
+    resetPersonalizedShoppingMeta,
   ];
 
   constructor(

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -20,7 +20,7 @@ import { ProductsService } from 'ish-core/services/products/products.service';
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
 import { categoryTree } from 'ish-core/utils/dev/test-data-utils';
@@ -196,7 +196,7 @@ describe('Shopping Store', () => {
     TestBed.inject(SelectedProductContextFacade);
     store.reset();
 
-    store.dispatch(waitForSPGIDComplete());
+    store.dispatch(personalizationStatusDetermined());
   });
 
   it('should be created', () => {
@@ -211,7 +211,7 @@ describe('Shopping Store', () => {
 
     it('should just load toplevel categories when no specific shopping page is loaded', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /home
         @ngrx/router-store/navigation: /home
         @ngrx/router-store/navigated: /home
@@ -360,7 +360,7 @@ describe('Shopping Store', () => {
 
     it('should have toplevel loading and category loading actions when going to a category page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /category/A.123
         @ngrx/router-store/navigation: /category/A.123
         [Categories Internal] Load Category:
@@ -425,7 +425,7 @@ describe('Shopping Store', () => {
 
     it('should have all required actions when going to a family page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /category/A.123.456
         @ngrx/router-store/navigation: /category/A.123.456
         [Categories Internal] Load Category:
@@ -646,7 +646,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /category/A.123.456/product/P1
         @ngrx/router-store/navigation: /category/A.123.456/product/P1
         [Categories Internal] Load Category:
@@ -764,7 +764,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /product/P1
         @ngrx/router-store/navigation: /product/P1
         [Products Internal] Load Product:
@@ -821,7 +821,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page with invalid product sku', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /category/A.123.456/product/P3
         @ngrx/router-store/navigation: /category/A.123.456/product/P3
         [Categories Internal] Load Category:
@@ -859,7 +859,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a category page with invalid category uniqueId', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /category/A.123.XXX
         @ngrx/router-store/navigation: /category/A.123.XXX
         [Categories Internal] Load Category:
@@ -891,7 +891,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required actions when searching', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
-        [User Internal] Wait for SPGID Complete
+        [User Internal] Personalization Status Determined
         @ngrx/router-store/request: /search/something
         @ngrx/router-store/navigation: /search/something
         @ngrx/router-store/navigated: /search/something

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -20,6 +20,7 @@ import { ProductsService } from 'ish-core/services/products/products.service';
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
 import { SuggestService } from 'ish-core/services/suggest/suggest.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { waitForSPGIDComplete } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
 import { categoryTree } from 'ish-core/utils/dev/test-data-utils';
@@ -194,6 +195,8 @@ describe('Shopping Store', () => {
     router = TestBed.inject(Router);
     TestBed.inject(SelectedProductContextFacade);
     store.reset();
+
+    store.dispatch(waitForSPGIDComplete());
   });
 
   it('should be created', () => {
@@ -208,6 +211,7 @@ describe('Shopping Store', () => {
 
     it('should just load toplevel categories when no specific shopping page is loaded', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /home
         @ngrx/router-store/navigation: /home
         @ngrx/router-store/navigated: /home
@@ -356,6 +360,7 @@ describe('Shopping Store', () => {
 
     it('should have toplevel loading and category loading actions when going to a category page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /category/A.123
         @ngrx/router-store/navigation: /category/A.123
         [Categories Internal] Load Category:
@@ -420,6 +425,7 @@ describe('Shopping Store', () => {
 
     it('should have all required actions when going to a family page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /category/A.123.456
         @ngrx/router-store/navigation: /category/A.123.456
         [Categories Internal] Load Category:
@@ -640,6 +646,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /category/A.123.456/product/P1
         @ngrx/router-store/navigation: /category/A.123.456/product/P1
         [Categories Internal] Load Category:
@@ -757,6 +764,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /product/P1
         @ngrx/router-store/navigation: /product/P1
         [Products Internal] Load Product:
@@ -813,6 +821,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a product page with invalid product sku', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /category/A.123.456/product/P3
         @ngrx/router-store/navigation: /category/A.123.456/product/P3
         [Categories Internal] Load Category:
@@ -850,6 +859,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required load actions when going to a category page with invalid category uniqueId', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /category/A.123.XXX
         @ngrx/router-store/navigation: /category/A.123.XXX
         [Categories Internal] Load Category:
@@ -881,6 +891,7 @@ describe('Shopping Store', () => {
 
     it('should trigger required actions when searching', fakeAsync(() => {
       expect(store.actionsArray()).toMatchInlineSnapshot(`
+        [User Internal] Wait for SPGID Complete
         @ngrx/router-store/request: /search/something
         @ngrx/router-store/navigation: /search/something
         @ngrx/router-store/navigated: /search/something

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -131,7 +131,7 @@ export class ApiTokenService {
     }
   }
 
-  hasApiToken() {
+  hasApiTokenCookie() {
     return !!this.cookiesService.get('apiToken');
   }
 

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -139,8 +139,7 @@ export class ApiTokenService {
     if (isPlatformServer(this.platformId)) {
       return of(true);
     }
-    return timer(500, 200).pipe(
-      filter(() => this.router.navigated),
+    return this.router.events.pipe(
       first(),
       switchMap(() => this.initialCookie$),
       switchMap(cookie => {

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -131,6 +131,10 @@ export class ApiTokenService {
     }
   }
 
+  hasApiToken() {
+    return !!this.cookiesService.get('apiToken');
+  }
+
   restore$(types: ApiTokenCookieType[] = ['user', 'basket', 'order']): Observable<boolean> {
     if (isPlatformServer(this.platformId)) {
       return of(true);

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -131,8 +131,9 @@ export class ApiTokenService {
     }
   }
 
-  hasApiTokenCookie() {
-    return !!this.cookiesService.get('apiToken');
+  hasUserApiTokenCookie() {
+    const apiTokenCookie = this.parseCookie();
+    return apiTokenCookie?.type === 'user';
   }
 
   restore$(types: ApiTokenCookieType[] = ['user', 'basket', 'order']): Observable<boolean> {

--- a/src/app/core/utils/meta-reducers.spec.ts
+++ b/src/app/core/utils/meta-reducers.spec.ts
@@ -1,11 +1,72 @@
-import { Action, combineReducers } from '@ngrx/store';
+import { Action, ActionReducerMap, combineReducers } from '@ngrx/store';
 import { identity } from 'rxjs';
 
-import { logoutUser } from 'ish-core/store/customer/user';
+import { CustomerUserType } from 'ish-core/models/customer/customer.model';
+import { Promotion } from 'ish-core/models/promotion/promotion.model';
+import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user';
+import { PromotionsState, promotionsReducer } from 'ish-core/store/shopping/promotions/promotions.reducer';
+import { ShoppingState } from 'ish-core/store/shopping/shopping-store';
 
-import { resetOnLogoutMeta } from './meta-reducers';
+import { resetOnLogoutMeta, resetPersonalizedShoppingMeta } from './meta-reducers';
 
 describe('Meta Reducers', () => {
+  describe('resetPersonalizedShoppingMeta', () => {
+    const state = {
+      promotions: { ids: ['id'], entities: { id: { id: '123' } as Promotion } } as PromotionsState,
+      productListing: { loading: false, itemsPerPage: 9, viewType: undefined, currentSettings: undefined },
+    } as ShoppingState;
+
+    const reducer = combineReducers({ promotions: promotionsReducer } as ActionReducerMap<ShoppingState>);
+
+    it('should reset state when reducing LogoutUser action', () => {
+      const result = resetPersonalizedShoppingMeta(identity)(state, logoutUser());
+      expect(result.promotions).toBeUndefined();
+      expect(result.productListing.itemsPerPage).toBe(9);
+    });
+
+    it('should reset state when reducing LoginUserSuccess action', () => {
+      const result = resetPersonalizedShoppingMeta(identity)(
+        state,
+        loginUserSuccess({ customer: { customerNo: 'user' } } as CustomerUserType)
+      );
+      expect(result.promotions).toBeUndefined();
+      expect(result.productListing.itemsPerPage).toBe(9);
+    });
+
+    it('should reset and delegate to reducer initial state when reducing LogoutUser action', () => {
+      const result = resetPersonalizedShoppingMeta(reducer)(state, logoutUser());
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "promotions": Object {
+            "entities": Object {},
+            "ids": Array [],
+          },
+        }
+      `);
+    });
+
+    it('should reset and delegate to reducer initial state when reducing LoginUserSuccess action', () => {
+      const result = resetPersonalizedShoppingMeta(reducer)(
+        state,
+        loginUserSuccess({ customer: { customerNo: 'user' } } as CustomerUserType)
+      );
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "promotions": Object {
+            "entities": Object {},
+            "ids": Array [],
+          },
+        }
+      `);
+    });
+
+    it('should not react on any other action with upstream reducer', () => {
+      const result = resetPersonalizedShoppingMeta(reducer)(state, {} as Action);
+      expect(result).toBe(state);
+    });
+  });
+
   describe('resetOnLogoutMeta', () => {
     const state = {
       a: 1,

--- a/src/app/core/utils/meta-reducers.ts
+++ b/src/app/core/utils/meta-reducers.ts
@@ -2,12 +2,32 @@ import { Action, ActionReducer, MetaReducer } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
 import { identity } from 'rxjs';
 
-import { logoutUser } from 'ish-core/store/customer/user';
+import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user';
+import { ShoppingState } from 'ish-core/store/shopping/shopping-store';
 
 export function resetOnLogoutMeta<S>(reducer: ActionReducer<S>): ActionReducer<S> {
   return (state: S, action: Action) => {
     if (action.type === logoutUser.type) {
       return reducer(undefined, action);
+    }
+    return reducer(state, action);
+  };
+}
+
+export function resetPersonalizedShoppingMeta(reducer: ActionReducer<ShoppingState>): ActionReducer<ShoppingState> {
+  return (state: ShoppingState, action: Action) => {
+    if (action.type === logoutUser.type || action.type === loginUserSuccess.type) {
+      return reducer(
+        {
+          ...state,
+          categories: undefined,
+          products: undefined,
+          search: undefined,
+          filter: undefined,
+          promotions: undefined,
+        },
+        action
+      );
     }
     return reducer(state, action);
   };

--- a/src/app/core/utils/meta-reducers.ts
+++ b/src/app/core/utils/meta-reducers.ts
@@ -2,8 +2,9 @@ import { Action, ActionReducer, MetaReducer } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
 import { identity } from 'rxjs';
 
-import { loginUserSuccess, logoutUser } from 'ish-core/store/customer/user';
-import { ShoppingState } from 'ish-core/store/shopping/shopping-store';
+import { logoutUser } from 'ish-core/store/customer/user';
+
+import { omit } from './functions';
 
 export function resetOnLogoutMeta<S>(reducer: ActionReducer<S>): ActionReducer<S> {
   return (state: S, action: Action) => {
@@ -14,23 +15,14 @@ export function resetOnLogoutMeta<S>(reducer: ActionReducer<S>): ActionReducer<S
   };
 }
 
-export function resetPersonalizedShoppingMeta(reducer: ActionReducer<ShoppingState>): ActionReducer<ShoppingState> {
-  return (state: ShoppingState, action: Action) => {
-    if (action.type === logoutUser.type || action.type === loginUserSuccess.type) {
-      return reducer(
-        {
-          ...state,
-          categories: undefined,
-          products: undefined,
-          search: undefined,
-          filter: undefined,
-          promotions: undefined,
-        },
-        action
-      );
-    }
-    return reducer(state, action);
-  };
+export function resetSubStatesOnActionsMeta<S>(subStates: (keyof S)[], actions: Action[]): MetaReducer<S, Action> {
+  return (reducer): ActionReducer<S> =>
+    (state: S, action: Action) => {
+      if (actions?.some(a => a.type === action.type)) {
+        return reducer(omit<S>(state, ...subStates) as S, action);
+      }
+      return reducer(state, action);
+    };
 }
 
 function saveMeta<S>(

--- a/src/app/core/utils/operators.ts
+++ b/src/app/core/utils/operators.ts
@@ -1,7 +1,17 @@
 import { ofType } from '@ngrx/effects';
 import { Action, ActionCreator } from '@ngrx/store';
-import { MonoTypeOperatorFunction, Observable, OperatorFunction, combineLatest, of, throwError } from 'rxjs';
-import { catchError, distinctUntilChanged, filter, map, withLatestFrom } from 'rxjs/operators';
+import {
+  MonoTypeOperatorFunction,
+  NEVER,
+  Observable,
+  OperatorFunction,
+  combineLatest,
+  concat,
+  of,
+  throwError,
+  connect,
+} from 'rxjs';
+import { buffer, catchError, distinctUntilChanged, filter, map, mergeAll, take, withLatestFrom } from 'rxjs/operators';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 
@@ -70,4 +80,18 @@ export function useCombinedObservableOnAction<T>(
 ): OperatorFunction<Action, T> {
   return (source$: Observable<Action>) =>
     combineLatest([observable$, source$.pipe(ofType(action))]).pipe(map(([obs, _]) => obs));
+}
+
+/**
+ * Delays emissions until the notifier emits.
+ * Taken from https://ncjamieson.com/how-to-write-delayuntil/
+ *
+ * @param notifier the observable that will be waited for
+ * @returns an observable that starts emitting only after the notifier emits
+ */
+export function delayUntil<T>(notifier: Observable<unknown>): OperatorFunction<T, T> {
+  return source =>
+    source.pipe(
+      connect(connected => concat(concat(connected, NEVER).pipe(buffer(notifier), take(1), mergeAll()), connected))
+    );
 }

--- a/src/app/core/utils/operators.ts
+++ b/src/app/core/utils/operators.ts
@@ -1,5 +1,6 @@
-import { Action } from '@ngrx/store';
-import { MonoTypeOperatorFunction, Observable, OperatorFunction, of, throwError } from 'rxjs';
+import { ofType } from '@ngrx/effects';
+import { Action, ActionCreator } from '@ngrx/store';
+import { MonoTypeOperatorFunction, Observable, OperatorFunction, combineLatest, of, throwError } from 'rxjs';
 import { catchError, distinctUntilChanged, filter, map, withLatestFrom } from 'rxjs/operators';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
@@ -53,4 +54,20 @@ export function whenTruthy<T>(): MonoTypeOperatorFunction<T> {
 
 export function whenFalsy<T>(): MonoTypeOperatorFunction<T> {
   return (source$: Observable<T>) => source$.pipe(filter(x => !x));
+}
+
+/**
+ * Operator that maps to an observable when the stream contains the specified action.
+ * Uses combineLatest so it will emit after both the action is fired and the observable emits.
+ *
+ * @param observable$ the observable that will be mapped to
+ * @param action the action to listen for
+ * @returns a stream containing only the values of the provided observable
+ */
+export function useCombinedObservableOnAction<T>(
+  observable$: Observable<T>,
+  action: ActionCreator
+): OperatorFunction<Action, T> {
+  return (source$: Observable<Action>) =>
+    combineLatest([observable$, source$.pipe(ofType(action))]).pipe(map(([obs, _]) => obs));
 }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?
Category and product REST calls are sent without pgid (unpersonalized). Category views, personalized product prices or promotions defined in the ICM back office are not respected in the storefront.

Issue Number: Closes #315

## What Is the New Behavior?
Category and product data are personalized.

## Does this PR Introduce a Breaking Change?

[x] Yes


## Other Information


[AB#74465](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74465)