### PR TITLE
fix: update propagation of parent context if child context is removed

### DIFF
--- a/src/app/core/directives/product-context.directive.ts
+++ b/src/app/core/directives/product-context.directive.ts
@@ -1,4 +1,14 @@
-import { Directive, Input, OnChanges, OnInit, Optional, Output, SimpleChanges, SkipSelf } from '@angular/core';
+import {
+  Directive,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Optional,
+  Output,
+  SimpleChanges,
+  SkipSelf,
+} from '@angular/core';
 
 import { ProductContextDisplayProperties, ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductCompletenessLevel, SkuQuantityType } from 'ish-core/models/product/product.model';
@@ -7,7 +17,7 @@ import { ProductCompletenessLevel, SkuQuantityType } from 'ish-core/models/produ
   selector: '[ishProductContext]',
   providers: [ProductContextFacade],
 })
-export class ProductContextDirective implements OnInit, OnChanges {
+export class ProductContextDirective implements OnInit, OnChanges, OnDestroy {
   @Input() completeness: 'List' | 'Detail' = 'List';
   @Input() propagateIndex: number;
 
@@ -60,14 +70,14 @@ export class ProductContextDirective implements OnInit, OnChanges {
     this.context.config = config;
   }
 
-  private propagate() {
+  private propagate(remove = false) {
     if (this.propagateIndex !== undefined) {
       if (!this.parentContext) {
         throw new Error('cannot propagate without parent context');
       }
       this.parentContext.propagate(
         this.propagateIndex,
-        this.context.get('propagateActive') ? this.context.get() : undefined
+        this.context.get('propagateActive') && !remove ? this.context.get() : undefined
       );
     }
   }
@@ -82,5 +92,9 @@ export class ProductContextDirective implements OnInit, OnChanges {
     this.context.set('requiredCompletenessLevel', () =>
       this.completeness === 'List' ? ProductCompletenessLevel.List : ProductCompletenessLevel.Detail
     );
+  }
+
+  ngOnDestroy(): void {
+    this.propagate(true);
   }
 }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

If a child product context is created in the template, and afterwards removed, the parent context does not get the removal update.

## What Is the New Behavior?

Removals are propagated on destroy.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#74466](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74466)