### PR TITLE
chore: lint-hard with auto restore of configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # dockerignore-update:start
 
 # The content between these markers is generated.
-# It can be synchronized using 'node scripts/update-dockerignore'
+# It can be synchronized using 'npm run update-dockerignore'
 
 # from .gitignore
 **/*.xliff
@@ -113,7 +113,7 @@
 /schematics/src/extension/files/__name@dasherize__/exports/*/**/*.*
 
 # The content between these markers is generated.
-# It can be synchronized using 'node scripts/update-dockerignore'
+# It can be synchronized using 'npm run update-dockerignore'
 
 # dockerignore-update:end
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 # It can be synchronized using 'node scripts/update-dockerignore'
 
 # from .gitignore
-/eslint*hard*
 **/*.xliff
 **/*.ut.spec.ts
 **/node_modules

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -70,9 +70,7 @@ jobs:
         run: (cd e2e && npx tsc -p cypress/tsconfig.json)
 
       - name: Run Escalated ESLint Rules
-        run: |
-          node scripts/eslint-hard
-          npm run lint
+        run: npm run lint-hard
 
       - name: Check File Synchronization Status
         run: node scripts/check-file-synchronization
@@ -151,8 +149,7 @@ jobs:
       - name: Test Schematics
         run: |
           bash e2e/test-schematics-${{ matrix.test }}.sh
-          node scripts/eslint-hard
-          npm run lint
+          npm run lint-hard
 
   ProductionPWA:
     needs: [Quality, Jest]

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -53,7 +53,7 @@ jobs:
         run: git diff --exit-code --raw -p --stat
 
       - name: .dockerignore Sync
-        run: node scripts/update-dockerignore
+        run: npm run update-dockerignore
 
       - name: Check No Changes from .dockerignore Sync
         run: git diff --exit-code --raw -p --stat

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled or cached output
-/eslint*hard*
 *.xliff
 *.ut.spec.ts
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:schematics": "cd schematics && npm run test",
     "e2e": "cd e2e && npm install && node open-cypress",
     "lint": "ng lint",
+    "lint-hard": "node scripts/eslint-hard",
     "format": "node docs/check-sentence-newline && stylelint \"**/*.{css,scss}\" --fix && prettier --loglevel warn --write \"**/*.*\"",
     "compile": "tsc --project tsconfig.all.json",
     "dead-code": "npx ts-node scripts/find-dead-code.ts",
@@ -191,7 +192,7 @@
     "*": [
       "prettier --loglevel warn --write"
     ],
-    "*.html" : [
+    "*.html": [
       "eslint --fix"
     ],
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "scripts": {
     "prepare": "husky install",
+    "update-dockerignore": "node scripts/update-dockerignore",
     "init-development-environment": "node scripts/init-development-environment",
     "postinstall": "postinstall && npm-run-all --silent build:eslint-rules build:schematics synchronize-lazy-components init-development-environment ngcc",
     "build:eslint-rules": "cd eslint-rules && npm run build",

--- a/scripts/eslint-hard.js
+++ b/scripts/eslint-hard.js
@@ -1,21 +1,75 @@
 const fs = require('fs');
 const { parse, stringify } = require('comment-json');
 const { execSync } = require('child_process');
+const glob = require('glob');
 
-const eslintJson = parse(fs.readFileSync('./.eslintrc.json', { encoding: 'UTF-8' }));
+const savedConfigs = {};
 
-eslintJson.overrides.forEach((overrideObject, index) => {
-  Object.keys(overrideObject.rules)
-    .filter(k => k !== 'jest/no-disabled-tests')
-    .forEach(key => {
-      let ruleInfo = eslintJson.overrides[index].rules[key];
-      if (typeof ruleInfo === 'string' && ruleInfo === 'warn') {
-        eslintJson.overrides[index].rules[key] = 'error';
-      } else if (ruleInfo?.[0] === 'warn') {
-        eslintJson.overrides[index].rules[key][0] = 'error';
-      }
-    });
+function restoreConfigs() {
+  Object.entries(savedConfigs).forEach(([key, config]) => {
+    console.log('restoring', key);
+    fs.writeFileSync(key, config);
+  });
+}
+
+// https://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js/14861513#14861513
+if (process.platform === 'win32') {
+  var rl = require('readline').createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  rl.on('SIGINT', function () {
+    process.emit('SIGINT');
+  });
+}
+
+process.on('SIGINT', function () {
+  restoreConfigs();
+  process.exit(1);
 });
 
-fs.writeFileSync('./.eslintrc.json', stringify(eslintJson, null, 2));
-execSync('npx prettier --write .eslintrc.json');
+glob.sync('**/.eslintrc.json', { ignore: ['node_modules/**'] }).forEach(eslintConfigPath => {
+  const eslintConfig = fs.readFileSync(eslintConfigPath, { encoding: 'UTF-8' });
+
+  const eslintJson = parse(eslintConfig);
+  if (eslintJson.overrides) {
+    console.log('modifying', eslintConfigPath);
+    savedConfigs[eslintConfigPath] = eslintConfig;
+
+    eslintJson.overrides.forEach((overrideObject, index) => {
+      Object.keys(overrideObject.rules)
+        .filter(k => k !== 'jest/no-disabled-tests')
+        .forEach(key => {
+          let ruleInfo = eslintJson.overrides[index].rules[key];
+          if (typeof ruleInfo === 'string' && ruleInfo === 'warn') {
+            eslintJson.overrides[index].rules[key] = 'error';
+          } else if (ruleInfo?.[0] === 'warn') {
+            eslintJson.overrides[index].rules[key][0] = 'error';
+          }
+        });
+    });
+
+    fs.writeFileSync(eslintConfigPath, stringify(eslintJson, null, 2));
+  }
+});
+
+let command = 'npm run lint';
+
+if (process.argv.length > 2) {
+  command = 'npx eslint ' + process.argv.slice(2).join(' ');
+}
+
+let foundError = false;
+
+try {
+  execSync(command, { stdio: 'inherit' });
+} catch (error) {
+  foundError = true;
+} finally {
+  restoreConfigs();
+}
+
+if (foundError) {
+  process.exit(1);
+}

--- a/scripts/eslint-hard.js
+++ b/scripts/eslint-hard.js
@@ -12,18 +12,6 @@ function restoreConfigs() {
   });
 }
 
-// https://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js/14861513#14861513
-if (process.platform === 'win32') {
-  var rl = require('readline').createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  rl.on('SIGINT', function () {
-    process.emit('SIGINT');
-  });
-}
-
 process.on('SIGINT', function () {
   restoreConfigs();
   process.exit(1);

--- a/scripts/update-dockerignore.js
+++ b/scripts/update-dockerignore.js
@@ -47,7 +47,7 @@ if (!regex.test(dockerIgnore)) {
   process.exit(1);
 }
 const sync =
-  "# The content between these markers is generated.\n# It can be synchronized using 'node scripts/update-dockerignore'";
+  "# The content between these markers is generated.\n# It can be synchronized using 'npm run update-dockerignore'";
 const newDockerIgnore = dockerIgnore.replace(regex, (_, b, e) => `${b}\n\n${sync}\n\n${content}\n\n${sync}\n\n# ${e}`);
 
 if (dockerIgnore !== newDockerIgnore) {


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

`scripts/lint-hard` only modifies the root ESLint config and linting has to be performed afterwards. The script is not runnable for single files.

## What Is the New Behavior?

- Script modifies all eslint configs
- Automatic restore after run or interrupt
- Script can run on single files

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#74496](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74496)