### PR TITLE
Product Search is cached in PWA and does not trigger a new REST call

### DIFF
--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -8,7 +8,6 @@ import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,
   PRODUCT_LISTING_ITEMS_PER_PAGE,
 } from 'ish-core/configurations/injection-keys';
-import { ProductListingView } from 'ish-core/models/product-listing/product-listing.model';
 import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
 import { selectQueryParam, selectQueryParams } from 'ish-core/store/core/router';
 import {
@@ -27,10 +26,9 @@ import {
   loadMoreProducts,
   loadMoreProductsForParams,
   setProductListingPageSize,
-  setProductListingPages,
   setViewType,
 } from './product-listing.actions';
-import { getProductListingView, getProductListingViewType } from './product-listing.selectors';
+import { getProductListingViewType } from './product-listing.selectors';
 
 @Injectable()
 export class ProductListingEffects {
@@ -114,23 +112,8 @@ export class ProductListingEffects {
     this.actions$.pipe(
       ofType(loadMoreProductsForParams),
       mapToPayload(),
-      switchMap(({ id, sorting, page, filters }) =>
-        this.store.pipe(
-          select(getProductListingView({ ...id, sorting, page, filters })),
-          map((view: ProductListingView) => ({
-            id,
-            sorting,
-            page,
-            filters,
-            viewAvailable: !view.empty() && view.productsOfPage(page).length,
-          }))
-        )
-      ),
-      distinctUntilChanged((a, b) => isEqual({ ...a, viewAvailable: undefined }, { ...b, viewAvailable: undefined })),
-      map(({ id, sorting, page, filters, viewAvailable }) => {
-        if (viewAvailable) {
-          return setProductListingPages({ id: { page, sorting, filters, ...id } });
-        }
+      distinctUntilChanged(isEqual),
+      map(({ id, sorting, page, filters }) => {
         if (filters) {
           const searchParameter = filters;
           return loadProductsForFilter({ id: { ...id, filters }, searchParameter, page, sorting });

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -576,10 +576,21 @@ describe('Shopping Store', () => {
               filters: undefined
               sorting: undefined
               page: undefined
-            [Product Listing Internal] Set Product Listing Pages:
-              id: {"type":"category","value":"A.123.456"}
+            [Products Internal] Load Products for Category:
+              categoryId: "A.123.456"
+              page: undefined
+              sorting: undefined
             [Filter Internal] Load Filter For Category:
               uniqueId: "A.123.456"
+            [Products API] Load Product Success:
+              product: {"sku":"P1"}
+            [Products API] Load Product Success:
+              product: {"sku":"P2"}
+            [Product Listing Internal] Set Product Listing Pages:
+              1: ["P1","P2"]
+              id: {"type":"category","value":"A.123.456"}
+              itemCount: 2
+              sortableAttributes: []
             [Filter API] Load Filter Success:
               filterNavigation: {}
             @ngrx/router-store/navigated: /category/A.123.456


### PR DESCRIPTION
… state is stored

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Once a product search is successfully done the result is added to the State Management. In a later search for the same search term the result is taken from the State Management (this is okay for fast result rendering) but no REST request is triggered to update this result information. This should be done for search results.

Issue Number: Closes #983 

## What Is the New Behavior?

Every product search triggers a REST call that fetches and updates any search result information the State Management might already have.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#74515](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74515)