### PR TITLE
fix: render content of product detail description tab as html

### DIFF
--- a/src/app/pages/product/product-detail-info/product-detail-info.component.html
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.html
@@ -2,17 +2,23 @@
   <ul ngbNav #nav="ngbNav" class="nav-tabs w-100" [(activeId)]="active">
     <li [ngbNavItem]="'DESCRIPTION'">
       <a ngbNavLink>{{ 'product.description.heading' | translate }}</a>
-      <ng-template ngbNavContent>{{ product.longDescription }}</ng-template>
+      <ng-template ngbNavContent>
+        <div [innerHTML]="product.longDescription"></div>
+      </ng-template>
     </li>
 
     <li *ngIf="product.attributes?.length" [ngbNavItem]="'DETAILS'">
       <a ngbNavLink>{{ 'product.details.heading' | translate }}</a>
-      <ng-template ngbNavContent><ish-product-attributes [product]="product"></ish-product-attributes></ng-template>
+      <ng-template ngbNavContent>
+        <ish-product-attributes [product]="product"></ish-product-attributes>
+      </ng-template>
     </li>
 
     <li *ngIf="product.attachments?.length" [ngbNavItem]="'ATTACHMENTS'">
       <a ngbNavLink>{{ 'product.attachments.heading' | translate }}</a>
-      <ng-template ngbNavContent><ish-product-attachments></ish-product-attachments></ng-template>
+      <ng-template ngbNavContent>
+        <ish-product-attachments></ish-product-attachments>
+      </ng-template>
     </li>
   </ul>
 


### PR DESCRIPTION
##  PR Type
 [ x ] Bugfix  

## What Is the Current Behavior?
HTML content for long description on product detail page is not rendered.

## What Is the New Behavior?
Long description is displayed correctly.

## Does this PR Introduce a Breaking Change?
 [ ] Yes  
 [ X ] No

[AB#74768](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74768)