### PR TITLE
feat: use demo content artifact in header navigation

### DIFF
--- a/src/app/shell/header/header-navigation/header-navigation.component.html
+++ b/src/app/shell/header/header-navigation/header-navigation.component.html
@@ -27,4 +27,5 @@
       ></ish-sub-category-navigation>
     </ng-container>
   </li>
+  <ish-lazy-content-include includeId="include.header.navigation.pagelet2-Include"></ish-lazy-content-include>
 </ul>

--- a/src/app/shell/header/header-navigation/header-navigation.component.spec.ts
+++ b/src/app/shell/header/header-navigation/header-navigation.component.spec.ts
@@ -65,6 +65,9 @@ describe('Header Navigation Component', () => {
             CAT_C
           </a>
         </li>
+        <ish-lazy-content-include
+          includeid="include.header.navigation.pagelet2-Include"
+        ></ish-lazy-content-include>
       </ul>
     `);
   });


### PR DESCRIPTION
## PR Type
[x] Feature

## What Is the Current Behavior?
With ICM 7.10.38-LTS demo content artifact for header navigation is provided to manage CMS content but this is not used in the PWA.

## What Is the New Behavior?
The PWA uses this artifact and can present demo content for header navigation provided in ICM.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x ] No

## Other Information
ICM release 7.10.38-LTS is necessary.

[AB#74771](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74771)