### PR TITLE
test: fail on console error

### DIFF
--- a/src/app/pages/basket/shopping-basket/shopping-basket.component.spec.ts
+++ b/src/app/pages/basket/shopping-basket/shopping-basket.component.spec.ts
@@ -3,6 +3,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 
 import { AuthorizationToggleModule } from 'ish-core/authorization-toggle.module';
+import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { RoleToggleModule } from 'ish-core/role-toggle.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
@@ -46,7 +47,12 @@ describe('Shopping Basket Component', () => {
         MockComponent(ModalDialogLinkComponent),
         ShoppingBasketComponent,
       ],
-      imports: [AuthorizationToggleModule.forTesting(), RoleToggleModule.forTesting(), TranslateModule.forRoot()],
+      imports: [
+        AuthorizationToggleModule.forTesting(),
+        FeatureToggleModule.forTesting(),
+        RoleToggleModule.forTesting(),
+        TranslateModule.forRoot(),
+      ],
     }).compileComponents();
   });
 

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -23,12 +23,8 @@ beforeEach(() => {
     logFunction(...args);
   };
 
-  const errorFunction = global.console.error;
   global.console.error = (...args: unknown[]) => {
-    if (args?.some(arg => arg instanceof Error)) {
-      fail(...args);
-    }
-    errorFunction(...args);
+    fail(...args);
   };
 
   jest.spyOn(global.console, 'warn').mockImplementation(arg => {


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

It looks like template errors are no longer reported as `Error`s since the last upgrade and so they don't fail the test anymore.

## What Is the New Behavior?

Fail on every test error message.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#74936](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74936)