### PR TITLE
perf(schematics): better linter performance

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,4 @@ polyfills.ts
 
 environment.development.ts
 
-**/lazy-*.component.ts
-
 **/index.html

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -40,6 +40,9 @@ jobs:
 
       - name: Install root dependencies
         run: npm ci
+        # disable CI mode so lazy components are linted
+        env:
+          CI: false
 
       - name: Install e2e dependencies
         run: |

--- a/e2e/test-schematics-customization.sh
+++ b/e2e/test-schematics-customization.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-set -x
+# disable interactive mode with `| cat` at end of call
+
 set -e
+set -x
 
 node schematics/customization/add --default brand
 grep brand angular.json
@@ -10,60 +12,48 @@ grep brand package.json
 # format without source folder prefix from project root
 npx ng g customized-copy shell/footer/footer
 
-stat src/app/shell/footer/custom-footer/custom-footer.component.ts
+test -f src/app/shell/footer/custom-footer/custom-footer.component.ts
 grep 'custom-footer' src/app/app.component.html
 
 # format with source folder prefix from project root
 npx ng g customized-copy src/app/shared/components/basket/basket-promotion
-stat src/app/shared/components/basket/custom-basket-promotion/custom-basket-promotion.component.html
+test -f src/app/shared/components/basket/custom-basket-promotion/custom-basket-promotion.component.html
 grep 'custom-basket-promotion' src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
 
 # from subfolder
 (cd src/app/pages/checkout-review && npx ng g customized-copy checkout-review)
-stat src/app/pages/checkout-review/custom-checkout-review/custom-checkout-review.component.html
+test -f src/app/pages/checkout-review/custom-checkout-review/custom-checkout-review.component.html
 grep 'custom-checkout-review' src/app/pages/checkout-review/checkout-review-page.component.html
 
-npx ng g customized-copy src/app/extensions/quoting/shared/quote-widget
-stat src/app/extensions/quoting/shared/custom-quote-widget/custom-quote-widget.component.ts
-# TODO
-# grep 'custom-lazy-quote-widget' src/app/pages/account-overview/account-overview/account-overview.component.html
-
-npx ng g override --theme brand --html --ts --scss src/app/pages/home/home-page.component.ts
-stat src/app/pages/home/home-page.component.brand.html
-stat src/app/pages/home/home-page.component.brand.scss
-stat src/app/pages/home/home-page.component.brand.ts
-stat src/app/pages/home/home-page.component.scss
+npx ng g override --theme brand --html --ts --scss src/app/pages/home/home-page.component.ts | cat
+test -f src/app/pages/home/home-page.component.brand.html
+test -f src/app/pages/home/home-page.component.brand.scss
+test -f src/app/pages/home/home-page.component.brand.ts
+test -f src/app/pages/home/home-page.component.scss
 grep './home-page.component.scss' src/app/pages/home/home-page.component.brand.ts
 grep './home-page.component.scss' src/app/pages/home/home-page.component.ts
 echo '<p>COMPONENT_OVERRIDES</p>' > src/app/pages/home/home-page.component.brand.html
 echo "@import 'variables';" > src/app/pages/home/home-page.component.brand.scss
 
-npx ng g override --theme brand --html --ts src/app/shared/components/product/product-image/product-image.component.ts
-stat src/app/shared/components/product/product-image/product-image.component.brand.ts
-stat src/app/shared/components/product/product-image/product-image.component.brand.html
+npx ng g override --theme brand --html --ts src/app/shared/components/product/product-image/product-image.component.ts | cat
+test -f src/app/shared/components/product/product-image/product-image.component.brand.ts
+test -f src/app/shared/components/product/product-image/product-image.component.brand.html
 
-npx ng g override --theme brand --ts src/app/core/routing/product/product.route.ts
-stat src/app/core/routing/product/product.route.brand.ts
+npx ng g override --theme brand --ts src/app/core/routing/product/product.route.ts | cat
+test -f src/app/core/routing/product/product.route.brand.ts
 
-npx ng g override --theme brand --ts src/app/core/services/cms/cms.service.ts
-stat src/app/core/services/cms/cms.service.brand.ts
-
-sed -i -e "s%icmBaseURL.*%icmBaseURL: 'http://localhost:4200',%g" src/environments/environment.ts
+npx ng g override --theme brand --ts src/app/core/services/cms/cms.service.ts | cat
+test -f src/app/core/services/cms/cms.service.brand.ts
 
 node schematics/customization/service-worker false
 grep '"serviceWorker": false' angular.json
 
-git add -A
-npm run clean
-npx lint-staged
-npx tsc --project tsconfig.all.json
-
 export NODE_OPTIONS=--max_old_space_size=8192
 
-npm run build
+npx npm-run-all format "lint -- --fix" compile build
 
 nohup bash -c "npm run serve &"
-wget -q --wait 10 --tries 10 --retry-connrefused http://localhost:4200
+npx wait-on --verbose --interval 1000 --delay 1000 --timeout 30000 tcp:4200
 
-wget -O - -q "http://localhost:4200/home" | grep -q "COMPONENT_OVERRIDES"
-wget -O - -q "http://localhost:4200/home" | grep -q "<custom-footer"
+curl -s "http://localhost:4200/home" | grep -q "COMPONENT_OVERRIDES"
+curl -s "http://localhost:4200/home" | grep -q "<custom-footer"

--- a/e2e/test-schematics-normal.sh
+++ b/e2e/test-schematics-normal.sh
@@ -1,134 +1,129 @@
 #!/bin/sh
 
-set -x
 set -e
+set -x
 
 npx ng g model warehouse
-stat src/app/core/models/warehouse/warehouse.model.ts
-stat src/app/core/models/warehouse/warehouse.interface.ts
-stat src/app/core/models/warehouse/warehouse.mapper.ts
-stat src/app/core/models/warehouse/warehouse.helper.ts
+test -f src/app/core/models/warehouse/warehouse.model.ts
+test -f src/app/core/models/warehouse/warehouse.interface.ts
+test -f src/app/core/models/warehouse/warehouse.mapper.ts
+test -f src/app/core/models/warehouse/warehouse.helper.ts
 
 npx ng g model stock --simple
-stat src/app/core/models/stock/stock.model.ts
+test -f src/app/core/models/stock/stock.model.ts
 
 npx ng g s warehouses
-stat src/app/core/services/warehouses/warehouses.service.ts
+test -f src/app/core/services/warehouses/warehouses.service.ts
 
 npx ng g store dummy
-stat src/app/core/store/core/dummy/dummy.actions.ts
-stat src/app/core/store/core/dummy/dummy.effects.ts
-stat src/app/core/store/core/dummy/dummy.reducer.ts
-stat src/app/core/store/core/dummy/dummy.selectors.ts
+test -f src/app/core/store/core/dummy/dummy.actions.ts
+test -f src/app/core/store/core/dummy/dummy.effects.ts
+test -f src/app/core/store/core/dummy/dummy.reducer.ts
+test -f src/app/core/store/core/dummy/dummy.selectors.ts
 grep "DummyState" src/app/core/store/core/core-store.ts
 
 npx ng g store-group training
-stat src/app/core/store/training/training-store.ts
+test -f src/app/core/store/training/training-store.ts
 grep "TrainingStoreModule" src/app/core/state-management.module.ts
 
 npx ng g store training/warehouses --entity warehouse
-stat src/app/core/store/training/warehouses/warehouses.actions.ts
-stat src/app/core/store/training/warehouses/warehouses.effects.ts
-stat src/app/core/store/training/warehouses/warehouses.reducer.ts
-stat src/app/core/store/training/warehouses/warehouses.selectors.ts
+test -f src/app/core/store/training/warehouses/warehouses.actions.ts
+test -f src/app/core/store/training/warehouses/warehouses.effects.ts
+test -f src/app/core/store/training/warehouses/warehouses.reducer.ts
+test -f src/app/core/store/training/warehouses/warehouses.selectors.ts
 grep "WarehousesState" src/app/core/store/training/training-store.ts
 
 npx ng g pipe warehouses
-stat src/app/core/pipes/warehouses.pipe.ts
+test -f src/app/core/pipes/warehouses.pipe.ts
 grep "WarehousesPipe" src/app/core/pipes.module.ts
 
 npx ng g c shared/components/inventory/warehouse
-stat src/app/shared/components/inventory/warehouse/warehouse.component.ts
+test -f src/app/shared/components/inventory/warehouse/warehouse.component.ts
 grep "WarehouseComponent" src/app/shared/shared.module.ts
 
 npx ng g lazy-component src/app/shared/components/inventory/warehouse/warehouse.component.ts
-stat src/app/shell/shared/lazy-warehouse/lazy-warehouse.component.ts
+test -f src/app/shell/shared/lazy-warehouse/lazy-warehouse.component.ts
 grep GenerateLazyComponent src/app/shared/components/inventory/warehouse/warehouse.component.ts
 
 
 npx ng g p warehouses
-stat src/app/pages/warehouses/warehouses-page.module.ts
-stat src/app/pages/warehouses/warehouses-page.component.ts
+test -f src/app/pages/warehouses/warehouses-page.module.ts
+test -f src/app/pages/warehouses/warehouses-page.component.ts
 grep "WarehousesPageComponent" src/app/pages/warehouses/warehouses-page.module.ts
 grep "warehouses" src/app/pages/app-routing.module.ts
 
 
 npx ng g e awesome
-stat src/app/extensions/awesome/awesome.module.ts
-stat src/app/extensions/awesome/pages/awesome-routing.module.ts
-stat src/app/extensions/awesome/store/awesome-store.module.ts
-stat src/app/extensions/awesome/exports/awesome-exports.module.ts
+test -f src/app/extensions/awesome/awesome.module.ts
+test -f src/app/extensions/awesome/pages/awesome-routing.module.ts
+test -f src/app/extensions/awesome/store/awesome-store.module.ts
+test -f src/app/extensions/awesome/exports/awesome-exports.module.ts
 
 npx ng g c extensions/awesome/shared/dummy
-stat src/app/extensions/awesome/shared/dummy/dummy.component.ts
+test -f src/app/extensions/awesome/shared/dummy/dummy.component.ts
 
 npx ng g lazy-component extensions/awesome/shared/dummy/dummy.component.ts
-stat src/app/extensions/awesome/exports/lazy-dummy/lazy-dummy.component.ts
+test -f src/app/extensions/awesome/exports/lazy-dummy/lazy-dummy.component.ts
 grep "LazyDummyComponent" src/app/extensions/awesome/exports/awesome-exports.module.ts
 
+(cd src/app/shared && npx ng g c common/foobar --export)
+test -f src/app/shared/common/foobar/foobar.component.ts
+grep "FoobarComponent" src/app/shared/common/foobar/foobar.component.ts
+grep "FoobarComponent" src/app/shared/shared.module.ts
 
 npx ng g s super -e awesome
-stat src/app/extensions/awesome/services/super/super.service.ts
+test -f src/app/extensions/awesome/services/super/super.service.ts
 
 npx ng g s src/app/extensions/awesome/duper
-stat src/app/extensions/awesome/services/duper/duper.service.ts
+test -f src/app/extensions/awesome/services/duper/duper.service.ts
 
 npx ng g store -e awesome super
-stat src/app/extensions/awesome/store/super/super.actions.ts
-stat src/app/extensions/awesome/store/super/super.effects.ts
-stat src/app/extensions/awesome/store/super/super.reducer.ts
-stat src/app/extensions/awesome/store/super/super.selectors.ts
+test -f src/app/extensions/awesome/store/super/super.actions.ts
+test -f src/app/extensions/awesome/store/super/super.effects.ts
+test -f src/app/extensions/awesome/store/super/super.reducer.ts
+test -f src/app/extensions/awesome/store/super/super.selectors.ts
 grep "SuperState" src/app/extensions/awesome/store/awesome-store.ts
 
 npx ng g cms --definition-qualified-name app:component.custom.inventory.pagelet2-Component inventory
-stat src/app/shared/cms/components/cms-inventory/cms-inventory.component.ts
+test -f src/app/shared/cms/components/cms-inventory/cms-inventory.component.ts
 grep "CMSInventoryComponent" src/app/shared/cms/cms.module.ts
 grep "CMSInventoryComponent" src/app/shared/shared.module.ts
 
 npx ng g cms --definition-qualified-name app:component.custom.audio.pagelet2-Component --noCMSPrefixing audio
-stat src/app/shared/cms/components/audio/audio.component.ts
+test -f src/app/shared/cms/components/audio/audio.component.ts
 grep "AudioComponent" src/app/shared/cms/cms.module.ts
 grep "AudioComponent" src/app/shared/shared.module.ts
 
 npx ng g lazy-component --project organization-management --path projects/organization-management/src/app/components/user-profile-form/user-profile-form.component.ts
-stat projects/organization-management/src/app/exports/lazy-user-profile-form/lazy-user-profile-form.component.ts
-stat projects/organization-management/src/app/exports/lazy-user-profile-form/lazy-user-profile-form.component.html
-stat projects/organization-management/src/app/exports/organization-management-exports.module.ts
+test -f projects/organization-management/src/app/exports/lazy-user-profile-form/lazy-user-profile-form.component.ts
+test -f projects/organization-management/src/app/exports/lazy-user-profile-form/lazy-user-profile-form.component.html
+test -f projects/organization-management/src/app/exports/organization-management-exports.module.ts
 grep "LazyUserProfileFormComponent" projects/organization-management/src/app/exports/organization-management-exports.module.ts
 grep "LazyUserProfileFormComponent" projects/organization-management/src/app/exports/index.ts
 
 npx ng g lazy-component --project organization-management --path projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.ts
-stat projects/organization-management/src/app/exports/lazy-user-roles-selection/lazy-user-roles-selection.component.ts
-stat projects/organization-management/src/app/exports/lazy-user-roles-selection/lazy-user-roles-selection.component.html
+test -f projects/organization-management/src/app/exports/lazy-user-roles-selection/lazy-user-roles-selection.component.ts
+test -f projects/organization-management/src/app/exports/lazy-user-roles-selection/lazy-user-roles-selection.component.html
 grep "LazyUserRolesSelectionComponent" projects/organization-management/src/app/exports/organization-management-exports.module.ts
 grep "LazyUserRolesSelectionComponent" projects/organization-management/src/app/exports/index.ts
 
-npm run lint
-
-sed -i -e "s%icmBaseURL.*%icmBaseURL: 'http://localhost:4200',%g" src/environments/environment.ts
-
 node schematics/customization/service-worker false
 grep '"serviceWorker": false' angular.json
-
-git add -A
-npm run clean
-npx lint-staged
-npx tsc --project tsconfig.all.json
 
 npx ng g add-destroy src/app/extensions/awesome/shared/dummy/dummy.component.ts
 grep destroy src/app/extensions/awesome/shared/dummy/dummy.component.ts
 
 export NODE_OPTIONS=--max_old_space_size=8192
 
-npm run build
+npx npm-run-all format "lint -- --fix" compile build
 
 nohup bash -c "npm run serve &"
-wget -q --wait 10 --tries 10 --retry-connrefused http://localhost:4200
+npx wait-on --verbose --interval 1000 --delay 1000 --timeout 30000 tcp:4200
 
-wget -O - -q "http://localhost:4200/warehouses" | grep -q "warehouses-page works"
+curl -s "http://localhost:4200/warehouses" | grep -q "warehouses-page works"
 
 npx ng g kubernetes-deployment
 find charts
 
 npx ng g azure-pipeline
-stat azure-pipelines.yml
+test -f azure-pipelines.yml

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "docs": "npx markserv -a 0.0.0.0 docs/README.md",
     "compodoc": "npx compodoc -p tsconfig.doc.json -d docs/compodoc -y docs/theme --hideGenerator",
     "compodoc:serve": "npm run compodoc -- -s -w",
-    "synchronize-lazy-components": "ng g lazy-components && prettier --loglevel warn --write \"**/lazy-*.component.{ts,html}\"",
+    "synchronize-lazy-components": "ng g lazy-components",
     "build:watch": "npm run build client -- --watch",
     "build": "node scripts/build-pwa",
     "build:multi": "node scripts/build-multi-pwa",

--- a/schematics/src/helpers/add-destroy/factory.ts
+++ b/schematics/src/helpers/add-destroy/factory.ts
@@ -76,9 +76,7 @@ this.destroy$.complete();`);
     host.overwrite(path, sourceFile.getText());
 
     const operations = [];
-    if (process.env.CI !== 'true') {
-      operations.push(applyLintFix());
-    }
+    operations.push(applyLintFix());
 
     return chain(operations);
   };

--- a/schematics/src/lazy-component/factory.ts
+++ b/schematics/src/lazy-component/factory.ts
@@ -216,9 +216,7 @@ export function createLazyComponent(options: Options): Rule {
       )
     );
 
-    if (process.env.CI !== 'true') {
-      operations.push(applyLintFix());
-    }
+    operations.push(applyLintFix());
 
     return chain(operations);
   };

--- a/schematics/src/utils/filesystem.ts
+++ b/schematics/src/utils/filesystem.ts
@@ -1,4 +1,7 @@
 import { Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { existsSync } from 'fs';
+import { once } from 'lodash';
+import { dirname, join, normalize } from 'path';
 import * as ts from 'typescript';
 
 export function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
@@ -17,3 +20,15 @@ export function copyFile(from: string, to: string): Rule {
     host.create(to, host.read(from));
   };
 }
+
+export const findProjectRoot = once(() => {
+  let projectRoot = normalize(process.cwd());
+
+  while (!existsSync(join(projectRoot, 'angular.json'))) {
+    if (dirname(projectRoot) === projectRoot) {
+      throw new Error('cannot determine project root');
+    }
+    projectRoot = dirname(projectRoot);
+  }
+  return projectRoot;
+});

--- a/schematics/src/utils/lint-fix.ts
+++ b/schematics/src/utils/lint-fix.ts
@@ -1,50 +1,36 @@
 import { Rule } from '@angular-devkit/schematics';
-import { ESLint } from 'eslint';
-import { existsSync } from 'fs';
-import { normalize, sep } from 'path';
-import { forkJoin, from } from 'rxjs';
-import { mapTo, tap } from 'rxjs/operators';
+import { execSync } from 'child_process';
+import { once } from 'lodash';
 
-import { readIntoSourceFile } from './filesystem';
+import { findProjectRoot } from './filesystem';
 
-function getRootESLintConfigPath() {
-  const p = normalize(process.cwd());
-  const segments = p.split(sep);
+const lintFiles: string[] = [];
 
-  let configPath = '';
+const registerLintAtEnd = once((root: string) => {
+  process.on('exit', () => {
+    if (process.env.CI !== 'true') {
+      if (lintFiles.length) {
+        console.log('LINTING', lintFiles.length, lintFiles.length === 1 ? 'file' : 'files');
 
-  for (let i = segments.length; i > 0; i--) {
-    const path = segments.slice(0, i).concat('.eslintrc.json').join(sep);
-    if (existsSync(path)) {
-      configPath = path;
+        execSync(`npx prettier --write --loglevel warn ${lintFiles.join(' ')}`, { cwd: root });
+        execSync(`npx eslint --fix ${lintFiles.join(' ')}`, { cwd: root });
+      }
+    } else {
+      console.log('LINTING skipped for CI=true');
     }
-  }
-  return configPath;
-}
+  });
+});
 
 export function applyLintFix(): Rule {
-  const eslint = new ESLint({ fix: true, overrideConfigFile: getRootESLintConfigPath() });
   return tree => {
     // Only include files that have been touched.
-    const files = tree.actions
+    tree.actions
       .map(action => action.path.substring(1))
       .filter(path => path.endsWith('.ts') || path.endsWith('.html'))
-      .filter((v, i, a) => a.indexOf(v) === i);
+      .forEach(file => {
+        if (!lintFiles.includes(file)) lintFiles.push(file);
+      });
 
-    if (files.length)
-      return forkJoin(
-        files
-          .map(filePath => ({ filePath, source: readIntoSourceFile(tree, filePath) }))
-          .map(({ source, filePath }) =>
-            from(eslint.lintText(source.text, { filePath })).pipe(
-              tap(results => {
-                if (results[0]?.output) {
-                  tree.overwrite(filePath, results[0].output);
-                }
-              })
-            )
-          )
-      ).pipe(mapTo(tree));
-    else return tree;
+    registerLintAtEnd(findProjectRoot());
   };
 }


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

- Since tslint->eslint migration, all lazy components are excempt from linting. (Also the not generated ones)
- Linting after schematics is not fast

## What Is the New Behavior?

- Exit hook for schematics that applies linting only once using command line.
- Activate linting for all files again.
- Cleanup and optimize schematics test scripts for git bash (no `wget`, verbose output from `stat`)
- Removed one test for `customized-copy` on lazy component, because it wasn't working and `customized-copy` is deprecated.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#74941](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74941)