### PR TITLE
fix: repair service worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN if [ ! -z "${activeThemes}" ]; then npm config set intershop-pwa:active-them
 RUN npm run build:multi client -- --deploy-url=DEPLOY_URL_PLACEHOLDER
 COPY tsconfig.server.json server.ts /workspace/
 RUN npm run build:multi server
-# remove cache check for resources (especially index.html)
-# https://github.com/angular/angular/issues/23613#issuecomment-415886919
-RUN test "${serviceWorker}" = "true" && sed -i 's/canonicalHash !== cacheBustedHash/false/g' /workspace/dist/browser/ngsw-worker.js || true
 RUN node scripts/compile-docker-scripts
 COPY dist/* /workspace/dist/
 

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -144,7 +144,7 @@ server {
     }
 
     # respect cache entries of static assets
-    location ~* ^/(ngx_pagespeed_beacon|metrics|assets|.*\.(js|css|ico|json|txt|webmanifest|woff|woff2))(.*)$ {
+    location ~* ^/(?!ngsw\.json)(ngx_pagespeed_beacon|metrics|assets|.*\.(js|css|ico|json|txt|webmanifest|woff|woff2))(.*)$ {
         allow all;
         auth_basic off;
 

--- a/scripts/build-pwa.js
+++ b/scripts/build-pwa.js
@@ -1,7 +1,33 @@
-// https://stackoverflow.com/questions/51388921/pass-command-line-args-to-npm-scripts-in-package-json/51401577
-
+const fs = require('fs');
+const path = require('path');
 const execSync = require('child_process').execSync;
 
+/**
+ * remove service worker cache check for resources (especially index.html)
+ * https://github.com/angular/angular/issues/23613#issuecomment-415886919
+ */
+function removeServiceWorkerCacheCheck(args) {
+  const outputPathArg = args.find(arg => arg.startsWith('--output-path'));
+
+  let outputPath = '';
+  if (outputPathArg) {
+    // get outputPath from build args (in case of build:multi)
+    outputPath = outputPathArg.split('=')[1];
+  } else {
+    // get default outputPath from angular.json
+    const angularJson = JSON.parse(fs.readFileSync('./angular.json', { encoding: 'utf-8' }));
+    outputPath = angularJson.projects[angularJson.defaultProject].architect.build.options.outputPath;
+  }
+
+  const serviceWorkerScript = path.join(outputPath, 'ngsw-worker.js');
+  if (fs.existsSync(serviceWorkerScript)) {
+    console.warn('replacing cache check for service worker in', serviceWorkerScript);
+    const script = fs.readFileSync(serviceWorkerScript, { encoding: 'utf-8' });
+    fs.writeFileSync(serviceWorkerScript, script.replace('canonicalHash !== cacheBustedHash', 'false'));
+  }
+}
+
+// https://stackoverflow.com/questions/51388921/pass-command-line-args-to-npm-scripts-in-package-json/64694166#64694166
 let configuration = process.env.npm_config_configuration;
 
 if (configuration === 'true') {
@@ -24,6 +50,7 @@ if (client) {
   execSync(`npm run ng -- build ${configString} ${remainingArgs.join(' ')}`, {
     stdio: 'inherit',
   });
+  removeServiceWorkerCacheCheck(remainingArgs);
 }
 
 if (server) {

--- a/server.ts
+++ b/server.ts
@@ -188,13 +188,25 @@ export function app() {
 
   // Serve static files from browser folder
   server.get(/\/.*\.(js|css)$/, (req, res) => {
-    const path = req.originalUrl.substring(1);
+    // remove all parameters
+    const path = req.originalUrl.substring(1).replace(/[;?&].*$/, '');
+
     fs.readFile(join(BROWSER_FOLDER, path), { encoding: 'utf-8' }, (err, data) => {
       if (err) {
         res.sendStatus(404);
       } else {
         res.set('Content-Type', `${path.endsWith('css') ? 'text/css' : 'application/javascript'}; charset=UTF-8`);
         res.send(setDeployUrlInFile(DEPLOY_URL, path, data));
+      }
+    });
+  });
+  server.get(/\/ngsw\.json/, (_, res) => {
+    fs.readFile(join(BROWSER_FOLDER, 'ngsw.json'), { encoding: 'utf-8' }, (err, data) => {
+      if (err) {
+        res.sendStatus(404);
+      } else {
+        res.set('Content-Type', 'application/json; charset=UTF-8');
+        res.send(data);
       }
     });
   });

--- a/src/ssr/server-scripts/server.js
+++ b/src/ssr/server-scripts/server.js
@@ -12,7 +12,7 @@ app.use((req, res, next) => {
 
   if (!match) {
     match = Object.keys(ports).find(config => {
-      const p = path.join(process.cwd(), 'dist', config, 'browser', req.path);
+      const p = path.join(process.cwd(), 'dist', config, 'browser', req.path.substring(1).replace(/[;?&].*$/, ''));
       return fs.existsSync(p);
     });
   }


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Build-related changes

## What Is the Current Behavior?

Service Worker functionality is broken since v1.0.

### Steps to reproduce

1. Modify `docker-compose.yml` (SW need a full deploy as part is handled in nginx and PWA SSR)
   - enable SW by setting `serviceWorker: 'true'` on the SSR image
   - comment out `MULTI_CHANNEL` of the nginx (SW never worked with multi-site using context paths)
2. Start up with `docker compose up --build`
3. Go to `http://localhost:4200/home` and give the SW time to boot up (check dev tools)
4. Go to `http://localhost:4200/ngsw/state`
   - Expected: everything should be fine: `Driver state: NORMAL`
   - Actual: SW is `Degraded due to: Failed to retrieve hashed resource from the server.`
5. stop the `docker compose` and refresh page in browser
   - Expected: Page should still work because SW has installed correctly
   - Actual: 504 in browser and more errors in `http://localhost:4200/ngsw/state`

## What Is the New Behavior?

Service worker works again.
- repaired lookup of static resources in `server.ts` and `src/ssr/server-scripts/server.js` ignoring query parameters.
- exempt ngsw.json from location in nginx that adds no `theme` matrix parameter
- add handling of `ngsw.json` to `server.ts`
- moved cache check removal logic from `Dockerfile` into `scripts/build-pwa.js`

Is this cache bust logic still needed? - Yes
- the nginx responds to `/index.html` with `/loading`, which is not the original index.html hashed during build time
- comment it out, rebuild, clear site data and repeat steps above to see the following error in `http://localhost:4200/ngsw/state`: `Degraded due to: Hash mismatch (cacheBustedFetchFromNetwork)`

Do updates still work? -Yes
- After a successful SW install, change something (i.e. `ng g override src/app/pages/home/home-page.component.ts --theme all --html`) and restart `docker compose`
- The SW will download the new sources on the first refresh in the browser
- The SW will use the new sources after the second refresh

Will the SW still deinstall automatically? - Yes
- set `serviceWorker: 'false'` in `docker-compose.yml` and restart the deployment.
- the nginx/PWA will now respond with a 404 to requests with `/ngsw.json` which deinstalls the service worker again

Does the SW still work with domain multi-site? - Yes
- modify the `MULTI_CHANNEL`:
  ```
      MULTI_CHANNEL: |
        localhost:
          channel: default
          theme: b2b
        127.0.0.1:
          channel: default
          theme: b2c
  ```
- SW only installs for `https` sites and everything local, so using `localhost` and `127.0.0.1` works best. (For some reason for me the SW did not install for `127.0.0.1` in Chrome, but everything works in Firefox)
- visit each domain (http://localhost:4200/home, http://127.0.0.1:4200/home) and verify everything is installing correctly
- after stopping `docker compose`, every domain should still work correctly
- FYI: I also tested this with a full setup of creating and trusting self-signed certificates.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## TODOs for follow-up work:
- make SW work with multi-site context path deployments
- on updated JS sources, the SW should query the user of the shop to refresh the page

## Other Information

[AB#74945](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/74945)