### PR TITLE
feat: clean-localizations on used sources

### DIFF
--- a/docs/concepts/localization.md
+++ b/docs/concepts/localization.md
@@ -298,6 +298,10 @@ HTML
 
 The clean up script is integrated in the full check run (`npm run check`) and will also be performed in continuous integration on the whole code base.
 
+The cleanup script also supports a build argument: `npm run clean-localizations --build`.
+When supplied, an Angular build with source maps is performed to limit the project to sources that are actually used before performing a cleanup.
+With this, project customizations can clean-up keys from features that are not required in the project.
+
 ## Extend Locales
 
 To learn how languages other than English, German and French can be used in the progressive web app, see [Configuration - Extend Localization](./configuration.md#extend-locales).

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -1,5 +1,6 @@
 import { CustomWebpackBrowserSchema, TargetOptions } from '@angular-builders/custom-webpack';
 import * as fs from 'fs';
+import { flatten } from 'lodash';
 import { basename, join, resolve } from 'path';
 import { Configuration, DefinePlugin, WebpackPluginInstance } from 'webpack';
 
@@ -334,8 +335,91 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
     }
   }
 
-  // eslint-disable-next-line etc/no-commented-out-code
-  // fs.writeFileSync('effective.config.json', JSON.stringify(config, undefined, 2), { encoding: 'utf-8' });
+  process.on('exit', () => {
+    fs.mkdirSync(config.output.path, { recursive: true });
+
+    const l = process.cwd().length + 1;
+    const logOutputFile = (file: string) => file.substring(l).replace(/\\/g, '/');
+
+    // write replacements json with relative parts for script use
+    const relativeReplacements = Object.entries(angularCompilerPlugin.options.fileReplacements).reduce<
+      Record<string, string>
+    >((acc, [k, v]) => ({ ...acc, [k.substring(l).replace(/\\/g, '/')]: v.substring(l).replace(/\\/g, '/') }), {});
+
+    const replacementsPath = join(config.output.path, 'replacements.json');
+    logger.log('writing', logOutputFile(replacementsPath));
+    fs.writeFileSync(replacementsPath, JSON.stringify(relativeReplacements, undefined, 2));
+
+    const outputFolder = fs.readdirSync(config.output.path);
+    const sourceMaps = outputFolder.filter(f => f.endsWith('.js.map'));
+    if (sourceMaps.length) {
+      const activeFilesPath = join(config.output.path, 'active-files.json');
+      logger.log('writing', logOutputFile(activeFilesPath));
+
+      // write active file report
+      const activeFiles = flatten(
+        sourceMaps.map(sourceMapPath => {
+          const sourceMap: { sources: string[] } = JSON.parse(
+            fs.readFileSync(join(config.output.path, sourceMapPath), { encoding: 'utf-8' })
+          );
+          // replacements needed because html overrides are not swapped in source maps
+          return (
+            sourceMap.sources
+              // source map entries start with './
+              .map(path => path.substring(2))
+              .filter(path => path.startsWith('src') || path.startsWith('projects'))
+              .map(path => relativeReplacements[path] ?? path)
+              .filter(path => {
+                // TODO: handle lazy sources whenever this becomes a problem
+                if (path.includes('|lazy|')) {
+                  logger.warn('cannot handle lazy source:', path);
+                  return false;
+                }
+                return true;
+              })
+          );
+        })
+      )
+        .filter((v, i, a) => a.indexOf(v) === i)
+        .sort();
+      fs.writeFileSync(activeFilesPath, JSON.stringify(activeFiles, undefined, 2));
+    }
+
+    if (process.env.npm_config_dry_run) {
+      const effectiveConfigPath = join(config.output.path, 'effective.config.json');
+      logger.log('writing', logOutputFile(effectiveConfigPath));
+      fs.writeFileSync(effectiveConfigPath, JSON.stringify(config, undefined, 2));
+
+      const normalDefaultThemePath = defaultThemePath.replace(/\\/g, '/');
+      const normalNewThemePath = newThemePath.replace(/\\/g, '/');
+
+      traverse(
+        angularJsonConfig,
+        v => typeof v === 'string' && v.includes(normalDefaultThemePath),
+        (obj, key) => {
+          obj[key] = (obj[key] as string).replace(normalDefaultThemePath, normalNewThemePath);
+        }
+      );
+
+      Object.entries(angularCompilerPlugin.options.fileReplacements).map(([original, replacement]) => {
+        angularJsonConfig.fileReplacements.push({
+          replace: original,
+          with: replacement,
+        });
+      });
+
+      const effectiveAngularPath = join(config.output.path, 'effective.angular.json');
+      logger.log('writing', logOutputFile(effectiveAngularPath));
+      fs.writeFileSync(effectiveAngularPath, JSON.stringify(angularJsonConfig, undefined, 2));
+    }
+  });
+
+  // do not execute the build if npm was started with --dry-run
+  // useful for debugging config and reusing replacement logic in other places
+  if (process.env.npm_config_dry_run) {
+    logger.warn('got --dry-run -- EXITING!');
+    process.exit(0);
+  }
 
   return config;
 };


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

In projects not all out-of-box features of the PWA are used and when using component overrides, translation keys can become unused. It should be possible to run the `clean-localizations` script so it excludes keys that are in dead code considering the project customization.

## What Is the New Behavior?

`npm run clean-localizations --build` performs a build and can hereby filter out unused translation keys.

For testing (component overrides):
- add a component override `ng g override src/app/pages/search/search-result/search-result.component.ts --theme all --html --defaults`
- run `npm run clean-localizations --build`
- `Localization key search.title.text removed because it is not used` 🎉 

For testing (excluding a feature):
- remove `QuickorderRoutingModule` from `app.module.ts` (removes page routing)
- comment out all usages of `<ish-lazy-quickorder-link>` and `<ish-lazy-direct-order>` (tree-shaking will exclude component)
- run `npm run clean-localizations --build`
- all quickorder translations removed 🎉 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

#960 was a prerequisite for this. 😉 

[AB#75006](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75006)