### PR TITLE
filter effects that trigger loadFilterSuccess action into a single effect

### DIFF
--- a/src/app/core/store/shopping/filter/filter.effects.spec.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.spec.ts
@@ -1,9 +1,9 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action, Store } from '@ngrx/store';
 import { cold, hot } from 'jest-marbles';
-import { Observable, of, throwError } from 'rxjs';
-import { toArray } from 'rxjs/operators';
+import { Observable, merge, of, throwError } from 'rxjs';
+import { delay, toArray } from 'rxjs/operators';
 import { anyNumber, anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
@@ -19,6 +19,7 @@ import {
   applyFilterSuccess,
   loadFilterFail,
   loadFilterForCategory,
+  loadFilterForMaster,
   loadFilterForSearch,
   loadFilterSuccess,
   loadProductsForFilter,
@@ -43,6 +44,13 @@ describe('Filter Effects', () => {
       }
     });
     when(filterServiceMock.getFilterForCategory(anything())).thenCall(a => {
+      if (a === 'invalid') {
+        return throwError(() => makeHttpError({ message: 'invalid' }));
+      } else {
+        return of(filterNav);
+      }
+    });
+    when(filterServiceMock.getFilterForMaster(anything())).thenCall(a => {
       if (a === 'invalid') {
         return throwError(() => makeHttpError({ message: 'invalid' }));
       } else {
@@ -82,13 +90,33 @@ describe('Filter Effects', () => {
     store$.dispatch(setProductListingPageSize({ itemsPerPage: 2 }));
   });
 
-  describe('loadAvailableFilterForCategories$', () => {
+  describe('loadAvailableFilters$', () => {
     it('should call the filterService for LoadFilterForCategories action', done => {
       const action = loadFilterForCategory({ uniqueId: 'c' });
       actions$ = of(action);
 
-      effects.loadAvailableFilterForCategories$.subscribe(() => {
+      effects.loadAvailableFilters$.subscribe(() => {
         verify(filterServiceMock.getFilterForCategory(anything())).once();
+        done();
+      });
+    });
+
+    it('should call the filterService for loadFilterForSearch action', done => {
+      const action = loadFilterForSearch({ searchTerm: 'c' });
+      actions$ = of(action);
+
+      effects.loadAvailableFilters$.subscribe(() => {
+        verify(filterServiceMock.getFilterForSearch(anything())).once();
+        done();
+      });
+    });
+
+    it('should call the filterService for loadFilterForMaster action', done => {
+      const action = loadFilterForMaster({ masterSKU: 'c' });
+      actions$ = of(action);
+
+      effects.loadAvailableFilters$.subscribe(() => {
+        verify(filterServiceMock.getFilterForMaster(anything())).once();
         done();
       });
     });
@@ -99,7 +127,7 @@ describe('Filter Effects', () => {
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
 
-      expect(effects.loadAvailableFilterForCategories$).toBeObservable(expected$);
+      expect(effects.loadAvailableFilters$).toBeObservable(expected$);
     });
 
     it('should map invalid request to action of type LoadFilterFail', () => {
@@ -108,10 +136,80 @@ describe('Filter Effects', () => {
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
 
-      expect(effects.loadAvailableFilterForCategories$).toBeObservable(expected$);
+      expect(effects.loadAvailableFilters$).toBeObservable(expected$);
     });
-  });
 
+    it('should always have the latest filters emitting', fakeAsync(() => {
+      when(filterServiceMock.getFilterForMaster('master1')).thenReturn(of('filter master 1' as any).pipe(delay(10)));
+      when(filterServiceMock.getFilterForMaster('master2')).thenReturn(of('filter master 2' as any).pipe(delay(100)));
+      when(filterServiceMock.getFilterForCategory('category')).thenReturn(
+        of('filter categories' as any).pipe(delay(1000))
+      );
+
+      actions$ = merge(
+        // go to master 1
+        of(loadFilterForMaster({ masterSKU: 'master1' })),
+        // go to category
+        of(loadFilterForCategory({ uniqueId: 'category' })).pipe(delay(300)),
+        // go to master 2 before category filters are loaded
+        of(loadFilterForMaster({ masterSKU: 'master2' })).pipe(delay(500))
+      );
+
+      let lastAction;
+      effects.loadAvailableFilters$.subscribe(action => {
+        lastAction = action;
+      });
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 1"
+      `);
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 1"
+      `);
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 2"
+      `);
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 2"
+      `);
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 2"
+      `);
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 2"
+      `);
+
+      tick(200);
+
+      expect(lastAction).toMatchInlineSnapshot(`
+        [Filter API] Load Filter Success:
+          filterNavigation: "filter master 2"
+      `);
+    }));
+  });
   describe('applyFilter$', () => {
     it('should call the filterService for ApplyFilter action', done => {
       const action = applyFilter({ searchParameter: { param: ['b'] } });
@@ -171,36 +269,6 @@ describe('Filter Effects', () => {
         `);
         done();
       });
-    });
-  });
-
-  describe('loadFilterForSearch$', () => {
-    it('should call the filterService for LoadFilterForSearch action', done => {
-      const action = loadFilterForSearch({ searchTerm: 'search' });
-      actions$ = of(action);
-
-      effects.loadFilterForSearch$.subscribe(() => {
-        verify(filterServiceMock.getFilterForSearch(anything())).once();
-        done();
-      });
-    });
-
-    it('should map to action of type LoadFilterSuccess', () => {
-      const action = loadFilterForSearch({ searchTerm: 'search' });
-      const completion = loadFilterSuccess({ filterNavigation: filterNav });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
-
-      expect(effects.loadFilterForSearch$).toBeObservable(expected$);
-    });
-
-    it('should map invalid request to action of type LoadFilterFail', () => {
-      const action = loadFilterForSearch({ searchTerm: 'invalid' });
-      const completion = loadFilterFail({ error: makeHttpError({ message: 'invalid' }) });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
-
-      expect(effects.loadFilterForSearch$).toBeObservable(expected$);
     });
   });
 });

--- a/src/app/core/store/shopping/filter/filter.effects.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.ts
@@ -8,7 +8,7 @@ import { Product } from 'ish-core/models/product/product.model';
 import { FilterService } from 'ish-core/services/filter/filter.service';
 import { getProductListingItemsPerPage, setProductListingPages } from 'ish-core/store/shopping/product-listing';
 import { loadProductFail, loadProductSuccess } from 'ish-core/store/shopping/products';
-import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
+import { mapErrorToAction, mapToPayload, whenTruthy } from 'ish-core/utils/operators';
 
 import {
   applyFilter,
@@ -31,38 +31,21 @@ export class FilterEffects {
     private store: Store
   ) {}
 
-  loadAvailableFilterForCategories$ = createEffect(() =>
+  loadAvailableFilters$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(loadFilterForCategory),
-      mapToPayloadProperty('uniqueId'),
-      mergeMap(uniqueId =>
-        this.filterService.getFilterForCategory(uniqueId).pipe(
-          map(filterNavigation => loadFilterSuccess({ filterNavigation })),
-          mapErrorToAction(loadFilterFail)
-        )
-      )
-    )
-  );
-
-  loadFilterForSearch$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(loadFilterForSearch),
-      mapToPayloadProperty('searchTerm'),
-      mergeMap(searchTerm =>
-        this.filterService.getFilterForSearch(searchTerm).pipe(
-          map(filterNavigation => loadFilterSuccess({ filterNavigation })),
-          mapErrorToAction(loadFilterFail)
-        )
-      )
-    )
-  );
-
-  loadFilterForMaster$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(loadFilterForMaster),
-      mapToPayloadProperty('masterSKU'),
-      mergeMap(masterSKU =>
-        this.filterService.getFilterForMaster(masterSKU).pipe(
+      ofType(loadFilterForCategory, loadFilterForSearch, loadFilterForMaster),
+      map(action => {
+        switch (action.type) {
+          case loadFilterForCategory.type:
+            return this.filterService.getFilterForCategory(action.payload.uniqueId);
+          case loadFilterForSearch.type:
+            return this.filterService.getFilterForSearch(action.payload.searchTerm);
+          case loadFilterForMaster.type:
+            return this.filterService.getFilterForMaster(action.payload.masterSKU);
+        }
+      }),
+      switchMap(observable$ =>
+        observable$.pipe(
           map(filterNavigation => loadFilterSuccess({ filterNavigation })),
           mapErrorToAction(loadFilterFail)
         )


### PR DESCRIPTION


<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently the filter effects contains multiple effects that trigger the same action. If the userchanges really fast from a filter triggered by a search and then triggers a category filter the current implementation allows the search filter to be applied after the category filter. Therefore the order is not respected and the wrong filters are displayed

Issue Number: Closes #

## What Is the New Behavior?

The effects that trigger the same action (loadFilterSuccess) are now merged into a single effect. Switch map was added since we always want the latest source (previous ones can be dropped)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x] No

## Other Information
