### PR TITLE
chore: cypress test stabilization

### DIFF
--- a/e2e/cypress-ci-e2e.js
+++ b/e2e/cypress-ci-e2e.js
@@ -39,8 +39,9 @@ const DEFAULT_CONFIG = {
   env: { ICM_BASE_URL: process.env.ICM_BASE_URL },
 };
 
-const checkMaxRunsReached = num => {
-  if (num >= MAX_NUM_RUNS) {
+const checkMaxRunsReached = (num, noOfSpecs) => {
+  // retry a single flaky test more often
+  if ((num >= MAX_NUM_RUNS && noOfSpecs !== 1) || num >= 2 * MAX_NUM_RUNS) {
     console.log(`Ran a total of '${num}' times but still have failures. Exiting...`);
     return process.exit(1);
   }
@@ -85,7 +86,7 @@ const run = (num, spec, retryGroup) => {
           .map(result => ({ title: result.title.join(' > '), error: result.error }))
           .forEach(result => console.warn(result.title, '\n', result.error, '\n'));
 
-        checkMaxRunsReached(num);
+        checkMaxRunsReached(num, specs.length);
 
         console.log(`Retrying '${specs.length}' specs...`);
 
@@ -97,7 +98,7 @@ const run = (num, spec, retryGroup) => {
     })
     .catch(err => {
       console.error(err.message);
-      checkMaxRunsReached(num);
+      checkMaxRunsReached(num, spec?.length);
       return run(num, spec, newGroupName(num));
     });
 };

--- a/e2e/cypress/integration/framework/index.ts
+++ b/e2e/cypress/integration/framework/index.ts
@@ -11,7 +11,7 @@ export function waitLoadingEnd(initialWait: number = 500) {
 
 function onPage<T extends Page>(page: new () => T) {
   currentPage = new page();
-  return cy.get(currentPage.tag);
+  return cy.get(currentPage.tag, { timeout: 3000 });
 }
 
 export function at<T extends Page>(type: new () => T, callback?: (page: T) => void) {

--- a/e2e/cypress/integration/pages/checkout/cart.page.ts
+++ b/e2e/cypress/integration/pages/checkout/cart.page.ts
@@ -18,9 +18,9 @@ export class CartPage {
   }
 
   createQuoteRequest() {
-    waitLoadingEnd(1000);
+    waitLoadingEnd(5000);
     this.saveQuoteRequestButton().click();
-    waitLoadingEnd(1000);
+    waitLoadingEnd(5000);
   }
 
   private addToWishlistButton = () => cy.get('ish-shopping-basket').find('[data-testing-id="addToWishlistButton"]');

--- a/e2e/cypress/integration/pages/meta-data.module.ts
+++ b/e2e/cypress/integration/pages/meta-data.module.ts
@@ -1,3 +1,5 @@
+import { waitLoadingEnd } from '../framework';
+
 export class MetaDataModule {
   get canonicalLink() {
     return cy.get('head link[rel="canonical"]').then(el => el.attr('href'));
@@ -33,6 +35,7 @@ export class MetaDataModule {
   }
 
   check(expect: { title?: string; url?: RegExp; description?: string; [key: string]: string | RegExp }) {
+    waitLoadingEnd(3000);
     const expected = {
       ...MetaDataModule.defaultMeta,
       ...expect,

--- a/e2e/cypress/integration/specs/quoting/quote-handling-anonymous-basket-to-quote-request.b2b.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/quoting/quote-handling-anonymous-basket-to-quote-request.b2b.e2e-spec.ts
@@ -29,7 +29,9 @@ describe('Quote Handling as Anonymous User', () => {
         page.addProductToCart();
         page.header.miniCart.goToCart();
       });
-      at(CartPage, page => page.createQuoteRequest());
+      at(CartPage, page => {
+        page.createQuoteRequest();
+      });
     });
 
     it('user should log in and land at basket page', () => {
@@ -41,7 +43,9 @@ describe('Quote Handling as Anonymous User', () => {
     });
 
     it('user should be able to see quote request', () => {
-      at(CartPage, page => page.createQuoteRequest());
+      at(CartPage, page => {
+        page.createQuoteRequest();
+      });
       at(QuoteDetailPage, page => {
         page.productId.eq(0).should('contain', _.product.sku);
         page.quoteState.should('have.text', 'New');

--- a/e2e/cypress/integration/specs/system/seo-home-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/seo-home-page.b2c.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { at, waitLoadingEnd } from '../../framework';
+import { at } from '../../framework';
 import { HomePage } from '../../pages/home.page';
 import { NotFoundPage } from '../../pages/shopping/not-found.page';
 
@@ -7,7 +7,6 @@ describe('Page Meta', () => {
 
   it('should have all metadata set on home page', () => {
     at(HomePage, page => {
-      waitLoadingEnd(1000);
       page.metaData.check({
         title: 'inTRONICS Home | Intershop PWA',
         url: /.*\/home$/,
@@ -19,7 +18,6 @@ describe('Page Meta', () => {
   it('should switch to error page meta when navigating there', () => {
     at(HomePage, page => {
       page.footer.gotoErrorPage();
-      waitLoadingEnd(1000);
     });
     at(NotFoundPage, page => {
       page.metaData.check({

--- a/e2e/cypress/integration/specs/system/seo-product-detail-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/seo-product-detail-page.b2c.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { at, waitLoadingEnd } from '../../framework';
+import { at } from '../../framework';
 import { HomePage } from '../../pages/home.page';
 import { FamilyPage } from '../../pages/shopping/family.page';
 import { NotFoundPage } from '../../pages/shopping/not-found.page';
@@ -9,7 +9,6 @@ describe('Page Meta', () => {
 
   it('should have all metadata set on product detail page', () => {
     at(ProductDetailPage, page => {
-      waitLoadingEnd(1000);
       page.metaData.check({
         title: 'Google Home - Smart Home | Intershop PWA',
         url: /.*\/Smart-Home\/Google-Home-sku201807171-catHome-Entertainment.SmartHome$/,
@@ -22,7 +21,6 @@ describe('Page Meta', () => {
   it('should switch to family page meta when navigating there', () => {
     at(ProductDetailPage, page => {
       page.breadcrumb.items.eq(2).click();
-      waitLoadingEnd(1000);
     });
     at(FamilyPage, page => {
       page.metaData.check({
@@ -36,7 +34,6 @@ describe('Page Meta', () => {
   it('should switch to home page meta when navigating there', () => {
     at(FamilyPage, page => {
       page.header.gotoHomePage();
-      waitLoadingEnd(1000);
     });
     at(HomePage, page => {
       page.metaData.check({
@@ -50,7 +47,6 @@ describe('Page Meta', () => {
   it('should switch to error page meta when navigating there', () => {
     at(HomePage, page => {
       page.footer.gotoErrorPage();
-      waitLoadingEnd(1000);
     });
     at(NotFoundPage, page => {
       page.metaData.check({

--- a/e2e/cypress/integration/specs/system/seo-search-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/seo-search-page.b2c.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { at, waitLoadingEnd } from '../../framework';
+import { at } from '../../framework';
 import { HomePage } from '../../pages/home.page';
 import { NotFoundPage } from '../../pages/shopping/not-found.page';
 import { ProductDetailPage } from '../../pages/shopping/product-detail.page';
@@ -9,7 +9,6 @@ describe('Page Meta', () => {
 
   it('should have all metadata set on search result page', () => {
     at(SearchResultPage, page => {
-      waitLoadingEnd(1000);
       page.metaData.check({
         title: "Search Result for 'kodak' | Intershop PWA",
         url: /.*\/search\/kodak$/,
@@ -21,7 +20,6 @@ describe('Page Meta', () => {
   it('should switch to product detail page meta when navigating there', () => {
     at(SearchResultPage, page => {
       page.productList.gotoProductDetailPageBySku('3957284');
-      waitLoadingEnd(1000);
     });
     at(ProductDetailPage, page => {
       page.metaData.check({
@@ -36,7 +34,6 @@ describe('Page Meta', () => {
   it('should switch to home page meta when navigating there', () => {
     at(ProductDetailPage, page => {
       page.header.gotoHomePage();
-      waitLoadingEnd(1000);
     });
     at(HomePage, page => {
       page.metaData.check({
@@ -50,7 +47,6 @@ describe('Page Meta', () => {
   it('should switch to error page meta when navigating there', () => {
     at(HomePage, page => {
       page.footer.gotoErrorPage();
-      waitLoadingEnd(1000);
     });
     at(NotFoundPage, page => {
       page.metaData.check({

--- a/src/app/core/services/filter/filter.service.spec.ts
+++ b/src/app/core/services/filter/filter.service.spec.ts
@@ -113,7 +113,7 @@ describe('Filter Service', () => {
       const [resource, params] = capture(apiService.get).last();
       expect(resource).toMatchInlineSnapshot(`"products"`);
       expect((params as AvailableOptions)?.params?.toString()).toMatchInlineSnapshot(
-        `"amount=2&offset=0&attrs=sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet&attributeGroup=PRODUCT_LABEL_ATTRIBUTES&returnSortKeys=true&SearchParameter=b"`
+        `"amount=2&offset=0&attrs=sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet,defaultCategory&attributeGroup=PRODUCT_LABEL_ATTRIBUTES&returnSortKeys=true&SearchParameter=b"`
       );
 
       done();

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -28,7 +28,7 @@ import { mapToProperty } from 'ish-core/utils/operators';
 @Injectable({ providedIn: 'root' })
 export class ProductsService {
   static STUB_ATTRS =
-    'sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet';
+    'sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet,defaultCategory';
 
   constructor(private apiService: ApiService, private productMapper: ProductMapper, private appFacade: AppFacade) {}
 


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

Some e2e tests unstable.

## What Is the New Behavior?

- [x] `e2e/cypress/integration/specs/system/seo-search-page.b2c.e2e-spec.ts`: defaultCategory wasn't retrieved in list call.
- [x] `e2e/cypress/integration/specs/quoting/quote-handling-anonymous-basket-to-quote-request.b2b.e2e-spec.ts`: increased wait
- [x] retry a single flaky test more often

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75134](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75134)