### PR TITLE
build: simplify win check for PR build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,6 +11,17 @@ on:
 env:
   NODE_OPTIONS: --max_old_space_size=8192
   JEST_MAX_WORKERS: 1
+  CI: false
+  SCRIPT: |
+    npm run clean
+    npm run build client --configuration=b2b,development
+    npm run test products.service
+    npm run test shell
+    npm run format
+    npm run lint
+    npm run clean-localizations
+    npx ng g c shared/dummy
+    npx ng g override src/app/shared/dummy/dummy.component.ts --theme b2b --html --defaults
 
 jobs:
   CancelPrevious:
@@ -44,7 +55,7 @@ jobs:
       - name: Check No Changes
         run: npm run check-no-changes
 
-  Local:
+  CommandLine:
     needs: [CancelPrevious]
     runs-on: windows-latest
 
@@ -56,22 +67,52 @@ jobs:
           node-version: 14
           cache: npm
 
-      - name: Install Clean Repository
-        run: npm run clean
+      - uses: 1arp/create-a-file-action@0.2
+        with:
+          path: '.'
+          file: 'script.bat'
+          content: ${{ env.SCRIPT }}
 
-      - name: Build with development environment
-        run: npm run build --configuration=b2b,development
+      - name: Add call to every line
+        shell: cmd
+        run: perl -pi -e "s/(.*)/call $1/" script.bat
 
-      - name: Run some tests
-        run: |
-          npm run test service
-          npm run test shell
+      - name: Stage script file
+        shell: cmd
+        run: git add script.bat
 
-      - name: Run Formatter
-        run: npm run format
+      - name: Run developer workflow
+        shell: cmd
+        run: script.bat
 
-      - name: Run Linter
-        run: npm run lint
+  Powershell:
+    needs: [CancelPrevious]
+    runs-on: windows-latest
 
-      - name: Clean Localizations
-        run: npm run clean-localizations
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
+
+      - name: Run developer workflow
+        shell: powershell
+        run: ${{ env.SCRIPT }}
+
+  GitBash:
+    needs: [CancelPrevious]
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
+
+      - name: Run developer workflow
+        shell: bash
+        run: ${{ env.SCRIPT }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   NODE_OPTIONS: --max_old_space_size=8192
+  JEST_MAX_WORKERS: 1
 
 jobs:
   CancelPrevious:
@@ -23,6 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Check:
+    if: github.ref == 'refs/heads/develop'
     needs: [CancelPrevious]
     runs-on: windows-latest
 
@@ -59,3 +61,17 @@ jobs:
 
       - name: Build with development environment
         run: npm run build --configuration=b2b,development
+
+      - name: Run some tests
+        run: |
+          npm run test service
+          npm run test shell
+
+      - name: Run Formatter
+        run: npm run format
+
+      - name: Run Linter
+        run: npm run lint
+
+      - name: Clean Localizations
+        run: npm run clean-localizations


### PR DESCRIPTION
## PR Type

[x] CI-related changes

## What Is the Current Behavior?

Windows job runs `npm run check` which takes a lot of time on the GitHub shared runners.

## What Is the New Behavior?

- Run a simplified version with Local task and run Check only on develop builds.
- Run the simplified workflow for `cmd`, `powershell` and Git Bash

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75150](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75150)