### PR TITLE
chore: enable function argument to log operator

### DIFF
--- a/src/app/core/utils/dev/operators.spec.ts
+++ b/src/app/core/utils/dev/operators.spec.ts
@@ -41,6 +41,15 @@ describe('Operators', () => {
       subject$.next('a');
     });
 
+    it('should execute message if it is a function', done => {
+      subject$.pipe(log(() => 1234)).subscribe(() => {
+        expect(console.log).toHaveBeenCalledWith(1234, 'a');
+        done();
+      });
+
+      subject$.next('a');
+    });
+
     it('should leave emitted values for stream unchanged', done => {
       subject$.pipe(log()).subscribe(e => {
         expect(e).toEqual('a');

--- a/src/app/core/utils/dev/operators.ts
+++ b/src/app/core/utils/dev/operators.ts
@@ -5,9 +5,53 @@ export function randomDelay<T>(min = 1000, max = 10000): OperatorFunction<T, T> 
   return source$ => source$.pipe(delay(Math.floor(Math.random() * (max - min + 1)) + min));
 }
 
+/**
+ * Operator logging the current stream content to the console.
+ *
+ * If used without argument just prints the content:
+ *
+ * ```ts
+ * from(1, 'foo' ,false).pipe(log()).subscribe(...)
+ * // 1
+ * // 'foo'
+ * // true
+ * ```
+ * If used with a message will prefix the message:
+ *
+ * ```ts
+ * from(1, 'foo' ,false).pipe(log('message')).subscribe(...)
+ * // "message" 1
+ * // "message" "foo"
+ * // "message" true
+ * ```
+ *
+ * The message argument can be anything, also a function.
+ * The function will be evaluated when the stream element is emitted.
+ * This can be useful when the message value is not constant during the stream lifetime.
+ *
+ * ```ts
+ * from(1, 'foo').pipe(log(() => this.value)).subscribe(...)
+ * ```
+ *
+ * As a second argument the `stringify` function can be activated (default false).
+ * With this the stream element is passed through `JSON.stringify`.
+ * Of course the element must be serializable for this, otherwise an Error is thrown.
+ *
+ * ```ts
+ * from(1, 'foo' , { element: { test: true } }).pipe(log('message', true)).subscribe(...)
+ * // "message" "1"
+ * // "message" "foo"
+ * // "message" "{ "element": { "test": true } }"
+ * ```
+ */
 export function log<T>(message?: unknown, stringify?: boolean): OperatorFunction<T, T> {
-  // eslint-disable-next-line no-console
-  return source$ => source$.pipe(tap(e => console.log(message || '', stringify ? JSON.stringify(e) : e)));
+  return source$ =>
+    source$.pipe(
+      tap(e =>
+        // eslint-disable-next-line no-console
+        console.log(typeof message === 'function' ? message() : message || '', stringify ? JSON.stringify(e) : e)
+      )
+    );
 }
 
 export function logDiff<T>(message?: unknown): OperatorFunction<T, T> {


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Dynamic values cannot be printed as a message in the `log` operator, when they change during the stream lifetime.

## What Is the New Behavior?

The `log` operator supports a function argument for message.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75187](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75187)