### PR TITLE
fix: disable add-to-basket when quantity is zero

### DIFF
--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -260,6 +260,25 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
     );
 
     this.connect(
+      'quantity',
+      this.select('children').pipe(
+        map(children => Object.values(children)),
+        skipWhile(children => !children?.length),
+        map(children =>
+          children.reduce(
+            (sum, child) =>
+              sum +
+              (Number.isInteger(child.quantity) && !child.hasQuantityError && !child.hasProductError
+                ? child.quantity
+                : 0),
+            0
+          )
+        ),
+        distinctUntilChanged()
+      )
+    );
+
+    this.connect(
       'hasProductError',
       this.select('product').pipe(
         map(product => !!product && (!!product.failed || !product.available)),

--- a/src/app/shared/components/product/product-add-to-basket/product-add-to-basket.component.spec.ts
+++ b/src/app/shared/components/product/product-add-to-basket/product-add-to-basket.component.spec.ts
@@ -24,6 +24,7 @@ describe('Product Add To Basket Component', () => {
     context = mock(ProductContextFacade);
     when(context.select('displayProperties', 'addToBasket')).thenReturn(of(true));
     when(context.select('product')).thenReturn(of({} as ProductView));
+    when(context.select('quantity')).thenReturn(of(1));
     when(context.select('hasQuantityError')).thenReturn(of(false));
     when(context.select('hasProductError')).thenReturn(of(false));
 
@@ -74,6 +75,12 @@ describe('Product Add To Basket Component', () => {
 
   it('should show disabled button when context has product error', () => {
     when(context.select('hasProductError')).thenReturn(of(true));
+    fixture.detectChanges();
+    expect(element.querySelector('button').disabled).toBeTruthy();
+  });
+
+  it('should show disabled button when context has no quantity', () => {
+    when(context.select('quantity')).thenReturn(of(0));
     fixture.detectChanges();
     expect(element.querySelector('button').disabled).toBeTruthy();
   });

--- a/src/app/shared/components/product/product-add-to-basket/product-add-to-basket.component.ts
+++ b/src/app/shared/components/product/product-add-to-basket/product-add-to-basket.component.ts
@@ -61,11 +61,11 @@ export class ProductAddToBasketComponent implements OnInit, OnDestroy {
 
     const hasQuantityError$ = this.context.select('hasQuantityError');
     const hasProductError$ = this.context.select('hasProductError');
-    this.buttonDisabled$ = combineLatest([
-      this.displaySpinner$.pipe(startWith(false)),
-      hasQuantityError$.pipe(),
-      hasProductError$.pipe(),
-    ]).pipe(map(conditions => conditions.some(c => !!c)));
+    const hasNoQuantity$ = this.context.select('quantity').pipe(map(quantity => quantity <= 0));
+    const loading$ = this.displaySpinner$.pipe(startWith(false));
+    this.buttonDisabled$ = combineLatest([loading$, hasQuantityError$, hasProductError$, hasNoQuantity$]).pipe(
+      map(conditions => conditions.some(c => !!c))
+    );
   }
 
   addToBasket() {


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

"Add to Cart" buttons on retail sets are active when quantity is 0.

Steps to reproduce:
- Navigate to a retail set (i.e. https://intershoppwa.azurewebsites.net/PCs/Fujitsu-ESPRIMO-Edition-skuM8540840-catComputers.1835.153)
- set an individual quantity of a retail set part to 0
  Expected: Add to cart should not be possible
  Actual: Add to cart button is enabled, clicking it will lead to an endless loading animation
- set all quantities to 0
  Expected: All add to cart buttons should be disabled
  Actual: Add to cart button is enabled, clicking it will lead to an endless loading animation

## What Is the New Behavior?

- disable add to cart for quantity below 1
- track quantity of children in parent context to enable the same behavior

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

WAIT: Fix is based on #1063, please review and merge before this fix.


[AB#76057](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76057)