### PR TITLE
build: dedicated directory for angular cache per theme

### DIFF
--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -309,6 +309,16 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
     }
   );
 
+  // set theme specific angular cache directory
+  const cacheDir = join('.angular', 'cache');
+  traverse(
+    config,
+    v => typeof v === 'string' && v.includes(cacheDir),
+    (obj, key) => {
+      obj[key] = (obj[key] as string).replace(cacheDir, join(cacheDir, theme));
+    }
+  );
+
   if (angularJsonConfig.tsConfig.endsWith('tsconfig.app-no-checks.json')) {
     logger.warn('using tsconfig without compile checks');
     if (production) {


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Build-related changes

## What Is the Current Behavior?

When using theme specific component overrides, the angular cache gets confused.

Steps to reproduce:
- `ng g override src/app/pages/home/home-page.component.ts --ts --html --theme b2b --defaults`
- add `test$ = of('test');` to `src/app/pages/home/home-page.component.b2b.ts`
- add `<pre>{{ test$ | async | json }}</pre>` to `src/app/pages/home/home-page.component.b2b.html`
- Do `ng serve` and once up stop it
- Do `ng serve --configuration="b2c,development"`
  Expected: no error
  Actual:
```
Error: src/app/pages/home/home-page.component.html:1:9 - error TS2339: Property 'test$' does not exist on type 'HomePageComponent'.

1 <pre>{{ test$ | async | json }}</pre>
          ~~~~~

  src/app/pages/home/home-page.component.ts:5:16
    5   templateUrl: './home-page.component.html',
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Error occurs in the template of component HomePageComponent.

```

## What Is the New Behavior?

Each theme has a dedicated cache folder.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75202](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75202)