### PR TITLE
feat: hide node modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,5 +37,8 @@
   "eslint.options": {
     "extensions": [".ts", ".html"]
   },
-  "eslint.validate": ["javascript", "typescript", "html"]
+  "eslint.validate": ["javascript", "typescript", "html"],
+  "files.exclude": {
+    "**/node_modules": true
+  }
 }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Node modules are currently visible in vscode.


## What Is the New Behavior?

Hide node modules in vscode to help improve development experience.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#75306](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75306)