### PR TITLE
chore: activate eslint rules arrow-body-style and prefer-arrow-callback

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -129,6 +129,7 @@
         ],
         "@typescript-eslint/no-var-requires": "error",
         "@typescript-eslint/prefer-optional-chain": "warn",
+        "arrow-body-style": ["warn", "as-needed"],
         "arrow-parens": ["warn", "as-needed"],
         "ban/ban": [
           "error",
@@ -780,6 +781,7 @@
           }
         ],
         "object-shorthand": "error",
+        "prefer-arrow-callback": "warn",
         "prefer-template": "warn",
         "prettier/prettier": "warn",
         "rxjs-angular/prefer-takeuntil": [
@@ -838,6 +840,8 @@
         "ecmaVersion": "latest"
       },
       "rules": {
+        "arrow-body-style": ["warn", "as-needed"],
+        "prefer-arrow-callback": "warn",
         "prettier/prettier": "warn"
       }
     },
@@ -853,6 +857,8 @@
         "sourceType": "module"
       },
       "rules": {
+        "arrow-body-style": ["warn", "as-needed"],
+        "prefer-arrow-callback": "warn",
         "prettier/prettier": "warn"
       }
     },

--- a/eslint-rules/src/rules/sort-testbed-metadata-arrays.ts
+++ b/eslint-rules/src/rules/sort-testbed-metadata-arrays.ts
@@ -28,9 +28,7 @@ export const sortTestbedMetadataArraysRule: TSESLint.RuleModule<string, []> = {
 
         const unorderedNodes = elements
           .map((current, index, list) => [current, list[index + 1]])
-          .find(([current, next]) => {
-            return next && getText(current).localeCompare(getText(next)) === 1;
-          });
+          .find(([current, next]) => next && getText(current).localeCompare(getText(next)) === 1);
 
         if (!unorderedNodes) return;
 

--- a/intershop-changelog.js
+++ b/intershop-changelog.js
@@ -17,7 +17,7 @@ var writerOpts = {
     var discard = true;
     var issues = [];
 
-    commit.notes.forEach(function (note) {
+    commit.notes.forEach(note => {
       note.title = 'BREAKING CHANGES';
       discard = false;
     });
@@ -53,7 +53,7 @@ var writerOpts = {
     }
 
     // remove references that already appear in the subject
-    commit.references = commit.references.filter(function (reference) {
+    commit.references = commit.references.filter(reference => {
       if (issues.indexOf(reference.issue) === -1) {
         return true;
       }
@@ -84,7 +84,7 @@ module.exports = Q.all([
   readFile(resolve(__dirname, 'templates/header.hbs'), 'utf-8'),
   readFile(resolve(__dirname, 'templates/commit.hbs'), 'utf-8'),
   readFile(resolve(__dirname, 'templates/footer.hbs'), 'utf-8'),
-]).spread(function (template, header, commit, footer) {
+]).spread((template, header, commit, footer) => {
   writerOpts.mainTemplate = template;
   writerOpts.headerPartial = header;
   writerOpts.commitPartial = commit;

--- a/scripts/eslint-hard.js
+++ b/scripts/eslint-hard.js
@@ -12,7 +12,7 @@ function restoreConfigs() {
   });
 }
 
-process.on('SIGINT', function () {
+process.on('SIGINT', () => {
   restoreConfigs();
   process.exit(1);
 });

--- a/src/app/core/interceptors/payment-payone.interceptor.ts
+++ b/src/app/core/interceptors/payment-payone.interceptor.ts
@@ -35,9 +35,10 @@ export class PaymentPayoneInterceptor implements HttpInterceptor {
    * @returns The mapped payment method data
    */
   private mapPayoneBankGroupParameters(paymentMethod: PaymentMethodBaseData): PaymentMethodBaseData {
-    const options = paymentMethod.hostedPaymentPageParameters?.map(param => {
-      return { displayName: param.value, id: param.name };
-    });
+    const options = paymentMethod.hostedPaymentPageParameters?.map(param => ({
+      displayName: param.value,
+      id: param.name,
+    }));
 
     const parameterDefinitions = paymentMethod.parameterDefinitions?.map(data => {
       const constraints = data.constraints.required

--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -127,9 +127,9 @@ describe('Products Service', () => {
 
   it("should get all product variations data when 'getProductVariations' is called and more than 50 variations exist", done => {
     const total = 156;
-    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenCall((_, opts) => {
-      return !opts.params ? of({ elements: [], amount: 40, total }) : of({ elements: [], total });
-    });
+    when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenCall((_, opts) =>
+      !opts.params ? of({ elements: [], amount: 40, total }) : of({ elements: [], total })
+    );
 
     productsService.getProductVariations(productSku).subscribe(() => {
       verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).times(4);

--- a/src/app/core/store/shopping/product-prices/product-prices.reducer.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.reducer.ts
@@ -15,7 +15,5 @@ const initialState: ProductPricesState = productPriceAdapter.getInitialState({})
 
 export const productPricesReducer = createReducer(
   initialState,
-  on(loadProductPricesSuccess, (state, action) => {
-    return productPriceAdapter.upsertMany(action.payload.prices, state);
-  })
+  on(loadProductPricesSuccess, (state, action) => productPriceAdapter.upsertMany(action.payload.prices, state))
 );

--- a/src/jest-serializer/NgrxActionArraySerializer.js
+++ b/src/jest-serializer/NgrxActionArraySerializer.js
@@ -1,19 +1,14 @@
-const print = (val, serialize) => {
-  return val.map(serialize).join('\n');
-};
+const print = (val, serialize) => val.map(serialize).join('\n');
 
-const test = val => {
-  return (
-    val instanceof Array &&
-    val.length &&
-    val.every(
-      action =>
-        typeof action === 'object' &&
-        Object.keys(action).includes('type') &&
-        Object.keys(action).filter(key => !['type', 'payload'].includes(key)).length === 0
-    )
+const test = val =>
+  val instanceof Array &&
+  val.length &&
+  val.every(
+    action =>
+      typeof action === 'object' &&
+      Object.keys(action).includes('type') &&
+      Object.keys(action).filter(key => !['type', 'payload'].includes(key)).length === 0
   );
-};
 
 module.exports = {
   print: print,

--- a/src/jest-serializer/NgrxActionSerializer.js
+++ b/src/jest-serializer/NgrxActionSerializer.js
@@ -13,11 +13,10 @@ const serializeValue = v => {
   return stringified.length >= 64 ? stringified.substring(0, 61) + '...' : stringified;
 };
 
-const serializePayload = v => {
-  return Object.entries(v)
+const serializePayload = v =>
+  Object.entries(v)
     .map(([key, val]) => `${key}:${serializeValue(val)}`)
     .join('\n');
-};
 
 const print = (val, _, indent) => {
   let ret = val.type;
@@ -30,14 +29,11 @@ const print = (val, _, indent) => {
   return ret;
 };
 
-const test = val => {
-  return (
-    !!val &&
-    typeof val === 'object' &&
-    Object.keys(val).includes('type') &&
-    Object.keys(val).every(key => ['type', 'payload'].includes(key))
-  );
-};
+const test = val =>
+  !!val &&
+  typeof val === 'object' &&
+  Object.keys(val).includes('type') &&
+  Object.keys(val).every(key => ['type', 'payload'].includes(key));
 
 module.exports = {
   print: print,

--- a/templates/review-server/review-proxy.js
+++ b/templates/review-server/review-proxy.js
@@ -2,7 +2,7 @@ const { exec } = require('child_process');
 var express = require('express');
 var app = express();
 
-app.get('/*', function (req, res) {
+app.get('/*', (req, res) => {
   const name = req.url.substring(1).replace(/\/.*/g, '');
   const path = req.url.replace(/^\/[^/]*/, '');
 
@@ -69,6 +69,6 @@ app.get('/*', function (req, res) {
   }
 });
 
-app.listen(3000, function () {
+app.listen(3000, () => {
   console.log('app listening');
 });


### PR DESCRIPTION
## PR Type

[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)

## What Is the New Behavior?

ESLint rules [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style) and [prefer-arrow-callback](https://eslint.org/docs/rules/prefer-arrow-callback) are activated again like they were for TSLint with similar rules: https://github.com/intershop/intershop-pwa/blob/892a1ef31a4442a0bda2a17ac889eaca8ed5e5c4/tslint.json#L26-L27

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75394](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75394)