### PR TITLE
chore: add rule for meaningful top-level describes in tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -344,6 +344,7 @@
         ],
         "ish-custom-rules/component-creation-test": "error",
         "ish-custom-rules/do-not-use-theme-identifier": "warn",
+        "ish-custom-rules/meaningful-describe-in-tests": "warn",
         "ish-custom-rules/newline-before-root-members": "warn",
         "ish-custom-rules/no-assignment-to-inputs": "error",
         "ish-custom-rules/no-collapsible-if": "warn",

--- a/eslint-rules/src/index.ts
+++ b/eslint-rules/src/index.ts
@@ -1,6 +1,7 @@
 import { banImportsFilePatternRule } from './rules/ban-imports-file-pattern';
 import { componentCreationTestRule } from './rules/component-creation-test';
 import { doNotUseThemeIdentifierRule } from './rules/do-not-use-theme-identifier';
+import { meaningfulDescribeInTestsRule } from './rules/meaningful-describe-in-tests';
 import { newlineBeforeRootMembersRule } from './rules/newline-before-root-members';
 import { noAssignmentToInputsRule } from './rules/no-assignment-to-inputs';
 import { noCollapsibleIfRule } from './rules/no-collapsible-if';
@@ -48,6 +49,7 @@ const rules = {
   'sort-testbed-metadata-arrays': sortTestbedMetadataArraysRule,
   'do-not-use-theme-identifier': doNotUseThemeIdentifierRule,
   'use-correct-component-overrides': useCorrectComponentOverridesRule,
+  'meaningful-describe-in-tests': meaningfulDescribeInTestsRule,
 };
 
 module.exports = {

--- a/eslint-rules/src/rules/meaningful-describe-in-tests.ts
+++ b/eslint-rules/src/rules/meaningful-describe-in-tests.ts
@@ -1,0 +1,42 @@
+import { strings } from '@angular-devkit/core';
+import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { basename } from 'path';
+
+export const meaningfulDescribeInTestsRule: TSESLint.RuleModule<string, []> = {
+  meta: {
+    docs: {
+      description:
+        'A rule making sure the top-level describes match the file name. This is good for hiding tests that came into life with copy&paste.',
+      recommended: 'warn',
+      url: '',
+    },
+    messages: {
+      meaningfulDescribeInTests: 'The top level describes of the test should be constructed out of the file name.',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    if (!context.getFilename().endsWith('.spec.ts')) {
+      return {};
+    }
+
+    const expected = strings
+      .classify(basename(context.getFilename()).replace('.spec.ts', '').replace(/\W/g, '-'))
+      .replace(/[A-Z]/g, ' $&')
+      .trim();
+
+    return {
+      'Program > ExpressionStatement > CallExpression[callee.name="describe"]'(node: TSESTree.CallExpression) {
+        if (node.arguments[0]?.type === TSESTree.AST_NODE_TYPES.Literal && node.arguments[0].value !== expected) {
+          context.report({
+            node: node.arguments[0],
+            messageId: 'meaningfulDescribeInTests',
+            fix: fixer => fixer.replaceText(node.arguments[0], `'${expected}'`),
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/tests/meaningful-describe-in-tests.spec.ts
+++ b/eslint-rules/tests/meaningful-describe-in-tests.spec.ts
@@ -1,0 +1,38 @@
+import { meaningfulDescribeInTestsRule } from '../src/rules/meaningful-describe-in-tests';
+
+import { RuleTestConfig } from './_execute-tests';
+
+const config: RuleTestConfig = {
+  ruleName: 'meaningful-describe-in-tests',
+  rule: meaningfulDescribeInTestsRule,
+  tests: {
+    valid: [
+      {
+        filename: 'test.component.spec.ts',
+        code: `describe('Test Component', () => {});`,
+      },
+      {
+        filename: 'test.component.spec.ts',
+        code: `describe('Test Component', () => {
+          describe('something embedded', () => {});
+        });`,
+      },
+    ],
+    invalid: [
+      {
+        filename: 'test.component.spec.ts',
+        code: `describe('Test', () => {});`,
+        errors: [{ messageId: 'meaningfulDescribeInTests' }],
+        output: `describe('Test Component', () => {});`,
+      },
+      {
+        filename: 'test.component.spec.ts',
+        code: `describe('Test', () => {}); describe('Test2', () => {});`,
+        errors: [{ messageId: 'meaningfulDescribeInTests' }, { messageId: 'meaningfulDescribeInTests' }],
+        output: `describe('Test Component', () => {}); describe('Test Component', () => {});`,
+      },
+    ],
+  },
+};
+
+export default config;

--- a/src/app/core/store/shopping/product-prices/product-prices.effects.spec.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.effects.spec.ts
@@ -11,7 +11,7 @@ import { PricesService } from 'ish-core/services/prices/prices.service';
 import { loadProductPrices, loadProductPricesSuccess } from '.';
 import { ProductPricesEffects } from './product-prices.effects';
 
-describe('Products Effects', () => {
+describe('Product Prices Effects', () => {
   let actions$: Observable<Action>;
   let effects: ProductPricesEffects;
   let pricesServiceMock: PricesService;

--- a/src/app/core/store/shopping/product-prices/product-prices.selectors.spec.ts
+++ b/src/app/core/store/shopping/product-prices/product-prices.selectors.spec.ts
@@ -8,7 +8,7 @@ import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ng
 import { loadProductPricesSuccess } from '.';
 import { getProductPrice } from './product-prices.selectors';
 
-describe('Product Price Selectors', () => {
+describe('Product Prices Selectors', () => {
   let store$: StoreWithSnapshots;
 
   beforeEach(() => {

--- a/src/app/extensions/quoting/shared/quoting-basket-line-items/quoting-basket-line-items.component.spec.ts
+++ b/src/app/extensions/quoting/shared/quoting-basket-line-items/quoting-basket-line-items.component.spec.ts
@@ -8,7 +8,7 @@ import { QuotingFacade } from '../../facades/quoting.facade';
 
 import { QuotingBasketLineItemsComponent } from './quoting-basket-line-items.component';
 
-describe('QuotingBasketLineItemsComponent', () => {
+describe('Quoting Basket Line Items Component', () => {
   let component: QuotingBasketLineItemsComponent;
   let fixture: ComponentFixture<QuotingBasketLineItemsComponent>;
   let element: HTMLElement;

--- a/src/app/extensions/recently/store/recently/recently.integration.spec.ts
+++ b/src/app/extensions/recently/store/recently/recently.integration.spec.ts
@@ -16,7 +16,7 @@ import { clearRecently } from './recently.actions';
 import { RecentlyEffects } from './recently.effects';
 import { getMostRecentlyViewedProducts, getRecentlyViewedProducts } from './recently.selectors';
 
-describe('Recently Selectors', () => {
+describe('Recently Integration', () => {
   let store$: StoreWithSnapshots;
   let router: Router;
 

--- a/src/app/extensions/store-locator/store/store-locator-config/store-locator-config.selectors.spec.ts
+++ b/src/app/extensions/store-locator/store/store-locator-config/store-locator-config.selectors.spec.ts
@@ -8,7 +8,7 @@ import { StoreLocatorStoreModule } from '../store-locator-store.module';
 import { setGMAKey } from './store-locator-config.actions';
 import { getGMAKey } from './store-locator-config.selectors';
 
-describe('StoreLocatorConfig Selectors', () => {
+describe('Store Locator Config Selectors', () => {
   let store$: StoreWithSnapshots;
 
   beforeEach(() => {


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Top-level describes in tests are no longer corrected after the TSLint-> ESLint migration. This can lead to confusing test outputs if a new test has an wrong name due to refactoring or copy&paste.

## What Is the New Behavior?

New rule to assert the old behavior.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75398](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75398)