### PR TITLE
chore: minor cleanup testbed improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -861,6 +861,7 @@
       },
       "rules": {
         "arrow-body-style": ["warn", "as-needed"],
+        "ish-custom-rules/ordered-imports": "warn",
         "prefer-arrow-callback": "warn",
         "prettier/prettier": "warn"
       }

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "*": [
       "prettier --loglevel warn --write"
     ],
-    "*.{html,js}": [
+    "*.{html,js,mjs}": [
       "eslint --fix"
     ],
     "*.ts": [


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When `cleanup-testbed` is run in CI, it will try to execute against eslint rules specs, but ignores the file in the individual run:
```
> node scripts/cleanup-testbed.mjs "origin/develop"

found 6 test files
did not find any test files <-- that one is a eslint test
at src/app/core/store/shopping/product-prices/product-prices.effects.spec.ts 3 tests
...
```

Execution for folders and multiple files on powershell does not work

## What Is the New Behavior?

- Minimatch is used to filter out potential files from git diff checks.
- ordered-imports check and pre-commit check for `.mjs` files.
- normalizing paths to work with windows cmd and powershell

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75414](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75414)