### PR TITLE
refactor: introduce SSR variable for platform checks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -657,6 +657,7 @@
         "ish-custom-rules/use-component-change-detection": "warn",
         "ish-custom-rules/use-correct-component-overrides": "warn",
         "ish-custom-rules/use-jest-extended-matchers-in-tests": "warn",
+        "ish-custom-rules/use-ssr-variable-instead-of-platform-id": "warn",
         "ish-custom-rules/require-formly-code-documentation": "warn",
         "jest/no-commented-out-tests": "warn",
         "jest/no-disabled-tests": "warn",

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -66,18 +66,13 @@ The actual transfer is handled by the [`app.server.module.ts`](../../src/app/app
 Accessing the transferred state in a service or a component is pretty straight forward:
 
 ```typescript
-import { isPlatformBrowser } from '@angular/common';
-import { PLATFORM_ID } from '@angular/core';
 import { NEW_KEY } from 'ish-core/configurations/state-keys';
 
 newKey string;
 
-constructor(
-  @Inject(PLATFORM_ID) private platformId: string,
-  private transferState: TransferState,
-) {}
+constructor(private transferState: TransferState) {}
 
-if (isPlatformBrowser(this.platformId)) {
+if (!SSR) {
   this.newKey = this.transferState.get<string>(NEW_KEY, 'default value');
 }
 ```

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -22,6 +22,11 @@ You might need to keep this dependency if you are loading translations different
 
 The deprecated `customized-copy` schematic for copying components and replacing all usages was removed.
 
+We introduced a build variable `SSR` that is now used for all checks if the application is running in SSR or Browser context.
+We no longer use the verbose way of injecting the `PLATFORM_ID` and check it with the methods `isPlatformBrowser` or `isPlatformServer`.
+This way still works but it is discouraged by a new ESLint rule that suggests using the new `SSR` variable instead.
+So running `npm run lint` will help with finding custom code that still relies on the platform checks.
+
 ## 2.3 to 2.4
 
 The PWA 2.4 contains an Angular update to version 13.3.10 and many other dependencies updates.

--- a/eslint-rules/src/rules/use-ssr-variable-instead-of-platform-id.ts
+++ b/eslint-rules/src/rules/use-ssr-variable-instead-of-platform-id.ts
@@ -1,0 +1,42 @@
+import { TSESLint } from '@typescript-eslint/utils';
+
+const useSsrVariableInsteadOfPlatformIdRule: TSESLint.RuleModule<string> = {
+  meta: {
+    docs: {
+      description:
+        'Instead of using `isPlatformBrowser` and `isPlatformServer` together with the injected `PLATFORM_ID`, the Intershop PWA provides a `SSR` variable that can be used for this.',
+      recommended: 'warn',
+      url: '',
+    },
+    messages: {
+      useSsrVariableInsteadOfPlatformIdForBrowser: 'Use the expression !SSR instead.',
+      useSsrVariableInsteadOfPlatformIdForServer: 'Use the variable SSR instead.',
+    },
+    type: 'problem',
+    schema: [],
+    fixable: 'code',
+    hasSuggestions: true,
+  },
+  create: context => ({
+    'CallExpression[callee.name=isPlatformBrowser]'(node) {
+      context.report({
+        messageId: 'useSsrVariableInsteadOfPlatformIdForBrowser',
+        node,
+        suggest: [
+          { fix: fixer => fixer.replaceText(node, '!SSR'), messageId: 'useSsrVariableInsteadOfPlatformIdForBrowser' },
+        ],
+      });
+    },
+    'CallExpression[callee.name=isPlatformServer]'(node) {
+      context.report({
+        messageId: 'useSsrVariableInsteadOfPlatformIdForServer',
+        node,
+        suggest: [
+          { fix: fixer => fixer.replaceText(node, 'SSR'), messageId: 'useSsrVariableInsteadOfPlatformIdForServer' },
+        ],
+      });
+    },
+  }),
+};
+
+export default useSsrVariableInsteadOfPlatformIdRule;

--- a/eslint-rules/tests/use-ssr-variable-instead-of-platform-id.spec.ts
+++ b/eslint-rules/tests/use-ssr-variable-instead-of-platform-id.spec.ts
@@ -1,0 +1,39 @@
+import useSsrVariableInsteadOfPlatformIdRule from '../src/rules/use-ssr-variable-instead-of-platform-id';
+
+import testRule from './rule-tester';
+
+testRule(useSsrVariableInsteadOfPlatformIdRule, {
+  valid: [],
+  invalid: [
+    {
+      filename: 'file.ts',
+      code: `if (isPlatformBrowser(this.platformId)) {}`,
+      errors: [
+        {
+          messageId: 'useSsrVariableInsteadOfPlatformIdForBrowser',
+          suggestions: [
+            {
+              messageId: 'useSsrVariableInsteadOfPlatformIdForBrowser',
+              output: `if (!SSR) {}`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      filename: 'file.ts',
+      code: `if (isPlatformServer(this.platformId)) {}`,
+      errors: [
+        {
+          messageId: 'useSsrVariableInsteadOfPlatformIdForServer',
+          suggestions: [
+            {
+              messageId: 'useSsrVariableInsteadOfPlatformIdForServer',
+              output: `if (SSR) {}`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject, OnInit, PLATFORM_ID, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
@@ -17,13 +16,11 @@ import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 })
 export class AppComponent implements OnInit {
   @ViewChild('cookie', { static: true })
-  isBrowser: boolean;
+  isBrowser = !SSR;
   wrapperClasses$: Observable<string[]>;
   deviceType$: Observable<DeviceType>;
 
-  constructor(private appFacade: AppFacade, @Inject(PLATFORM_ID) platformId: string) {
-    this.isBrowser = isPlatformBrowser(platformId);
-  }
+  constructor(private appFacade: AppFacade) {}
 
   ngOnInit() {
     this.deviceType$ = this.appFacade.deviceType$;

--- a/src/app/core/directives/intersection-observer.directive.ts
+++ b/src/app/core/directives/intersection-observer.directive.ts
@@ -1,15 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import {
-  Directive,
-  ElementRef,
-  EventEmitter,
-  Inject,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  PLATFORM_ID,
-} from '@angular/core';
+import { Directive, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 
@@ -31,10 +20,10 @@ export class IntersectionObserverDirective implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(private element: ElementRef, @Inject(PLATFORM_ID) private platformId: string) {}
+  constructor(private element: ElementRef) {}
 
   ngOnInit() {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       const element = this.element.nativeElement;
       const config = {
         root: this.intersectionRoot,

--- a/src/app/core/facades/checkout.facade.ts
+++ b/src/app/core/facades/checkout.facade.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Store, createSelector, select } from '@ngrx/store';
 import { Subject, combineLatest, merge } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, sample, switchMap, take, tap } from 'rxjs/operators';
@@ -57,8 +56,8 @@ import { whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 export class CheckoutFacade {
   private basketChangeInternal$ = new Subject<void>();
 
-  constructor(private store: Store, @Inject(PLATFORM_ID) platformId: string) {
-    if (isPlatformBrowser(platformId)) {
+  constructor(private store: Store) {
+    if (!SSR) {
       this.store
         .pipe(
           select(getBasketLastTimeProductAdded),

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
   CanActivate,
@@ -22,12 +21,7 @@ import { whenTruthy } from 'ish-core/utils/operators';
  */
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate, CanActivateChild {
-  constructor(
-    private store: Store,
-    private router: Router,
-    @Inject(PLATFORM_ID) private platformId: string,
-    private cookieService: CookiesService
-  ) {}
+  constructor(private store: Store, private router: Router, private cookieService: CookiesService) {}
 
   canActivate(snapshot: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     return this.guardAccess({ ...snapshot.data?.queryParams, ...snapshot.queryParams, returnUrl: state.url });
@@ -41,7 +35,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     const defaultRedirect = this.router.createUrlTree(['/login'], { queryParams });
 
     return iif(
-      () => isPlatformServer(this.platformId),
+      () => SSR,
       // shortcut on ssr
       of(defaultRedirect),
       race(

--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -1,6 +1,5 @@
-import { isPlatformBrowser } from '@angular/common';
 import { HttpHandler, HttpRequest } from '@angular/common/http';
-import { ModuleWithProviders, NgModule, PLATFORM_ID } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { noop } from 'rxjs';
 
@@ -15,8 +14,8 @@ import { IdentityProviderCapabilities } from './identity-provider/identity-provi
  * provider factory for storage
  * We need a factory, since localStorage is not available during AOT build time.
  */
-export function storageFactory(platformId: string): OAuthStorage {
-  if (isPlatformBrowser(platformId)) {
+export function storageFactory(): OAuthStorage {
+  if (!SSR) {
     return localStorage;
   }
 }
@@ -24,7 +23,7 @@ export function storageFactory(platformId: string): OAuthStorage {
 @NgModule({
   imports: [OAuthModule.forRoot({ resourceServer: { sendAccessToken: false } }), PunchoutIdentityProviderModule],
   providers: [
-    { provide: OAuthStorage, useFactory: storageFactory, deps: [PLATFORM_ID] },
+    { provide: OAuthStorage, useFactory: storageFactory },
     {
       provide: IDENTITY_PROVIDER_IMPLEMENTOR,
       multi: true,

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, InjectionToken, Injector, PLATFORM_ID, Type } from '@angular/core';
+import { Injectable, InjectionToken, Injector, Type } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { noop } from 'rxjs';
 import { first } from 'rxjs/operators';
@@ -28,13 +27,8 @@ export class IdentityProviderFactory {
     type?: string;
   };
 
-  constructor(
-    private store: Store,
-    private injector: Injector,
-    private featureToggleService: FeatureToggleService,
-    @Inject(PLATFORM_ID) platformId: string
-  ) {
-    if (isPlatformBrowser(platformId)) {
+  constructor(private store: Store, private injector: Injector, private featureToggleService: FeatureToggleService) {
+    if (!SSR) {
       this.store.pipe(select(getIdentityProvider), whenTruthy(), first()).subscribe(config => {
         const provider = this.injector
           .get<IdentityProviderImplementor[]>(IDENTITY_PROVIDER_IMPLEMENTOR, [])

--- a/src/app/core/interceptors/icm-error-mapper.interceptor.ts
+++ b/src/app/core/interceptors/icm-error-mapper.interceptor.ts
@@ -1,6 +1,5 @@
-import { isPlatformBrowser } from '@angular/common';
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { ErrorHandler, Inject, Injectable, InjectionToken, Injector, PLATFORM_ID } from '@angular/core';
+import { ErrorHandler, Injectable, InjectionToken, Injector } from '@angular/core';
 import { pick } from 'lodash-es';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -18,11 +17,7 @@ export const SPECIAL_HTTP_ERROR_HANDLER = new InjectionToken<SpecialHttpErrorHan
 
 @Injectable()
 export class ICMErrorMapperInterceptor implements HttpInterceptor {
-  constructor(
-    private injector: Injector,
-    @Inject(PLATFORM_ID) private platformId: string,
-    private errorHandler: ErrorHandler
-  ) {}
+  constructor(private injector: Injector, private errorHandler: ErrorHandler) {}
 
   // eslint-disable-next-line complexity
   private mapError(httpError: HttpErrorResponse, request: HttpRequest<unknown>): HttpError {
@@ -104,7 +99,7 @@ export class ICMErrorMapperInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (!isPlatformBrowser(this.platformId)) {
+        if (SSR) {
           this.errorHandler.handleError(error);
         }
         if (error.name === 'HttpErrorResponse') {

--- a/src/app/core/interceptors/universal-mock.interceptor.ts
+++ b/src/app/core/interceptors/universal-mock.interceptor.ts
@@ -1,6 +1,5 @@
-import { isPlatformServer } from '@angular/common';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { Observable, Observer } from 'rxjs';
@@ -10,10 +9,8 @@ import { Observable, Observer } from 'rxjs';
  */
 @Injectable()
 export class UniversalMockInterceptor implements HttpInterceptor {
-  constructor(@Inject(PLATFORM_ID) private platformId: string) {}
-
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    if (!isPlatformServer(this.platformId)) {
+    if (!SSR) {
       console.warn('UniversalMockInterceptor is active for non-server platform');
     }
     if (!req.url.startsWith('http')) {

--- a/src/app/core/store/core/server-config/server-config.effects.ts
+++ b/src/app/core/store/core/server-config/server-config.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigationAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
@@ -14,12 +13,7 @@ import { isServerConfigurationLoaded } from './server-config.selectors';
 
 @Injectable()
 export class ServerConfigEffects {
-  constructor(
-    private actions$: Actions,
-    private store: Store,
-    private configService: ConfigurationService,
-    @Inject(PLATFORM_ID) private platformId: string
-  ) {}
+  constructor(private actions$: Actions, private store: Store, private configService: ConfigurationService) {}
 
   /**
    * get server configuration on routing event, if it is not already loaded
@@ -27,7 +21,7 @@ export class ServerConfigEffects {
   loadServerConfigOnInit$ = createEffect(() =>
     this.actions$.pipe(
       ofType(routerNavigationAction),
-      isPlatformServer(this.platformId) ? first() : identity,
+      SSR ? first() : identity,
       switchMap(() => this.store.pipe(select(isServerConfigurationLoaded))),
       whenFalsy(),
       map(() => loadServerConfig())

--- a/src/app/core/store/core/viewconf/viewconf.effects.ts
+++ b/src/app/core/store/core/viewconf/viewconf.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction, routerRequestAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
@@ -14,11 +13,11 @@ import { setBreadcrumbData, setStickyHeader } from './viewconf.actions';
 
 @Injectable()
 export class ViewconfEffects {
-  constructor(private store: Store, private actions$: Actions, @Inject(PLATFORM_ID) private platformId: string) {}
+  constructor(private store: Store, private actions$: Actions) {}
 
   toggleStickyHeader$ = createEffect(() =>
     iif(
-      () => isPlatformBrowser(this.platformId),
+      () => !SSR,
       defer(() =>
         fromEvent(window, 'scroll').pipe(
           map(() => window.scrollY >= 170),

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
@@ -65,8 +64,7 @@ export class BasketEffects {
     private basketService: BasketService,
     private apiTokenService: ApiTokenService,
     private router: Router,
-    private store: Store,
-    @Inject(PLATFORM_ID) private platformId: string
+    private store: Store
   ) {}
 
   /**
@@ -76,7 +74,7 @@ export class BasketEffects {
     this.actions$.pipe(
       ofType(loadBasket),
       mergeMap(() =>
-        isPlatformBrowser(this.platformId) && window.sessionStorage.getItem('basket-id')
+        !SSR && window.sessionStorage.getItem('basket-id')
           ? of(loadBasketWithId({ basketId: window.sessionStorage.getItem('basket-id') }))
           : this.basketService.getBasket().pipe(
               map(basket => loadBasketSuccess({ basket })),

--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
@@ -48,7 +47,6 @@ export class OrdersEffects {
     private actions$: Actions,
     private orderService: OrderService,
     private router: Router,
-    @Inject(PLATFORM_ID) private platformId: string,
     private store: Store,
     private translateService: TranslateService
   ) {}
@@ -167,7 +165,7 @@ export class OrdersEffects {
    */
   loadOrderForSelectedOrder$ = createEffect(() =>
     iif(
-      () => isPlatformBrowser(this.platformId),
+      () => !SSR,
       this.actions$.pipe(
         ofType(selectOrder),
         mapToPayloadProperty('orderId'),

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
@@ -63,8 +62,7 @@ export class UserEffects {
     private userService: UserService,
     private paymentService: PaymentService,
     private router: Router,
-    private apiTokenService: ApiTokenService,
-    @Inject(PLATFORM_ID) private platformId: string
+    private apiTokenService: ApiTokenService
   ) {}
 
   loginUser$ = createEffect(() =>
@@ -106,7 +104,7 @@ export class UserEffects {
   redirectAfterLogin$ = createEffect(
     () =>
       this.store$.pipe(select(selectQueryParam('returnUrl'))).pipe(
-        takeWhile(() => isPlatformBrowser(this.platformId)),
+        takeWhile(() => !SSR),
         whenTruthy(),
         sample(this.actions$.pipe(ofType(loginUserSuccess))),
         concatMap(navigateTo => from(this.router.navigateByUrl(navigateTo)))

--- a/src/app/core/store/hybrid/hybrid-store.module.ts
+++ b/src/app/core/store/hybrid/hybrid-store.module.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, NgModule, PLATFORM_ID } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { EffectsModule } from '@ngrx/effects';
@@ -13,8 +12,8 @@ import { HybridEffects, SSR_HYBRID_STATE } from './hybrid.effects';
   imports: [EffectsModule.forFeature([HybridEffects])],
 })
 export class HybridStoreModule {
-  constructor(router: Router, transferState: TransferState, @Inject(PLATFORM_ID) platformId: string) {
-    if (isPlatformBrowser(platformId) && transferState.get(SSR_HYBRID_STATE, false)) {
+  constructor(router: Router, transferState: TransferState) {
+    if (!SSR && transferState.get(SSR_HYBRID_STATE, false)) {
       addGlobalGuard(router, HybridRedirectGuard);
     }
   }

--- a/src/app/core/store/hybrid/hybrid.effects.ts
+++ b/src/app/core/store/hybrid/hybrid.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { TransferState, makeStateKey } from '@angular/platform-browser';
 import { Actions } from '@ngrx/effects';
 import { filter, take } from 'rxjs/operators';
@@ -10,14 +9,13 @@ export const SSR_HYBRID_STATE = makeStateKey<boolean>('ssrHybrid');
 export class HybridEffects {
   constructor(
     actions: Actions,
-    @Inject(PLATFORM_ID) platformId: string,
     transferState: TransferState,
     @Optional() @Inject('SSR_HYBRID') ssrHybridState: boolean
   ) {
     actions
       .pipe(
         take(1),
-        filter(() => isPlatformServer(platformId)),
+        filter(() => SSR),
         filter(() => !!ssrHybridState)
       )
       .subscribe(() => transferState.set(SSR_HYBRID_STATE, true));

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
@@ -75,7 +74,6 @@ export class ProductsEffects {
     private productsService: ProductsService,
     private httpStatusCodeService: HttpStatusCodeService,
     private productListingMapper: ProductListingMapper,
-    @Inject(PLATFORM_ID) private platformId: string,
     private router: Router
   ) {}
 
@@ -398,6 +396,6 @@ export class ProductsEffects {
   );
 
   private throttleOnBrowser<T>() {
-    return isPlatformBrowser(this.platformId) && this.router.navigated ? throttleTime<T>(100) : map(identity);
+    return !SSR && this.router.navigated ? throttleTime<T>(100) : map(identity);
   }
 }

--- a/src/app/core/store/shopping/search/search.effects.ts
+++ b/src/app/core/store/shopping/search/search.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
@@ -49,8 +48,7 @@ export class SearchEffects {
     private suggestService: SuggestService,
     private httpStatusCodeService: HttpStatusCodeService,
     private productListingMapper: ProductListingMapper,
-    private translateService: TranslateService,
-    @Inject(PLATFORM_ID) private platformId: string
+    private translateService: TranslateService
   ) {}
 
   /**
@@ -108,7 +106,7 @@ export class SearchEffects {
 
   suggestSearch$ = createEffect(() =>
     this.actions$.pipe(
-      takeWhile(() => isPlatformBrowser(this.platformId)),
+      takeWhile(() => !SSR),
       ofType(suggestSearch),
       mapToPayloadProperty('searchTerm'),
       debounceTime(400),

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -1,6 +1,5 @@
-import { isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
-import { ApplicationRef, Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { ApplicationRef, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
@@ -47,18 +46,17 @@ export class ApiTokenService {
 
   constructor(
     private cookiesService: CookiesService,
-    @Inject(PLATFORM_ID) private platformId: string,
     private router: Router,
     private store: Store,
     appRef: ApplicationRef
   ) {
     const initialCookie = this.parseCookie();
-    this.initialCookie$ = of(isPlatformBrowser(platformId) ? initialCookie : undefined);
+    this.initialCookie$ = of(!SSR ? initialCookie : undefined);
     this.initialCookie$.pipe(mapToProperty('apiToken')).subscribe(token => {
       this.apiToken$.next(token);
     });
 
-    if (isPlatformBrowser(platformId)) {
+    if (!SSR) {
       // save token routine
       combineLatest([
         store.pipe(select(getLoggedInUser)),
@@ -145,7 +143,7 @@ export class ApiTokenService {
   }
 
   restore$(types: ApiTokenCookieType[] = ['user', 'order']): Observable<boolean> {
-    if (isPlatformServer(this.platformId)) {
+    if (SSR) {
       return of(true);
     }
     return this.router.events.pipe(

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -1,5 +1,5 @@
-import { APP_BASE_HREF, DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 
 import { COOKIE_CONSENT_OPTIONS } from 'ish-core/configurations/injection-keys';
@@ -23,7 +23,6 @@ interface CookiesOptions {
 @Injectable({ providedIn: 'root' })
 export class CookiesService {
   constructor(
-    @Inject(PLATFORM_ID) private platformId: string,
     @Inject(COOKIE_CONSENT_OPTIONS) private cookieConsentOptions: CookieConsentOptions,
     private transferState: TransferState,
     @Inject(APP_BASE_HREF) private baseHref: string,
@@ -31,17 +30,17 @@ export class CookiesService {
   ) {}
 
   get(key: string): string {
-    return isPlatformBrowser(this.platformId) ? (this.cookiesReader()[key] as string) : undefined;
+    return !SSR ? (this.cookiesReader()[key] as string) : undefined;
   }
 
   remove(key: string) {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       this.cookiesWriter()(key, undefined);
     }
   }
 
   put(key: string, value: string, options?: CookiesOptions) {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       this.cookiesWriter()(key, value, options);
     }
   }
@@ -73,7 +72,7 @@ export class CookiesService {
    * @returns      'true' if the user has given the consent for the requested option, 'false' otherwise.
    */
   cookieConsentFor(option: string): boolean {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       const cookieConsentSettings = JSON.parse(this.get('cookieConsent') || 'null') as CookieConsentSettings;
       return cookieConsentSettings?.enabledOptions ? cookieConsentSettings.enabledOptions.includes(option) : false;
     } else {

--- a/src/app/core/utils/http-status-code/http-status-code.service.spec.ts
+++ b/src/app/core/utils/http-status-code/http-status-code.service.spec.ts
@@ -1,5 +1,4 @@
 import { Location } from '@angular/common';
-import { PLATFORM_ID } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { RESPONSE } from '@nguniversal/express-engine/tokens';
@@ -60,14 +59,11 @@ describe('Http Status Code Service', () => {
     });
   });
 
-  describe('on server', () => {
+  describe.onSSREnvironment('on server', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [RouterTestingModule.withRoutes([{ path: 'error', children: [] }])],
-        providers: [
-          { provide: PLATFORM_ID, useValue: 'server' },
-          { provide: RESPONSE, useValue: RES },
-        ],
+        providers: [{ provide: RESPONSE, useValue: RES }],
       });
       httpStatusCodeService = TestBed.inject(HttpStatusCodeService);
       location = TestBed.inject(Location);

--- a/src/app/core/utils/http-status-code/http-status-code.service.ts
+++ b/src/app/core/utils/http-status-code/http-status-code.service.ts
@@ -1,16 +1,11 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { Router } from '@angular/router';
 import { RESPONSE } from '@nguniversal/express-engine/tokens';
 import { Response } from 'express';
 
 @Injectable({ providedIn: 'root' })
 export class HttpStatusCodeService {
-  constructor(
-    private router: Router,
-    @Inject(PLATFORM_ID) private platformId: string,
-    @Optional() @Inject(RESPONSE) private response: Response
-  ) {}
+  constructor(private router: Router, @Optional() @Inject(RESPONSE) private response: Response) {}
 
   /**
    * set status for SSR response
@@ -20,11 +15,11 @@ export class HttpStatusCodeService {
    * @returns the Promise from the Angular Router or a Promise resolving to true if no routing was necessary or it was disabled
    */
   setStatus(status: number, redirect = true) {
-    if (isPlatformServer(this.platformId)) {
+    if (SSR) {
       this.response.status(status);
     }
     if (redirect && status >= 400) {
-      if (isPlatformServer(this.platformId)) {
+      if (SSR) {
         return this.router.navigateByUrl('/error');
       } else {
         return this.router.navigateByUrl('/error', { skipLocationChange: status < 500 });

--- a/src/app/core/utils/state-transfer/state-properties.service.ts
+++ b/src/app/core/utils/state-transfer/state-properties.service.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -16,7 +15,7 @@ import { Environment } from '../../../../environments/environment.model';
  */
 @Injectable({ providedIn: 'root' })
 export class StatePropertiesService {
-  constructor(private store: Store, @Inject(PLATFORM_ID) private platformId: string) {}
+  constructor(private store: Store) {}
 
   /**
    * Retrieve property from first set property of server state, system environment or environment.ts
@@ -29,7 +28,7 @@ export class StatePropertiesService {
       map(value => {
         if (value?.length) {
           return value;
-        } else if (isPlatformServer(this.platformId) && process.env[envKey]) {
+        } else if (SSR && process.env[envKey]) {
           return process.env[envKey];
         } else {
           return environment[envPropKey];

--- a/src/app/core/utils/translate/fallback-missing-translation-handler.ts
+++ b/src/app/core/utils/translate/fallback-missing-translation-handler.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { ErrorHandler, Inject, Injectable, InjectionToken, PLATFORM_ID } from '@angular/core';
+import { ErrorHandler, Inject, Injectable, InjectionToken } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import {
   MissingTranslationHandler,
@@ -25,7 +24,6 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
     private translateParser: TranslateParser,
     private errorHandler: ErrorHandler,
     @Inject(FALLBACK_LANG) private fallback: string,
-    @Inject(PLATFORM_ID) private platformId: string,
     private store: Store
   ) {}
 
@@ -76,7 +74,7 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
         this.reportMissingTranslation(currentLang, params.key);
       }
 
-      const doSingleCheck = isPlatformBrowser(this.platformId) && /\berror\b/.test(params.key);
+      const doSingleCheck = !SSR && /\berror\b/.test(params.key);
       const isFallbackAvailable = currentLang !== this.fallback;
       return concat(
         // try API call with specific key

--- a/src/app/core/utils/translate/icm-translate-loader.ts
+++ b/src/app/core/utils/translate/icm-translate-loader.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { TransferState, makeStateKey } from '@angular/platform-browser';
 import { TranslateLoader } from '@ngx-translate/core';
 import { memoize } from 'lodash-es';
@@ -12,18 +11,14 @@ import { Translations } from './translations.type';
 
 @Injectable()
 export class ICMTranslateLoader implements TranslateLoader {
-  constructor(
-    private transferState: TransferState,
-    @Inject(PLATFORM_ID) private platformId: string,
-    private localizations: LocalizationsService
-  ) {}
+  constructor(private transferState: TransferState, private localizations: LocalizationsService) {}
 
   getTranslation = memoize(lang => {
     const SSR_TRANSLATIONS = makeStateKey<Translations>(`ssrTranslations-${lang}`);
 
     const local$ = defer(() => from(import(`../../../../assets/i18n/${lang}.json`)).pipe(catchError(() => of({}))));
     const server$ = iif(
-      () => isPlatformBrowser(this.platformId) && this.transferState.hasKey(SSR_TRANSLATIONS),
+      () => !SSR && this.transferState.hasKey(SSR_TRANSLATIONS),
       of(this.transferState.get(SSR_TRANSLATIONS, {})),
       this.localizations.getServerTranslations(lang).pipe(
         tap(data => {

--- a/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
+++ b/src/app/extensions/punchout/pages/punchout/punchout-page.guard.ts
@@ -1,14 +1,13 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
 
 @Injectable()
 export class PunchoutPageGuard implements CanActivate {
-  constructor(private router: Router, @Inject(PLATFORM_ID) private platformId: string) {}
+  constructor(private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot) {
     // prevent any punchout handling on the server and instead show loading
-    if (isPlatformServer(this.platformId)) {
+    if (SSR) {
       return this.router.parseUrl('/loading');
     }
 

--- a/src/app/extensions/sentry/sentry.module.ts
+++ b/src/app/extensions/sentry/sentry.module.ts
@@ -1,13 +1,12 @@
-import { isPlatformBrowser } from '@angular/common';
-import { ErrorHandler, Inject, NgModule, PLATFORM_ID } from '@angular/core';
+import { ErrorHandler, NgModule } from '@angular/core';
 import { captureException } from '@sentry/browser';
 
 import { DefaultErrorHandler } from 'ish-core/utils/default-error-handler';
 
 @NgModule({})
 export class SentryModule {
-  constructor(errorHandler: ErrorHandler, @Inject(PLATFORM_ID) platformId: string) {
-    if (isPlatformBrowser(platformId)) {
+  constructor(errorHandler: ErrorHandler) {
+    if (!SSR) {
       if (errorHandler instanceof DefaultErrorHandler) {
         errorHandler.addHandler(error => {
           captureException(error);

--- a/src/app/extensions/sentry/store/sentry-config/sentry-config.effects.ts
+++ b/src/app/extensions/sentry/store/sentry-config/sentry-config.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 import { Actions, createEffect } from '@ngrx/effects';
 import { Action, Store, select } from '@ngrx/store';
@@ -27,13 +26,12 @@ export class SentryConfigEffects {
     private stateProperties: StatePropertiesService,
     private transferState: TransferState,
     private store: Store,
-    @Inject(PLATFORM_ID) private platformId: string,
     private cookiesService: CookiesService
   ) {}
 
   setSentryConfig$ = createEffect(() =>
     this.actions$.pipe(
-      takeWhile(() => isPlatformServer(this.platformId) && this.featureToggleService.enabled('sentry')),
+      takeWhile(() => SSR && this.featureToggleService.enabled('sentry')),
       take(1),
       withLatestFrom(this.stateProperties.getStateOrEnvOrDefault<string>('SENTRY_DSN', 'sentryDSN')),
       map(([, sentryDSN]) => sentryDSN),

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -1,5 +1,5 @@
-import { APP_BASE_HREF, DOCUMENT, isPlatformServer } from '@angular/common';
-import { ApplicationRef, Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
+import { ApplicationRef, Inject, Injectable, Optional } from '@angular/core';
 import { Meta, MetaDefinition, Title } from '@angular/platform-browser';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction, routerNavigationAction } from '@ngrx/router-store';
@@ -35,8 +35,7 @@ export class SeoEffects {
     @Inject(DOCUMENT) private doc: Document,
     @Optional() @Inject(REQUEST) private request: Request,
     @Inject(APP_BASE_HREF) private baseHref: string,
-    private appRef: ApplicationRef,
-    @Inject(PLATFORM_ID) private platformId: string
+    private appRef: ApplicationRef
   ) {}
 
   private pageTitle$ = new Subject<string>();
@@ -143,7 +142,7 @@ export class SeoEffects {
         this.store.pipe(select(getCurrentLocale)),
         this.store.pipe(select(getAvailableLocales), whenTruthy()),
       ]).pipe(
-        takeWhile(() => isPlatformServer(this.platformId)),
+        takeWhile(() => SSR),
         tap(([current, locales]) => {
           this.metaService.addTag({ property: 'og:locale', content: current });
 

--- a/src/app/extensions/store-locator/store/store-locator-config/store-locator-config.effects.ts
+++ b/src/app/extensions/store-locator/store/store-locator-config/store-locator-config.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID, isDevMode } from '@angular/core';
+import { Injectable, isDevMode } from '@angular/core';
 import { Actions, createEffect } from '@ngrx/effects';
 import { map, take, takeWhile, withLatestFrom } from 'rxjs/operators';
 
@@ -13,16 +12,13 @@ import { setGMAKey } from '.';
 export class StoreLocatorConfigEffects {
   constructor(
     private actions$: Actions,
-    @Inject(PLATFORM_ID) private platformId: string,
     private featureToggleService: FeatureToggleService,
     private stateProperties: StatePropertiesService
   ) {}
 
   setGMAKey$ = createEffect(() =>
     this.actions$.pipe(
-      takeWhile(
-        () => (isPlatformServer(this.platformId) || isDevMode()) && this.featureToggleService.enabled('storeLocator')
-      ),
+      takeWhile(() => (SSR || isDevMode()) && this.featureToggleService.enabled('storeLocator')),
       take(1),
       withLatestFrom(this.stateProperties.getStateOrEnvOrDefault<string>('GMA_KEY', 'gmaKey')),
       map(([, gmaKey]) => gmaKey),

--- a/src/app/extensions/tracking/store/tracking-config/tracking-config.effects.ts
+++ b/src/app/extensions/tracking/store/tracking-config/tracking-config.effects.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser, isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Actions, createEffect } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { Angulartics2GoogleTagManager } from 'angulartics2';
@@ -18,13 +17,12 @@ export class TrackingConfigEffects {
   constructor(
     private actions$: Actions,
     private featureToggleService: FeatureToggleService,
-    @Inject(PLATFORM_ID) private platformId: string,
     private stateProperties: StatePropertiesService,
     angulartics2GoogleTagManager: Angulartics2GoogleTagManager,
     store: Store,
     cookiesService: CookiesService
   ) {
-    if (isPlatformBrowser(this.platformId) && cookiesService.cookieConsentFor('tracking')) {
+    if (!SSR && cookiesService.cookieConsentFor('tracking')) {
       store
         .pipe(
           select(getGTMToken),
@@ -40,7 +38,7 @@ export class TrackingConfigEffects {
 
   setGTMToken$ = createEffect(() =>
     this.actions$.pipe(
-      takeWhile(() => isPlatformServer(this.platformId) && this.featureToggleService.enabled('tracking')),
+      takeWhile(() => SSR && this.featureToggleService.enabled('tracking')),
       take(1),
       withLatestFrom(this.stateProperties.getStateOrEnvOrDefault<string>('GTM_TOKEN', 'gtmToken')),
       map(([, gtmToken]) => gtmToken),

--- a/src/app/pages/category/category-categories/category-categories.component.ts
+++ b/src/app/pages/category/category-categories/category-categories.component.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges, OnInit, PLATFORM_ID } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
@@ -15,14 +14,12 @@ export class CategoryCategoriesComponent implements OnInit, OnChanges {
 
   isCollapsed = false;
 
-  constructor(@Inject(PLATFORM_ID) private platformId: string) {}
-
   ngOnInit() {
     this.isCollapsed = this.deviceType === 'mobile';
   }
 
   ngOnChanges() {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       window.scroll(0, 0);
     }
     this.isCollapsed = this.deviceType === 'mobile';
@@ -30,7 +27,7 @@ export class CategoryCategoriesComponent implements OnInit, OnChanges {
 
   toggle() {
     this.isCollapsed = !this.isCollapsed;
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       window.scroll(0, 0);
     }
   }

--- a/src/app/pages/category/category-products/category-products.component.ts
+++ b/src/app/pages/category/category-products/category-products.component.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges, OnInit, PLATFORM_ID } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
@@ -18,14 +17,12 @@ export class CategoryProductsComponent implements OnInit, OnChanges {
 
   isCollapsed = false;
 
-  constructor(@Inject(PLATFORM_ID) private platformId: string) {}
-
   ngOnInit() {
     this.isCollapsed = this.deviceType === 'mobile';
   }
 
   ngOnChanges() {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       window.scroll(0, 0);
     }
     this.isCollapsed = this.deviceType === 'mobile';
@@ -33,7 +30,7 @@ export class CategoryProductsComponent implements OnInit, OnChanges {
 
   toggle() {
     this.isCollapsed = !this.isCollapsed;
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       window.scroll(0, 0);
     }
   }

--- a/src/app/pages/cookies/cookies-page.guard.ts
+++ b/src/app/pages/cookies/cookies-page.guard.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { CanActivate, NavigationEnd, Router } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { filter, first } from 'rxjs/operators';
@@ -10,14 +9,10 @@ import { CookiesModalComponent } from './cookies-modal/cookies-modal.component';
 export class CookiesPageGuard implements CanActivate {
   private currentDialog: NgbModalRef;
 
-  constructor(
-    @Inject(PLATFORM_ID) private platformId: string,
-    private modalService: NgbModal,
-    private router: Router
-  ) {}
+  constructor(private modalService: NgbModal, private router: Router) {}
 
   async canActivate() {
-    if (isPlatformServer(this.platformId)) {
+    if (SSR) {
       return this.router.parseUrl('/loading');
     }
 

--- a/src/app/pages/login/login-page.component.ts
+++ b/src/app/pages/login/login-page.component.ts
@@ -1,5 +1,4 @@
-import { isPlatformServer } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -19,16 +18,11 @@ export class LoginPageComponent implements OnInit {
   loginMessageKey$: Observable<string>;
   routingInProgress$: Observable<boolean>;
 
-  constructor(
-    private accountFacade: AccountFacade,
-    private route: ActivatedRoute,
-    private appFacade: AppFacade,
-    @Inject(PLATFORM_ID) private platformId: string
-  ) {}
+  constructor(private accountFacade: AccountFacade, private route: ActivatedRoute, private appFacade: AppFacade) {}
 
   ngOnInit() {
     this.isLoggedIn$ = this.accountFacade.isLoggedIn$;
-    if (isPlatformServer(this.platformId)) {
+    if (SSR) {
       // SSR response should always display loading animation
       this.routingInProgress$ = of(true);
     } else {

--- a/src/app/pages/search/search-result/search-result.component.ts
+++ b/src/app/pages/search/search-result/search-result.component.ts
@@ -1,14 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Inject,
-  Input,
-  OnChanges,
-  OnInit,
-  PLATFORM_ID,
-  SimpleChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 
@@ -41,14 +31,12 @@ export class SearchResultComponent implements OnInit, OnChanges {
 
   isCollapsed = false;
 
-  constructor(@Inject(PLATFORM_ID) private platformId: string) {}
-
   ngOnInit() {
     this.isCollapsed = this.deviceType === 'mobile';
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       window.scroll(0, 0);
     }
     if (changes.deviceType) {
@@ -58,7 +46,7 @@ export class SearchResultComponent implements OnInit, OnChanges {
 
   toggle() {
     this.isCollapsed = !this.isCollapsed;
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       window.scroll(0, 0);
     }
   }

--- a/src/app/shell/application/cookies-banner/cookies-banner.component.ts
+++ b/src/app/shell/application/cookies-banner/cookies-banner.component.ts
@@ -1,6 +1,5 @@
 import { AnimationEvent } from '@angular/animations';
-import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 
 import bottomOutAnimation from 'ish-core/animations/bottom-out.animation';
@@ -21,11 +20,7 @@ export class CookiesBannerComponent implements OnInit {
   showBanner = false;
   transitionBanner: string = undefined;
 
-  constructor(
-    @Inject(PLATFORM_ID) private platformId: string,
-    private transferState: TransferState,
-    private cookiesService: CookiesService
-  ) {}
+  constructor(private transferState: TransferState, private cookiesService: CookiesService) {}
 
   ngOnInit() {
     this.showBannerIfNecessary();
@@ -37,7 +32,7 @@ export class CookiesBannerComponent implements OnInit {
    * - consent outdated
    */
   showBannerIfNecessary() {
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       const cookieConsentSettings = JSON.parse(
         this.cookiesService.get('cookieConsent') || 'null'
       ) as CookieConsentSettings;

--- a/src/app/shell/footer/footer/footer.component.ts
+++ b/src/app/shell/footer/footer/footer.component.ts
@@ -1,5 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges, OnInit, PLATFORM_ID } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
 import { TransferState } from '@angular/platform-browser';
 
 import { DISPLAY_VERSION } from 'ish-core/configurations/state-keys';
@@ -22,14 +21,14 @@ export class FooterComponent implements OnInit, OnChanges {
 
   appVersion: string;
 
-  constructor(@Inject(PLATFORM_ID) private platformId: string, private transferState: TransferState) {}
+  constructor(private transferState: TransferState) {}
 
   collapsed: boolean[] = [false, false, false, false, false, false];
 
   ngOnInit() {
     this.collapsed = this.collapsed.map(() => this.deviceType === 'mobile');
 
-    if (isPlatformBrowser(this.platformId)) {
+    if (!SSR) {
       this.appVersion = this.transferState.get(DISPLAY_VERSION, '');
     }
   }

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -41,7 +41,23 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => jest.clearAllTimers());
+let ssr = false;
+
+Object.defineProperty(global, 'SSR', {
+  get: () => ssr,
+});
+
+describe.onSSREnvironment = (name: string, fn?: jest.EmptyFunction) =>
+  // eslint-disable-next-line jest/valid-title
+  describe(name, () => {
+    beforeAll(() => {
+      ssr = true;
+    });
+    fn();
+    afterAll(() => {
+      ssr = false;
+    });
+  });
 
 Object.defineProperty(global, 'PRODUCTION_MODE', {
   get: () => false,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -11,3 +11,5 @@ declare const NGRX_RUNTIME_CHECKS: boolean;
 declare const PWA_VERSION: string;
 
 declare const THEME: string;
+
+declare const SSR: boolean;

--- a/src/typings.spec.d.ts
+++ b/src/typings.spec.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="jest" />
+
+declare namespace jest {
+  interface Describe {
+    onSSREnvironment(name: string, fn: EmptyFunction): void;
+  }
+}

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -137,6 +137,7 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
       SERVICE_WORKER: serviceWorker,
       NGRX_RUNTIME_CHECKS: ngrxRuntimeChecks,
       THEME: JSON.stringify(theme),
+      SSR: targetOptions.target === 'server',
     })
   );
   logger.log('setting production:', production);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,5 +6,5 @@
     "module": "ESNext"
   },
   "files": ["src/main.ts", "src/polyfills.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["src/typings.d.ts"]
 }


### PR DESCRIPTION
## PR Type

[x] Feature
[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

For checking if the current Angular app is running in SSR or Browser, the `PLATFORM_ID` has to be injected and the methods `isPlatformBrowser` and `isPlatformServer` have to be used to perform the check. This always requires DI context and is rather verbose.

## What Is the New Behavior?

- The customized build sets the variable `SSR` that can be used for this check.
- Added lint rule that suggests code changes.
- Transformed all occurrences.
- Add `onSSREnvironment` to jest `describe` so the SSR variable can be set for testing (default is false)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

As the `SSR` value is now injected into the build process with the [webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/), the values can be used for code minification. When using the usual way with `PLATFORM_ID`, the chack can only be performed at runtime and all code is ending up in server and client bundles.

Verify this by adding the following code:
```ts
    if (!SSR) {
      console.log('browser - QWERTY1234');
    }
    if (SSR) {
      console.log('server - QWERTY1234');
    }
```

Check where it turns up with (bash):
```
~$ npm run build
...
~$ grep -ro '\w* - QWERTY1234' dist
dist/server/main.js:server - QWERTY1234
dist/browser/main.e9860fd746f0e9c6.js:browser - QWERTY1234
```



[AB#75426](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75426)