### PR TITLE
chore: prefix style bundle with theme

### DIFF
--- a/src/ssr/deploy-url.ts
+++ b/src/ssr/deploy-url.ts
@@ -22,7 +22,8 @@ export function setDeployUrlInFile(deployUrl: string, path: string, input: strin
       newInput = newInput.replace(assetsRegex, (...args) => `"${deployUrl}${args[1]}"`);
     }
 
-    const javascriptRegex = /"(DEPLOY_URL_PLACEHOLDER|\/)?((runtime|vendor|main|polyfills|styles)[^"]*\.(js|css))"/g;
+    const javascriptRegex =
+      /"(DEPLOY_URL_PLACEHOLDER|\/)?((runtime|vendor|main|polyfills|[\w-]*styles)[^"]*\.(js|css))"/g;
     if (javascriptRegex.test(newInput)) {
       newInput = newInput.replace(javascriptRegex, (...args) => `"${deployUrl}${args[2]}"`);
     }

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -1,5 +1,6 @@
 import { CustomWebpackBrowserSchema, TargetOptions } from '@angular-builders/custom-webpack';
 import * as fs from 'fs';
+import { PluginOptions as MiniCssExtractPluginOptions } from 'mini-css-extract-plugin';
 import { basename, join, resolve } from 'path';
 import { Configuration, DefinePlugin, WebpackPluginInstance } from 'webpack';
 
@@ -210,6 +211,19 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
           return 'common';
         },
       };
+
+      // prefix styles with theme
+      const miniCssExtractPlugin = config.plugins.find(
+        (p: WebpackPluginInstance) => p.constructor?.name === 'MiniCssExtractPlugin'
+      ) as WebpackPluginInstance & { options: MiniCssExtractPluginOptions };
+      if (miniCssExtractPlugin) {
+        if (typeof miniCssExtractPlugin.options.filename === 'string') {
+          miniCssExtractPlugin.options.filename = `${theme}-${miniCssExtractPlugin.options.filename}`;
+        }
+        if (typeof miniCssExtractPlugin.options.chunkFilename === 'string') {
+          miniCssExtractPlugin.options.chunkFilename = `${theme}-${miniCssExtractPlugin.options.chunkFilename}`;
+        }
+      }
     }
 
     if (!process.env.TESTING) {


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the New Behavior?

Style bundles are prefixed with the theme:
![image](https://user-images.githubusercontent.com/23452927/160455961-0b7ed27c-f901-418b-91bf-4fa9f62fd7b0.png)

This makes it easier to distinguish the build table when building in parallel.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75548](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75548)