### PR TITLE
refactor: disconnect pricing from product view model

### DIFF
--- a/src/app/core/facades/product-context.facade.spec.ts
+++ b/src/app/core/facades/product-context.facade.spec.ts
@@ -34,8 +34,6 @@ describe('Product Context Facade', () => {
 
   beforeEach(() => {
     shoppingFacade = mock(ShoppingFacade);
-    when(shoppingFacade.productLinks$(anything())).thenReturn(of({}));
-    when(shoppingFacade.productParts$(anything())).thenReturn(EMPTY);
     when(shoppingFacade.category$(anything())).thenReturn(of(undefined));
     when(shoppingFacade.productVariationCount$(anything())).thenReturn(of(undefined));
     when(shoppingFacade.inCompareProducts$(anything())).thenReturn(of(false));
@@ -312,6 +310,10 @@ describe('Product Context Facade', () => {
     });
 
     describe('lazy property handling', () => {
+      beforeEach(() => {
+        when(shoppingFacade.productLinks$(anything())).thenReturn(of({}));
+      });
+
       it('should not load product links until subscription', done => {
         verify(shoppingFacade.productLinks$(anything())).never();
 
@@ -739,7 +741,6 @@ describe('Product Context Facade', () => {
       someOther$ = new BehaviorSubject(false);
 
       shoppingFacade = mock(ShoppingFacade);
-      when(shoppingFacade.productParts$(anything())).thenReturn(EMPTY);
       when(shoppingFacade.category$(anything())).thenReturn(EMPTY);
       when(shoppingFacade.productVariationCount$(anything())).thenReturn(of(undefined));
       when(shoppingFacade.inCompareProducts$(anything())).thenReturn(of(undefined));

--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -7,6 +7,7 @@ import { debounceTime, distinctUntilChanged, filter, first, map, skip, startWith
 
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { Image } from 'ish-core/models/image/image.model';
+import { Pricing } from 'ish-core/models/price/price.model';
 import { ProductLinksDictionary } from 'ish-core/models/product-links/product-links.model';
 import { ProductVariationHelper } from 'ish-core/models/product-variation/product-variation.helper';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
@@ -73,6 +74,7 @@ export interface ProductContext {
   sku: string;
   requiredCompletenessLevel: ProductCompletenessLevel | true;
   product: ProductView;
+  prices: Pricing;
   hasProductError: boolean;
   productURL: string;
   loading: boolean;
@@ -353,6 +355,16 @@ export class ProductContextFacade extends RxState<ProductContext> {
             switchMap(() => this.shoppingFacade.productParts$(this.validProductSKU$))
           )
         );
+        break;
+      case 'prices':
+        wrap(
+          'prices',
+          combineLatest([this.select('displayProperties', 'price'), this.select('product', 'sku')]).pipe(
+            filter(([visible]) => !!visible),
+            switchMap(([, ids]) => this.shoppingFacade.productPrices$(ids))
+          )
+        );
+        break;
     }
     return k2 ? super.select(k1, k2) : k1 ? super.select(k1) : super.select();
   }

--- a/src/app/core/models/price-item/price-item.helper.ts
+++ b/src/app/core/models/price-item/price-item.helper.ts
@@ -1,4 +1,5 @@
-import { Price, ScaledPrice } from 'ish-core/models/price/price.model';
+import { Price, Pricing, ScaledPrice } from 'ish-core/models/price/price.model';
+import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 
 import { PriceItem, ScaledPriceItem } from './price-item.model';
 
@@ -22,5 +23,15 @@ export class PriceItemHelper {
         minQuantity: priceItem.minQuantity,
       };
     }
+  }
+
+  static selectPricing(priceDetails: ProductPriceDetails, type: 'gross' | 'net'): Pricing {
+    return {
+      salePrice: PriceItemHelper.selectType(priceDetails?.prices?.salePrice, type),
+      listPrice: PriceItemHelper.selectType(priceDetails?.prices?.listPrice, type),
+      scaledPrices: priceDetails?.prices?.scaledPrices?.map(priceItem =>
+        PriceItemHelper.selectScaledPriceType(priceItem, type)
+      ),
+    };
   }
 }

--- a/src/app/core/models/price/price.model.ts
+++ b/src/app/core/models/price/price.model.ts
@@ -8,4 +8,10 @@ export interface ScaledPrice extends Price {
   minQuantity: number;
 }
 
+export interface Pricing {
+  listPrice: Price;
+  salePrice: Price;
+  scaledPrices: ScaledPrice[];
+}
+
 export * from './price.helper';

--- a/src/app/core/models/product-view/product-view.model.spec.ts
+++ b/src/app/core/models/product-view/product-view.model.spec.ts
@@ -1,22 +1,21 @@
 import { Category } from 'ish-core/models/category/category.model';
-import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { Product } from 'ish-core/models/product/product.model';
 
 import { createProductView } from './product-view.model';
 
 describe('Product View Model', () => {
   it('should return undefined on falsy input', () => {
-    expect(createProductView(undefined, undefined, undefined)).toBeUndefined();
+    expect(createProductView(undefined)).toBeUndefined();
   });
 
   it('should return product without defaultCategory() if the product default category is not in the category tree', () => {
-    const view = createProductView({ defaultCategoryId: 'some' } as Product, undefined, undefined);
+    const view = createProductView({ defaultCategoryId: 'some' } as Product);
     expect(view).toBeTruthy();
     expect(view.defaultCategory).toBeUndefined();
   });
 
   it('should return product if the product default category is empty', () => {
-    const view = createProductView({ sku: 'some' } as Product, undefined, undefined);
+    const view = createProductView({ sku: 'some' } as Product);
     expect(view).toBeTruthy();
     expect(view).toHaveProperty('sku', 'some');
   });
@@ -28,26 +27,11 @@ describe('Product View Model', () => {
       categoryPath: ['123'],
     } as Category;
 
-    const productPrice = { sku: 'some', prices: { salePrice: { gross: 1, currency: 'EUR' } } } as ProductPriceDetails;
-    const productPriceType = 'gross';
-
-    const view = createProductView(
-      { sku: 'some', defaultCategoryId: '123' } as Product,
-      productPrice,
-      productPriceType,
-      category
-    );
+    const view = createProductView({ sku: 'some', defaultCategoryId: '123' } as Product, category);
 
     expect(view).toBeTruthy();
     expect(view.sku).toEqual('some');
     expect(view.defaultCategory).toHaveProperty('uniqueId', '123');
     expect(view.defaultCategory).toHaveProperty('name', 'test');
-    expect(view.salePrice).toMatchInlineSnapshot(`
-      Object {
-        "currency": "EUR",
-        "type": "Money",
-        "value": 1,
-      }
-    `);
   });
 });

--- a/src/app/core/models/product-view/product-view.model.ts
+++ b/src/app/core/models/product-view/product-view.model.ts
@@ -1,7 +1,4 @@
 import { Category } from 'ish-core/models/category/category.model';
-import { PriceItemHelper } from 'ish-core/models/price-item/price-item.helper';
-import { Price, ScaledPrice } from 'ish-core/models/price/price.model';
-import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { Product, VariationProduct, VariationProductMaster } from 'ish-core/models/product/product.model';
 
 export type ProductView = Partial<SimpleProductView> &
@@ -10,9 +7,6 @@ export type ProductView = Partial<SimpleProductView> &
 
 interface SimpleProductView extends Product {
   defaultCategory: Category;
-  listPrice: Price;
-  salePrice: Price;
-  scaledPrices: ScaledPrice[];
 }
 
 interface VariationProductView extends VariationProduct, SimpleProductView {
@@ -27,21 +21,11 @@ interface VariationProductMasterView extends VariationProductMaster, SimpleProdu
   defaultVariationSKU: string;
 }
 
-export function createProductView(
-  product: Product,
-  productPrice: ProductPriceDetails,
-  priceDisplayType: 'gross' | 'net',
-  defaultCategory?: Category
-): SimpleProductView {
+export function createProductView(product: Product, defaultCategory?: Category): SimpleProductView {
   return (
     product && {
       ...product,
       defaultCategory,
-      salePrice: PriceItemHelper.selectType(productPrice?.prices?.salePrice, priceDisplayType),
-      listPrice: PriceItemHelper.selectType(productPrice?.prices?.listPrice, priceDisplayType),
-      scaledPrices: productPrice?.prices?.scaledPrices?.map(priceItem =>
-        PriceItemHelper.selectScaledPriceType(priceItem, priceDisplayType)
-      ),
     }
   );
 }
@@ -50,14 +34,12 @@ export function createVariationProductMasterView(
   product: VariationProductMaster,
   defaultVariationSKU: string,
   variations: VariationProduct[],
-  productPrice: ProductPriceDetails,
-  priceDisplayType: 'gross' | 'net',
   defaultCategory?: Category
 ): VariationProductMasterView {
   return (
     product &&
     variations?.length && {
-      ...createProductView(product, productPrice, priceDisplayType, defaultCategory),
+      ...createProductView(product, defaultCategory),
       type: 'VariationProductMaster',
       defaultVariationSKU,
       variations,
@@ -69,15 +51,13 @@ export function createVariationProductView(
   product: VariationProduct,
   variations: VariationProduct[],
   productMaster: VariationProductMaster,
-  productPrice: ProductPriceDetails,
-  priceDisplayType: 'gross' | 'net',
   defaultCategory?: Category
 ): VariationProductView {
   return (
     product &&
     productMaster &&
     variations?.length && {
-      ...createProductView(product, productPrice, priceDisplayType, defaultCategory),
+      ...createProductView(product, defaultCategory),
       type: 'VariationProduct',
       variations,
       productMaster,

--- a/src/app/core/routing/product/product.route.spec.ts
+++ b/src/app/core/routing/product/product.route.spec.ts
@@ -60,7 +60,7 @@ describe('Product Route', () => {
 
   describe('without category', () => {
     describe('without product name', () => {
-      const product = createProductView({ sku: 'A' } as Product, undefined, undefined);
+      const product = createProductView({ sku: 'A' } as Product);
       it('should create simple link when just sku is supplied', () => {
         expect(generateProductUrl(product)).toMatchInlineSnapshot(`"/skuA"`);
       });
@@ -75,7 +75,7 @@ describe('Product Route', () => {
     });
 
     describe('with product name', () => {
-      const product = createProductView({ sku: 'A', name: 'some example name' } as Product, undefined, undefined);
+      const product = createProductView({ sku: 'A', name: 'some example name' } as Product);
 
       it('should include slug when product has a name', () => {
         expect(generateProductUrl(product)).toMatchInlineSnapshot(`"/some-example-name-skuA"`);
@@ -96,20 +96,16 @@ describe('Product Route', () => {
     });
 
     describe('variation product', () => {
-      const product = createProductView(
-        {
-          sku: 'A',
-          name: 'some example name',
-          type: 'VariationProduct',
-          variableVariationAttributes: [
-            { value: 'SSD - (HDD)' },
-            { value: 'Cobalt Blue & Yellow' },
-            { value: '500 r/min' },
-          ],
-        } as VariationProduct,
-        undefined,
-        undefined
-      );
+      const product = createProductView({
+        sku: 'A',
+        name: 'some example name',
+        type: 'VariationProduct',
+        variableVariationAttributes: [
+          { value: 'SSD - (HDD)' },
+          { value: 'Cobalt Blue & Yellow' },
+          { value: '500 r/min' },
+        ],
+      } as VariationProduct);
 
       it('should include attribute values in slug when product is a variation', () => {
         expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -124,7 +120,7 @@ describe('Product Route', () => {
 
     describe('as context', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, specials);
+        const product = createProductView({ sku: 'A' } as Product, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(`"/Spezielles/skuA-catSpecials"`);
@@ -141,12 +137,7 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView(
-          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
-          undefined,
-          undefined,
-          specials
-        );
+        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(
@@ -167,7 +158,7 @@ describe('Product Route', () => {
 
     describe('as default category', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, specials);
+        const product = createProductView({ sku: 'A' } as Product, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(`"/Spezielles/skuA-catSpecials"`);
@@ -184,12 +175,7 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView(
-          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
-          undefined,
-          undefined,
-          specials
-        );
+        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -215,7 +201,7 @@ describe('Product Route', () => {
 
     describe('as context', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, specials);
+        const product = createProductView({ sku: 'A' } as Product, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(
@@ -234,12 +220,7 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView(
-          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
-          undefined,
-          undefined,
-          specials
-        );
+        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, specials);
 
         it('should be created', () => {
           expect(generateProductUrl(product, category)).toMatchInlineSnapshot(
@@ -260,7 +241,7 @@ describe('Product Route', () => {
 
     describe('as default category', () => {
       describe('without product name', () => {
-        const product = createProductView({ sku: 'A' } as Product, undefined, undefined, limitedOffer);
+        const product = createProductView({ sku: 'A' } as Product, limitedOffer);
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -279,12 +260,7 @@ describe('Product Route', () => {
       });
 
       describe('with product name', () => {
-        const product = createProductView(
-          { sku: 'A', name: 'Das neue Surface Pro 7' } as Product,
-          undefined,
-          undefined,
-          limitedOffer
-        );
+        const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, limitedOffer);
 
         it('should be created', () => {
           expect(generateProductUrl(product)).toMatchInlineSnapshot(
@@ -320,7 +296,7 @@ describe('Product Route', () => {
   describe('additional URL params', () => {
     it('should ignore additional URL params when supplied', () => {
       const category = createCategoryView(categoryTree([specials, topSeller, limitedOffer]), limitedOffer.uniqueId);
-      const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product, undefined, undefined);
+      const product = createProductView({ sku: 'A', name: 'Das neue Surface Pro 7' } as Product);
 
       expect(matchProductRoute(wrap(`${generateProductUrl(product, category)};lang=de_DE`))).toMatchInlineSnapshot(`
         Object {

--- a/src/app/core/store/shopping/products/products.selectors.spec.ts
+++ b/src/app/core/store/shopping/products/products.selectors.spec.ts
@@ -5,7 +5,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Category } from 'ish-core/models/category/category.model';
 import { Product, ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { loadCategorySuccess } from 'ish-core/store/shopping/categories';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
@@ -43,7 +42,6 @@ describe('Products Selectors', () => {
     TestBed.configureTestingModule({
       imports: [
         CoreStoreModule.forTesting(['router', 'serverConfig']),
-        CustomerStoreModule.forTesting('user'),
         RouterTestingModule.withRoutes([{ path: '**', children: [] }]),
         ShoppingStoreModule.forTesting('products', 'categories', 'productPrices'),
       ],
@@ -114,9 +112,6 @@ describe('Products Selectors', () => {
           Object {
             "defaultCategory": undefined,
             "failed": true,
-            "listPrice": undefined,
-            "salePrice": undefined,
-            "scaledPrices": undefined,
             "sku": "invalid",
           }
         `);
@@ -324,9 +319,6 @@ describe('Products Selectors', () => {
           Object {
             "defaultCategory": undefined,
             "defaultVariationSKU": "VAR",
-            "listPrice": undefined,
-            "salePrice": undefined,
-            "scaledPrices": undefined,
             "sku": "SKU",
             "type": "VariationProductMaster",
             "variations": Array [

--- a/src/app/core/store/shopping/products/products.selectors.ts
+++ b/src/app/core/store/shopping/products/products.selectors.ts
@@ -22,10 +22,8 @@ import {
 } from 'ish-core/models/product/product.model';
 import { generateCategoryUrl } from 'ish-core/routing/category/category.route';
 import { selectRouteParam } from 'ish-core/store/core/router';
-import { getPriceDisplayType } from 'ish-core/store/customer/user';
 import { getCategoryEntities, getSelectedCategory } from 'ish-core/store/shopping/categories';
 import { getAvailableFilter } from 'ish-core/store/shopping/filter';
-import { getProductPrice } from 'ish-core/store/shopping/product-prices/product-prices.selectors';
 import { getShoppingState } from 'ish-core/store/shopping/shopping-store';
 
 import { ProductsState, productAdapter } from './products.reducer';
@@ -99,36 +97,12 @@ export const getProduct = (sku: string) =>
     internalProductDefaultVariationSKU(sku),
     internalProductVariations(sku),
     internalProductMaster(sku),
-    getProductPrice(sku),
-    getPriceDisplayType,
-    (
-      product,
-      defaultCategory,
-      defaultVariationSKU,
-      variations,
-      productMaster,
-      productPrice,
-      priceDisplayType
-    ): ProductView =>
+    (product, defaultCategory, defaultVariationSKU, variations, productMaster): ProductView =>
       ProductHelper.isMasterProduct(product)
-        ? createVariationProductMasterView(
-            product,
-            defaultVariationSKU,
-            variations,
-            productPrice,
-            priceDisplayType,
-            defaultCategory
-          )
+        ? createVariationProductMasterView(product, defaultVariationSKU, variations, defaultCategory)
         : ProductHelper.isVariationProduct(product)
-        ? createVariationProductView(
-            product,
-            variations,
-            productMaster,
-            productPrice,
-            priceDisplayType,
-            defaultCategory
-          )
-        : createProductView(product, productPrice, priceDisplayType, defaultCategory)
+        ? createVariationProductView(product, variations, productMaster, defaultCategory)
+        : createProductView(product, defaultCategory)
   );
 
 export const getSelectedProduct = createSelectorFactory<object, ProductView>(projector =>

--- a/src/app/pages/compare/product-compare-list/product-compare-list.component.spec.ts
+++ b/src/app/pages/compare/product-compare-list/product-compare-list.component.spec.ts
@@ -9,7 +9,6 @@ import { FeatureToggleDirective } from 'ish-core/directives/feature-toggle.direc
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { AttributeToStringPipe } from 'ish-core/models/attribute/attribute.pipe';
-import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { ProductView, createProductView } from 'ish-core/models/product-view/product-view.model';
 import { Product } from 'ish-core/models/product/product.model';
 import { ProductAttributesComponent } from 'ish-shared/components/product/product-attributes/product-attributes.component';
@@ -31,7 +30,7 @@ describe('Product Compare List Component', () => {
   let compareProduct2: ProductView;
 
   beforeEach(async () => {
-    compareProduct1 = createProductView({ sku: '111', available: true } as Product, {} as ProductPriceDetails, 'gross');
+    compareProduct1 = createProductView({ sku: '111', available: true } as Product);
     compareProduct1.attributes = [
       {
         name: 'Optical zoom',

--- a/src/app/pages/product/product-detail-actions/product-detail-actions.component.spec.ts
+++ b/src/app/pages/product/product-detail-actions/product-detail-actions.component.spec.ts
@@ -7,7 +7,6 @@ import { anyString, instance, mock, verify, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
-import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { createProductView } from 'ish-core/models/product-view/product-view.model';
 import { Product } from 'ish-core/models/product/product.model';
 
@@ -39,7 +38,7 @@ describe('Product Detail Actions Component', () => {
     translate.use('en');
 
     const product = { sku: 'sku', available: true } as Product;
-    when(context.select('product')).thenReturn(of(createProductView(product, {} as ProductPriceDetails, 'gross')));
+    when(context.select('product')).thenReturn(of(createProductView(product)));
     when(context.select('displayProperties', anyString())).thenReturn(of(true));
   });
 
@@ -76,13 +75,7 @@ describe('Product Detail Actions Component', () => {
 
     it('should not show "compare" link when product information is available and productMaster = true', () => {
       when(context.select('product')).thenReturn(
-        of(
-          createProductView(
-            { sku: 'SKU', type: 'VariationProductMaster' } as Product,
-            {} as ProductPriceDetails,
-            'gross'
-          )
-        )
+        of(createProductView({ sku: 'SKU', type: 'VariationProductMaster' } as Product))
       );
       fixture.detectChanges();
 

--- a/src/app/pages/product/product-page.component.spec.ts
+++ b/src/app/pages/product/product-page.component.spec.ts
@@ -75,7 +75,7 @@ describe('Product Page Component', () => {
   it('should display product page components when product is available', () => {
     const product = { sku: 'dummy', completenessLevel: ProductCompletenessLevel.Detail } as Product;
     const category = { uniqueId: 'A', categoryPath: ['A'] } as Category;
-    when(context.select('product')).thenReturn(of(createProductView(product, undefined, undefined, category)));
+    when(context.select('product')).thenReturn(of(createProductView(product, category)));
 
     fixture.detectChanges();
 

--- a/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.html
+++ b/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.html
@@ -13,7 +13,7 @@
       <ish-product-id></ish-product-id>
 
       <!-- price -->
-      <div class="current-price">{{ variation.salePrice | ishPrice }}</div>
+      <div class="current-price">{{ variationSalePrice$ | async | ishPrice }}</div>
 
       <!-- Availability -->
       <ish-product-inventory></ish-product-inventory>

--- a/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.spec.ts
+++ b/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockPipe } from 'ng-mocks';
-import { of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
@@ -55,6 +55,7 @@ describe('Line Item Edit Dialog Component', () => {
         completenessLevel: ProductCompletenessLevel.List,
       } as ProductView)
     );
+    when(context.select('prices')).thenReturn(EMPTY);
 
     when(context.select('loading')).thenReturn(of(false));
   });

--- a/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.ts
+++ b/src/app/shared/components/line-item/line-item-edit-dialog/line-item-edit-dialog.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { Price } from 'ish-core/models/price/price.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 
 /**
@@ -14,12 +15,14 @@ import { ProductView } from 'ish-core/models/product-view/product-view.model';
 })
 export class LineItemEditDialogComponent implements OnInit {
   variation$: Observable<ProductView>;
+  variationSalePrice$: Observable<Price>;
   loading$: Observable<boolean>;
 
   constructor(private context: ProductContextFacade) {}
 
   ngOnInit() {
     this.variation$ = this.context.select('product');
+    this.variationSalePrice$ = this.context.select('prices').pipe(map(prices => prices?.salePrice));
 
     this.loading$ = this.context.select('loading');
   }

--- a/src/app/shared/components/product/product-price/product-price.component.spec.ts
+++ b/src/app/shared/components/product/product-price/product-price.component.spec.ts
@@ -5,15 +5,13 @@ import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
-import { Price } from 'ish-core/models/price/price.model';
+import { Price, Pricing } from 'ish-core/models/price/price.model';
 import { PricePipe } from 'ish-core/models/price/price.pipe';
-import { ProductView } from 'ish-core/models/product-view/product-view.model';
 
 import { ProductPriceComponent } from './product-price.component';
 
-function dummyProduct(list: number, sale: number): ProductView {
+function dummyPricing(list: number, sale: number, scale?: [number, number][]): Pricing {
   return {
-    sku: '123',
     listPrice: list !== undefined && {
       type: 'Money',
       value: list,
@@ -24,7 +22,13 @@ function dummyProduct(list: number, sale: number): ProductView {
       value: sale,
       currency: 'USD',
     },
-  } as ProductView;
+    scaledPrices: scale?.map(([value, minQuantity]) => ({
+      type: 'Money',
+      currency: 'USD',
+      value,
+      minQuantity,
+    })),
+  };
 }
 
 describe('Product Price Component', () => {
@@ -37,7 +41,7 @@ describe('Product Price Component', () => {
   beforeEach(async () => {
     context = mock(ProductContextFacade);
     when(context.select('displayProperties', 'price')).thenReturn(of(true));
-    when(context.select('product')).thenReturn(of(dummyProduct(11, 10)));
+    when(context.select('product')).thenReturn(of({ sku: '123' }));
 
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -65,7 +69,7 @@ describe('Product Price Component', () => {
   describe('template rendering', () => {
     it('should show "N/A" text when sale price is not available', () => {
       translate.set('product.price.na.text', 'N/A');
-      when(context.select('product')).thenReturn(of(dummyProduct(11, undefined)));
+      when(context.select('prices')).thenReturn(of(dummyPricing(11, undefined)));
       fixture.detectChanges();
 
       expect(element.querySelector('.current-price').textContent.trim()).toEqual('N/A');
@@ -73,7 +77,7 @@ describe('Product Price Component', () => {
 
     it('should show "$10.00" when no list price is available but a sale price', () => {
       translate.set('product.price.salePriceFallback.text', '{{0}}');
-      when(context.select('product')).thenReturn(of(dummyProduct(undefined, 10)));
+      when(context.select('prices')).thenReturn(of(dummyPricing(undefined, 10)));
       fixture.detectChanges();
 
       expect(element.querySelector('.current-price').textContent.trim()).toEqual('$10.00');
@@ -81,6 +85,7 @@ describe('Product Price Component', () => {
 
     it('should show sale price with salePricePrefix text when sale price < list price', () => {
       translate.set('product.price.salePricePrefix.text', '{{0}}');
+      when(context.select('prices')).thenReturn(of(dummyPricing(11, 10)));
       fixture.detectChanges();
 
       expect(element.querySelector('.current-price').textContent.trim()).toEqual('$10.00');
@@ -88,7 +93,7 @@ describe('Product Price Component', () => {
 
     it('should show sale price with salePriceFallback text when sale price = list price', () => {
       translate.set('product.price.salePriceFallback.text', '{{0}}');
-      when(context.select('product')).thenReturn(of(dummyProduct(10, 10)));
+      when(context.select('prices')).thenReturn(of(dummyPricing(10, 10)));
       fixture.detectChanges();
 
       expect(element.querySelector('.current-price').textContent.trim()).toEqual('$10.00');
@@ -96,6 +101,7 @@ describe('Product Price Component', () => {
 
     it('should show list price as old price when showInformationalPrice = true and sale price < list price', () => {
       translate.set('product.price.listPriceFallback.text', '{{0}}');
+      when(context.select('prices')).thenReturn(of(dummyPricing(11, 10)));
       component.showInformationalPrice = true;
       fixture.detectChanges();
 
@@ -104,6 +110,7 @@ describe('Product Price Component', () => {
 
     it('should show price saving when showPriceSavings = true and sale price < list price', () => {
       translate.set('product.price.savingsFallback.text', 'you saved {{0}}');
+      when(context.select('prices')).thenReturn(of(dummyPricing(11, 10)));
       component.showPriceSavings = true;
       fixture.detectChanges();
 
@@ -121,7 +128,7 @@ describe('Product Price Component', () => {
         ['.current-price.sale-price', 'list price is greater than sale price', 11, 10],
         ['.current-price.sale-price-higher', 'list price is less than sale price', 10, 11],
       ])(`should apply "%s" class when showInformationalPrice = true and %s`, (querySelector, _, list, sale) => {
-        when(context.select('product')).thenReturn(of(dummyProduct(list, sale)));
+        when(context.select('prices')).thenReturn(of(dummyPricing(list, sale)));
         fixture.detectChanges();
 
         expect(element.querySelector(querySelector)).toBeTruthy();
@@ -129,6 +136,7 @@ describe('Product Price Component', () => {
     });
 
     it('should generate rich snippet meta tag when sale price is available', () => {
+      when(context.select('prices')).thenReturn(of(dummyPricing(11, 10)));
       fixture.detectChanges();
 
       expect(element.querySelector('meta[itemprop="price"]').getAttribute('content')).toEqual('10.00');
@@ -141,25 +149,14 @@ describe('Product Price Component', () => {
       translate.set('product.price.scaledPrice.text', 'Buy {{0}}-{{1}} for {{2}} each');
       translate.set('product.price.scaledPrice.text.last', 'Buy {{0}}+ for {{1}} each');
       translate.set('product.price.scaledPrice.single.text', 'Buy {{0}} for {{1}} each');
-      when(context.select('product')).thenReturn(
-        of({
-          sku: '123',
-          listPrice: {
-            type: 'Money',
-            value: 300,
-            currency: 'USD',
-          },
-          salePrice: {
-            type: 'Money',
-            value: 250,
-            currency: 'USD',
-          },
-          scaledPrices: [
-            { type: 'Money', value: 240.0, currency: 'USD', minQuantity: 2 },
-            { type: 'Money', value: 220.0, currency: 'USD', minQuantity: 3 },
-            { type: 'Money', value: 200.0, currency: 'USD', minQuantity: 5 },
-          ],
-        })
+      when(context.select('prices')).thenReturn(
+        of(
+          dummyPricing(300, 250, [
+            [240, 2],
+            [220, 3],
+            [200, 5],
+          ])
+        )
       );
       fixture.detectChanges();
 


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

With #1018, the `ProductView` model was extended with pricing information even though it is only really used on the `product-price.component`.
Keeping additional properties in the `ProductView` means it is firing (at least) once more for every property.
In the past, more properties were disconnected from the model, like `links` in 5e0e4c8559b98c1d277170b0e8fabb6b2e58dc9f or `parts` in f5b49e0763cf5625d7f1f6027b3865c5e896e57a, finished by a memoization overhaul in #528.

## What Is the New Behavior?

- disconnected pricing from product views
- added pricing to product context

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75549](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75549)