### PR TITLE
chore: fix import in identity-provider module

### DIFF
--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -1,8 +1,7 @@
 import { isPlatformBrowser } from '@angular/common';
 import { HttpHandler, HttpRequest } from '@angular/common/http';
-import { NgModule, PLATFORM_ID } from '@angular/core';
+import { ModuleWithProviders, NgModule, PLATFORM_ID } from '@angular/core';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
-import { NgModuleWithProviders } from 'ng-mocks';
 import { noop } from 'rxjs';
 
 import { PunchoutIdentityProviderModule } from '../extensions/punchout/identity-provider/punchout-identity-provider.module';
@@ -47,7 +46,7 @@ export function storageFactory(platformId: string): OAuthStorage {
 export class IdentityProviderModule {
   static forTesting(
     capabilities: IdentityProviderCapabilities = { editEmail: true, editPassword: true, editProfile: true }
-  ): NgModuleWithProviders {
+  ): ModuleWithProviders<IdentityProviderModule> {
     return {
       ngModule: IdentityProviderModule,
       providers: [


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Production code uses import from `ng-mocks`

## What Is the New Behavior?

Use correct import

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75596](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75596)