### PR TITLE
deps: remove postinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
         "ng-mocks": "^13.2.0",
         "npm-run-all": "^4.1.5",
         "pm2": "^5.2.0",
-        "postinstall": "^0.7.4",
         "prettier": "^2.5.1",
         "prom-client": "^14.0.1",
         "purgecss-webpack-plugin": "^4.1.3",
@@ -3814,18 +3813,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.3"
-      }
-    },
-    "node_modules/@danieldietrich/copy": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@danieldietrich/copy/-/copy-0.4.2.tgz",
-      "integrity": "sha512-ZVNZIrgb2KeomfNahP77rL445ho6aQj0HHqU6hNlQ61o4rhvca+NS+ePj0d82zQDq2UPk1mjVZBTXgP+ErsDgw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/danieldietrich"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -23357,22 +23344,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/postinstall": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/postinstall/-/postinstall-0.7.4.tgz",
-      "integrity": "sha512-jrItKnoJJCY6wuhP/LpTy5KyWJYUOOs+2477PUAXDCrJOZX2vgzCD3jgXawhJG4qdFxvAepaJLum1trieFbEuw==",
-      "dev": true,
-      "dependencies": {
-        "@danieldietrich/copy": "^0.4.2",
-        "glob": "^7.1.7",
-        "minimist": "^1.2.5",
-        "resolve-from": "^5.0.0",
-        "resolve-pkg": "^2.0.0"
-      },
-      "bin": {
-        "postinstall": "bin/postinstall.js"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -24290,18 +24261,6 @@
       "dev": true,
       "dependencies": {
         "global-dirs": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
-      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
-      "dev": true,
-      "dependencies": {
-        "resolve-from": "^5.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -31323,12 +31282,6 @@
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
-    },
-    "@danieldietrich/copy": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@danieldietrich/copy/-/copy-0.4.2.tgz",
-      "integrity": "sha512-ZVNZIrgb2KeomfNahP77rL445ho6aQj0HHqU6hNlQ61o4rhvca+NS+ePj0d82zQDq2UPk1mjVZBTXgP+ErsDgw==",
-      "dev": true
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
@@ -46004,19 +45957,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "postinstall": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/postinstall/-/postinstall-0.7.4.tgz",
-      "integrity": "sha512-jrItKnoJJCY6wuhP/LpTy5KyWJYUOOs+2477PUAXDCrJOZX2vgzCD3jgXawhJG4qdFxvAepaJLum1trieFbEuw==",
-      "dev": true,
-      "requires": {
-        "@danieldietrich/copy": "^0.4.2",
-        "glob": "^7.1.7",
-        "minimist": "^1.2.5",
-        "resolve-from": "^5.0.0",
-        "resolve-pkg": "^2.0.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -46734,15 +46674,6 @@
       "dev": true,
       "requires": {
         "global-dirs": "^0.1.1"
-      }
-    },
-    "resolve-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
-      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^5.0.0"
       }
     },
     "resolve-url-loader": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "update-dockerignore": "node scripts/update-dockerignore",
     "init-development-environment": "node scripts/init-development-environment",
     "check-file-synchronization": "node scripts/check-file-synchronization",
-    "postinstall": "postinstall && npm-run-all --silent build:eslint-rules build:schematics synchronize-lazy-components init-development-environment ngcc",
+    "postinstall": "npm-run-all --silent build:eslint-rules build:schematics synchronize-lazy-components init-development-environment ngcc",
     "build:eslint-rules": "cd eslint-rules && npm run build",
     "build:schematics": "cd schematics && npm run build",
     "ng": "ng",
@@ -167,7 +167,6 @@
     "ng-mocks": "^13.2.0",
     "npm-run-all": "^4.1.5",
     "pm2": "^5.2.0",
-    "postinstall": "^0.7.4",
     "prettier": "^2.5.1",
     "prom-client": "^14.0.1",
     "purgecss-webpack-plugin": "^4.1.3",
@@ -220,8 +219,5 @@
       "path": "./node_modules/cz-customizable"
     },
     "active-themes": "b2b,b2c"
-  },
-  "postinstall": {
-    "jest-extended/types/index.d.ts": "copy node_modules/@types/jest-extended/index.d.ts"
   }
 }


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

`postinstall` is used for installing `jest-extended` types, but it seems this is no longer necessary.

## What Is the New Behavior?

Removed `postinstall` dependency.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#75598](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75598)