### PR TITLE
fix: display buyer information for orders

### DIFF
--- a/projects/requisition-management/src/app/components/requisitions-list/requisitions-list.component.spec.ts
+++ b/projects/requisition-management/src/app/components/requisitions-list/requisitions-list.component.spec.ts
@@ -23,7 +23,8 @@ describe('Requisitions List Component', () => {
       approval: {
         approvalDate: 76543627,
       },
-      user: { firstName: 'Patricia', lastName: 'Miller', email: 'pmiller@test.intershop.de' },
+      email: 'pmiller@test.intershop.de',
+      user: { firstName: 'Patricia', lastName: 'Miller' },
       totals: {},
     },
     {
@@ -33,7 +34,8 @@ describe('Requisitions List Component', () => {
       approval: {
         approvalDate: 76543628,
       },
-      user: { firstName: 'Patricia', lastName: 'Miller', email: 'pmiller@test.intershop.de' },
+      email: 'pmiller@test.intershop.de',
+      user: { firstName: 'Patricia', lastName: 'Miller' },
       totals: {},
     },
   ] as Requisition[];

--- a/projects/requisition-management/src/app/models/requisition/requisition.mapper.spec.ts
+++ b/projects/requisition-management/src/app/models/requisition/requisition.mapper.spec.ts
@@ -108,6 +108,7 @@ describe('Requisition Mapper', () => {
           "purchaseCurrency": "USD",
           "requisitionNo": "0001",
           "systemRejected": true,
+          "taxationId": undefined,
           "totalProductQuantity": undefined,
           "totals": Object {
             "bucketSurchargeTotalsByType": undefined,

--- a/projects/requisition-management/src/app/models/requisition/requisition.model.ts
+++ b/projects/requisition-management/src/app/models/requisition/requisition.model.ts
@@ -5,7 +5,6 @@ import { AbstractBasket } from 'ish-core/models/basket/basket.model';
 import { CostCenter } from 'ish-core/models/cost-center/cost-center.model';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
 import { Price } from 'ish-core/models/price/price.model';
-import { User } from 'ish-core/models/user/user.model';
 
 export type RequisitionStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
@@ -43,7 +42,6 @@ export interface Requisition extends RequisitionBasket {
   creationDate: number;
   lineItemCount: number;
 
-  user: User;
   userBudget: RequisitionUserBudget;
   approval: RequisitionApproval;
   systemRejected?: boolean;

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-buyer-approval/requisition-buyer-approval.component.spec.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-buyer-approval/requisition-buyer-approval.component.spec.ts
@@ -55,7 +55,8 @@ describe('Requisition Buyer Approval Component', () => {
         approvers: [{ firstName: 'Bernhard', lastName: 'Boldner' }],
         approvalDate: 76543627,
       },
-      user: { firstName: 'Patricia', lastName: 'Miller', email: 'pmiller@test.intershop.de' },
+      email: 'pmiller@test.intershop.de',
+      user: { firstName: 'Patricia', lastName: 'Miller' },
       userBudget: {
         budgetPeriod: 'weekly',
         orderSpentLimit: { currency: 'USD', value: 500, type: 'Money' },

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-cost-center-approval/requisition-cost-center-approval.component.spec.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-cost-center-approval/requisition-cost-center-approval.component.spec.ts
@@ -70,7 +70,8 @@ describe('Requisition Cost Center Approval Component', () => {
           } as CostCenter,
         },
       },
-      user: { firstName: 'Patricia', lastName: 'Miller', email: 'pmiller@test.intershop.de' },
+      email: 'pmiller@test.intershop.de',
+      user: { firstName: 'Patricia', lastName: 'Miller' },
       totals: {
         total: { gross: 2000, net: 1800, currency: 'USD' },
       } as BasketTotal,

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-cost-center-approval/requisition-cost-center-approval.component.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-cost-center-approval/requisition-cost-center-approval.component.ts
@@ -50,7 +50,7 @@ export class RequisitionCostCenterApprovalComponent implements OnInit, OnChanges
 
       this.buyer =
         this.costCenter.buyers?.length &&
-        this.costCenter.buyers?.find(buyer => buyer.email === this.requisition?.user.email);
+        this.costCenter.buyers?.find(buyer => buyer.email === this.requisition?.email);
       this.bVal = this.determineBudgetValues(this.buyer);
     }
   }

--- a/projects/requisition-management/src/app/store/requisitions/requisitions.selectors.spec.ts
+++ b/projects/requisition-management/src/app/store/requisitions/requisitions.selectors.spec.ts
@@ -154,7 +154,7 @@ describe('Requisitions Selectors', () => {
       {
         id: '1',
         lineItems: [{ id: 'test1', productSKU: 'sku1', quantity: { value: 5 } } as LineItem],
-        user: { email: 'testmail@intershop.de' },
+        email: 'testmail@intershop.de',
         approval: {
           statusCode: 'PENDING',
           status: 'pending',
@@ -163,7 +163,7 @@ describe('Requisitions Selectors', () => {
       {
         id: '2',
         lineItems: [{ id: 'test2', productSKU: 'sku2', quantity: { value: 1 } } as LineItem],
-        user: { email: 'testmail@intershop.de' },
+        email: 'testmail@intershop.de',
         approval: {
           statusCode: 'PENDING',
           status: 'pending',

--- a/src/app/core/models/basket/basket.interface.ts
+++ b/src/app/core/models/basket/basket.interface.ts
@@ -46,6 +46,12 @@ export interface BasketBaseData {
   };
   approval?: BasketApproval;
   attributes?: Attribute[];
+  buyer?: {
+    companyName?: string;
+    companyName2?: string;
+    firstName: string;
+    lastName: string;
+  };
 }
 
 export interface BasketData {

--- a/src/app/core/models/basket/basket.mapper.ts
+++ b/src/app/core/models/basket/basket.mapper.ts
@@ -66,6 +66,8 @@ export class BasketMapper {
       infos: infos?.filter(info => info.code !== 'include.not_resolved.error'),
       approval: data.approval,
       attributes: data.attributes,
+      taxationId: data.attributes?.find(attr => attr.name === 'taxationID')?.value as string,
+      user: data.buyer,
     };
   }
 

--- a/src/app/core/models/basket/basket.model.ts
+++ b/src/app/core/models/basket/basket.model.ts
@@ -27,6 +27,13 @@ export interface AbstractBasket<T> {
   infos?: BasketInfo[];
   approval?: BasketApproval;
   attributes?: Attribute[];
+  taxationId?: string;
+  user?: {
+    companyName?: string;
+    companyName2?: string;
+    firstName: string;
+    lastName: string;
+  };
 }
 
 export type Basket = AbstractBasket<LineItem>;

--- a/src/app/core/models/order/order.interface.ts
+++ b/src/app/core/models/order/order.interface.ts
@@ -25,6 +25,7 @@ export interface OrderBaseData extends BasketBaseData {
   basket: string;
   requisitionDocumentNo?: string;
   attributes?: Attribute[];
+  taxIdentificationNumber?: string;
 }
 
 export interface OrderData {

--- a/src/app/core/models/order/order.mapper.ts
+++ b/src/app/core/models/order/order.mapper.ts
@@ -83,6 +83,8 @@ export class OrderMapper {
         totals,
         infos,
         attributes: data.attributes,
+        taxationId: data.taxIdentificationNumber,
+        user: data.buyer,
       };
     }
   }

--- a/src/app/shared/components/basket/basket-buyer/basket-buyer.component.html
+++ b/src/app/shared/components/basket/basket-buyer/basket-buyer.component.html
@@ -1,10 +1,5 @@
 <div *ngIf="object">
-  <ng-container *ngIf="customer$ | async as customer; else companyFromInvoice">
-    {{ customer.companyName }} {{ customer.companyName2 }}
-  </ng-container>
-  <ng-template #companyFromInvoice>
-    {{ object.invoiceToAddress.companyName1 }} {{ object.invoiceToAddress.companyName2 }}
-  </ng-template>
+  {{ companyName1 }} {{ companyName2 }}
   <span *ngIf="taxationID" data-testing-id="taxationID">
     <br />{{ 'checkout.widget.buyer.TaxationID' | translate }} {{ taxationID }}
   </span>

--- a/src/app/shared/components/basket/basket-buyer/basket-buyer.component.spec.ts
+++ b/src/app/shared/components/basket/basket-buyer/basket-buyer.component.spec.ts
@@ -5,7 +5,6 @@ import { instance, mock, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Customer } from 'ish-core/models/customer/customer.model';
-import { User } from 'ish-core/models/user/user.model';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 
 import { BasketBuyerComponent } from './basket-buyer.component';
@@ -35,7 +34,6 @@ describe('Basket Buyer Component', () => {
 
     component.object = BasketMockData.getBasket();
 
-    when(accountFacade.user$).thenReturn(of({ firstName: 'Patricia', lastName: 'Miller' } as User));
     when(accountFacade.customer$).thenReturn(of({ companyName: 'OilCorp', taxationID: '1234' } as Customer));
   });
 
@@ -45,7 +43,14 @@ describe('Basket Buyer Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
-  it('should display the taxation id of the customer', () => {
+  it('should display the taxation id of the object', () => {
+    component.object.taxationId = '5678';
+    fixture.detectChanges();
+    expect(element.querySelector('[data-testing-id="taxationID"]')).toBeTruthy();
+    expect(element.querySelector('[data-testing-id="taxationID"]').innerHTML).toContain('5678');
+  });
+
+  it('should display the taxation id of the customer if basket/order has no taxation Id', () => {
     fixture.detectChanges();
     expect(element.querySelector('[data-testing-id="taxationID"]')).toBeTruthy();
     expect(element.querySelector('[data-testing-id="taxationID"]').innerHTML).toContain('1234');

--- a/src/app/shared/components/basket/basket-buyer/basket-buyer.component.ts
+++ b/src/app/shared/components/basket/basket-buyer/basket-buyer.component.ts
@@ -6,7 +6,6 @@ import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { Order } from 'ish-core/models/order/order.model';
-import { User } from 'ish-core/models/user/user.model';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 @Component({
@@ -22,35 +21,37 @@ export class BasketBuyerComponent implements OnInit, OnDestroy {
   @Input() editRouterLink?: string;
 
   customer$: Observable<Customer>;
-  user$: Observable<User>;
 
   taxationID: string;
   orderReferenceID: string;
   costCenterName: string;
   userName: string;
+  companyName1: string;
+  companyName2: string;
 
   private destroy$ = new Subject<void>();
 
   constructor(private accountFacade: AccountFacade) {}
 
   ngOnInit() {
-    this.taxationID = this.getAttributeValue('taxationID');
+    this.taxationID = this.object.taxationId;
     this.orderReferenceID = this.getAttributeValue('orderReferenceID');
     this.costCenterName = this.getAttributeValue('BusinessObjectAttributes#Order_CostCenter_Name');
 
-    // default values for anonymous users
-    this.userName = `${this.object.invoiceToAddress?.firstName} ${this.object.invoiceToAddress?.lastName}`;
+    this.userName = this.object.user
+      ? `${this.object.user?.firstName} ${this.object.user?.lastName}`
+      : `${this.object.invoiceToAddress?.firstName} ${this.object.invoiceToAddress?.lastName}`;
+
+    this.companyName1 = this.object.user?.companyName || this.object.invoiceToAddress?.companyName1 || '';
+    this.companyName2 =
+      (this.object.user?.companyName ? this.object.user?.companyName2 : this.object.invoiceToAddress?.companyName2) ||
+      '';
 
     this.customer$ = this.accountFacade.customer$;
-    this.user$ = this.accountFacade.user$;
 
-    // values for registered users
+    // values for registered users and basket
     this.customer$.pipe(whenTruthy(), first(), takeUntil(this.destroy$)).subscribe(customer => {
-      this.taxationID = customer?.taxationID;
-    });
-
-    this.user$.pipe(whenTruthy(), first(), takeUntil(this.destroy$)).subscribe(user => {
-      this.userName = `${user.firstName} ${user.lastName}`;
+      this.taxationID = this.taxationID || customer?.taxationID;
     });
   }
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When buyer information (company name, tax ID, buyer name or e-mail address) are updated via profile settings, past orders are also changed.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
For past orders, the information is displayed which is valid at the time of placing the order.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

see also:

[AB#69203](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/69203)

[AB#75719](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75719)