### PR TITLE
fix: second login in another tab gets lost

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -72,6 +72,14 @@ export class ApiTokenService {
               return { type: 'basket', apiToken };
             } else if (orderId) {
               return { type: 'order', apiToken, orderId };
+            } else {
+              const existingApiToken = this.cookiesService.get('apiToken');
+              const existingApiTokenCookie: ApiTokenCookie = existingApiToken
+                ? JSON.parse(existingApiToken)
+                : undefined;
+              if (apiToken && existingApiTokenCookie) {
+                return { ...existingApiTokenCookie, apiToken };
+              }
             }
           }),
           distinctUntilChanged<ApiTokenCookie>(isEqual)

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -73,12 +73,12 @@ export class ApiTokenService {
             } else if (orderId) {
               return { type: 'order', apiToken, orderId };
             } else {
-              const existingApiToken = this.cookiesService.get('apiToken');
-              const existingApiTokenCookie: ApiTokenCookie = existingApiToken
-                ? JSON.parse(existingApiToken)
+              const apiTokenCookieString = this.cookiesService.get('apiToken');
+              const apiTokenCookie: ApiTokenCookie = apiTokenCookieString
+                ? JSON.parse(apiTokenCookieString)
                 : undefined;
-              if (apiToken && existingApiTokenCookie) {
-                return { ...existingApiTokenCookie, apiToken };
+              if (apiToken && apiTokenCookie) {
+                return { ...apiTokenCookie, apiToken };
               }
             }
           }),


### PR DESCRIPTION
## PR Type

[x] Bugfix


## What Is the Current Behavior?

If a logged in user opens an another tab, then the related api token cookie is removed temporary, which could lead to an automatic logout in the other tabs. The reason is, that the PWA gets new api tokens before the login process is completed.

Issue Number: Closes #938

## What Is the New Behavior?

If the logged in user gets new user api tokens before the log in process is completed, then the existing cookie should be overwritten with the new api token.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

[AB#75862](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75862)