### PR TITLE
fix: remove equal character from url slugs

### DIFF
--- a/src/app/core/utils/routing.ts
+++ b/src/app/core/utils/routing.ts
@@ -27,4 +27,4 @@ export function addGlobalGuard(
 /**
  * RegEx that finds reserved characters that should not be contained in non functional parts of routes/URLs (e.g product slugs for SEO)
  */
-export const reservedCharactersRegEx = /[ &\(\)]/g;
+export const reservedCharactersRegEx = /[ &\(\)=]/g;


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

`=` char in URL (even though it is escaped) causes problems in deployment.

Steps to reproduce:
1. put `=` into product name in ICM (no demo data for this available)
2. start full deployment (docker compose)
3. navigate to product and refresh

## What Is the New Behavior?

`=` char is replaced as part of the `reservedCharactersRegEx` used in generating slugs for category and product URLs.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#75910](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/75910)