### PR TITLE
fix: use jest test related for cleanup-testbed

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -122,7 +122,7 @@ jobs:
         run: npm run dead-code
 
       - name: Find Unused TestBed declarations
-        run: npm exec npm-run-all "cleanup-testbed origin/develop" check-no-changes
+        run: npm exec npm-run-all "cleanup-testbed --related origin/develop" check-no-changes
 
   Schematics:
     needs: [Quality, Jest]


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

`cleanup-testbed` script does not run on related tests when checking PRs. That way certain removals only will be detected on `develop` when a full run is performed.

## What Is the New Behavior?

`cleanup-testbed` has a new `--related` argument that uses [jest `--findRelatedTests`](https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles) under the hood.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76042](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76042)