### PR TITLE
perf(test): local jest speedup

### DIFF
--- a/jest.config.haste-map.js
+++ b/jest.config.haste-map.js
@@ -1,0 +1,15 @@
+const { default: HasteMap } = require('jest-haste-map');
+
+/**
+ * custom haste map implementation that ignores test relations over certain boundaries
+ */
+class CustomHasteMap extends HasteMap {
+  _ignore(filePath) {
+    if (/\.(module|facade)\.ts$/.test(filePath) && !/(store|shared)\.module\.ts$/.test(filePath)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+module.exports = CustomHasteMap;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,8 @@
 const path = require('path');
+const fs = require('fs');
+const { pathsToModuleNameMapper } = require('ts-jest');
+
+const tsConfig = require('comment-json').parse(fs.readFileSync('./tsconfig.json', { encoding: 'utf-8' }));
 
 const esModules = ['lodash-es/.*', 'swiper', 'ssr-window', 'dom7', '.*\\.mjs$'];
 
@@ -14,11 +18,7 @@ module.exports = {
   roots: ['src', 'projects'],
   setupFilesAfterEnv: ['<rootDir>/src/setupJest.ts'],
   transformIgnorePatterns: [`node_modules/(?!${esModules.join('|')})`],
-  moduleNameMapper: {
-    '^ish-(.*)$': '<rootDir>/src/app/$1',
-    '^organization-management$': '<rootDir>/projects/organization-management/src/app/exports',
-    '^requisition-management$': '<rootDir>/projects/requisition-management/src/app/exports',
-  },
+  moduleNameMapper: pathsToModuleNameMapper(tsConfig.compilerOptions.paths, { prefix: '<rootDir>' }),
   snapshotSerializers: [
     './src/jest-serializer/AngularHTMLSerializer.js',
     './src/jest-serializer/CategoryTreeSerializer.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const esModules = ['lodash-es/.*', 'swiper', 'ssr-window', 'dom7', '.*\\.mjs$'];
 
 module.exports = {
@@ -23,4 +25,7 @@ module.exports = {
     './src/jest-serializer/NgrxActionSerializer.js',
     './src/jest-serializer/NgrxActionArraySerializer.js',
   ],
+  haste: {
+    hasteMapModulePath: path.join(__dirname, 'jest.config.haste-map.js'),
+  },
 };


### PR DESCRIPTION
## PR Type

[x] Other: Local Test Performance

## What Is the Current Behavior?

Jest calculates dependencies over the whole source base. This can be time-consuming when running pre-commits with `--findRelatedTests`:

```
~$ npx jest --findRelatedTests --listTests src/app/shared/components/product/product-item/product-item.component.ts | wc -l
56
```

## What Is the New Behavior?

A custom haste map implementation breaks dependency crawling on some borders (facades, modules, ...) for a reduced test set:

```
~$ npx jest --findRelatedTests --listTests src/app/shared/components/product/product-item/product-item.component.ts | wc -l
6
```

Full runs on CI and `npm run check` don't use this and remain unaffected.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76043](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76043)