### PR TITLE
refactor: delegate types in lazy-component schematic

### DIFF
--- a/schematics/src/lazy-component/factory.ts
+++ b/schematics/src/lazy-component/factory.ts
@@ -65,8 +65,7 @@ export function createLazyComponent(options: Options): Rule {
     options = findDeclaringModule(host, options);
     options = determineArtifactName('component', host, options);
 
-    let bindings: { declaration: string; name: string }[] = [];
-    let imports: { types: string[]; from: string }[] = [];
+    let inputNames: string[] = [];
 
     const componentContent = host.read(componentPath).toString('utf-8');
     const componentSource = ts.createSourceFile(componentPath, componentContent, ts.ScriptTarget.Latest, true);
@@ -81,33 +80,9 @@ export function createLazyComponent(options: Options): Rule {
       .replace(originalName.replace(`${project.prefix}-`, ''), options.name.replace(`${project.prefix}-`, ''));
 
     if (componentContent.includes('@Input(')) {
-      const bindingNodes = tsquery(
-        componentSource,
-        'PropertyDeclaration:has(Decorator Identifier[text=Input])'
-      ) as ts.PropertyDeclaration[];
-
-      bindings = bindingNodes.map(node => ({
-        declaration: node.getText(),
-        name: node.name.getText(),
-      }));
-
-      const importTypes = bindingNodes
-        .map(node => tsquery(node, 'TypeReference > Identifier').map(identifier => identifier.getText()))
-        .reduce((acc, val) => acc.concat(...val), []);
-
-      if (importTypes.length) {
-        const importDeclarations = tsquery(componentSource, 'ImportDeclaration') as ts.ImportDeclaration[];
-        imports = importDeclarations
-          .map(decl => ({
-            from: decl.moduleSpecifier.getText(),
-            types: decl.importClause.namedBindings
-              ? tsquery(decl.importClause.namedBindings, 'Identifier')
-                  .map(n => n.getText())
-                  .filter(importType => importTypes.includes(importType))
-              : [],
-          }))
-          .filter(decl => decl.types.length);
-      }
+      inputNames = tsquery(componentSource, 'PropertyDeclaration:has(Decorator Identifier[text=Input])').map(
+        (node: ts.PropertyDeclaration) => node.name.getText()
+      );
     }
 
     let onChanges: 'simple' | 'complex';
@@ -190,8 +165,7 @@ export function createLazyComponent(options: Options): Rule {
           applyTemplates({
             ...strings,
             ...options,
-            bindings,
-            imports,
+            inputNames,
             originalPath,
             extension,
             originalName,

--- a/schematics/src/lazy-component/factory_spec.ts
+++ b/schematics/src/lazy-component/factory_spec.ts
@@ -225,14 +225,24 @@ export class DummyComponent {
       componentContent = tree.readContent('/src/app/extensions/ext/exports/lazy-dummy/lazy-dummy.component.ts');
     });
 
-    it('should copy inputs', () => {
-      expect(componentContent).toContain('@Input() simpleTyped: boolean;');
-      expect(componentContent).toContain('@Input() simpleTypedInitialized = true;');
-      expect(componentContent).toContain("@Input() complexTyped: 'a' | 'b';");
-      expect(componentContent).toContain("@Input() complexTypedInitialized: 'a' | 'b' = 'a';");
-      expect(componentContent).toContain('@Input() importTyped: Product;');
-      expect(componentContent).toContain('@Input() importComplexTyped: User[];');
-      expect(componentContent).toContain('@Input() importGenericTyped: Observable<Customer[]>;');
+    it('should import type of component which is lazy loaded', async () => {
+      expect(componentContent).toContain(
+        "import type { DummyComponent as OriginalComponent } from '../../shared/dummy/dummy.component';"
+      );
+    });
+
+    it('should delegate input types', () => {
+      expect(componentContent).toContain("@Input() simpleTyped: OriginalComponent['simpleTyped'];");
+      expect(componentContent).toContain(
+        "@Input() simpleTypedInitialized: OriginalComponent['simpleTypedInitialized'];"
+      );
+      expect(componentContent).toContain("@Input() complexTyped: OriginalComponent['complexTyped'];");
+      expect(componentContent).toContain(
+        "@Input() complexTypedInitialized: OriginalComponent['complexTypedInitialized'];"
+      );
+      expect(componentContent).toContain("@Input() importTyped: OriginalComponent['importTyped'];");
+      expect(componentContent).toContain("@Input() importComplexTyped: OriginalComponent['importComplexTyped'];");
+      expect(componentContent).toContain("@Input() importGenericTyped: OriginalComponent['importGenericTyped'];");
     });
 
     it('should transfer inputs', () => {
@@ -243,13 +253,6 @@ export class DummyComponent {
       expect(componentContent).toContain('component.instance.importTyped = this.importTyped');
       expect(componentContent).toContain('component.instance.importComplexTyped = this.importComplexTyped');
       expect(componentContent).toContain('component.instance.importGenericTyped = this.importGenericTyped');
-    });
-
-    it('should copy imports', () => {
-      expect(componentContent).toContain("import { Product } from 'ish-core/models/product/product.model';");
-      expect(componentContent).toContain("import { User } from 'ish-core/models/user/user.model';");
-      expect(componentContent).toContain("import { Observable } from 'rxjs';");
-      expect(componentContent).toContain("import { Customer } from 'ish-core/models/customer/customer.model';");
     });
   });
 

--- a/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -1,20 +1,23 @@
 import {
   ChangeDetectionStrategy, Component, createNgModuleRef, OnInit, ViewChild, ViewContainerRef,
   Injector,
-  <% if (bindings.length) { %>ComponentRef, Input, OnChanges, <% } %>
+  ComponentRef,
+  <% if (inputNames.length) { %>Input, OnChanges, <% } %>
   <% if (onChanges === 'complex') { %>SimpleChange, SimpleChanges, <% } %>
 } from '@angular/core';
 
-<% if(!isProject && !isShared) { %> import { FeatureToggleService } from 'ish-core/feature-toggle.module'; <% } %>
+<% if(!isProject && !isShared) { %>
+  import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+<% } %>
 
-<% if (imports.length) { %><%= imports.map(i => `import { ${i.types.join(', ')} } from ${i.from};`).join('\n') %><% } %>
+import type { <%= classify(originalName) %>Component as OriginalComponent } from '<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component';
 
 @Component({
   selector: '<%= selector %>',
   templateUrl: './<%= dasherize(name) %>.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class <%= classify(name) %>Component implements OnInit <% if (bindings.length) { %>, OnChanges <% } %>{
+export class <%= classify(name) %>Component implements OnInit <% if (inputNames.length) { %>, OnChanges <% } %>{
   /*
    * WARNING!
    *
@@ -26,42 +29,55 @@ export class <%= classify(name) %>Component implements OnInit <% if (bindings.le
    */
 
   @ViewChild('anchor', { read: ViewContainerRef, static: true }) anchor: ViewContainerRef;
-  <% if (bindings.length) { %><%= bindings.map(b => b.declaration).join('\n  ') %><% } %>
 
-  <% if (bindings.length) { %>// eslint-disable-next-line @typescript-eslint/no-explicit-any -- access in on-changes required
-  private component: ComponentRef<any>;<% } %>
+<% for (let name of inputNames) { %>
+  @Input() <%= name %>: OriginalComponent['<%= name %>'];
+<% } %>
+
+  private component: ComponentRef<OriginalComponent>;
 
   constructor(
-    <% if(!isProject && !isShared) { %> private featureToggleService: FeatureToggleService, <% } %>
+    <% if(!isProject && !isShared) { %>private featureToggleService: FeatureToggleService,<% } %>
     private injector: Injector
   ) {}
 
   async ngOnInit() {
     <% if(!isProject && !isShared) { %> if (this.featureToggleService.enabled('<%= camelize(extension) %>')) { <% } %>
+
       const module = await import(`../..<% if(isShared) { %>/../shared<% } %>/<%= dasherize(declaringModule) %>.module`).then(m => m.<%= classify(declaringModule) %>Module);
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { <%= classify(originalName) %>Component } = await import('<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component');
+      const { <%= classify(originalName) %>Component: originalComponent } = await import('<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component');
 
-      const moduleRef = createNgModuleRef(module, this.injector);
+      const ngModuleRef = createNgModuleRef(module, this.injector);
 
-    <% if (bindings.length) { %>
-      this.component = this.anchor.createComponent(<%= classify(originalName) %>Component, { ngModuleRef: moduleRef });
-      this.ngOnChanges(<% if (onChanges === 'complex') { %>{
-          <%= bindings.map(b => `${b.name}: new SimpleChange(undefined, this.${b.name}, true),`).join('\n        ') %>
-        }<% } %>);
-      this.component.changeDetectorRef.markForCheck();
-    <% } else { %>
-      this.anchor.createComponent(<%= classify(originalName) %>Component, { ngModuleRef: moduleRef }).changeDetectorRef.markForCheck();
+      this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
+    <% if (inputNames.length) { %>
+      this.ngOnChanges(
+        <% if (onChanges === 'complex') { %>{
+          <% for (let name of inputNames) { %>
+            <%= name %>: new SimpleChange(undefined, this.<%= name %>, true),
+          <% } %>
+          }
+        <% } %>
+      );
     <% } %>
+      this.component.changeDetectorRef.markForCheck();
+
     <% if(!isProject && !isShared){ %> } <% } %>
   }
 
-<% if (bindings.length) { %>
+<% if (inputNames.length) { %>
   ngOnChanges(<% if (onChanges === 'complex') { %>changes: SimpleChanges<% } %>) {
     if (this.component) {
-      <%= bindings.map(b => `this.component.instance.${b.name} = this.${b.name};`).join('\n    ') %>
-      <% if (onChanges === 'simple') { %>this.component.instance.ngOnChanges();<% } else if (onChanges === 'complex') { %>this.component.instance.ngOnChanges(changes);<% } %>
+      <% for (let name of inputNames) { %>
+        this.component.instance.<%= name %> = this.<%= name %>;
+      <% } %>
+
+      <% if (onChanges === 'simple') { %>
+        this.component.instance.ngOnChanges();
+      <% } else if (onChanges === 'complex') { %>
+        this.component.instance.ngOnChanges(changes);
+      <% } %>
     }
   }
 <% } %>


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

- Type updates in components which have the `@GenerateLazyComponent` decorator require a run of `npm run synchronize-lazy-components` to be reflected in the generated lazy components, because the initialization is copied.
- Generated lazy components contain eslint ignores, because the typing is not properly generated

## What Is the New Behavior?

- refactored lazy-component schematic to import the type of the original component and use it to delegate the typing of inputs
- improved readability of schematics template

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

It is important that the original component is imported twice in the generated lazy component:
- the typing is imported with `import type` and therefor exists only in Typescript
- the lazy import with `await import` is used for webpack lazy loading

If the component would be imported with just `import` in the header, then the original component becomes part of the initial bundle which is something we don't want.



[AB#76046](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76046)