### PR TITLE
fix(schematics): create gitignore with new ignore path

### DIFF
--- a/schematics/src/lazy-component/factory.ts
+++ b/schematics/src/lazy-component/factory.ts
@@ -168,7 +168,7 @@ export function createLazyComponent(options: Options): Rule {
         operations.push(addExportToNgModule(options));
       }
       if (!gitignoreExists) {
-        operations.push(generateGitignore({ path: options.path, content: '/lazy**' }));
+        operations.push(generateGitignore({ path: options.path, content: '**/lazy*\n' }));
       }
 
       if (isProject) {

--- a/schematics/src/lazy-component/factory_spec.ts
+++ b/schematics/src/lazy-component/factory_spec.ts
@@ -137,6 +137,11 @@ describe('Lazy Component Schematic', () => {
         '@GenerateLazyComponent()'
       );
     });
+
+    it('should create a .gitignore file in the exports folder', () => {
+      const gitignore = tree.readContent('/src/app/extensions/ext/exports/.gitignore');
+      expect(gitignore.trim()).toMatchInlineSnapshot(`"**/lazy*"`);
+    });
   });
 
   describe('ci', () => {


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When generating a lazy component in an extension that does not yet have lazy components or a gitignore, the gitignore is generated with the wrong entries.

## What Is the New Behavior?

Fixed

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
