### PR TITLE
fix: add missing feature guards to feature routing modules

### DIFF
--- a/schematics/src/page/factory_spec.ts
+++ b/schematics/src/page/factory_spec.ts
@@ -258,7 +258,9 @@ describe('Page Schematic', () => {
 
       const tree = await schematicRunner.runSchematicAsync('page', options, appTree).toPromise();
       const appRoutingModule = tree.readContent('/src/app/extensions/feature/pages/feature-routing.module.ts');
-      expect(appRoutingModule).toContain(`{ path: 'foo', component: FooPageComponent }`);
+      expect(appRoutingModule).toContain(
+        `{ path: 'foo', component: FooPageComponent, canActivate: [FeatureToggleGuard], data: { feature: 'feature' } }`
+      );
       expect(appRoutingModule).toContain("import { FooPageComponent } from './foo/foo-page.component'");
     });
 
@@ -267,7 +269,9 @@ describe('Page Schematic', () => {
 
       const tree = await schematicRunner.runSchematicAsync('page', options, appTree).toPromise();
       const appRoutingModule = tree.readContent('/src/app/extensions/feature2/pages/feature2-routing.module.ts');
-      expect(appRoutingModule).toContain(`{ path: 'foo', component: FooPageComponent }`);
+      expect(appRoutingModule).toContain(
+        `{ path: 'foo', component: FooPageComponent, canActivate: [FeatureToggleGuard], data: { feature: 'feature2' } }`
+      );
       expect(appRoutingModule).toContain("import { FooPageComponent } from './foo/foo-page.component'");
     });
 

--- a/src/app/extensions/recently/pages/recently-routing.module.ts
+++ b/src/app/extensions/recently/pages/recently-routing.module.ts
@@ -1,8 +1,15 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { FeatureToggleGuard } from 'ish-core/feature-toggle.module';
+
 const routes: Routes = [
-  { path: 'recently', loadChildren: () => import('./recently/recently-page.module').then(m => m.RecentlyPageModule) },
+  {
+    path: 'recently',
+    loadChildren: () => import('./recently/recently-page.module').then(m => m.RecentlyPageModule),
+    canActivate: [FeatureToggleGuard],
+    data: { feature: 'recently' },
+  },
 ];
 
 @NgModule({

--- a/src/app/extensions/store-locator/pages/store-locator-routing.module.ts
+++ b/src/app/extensions/store-locator/pages/store-locator-routing.module.ts
@@ -1,12 +1,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { FeatureToggleGuard } from 'ish-core/feature-toggle.module';
+
 import { STORE_MAP_ICON_CONFIGURATION } from '../services/stores-map/stores-map.service';
 
 const routes: Routes = [
   {
     path: 'store-finder',
     loadChildren: () => import('./store-locator/store-locator-page.module').then(m => m.StoreLocatorPageModule),
+    canActivate: [FeatureToggleGuard],
+    data: { feature: 'storeLocator' },
   },
 ];
 

--- a/src/app/extensions/tacton/pages/tacton-routing.module.ts
+++ b/src/app/extensions/tacton/pages/tacton-routing.module.ts
@@ -1,14 +1,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { FeatureToggleGuard } from 'ish-core/feature-toggle.module';
 import { AuthGuard } from 'ish-core/guards/auth.guard';
 
 const routes: Routes = [
   {
     path: 'configure',
     loadChildren: () => import('./configure/configure-page.module').then(m => m.ConfigurePageModule),
-    canActivate: [AuthGuard],
+    canActivate: [FeatureToggleGuard, AuthGuard],
     data: {
+      feature: 'tacton',
       queryParams: {
         messageKey: 'tacton',
       },


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Some extension pages are missing feature toggle guards, which will make the pages available even if the feature is not activated.

## What Is the New Behavior?

- added guards
- modified schematic to add guards when generating new pages in extensions

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76049](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76049)