### PR TITLE
fix: reimplement tracking of anonymous basket for merge basket logic

### DIFF
--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -4,17 +4,27 @@ import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
-import { EMPTY, combineLatest, from, iif, of } from 'rxjs';
-import { concatMap, filter, map, mergeMap, sample, startWith, switchMap, take, withLatestFrom } from 'rxjs/operators';
+import { EMPTY, from, iif, of } from 'rxjs';
+import {
+  concatMap,
+  filter,
+  map,
+  mergeMap,
+  shareReplay,
+  startWith,
+  switchMap,
+  take,
+  withLatestFrom,
+} from 'rxjs/operators';
 
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { getCurrentCurrency } from 'ish-core/store/core/configuration';
 import { mapToRouterState } from 'ish-core/store/core/router';
 import { resetOrderErrors } from 'ish-core/store/customer/orders';
-import { createUser, loadUserByAPIToken, loginUser, loginUserSuccess } from 'ish-core/store/customer/user';
+import { getLoggedInCustomer, loginUserSuccess } from 'ish-core/store/customer/user';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
-import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
+import { mapErrorToAction, mapToPayloadProperty, mapToProperty } from 'ish-core/utils/operators';
 
 import {
   createBasket,
@@ -232,9 +242,16 @@ export class BasketEffects {
    */
   private anonymousBasket$ = createEffect(
     () =>
-      combineLatest([this.store.pipe(select(getCurrentBasketId)), this.apiTokenService.apiToken$]).pipe(
-        sample(this.actions$.pipe(ofType(loginUser, createUser, loadUserByAPIToken))),
-        startWith([undefined, undefined])
+      this.store.pipe(
+        // track basket changes
+        select(getCurrentBasket),
+        mapToProperty('id'),
+        // append corresponding apiToken and customer
+        withLatestFrom(this.apiTokenService.apiToken$, this.store.pipe(select(getLoggedInCustomer))),
+        // don't emit when there is a customer
+        filter(([, , customer]) => !customer),
+        startWith([]),
+        shareReplay(1)
       ),
     { dispatch: false }
   );


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

E2E tests
```
e2e/cypress/integration/specs/checkout/basket-handling.b2c.e2e-spec.ts
e2e/cypress/integration/specs/quoting/quote-handling-anonymous-basket-to-quote-request.b2b.e2e-spec.ts
```
are flaky and the reason could be the current merge basket logic.

## What Is the New Behavior?

Reimplemented tracking of anonymous baskets.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76054](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76054)