### PR TITLE
chore: add pipeline for marking PRs with conflicts

### DIFF
--- a/.github/workflows/mark-conflicts.yml
+++ b/.github/workflows/mark-conflicts.yml
@@ -1,0 +1,16 @@
+name: 'MarkConflicts'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'has conflicts'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

GitHub has no automated way of searching for PRs with conflicts. As a contributor with a lot of open PRs it is hard to know which ones need an update.

## What Is the New Behavior?

Added action that [marks PRs with conflicts](https://github.com/intershop/intershop-pwa/pulls?q=is%3Aopen+is%3Apr+label%3A%22has+conflicts%22).

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76056](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76056)