### PR TITLE
feat: complex configuration can be supplied as yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,19 @@ services:
         # activeThemes: b2b
         # activeThemes: b2c
     environment:
-      - LOGGING=on
-      - SOURCE_MAPS=on
-      - ICM_BASE_URL
-      # - PROXY_ICM=true
-      - TRUST_ICM=true
-      # - PROMETHEUS=on
-      # - MULTI_SITE_LOCALE_MAP={"en_US":"/en","de_DE":"/de","fr_FR":"/fr"}
+      LOGGING: 'true'
+      SOURCE_MAPS: 'true'
+      ICM_BASE_URL:
+      # PROXY_ICM: 'true'
+      TRUST_ICM: 'true'
+      # PROMETHEUS: 'true'
+      # MULTI_SITE_LOCALE_MAP: |
+      #   en_US: /en
+      #   de_DE: /de
+      #   fr_FR: /fr
+      # FEATURES: |
+      #   - compare
+      #   - rating
 
   # <CDN-Example>
   # add 127.0.0.1 mypwa.net to your hosts file and

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "express-http-proxy": "^1.6.3",
         "express-robots-txt": "1.0.0",
         "file-replace-loader": "^1.4.0",
+        "js-yaml": "^4.1.0",
         "lodash-es": "^4.17.21",
         "morgan": "^1.10.0",
         "ng-recaptcha": "^10.0.0",
@@ -1071,22 +1072,6 @@
         "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3940,11 +3925,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.15.0",
       "dev": true,
@@ -3957,17 +3937,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -4149,6 +4118,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -13448,11 +13430,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -13546,17 +13523,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -18666,16 +18632,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "3.1.0",
@@ -28288,19 +28258,6 @@
         "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "@assemblyscript/loader": {
@@ -30122,22 +30079,11 @@
             "uri-js": "^4.2.2"
           }
         },
-        "argparse": {
-          "version": "2.0.1",
-          "dev": true
-        },
         "globals": {
           "version": "13.15.0",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
-          }
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
           }
         },
         "json-schema-traverse": {
@@ -30267,6 +30213,16 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {
@@ -36065,10 +36021,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "argparse": {
-          "version": "2.0.1",
-          "dev": true
-        },
         "chalk": {
           "version": "4.1.2",
           "dev": true,
@@ -36121,13 +36073,6 @@
         "has-flag": {
           "version": "4.0.0",
           "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -39878,11 +39823,18 @@
       "version": "4.0.0"
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        }
       }
     },
     "jsdoc-type-pratt-parser": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "express-http-proxy": "^1.6.3",
     "express-robots-txt": "1.0.0",
     "file-replace-loader": "^1.4.0",
+    "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",
     "morgan": "^1.10.0",
     "ng-recaptcha": "^10.0.0",

--- a/src/app/core/store/core/configuration/configuration.actions.ts
+++ b/src/app/core/store/core/configuration/configuration.actions.ts
@@ -4,7 +4,7 @@ import { payload } from 'ish-core/utils/ngrx-creators';
 
 import { ConfigurationState } from './configuration.reducer';
 
-type ConfigurationType = Partial<ConfigurationState>;
+export type ConfigurationType = Partial<ConfigurationState>;
 
 export const applyConfiguration = createAction('[Configuration] Apply Configuration', payload<ConfigurationType>());
 

--- a/src/app/core/store/core/configuration/configuration.effects.ts
+++ b/src/app/core/store/core/configuration/configuration.effects.ts
@@ -17,6 +17,7 @@ import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-prop
 
 import {
   applyConfiguration,
+  ConfigurationType,
   loadSingleServerTranslation,
   loadSingleServerTranslationSuccess,
 } from './configuration.actions';
@@ -73,20 +74,14 @@ export class ConfigurationEffects {
           this.stateProperties
             .getStateOrEnvOrDefault<string>('ICM_IDENTITY_PROVIDER', 'identityProvider')
             .pipe(map(x => x || 'ICM')),
-          this.stateProperties
-            .getStateOrEnvOrDefault<string | object>('IDENTITY_PROVIDERS', 'identityProviders')
-            .pipe(map(config => (typeof config === 'string' ? JSON.parse(config) : config))),
-          this.stateProperties
-            .getStateOrEnvOrDefault<Record<string, unknown> | string | false>(
-              'MULTI_SITE_LOCALE_MAP',
-              'multiSiteLocaleMap'
-            )
-            .pipe(
-              map(multiSiteLocaleMap => (multiSiteLocaleMap === false ? undefined : multiSiteLocaleMap)),
-              map(multiSiteLocaleMap =>
-                typeof multiSiteLocaleMap === 'string' ? JSON.parse(multiSiteLocaleMap) : multiSiteLocaleMap
-              )
-            )
+          this.stateProperties.getStateOrEnvOrDefault<ConfigurationType['identityProviders']>(
+            'IDENTITY_PROVIDERS',
+            'identityProviders'
+          ),
+          this.stateProperties.getStateOrEnvOrDefault<ConfigurationType['multiSiteLocaleMap']>(
+            'MULTI_SITE_LOCALE_MAP',
+            'multiSiteLocaleMap'
+          )
         ),
         map(
           ([

--- a/src/app/core/store/core/configuration/configuration.reducer.ts
+++ b/src/app/core/store/core/configuration/configuration.reducer.ts
@@ -40,7 +40,7 @@ const initialState: ConfigurationState = {
   lang: undefined,
   currency: undefined,
   serverTranslations: {},
-  multiSiteLocaleMap: {},
+  multiSiteLocaleMap: undefined,
   _deviceType: environment.defaultDeviceType,
 };
 

--- a/src/app/core/utils/functions.spec.ts
+++ b/src/app/core/utils/functions.spec.ts
@@ -74,6 +74,60 @@ describe('Functions', () => {
         }
       `);
     });
+
+    it('should handle empty source objects', () => {
+      expect(mergeDeep({ a: 1, b: { c: 2 }, d: 11 }, {})).toMatchInlineSnapshot(`
+        Object {
+          "a": 1,
+          "b": Object {
+            "c": 2,
+          },
+          "d": 11,
+        }
+      `);
+    });
+
+    it('should handle undefined source objects', () => {
+      expect(mergeDeep({ a: 1, b: { c: 2 }, d: 11 }, undefined)).toMatchInlineSnapshot(`
+        Object {
+          "a": 1,
+          "b": Object {
+            "c": 2,
+          },
+          "d": 11,
+        }
+      `);
+    });
+
+    it('should handle empty target objects', () => {
+      expect(mergeDeep({}, { a: 4, b: { c: 5 } })).toMatchInlineSnapshot(`
+        Object {
+          "a": 4,
+          "b": Object {
+            "c": 5,
+          },
+        }
+      `);
+    });
+
+    it('should handle undefined target objects', () => {
+      expect(mergeDeep(undefined, { a: 4, b: { c: 5 } })).toMatchInlineSnapshot(`
+        Object {
+          "a": 4,
+          "b": Object {
+            "c": 5,
+          },
+        }
+      `);
+    });
+
+    it('should handle empty target and source objects', () => {
+      expect(mergeDeep({}, {})).toMatchInlineSnapshot(`Object {}`);
+    });
+
+    it('should handle undefined target and source objects', () => {
+      expect(mergeDeep(undefined, undefined)).toBeUndefined();
+    });
   });
 
   describe('omit', () => {

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -23,7 +23,10 @@ function isObject(item: unknown) {
  * @see https://stackoverflow.com/a/37164538/13001898
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- utility function
-export function mergeDeep(target: any, source: any) {
+export function mergeDeep(target: any, source: any): any {
+  if (target === undefined && source === undefined) {
+    return;
+  }
   let output = { ...target };
   if (isObject(target) && isObject(source)) {
     Object.keys(source).forEach(key => {
@@ -37,6 +40,8 @@ export function mergeDeep(target: any, source: any) {
         output = { ...output, [key]: source[key] };
       }
     });
+  } else if (target === undefined) {
+    return mergeDeep({}, source);
   }
   return output;
 }

--- a/src/app/core/utils/state-transfer/state-properties.service.spec.ts
+++ b/src/app/core/utils/state-transfer/state-properties.service.spec.ts
@@ -1,0 +1,148 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+
+import { getConfigurationState } from 'ish-core/store/core/configuration';
+
+import { StatePropertiesService } from './state-properties.service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('State Properties Service', () => {
+  let service: StatePropertiesService;
+  let store$: MockStore;
+
+  beforeEach(() => {
+    process.env.COMPLEX1 = `
+      Auth0:
+        type: Auth0
+        clientId: clientId
+        domain: domain`;
+    process.env.COMPLEX2 = '{ "fr_FR": "/fr" }';
+    process.env.SIMPLE1 = 'Auth0';
+    process.env.SIMPLE3 = 'true';
+
+    TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+    });
+
+    service = TestBed.inject(StatePropertiesService);
+    store$ = TestBed.inject(MockStore);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('on client', () => {
+    beforeEach(() => {
+      store$.overrideSelector(getConfigurationState, {
+        complex1: {
+          ICM: { type: 'ICM' },
+        },
+        complex2: {
+          en_US: '/en',
+          de_DE: '/de',
+        },
+        simple1: 'ICM',
+        simple2: 'de_DE',
+      } as any);
+    });
+
+    it('should retrieve complex1 from state', done => {
+      service.getStateOrEnvOrDefault('COMPLEX1', 'complex1' as any).subscribe(complex1 => {
+        expect(complex1).toMatchInlineSnapshot(`
+          Object {
+            "ICM": ICM,
+          }
+        `);
+        done();
+      });
+    });
+
+    it('should retrieve complex2 from state', done => {
+      service.getStateOrEnvOrDefault('COMPLEX2', 'complex2' as any).subscribe(complex2 => {
+        expect(complex2).toMatchInlineSnapshot(`
+          Object {
+            "de_DE": "/de",
+            "en_US": "/en",
+          }
+        `);
+        done();
+      });
+    });
+
+    it('should retrieve simple1 from state', done => {
+      service.getStateOrEnvOrDefault('SIMPLE1', 'simple1' as any).subscribe(simple1 => {
+        expect(simple1).toMatchInlineSnapshot(`"ICM"`);
+        done();
+      });
+    });
+
+    it('should retrieve simple2 from state', done => {
+      service.getStateOrEnvOrDefault('SIMPLE2', 'simple2' as any).subscribe(simple2 => {
+        expect(simple2).toMatchInlineSnapshot(`"de_DE"`);
+        done();
+      });
+    });
+
+    it('should not have a value for simple3 because it does not check environment', done => {
+      service.getStateOrEnvOrDefault('SIMPLE3', 'simple3' as any).subscribe(simple3 => {
+        expect(simple3).toBeUndefined();
+        done();
+      });
+    });
+  });
+
+  describe.onSSREnvironment('on server', () => {
+    beforeEach(() => {
+      store$.overrideSelector(getConfigurationState, { simple2: 'de_DE' } as any);
+    });
+
+    it('should retrieve complex1 as YAML from environment', done => {
+      service.getStateOrEnvOrDefault('COMPLEX1', 'complex1' as any).subscribe(complex1 => {
+        expect(complex1).toMatchInlineSnapshot(`
+          Object {
+            "Auth0": Object {
+              "clientId": "clientId",
+              "domain": "domain",
+              "type": "Auth0",
+            },
+          }
+        `);
+        done();
+      });
+    });
+
+    it('should retrieve complex2 as JSON from environment', done => {
+      service.getStateOrEnvOrDefault('COMPLEX2', 'complex2' as any).subscribe(complex2 => {
+        expect(complex2).toMatchInlineSnapshot(`
+          Object {
+            "fr_FR": "/fr",
+          }
+        `);
+        done();
+      });
+    });
+
+    it('should retrieve simple1 from environment', done => {
+      service.getStateOrEnvOrDefault('SIMPLE1', 'simple1' as any).subscribe(simple1 => {
+        expect(simple1).toMatchInlineSnapshot(`"Auth0"`);
+        done();
+      });
+    });
+
+    it('should retrieve simple2 from state because it was set', done => {
+      service.getStateOrEnvOrDefault('SIMPLE2', 'simple2' as any).subscribe(simple2 => {
+        expect(simple2).toMatchInlineSnapshot(`"de_DE"`);
+        done();
+      });
+    });
+
+    it('should retrieve simple3 from environment', done => {
+      service.getStateOrEnvOrDefault('SIMPLE3', 'simple3' as any).subscribe(simple3 => {
+        expect(simple3).toMatchInlineSnapshot(`"true"`);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/core/utils/state-transfer/state-properties.service.ts
+++ b/src/app/core/utils/state-transfer/state-properties.service.ts
@@ -1,13 +1,25 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { Observable, identity } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { getConfigurationState } from 'ish-core/store/core/configuration';
+import { ConfigurationType, getConfigurationState } from 'ish-core/store/core/configuration';
 import { mapToProperty } from 'ish-core/utils/operators';
 
 import { environment } from '../../../../environments/environment';
 import { Environment } from '../../../../environments/environment.model';
+
+function isJSON(value: string): boolean {
+  return value.trim().startsWith('{');
+}
+
+function isYAML(value: string) {
+  const lines = value.split('\n').filter(x => !!x?.trim());
+  return (
+    (lines.length > 1 && value.split('\n').some(line => /:\s*$/.test(line))) ||
+    lines.every(line => line.includes(': ') || lines.every(line => line.trim().startsWith('- ')))
+  );
+}
 
 /**
  * Service for retrieving injection properties {@link ICM_BASE_URL} and {@link REST_ENDPOINT}.
@@ -23,17 +35,30 @@ export class StatePropertiesService {
   getStateOrEnvOrDefault<T>(envKey: string, envPropKey: keyof Environment): Observable<T> {
     return this.store.pipe(
       select(getConfigurationState),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- re-mapping type
-      mapToProperty(envPropKey as any),
+      mapToProperty(envPropKey as keyof ConfigurationType),
       map(value => {
-        if (value?.length) {
+        if (value !== undefined) {
           return value;
         } else if (SSR && process.env[envKey]) {
           return process.env[envKey];
         } else {
           return environment[envPropKey];
         }
-      })
+      }),
+      SSR
+        ? map(value => {
+            if (typeof value === 'string') {
+              if (isJSON(value)) {
+                return JSON.parse(value);
+              } else if (isYAML(value)) {
+                // import js-yaml with require so it doesn't turn up in the client bundle
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
+                return require('js-yaml').load(value);
+              }
+            }
+            return value;
+          })
+        : identity
     );
   }
 }

--- a/src/app/extensions/tacton/store/tacton-config/tacton-config.effects.ts
+++ b/src/app/extensions/tacton/store/tacton-config/tacton-config.effects.ts
@@ -7,6 +7,8 @@ import { getProductEntities, loadProductSuccess, productSpecialUpdate } from 'is
 import { mapToPayloadProperty, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
 
+import { TactonConfig } from '../../models/tacton-config/tacton-config.model';
+
 import { loadTactonConfig, setTactonConfig } from './tacton-config.actions';
 import { getTactonConfig } from './tacton-config.selectors';
 
@@ -22,10 +24,9 @@ export class TactonConfigEffects {
     this.actions$.pipe(
       ofType(loadTactonConfig),
       switchMap(() =>
-        this.statePropertiesService.getStateOrEnvOrDefault<string | object>('TACTON', 'tacton').pipe(
-          map(config => (typeof config === 'string' ? JSON.parse(config) : config)),
-          map(config => setTactonConfig({ config }))
-        )
+        this.statePropertiesService
+          .getStateOrEnvOrDefault<TactonConfig>('TACTON', 'tacton')
+          .pipe(map(config => setTactonConfig({ config })))
       )
     )
   );


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Complex configurations for `IDENTITY_PROVIDER` or `TACTON` have to be supplied as JSON to the deployments:

```
  IDENTITY_PROVIDERS: |
    { "Auth0": { "type": "auth0", "domain": "dev-asdf1234.eu.auth0.com", "clientID": "012ea8f1db7a838b65a8b29e8464742166877abb" } }
```

When trying to structure the data, it becomes very verbose and even then JSON parsing is very sensitive to commas and quotes and therefore prone to error:

```
  IDENTITY_PROVIDERS: |
    { 
      "Auth0": { 
        "type": "auth0",
        "domain": "dev-asdf1234.eu.auth0.com",
        "clientID": "012ea8f1db7a838b65a8b29e8464742166877abb"
      }
    }
```


## What Is the New Behavior?

Complex configuration can be supplied as YAML:

```
  IDENTITY_PROVIDERS: |
    Auth0:
      type: auth0
      domain: dev-asdf1234.eu.auth0.com
      clientID: 012ea8f1db7a838b65a8b29e8464742166877abb
```


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Depends on integration of #1080, so that `js-yaml` is only included into the server bundle.
