### PR TITLE
refactor: access to checkoutpages handled by guard

### DIFF
--- a/src/app/core/store/customer/basket/basket.reducer.ts
+++ b/src/app/core/store/customer/basket/basket.reducer.ts
@@ -36,6 +36,7 @@ import {
   deleteBasketPaymentFail,
   deleteBasketPaymentSuccess,
   loadBasket,
+  loadBasketByAPIToken,
   loadBasketEligiblePaymentMethods,
   loadBasketEligiblePaymentMethodsFail,
   loadBasketEligiblePaymentMethodsSuccess,
@@ -115,6 +116,7 @@ export const basketReducer = createReducer(
   setLoadingOn(
     loadBasket,
     loadBasketWithId,
+    loadBasketByAPIToken,
     assignBasketAddress,
     updateBasketShippingMethod,
     updateBasket,

--- a/src/app/pages/checkout/checkout-page.guard.ts
+++ b/src/app/pages/checkout/checkout-page.guard.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { Observable, map } from 'rxjs';
+
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { Basket } from 'ish-core/models/basket/basket.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CheckoutPageGuard implements CanActivate {
+  constructor(private checkoutFacade: CheckoutFacade, private router: Router) {}
+
+  canActivate(): Observable<boolean | UrlTree> {
+    return this.checkoutFacade.basket$.pipe(map(basket => this.hasBasket(basket)));
+  }
+
+  private hasBasket(basket: Basket) {
+    if (basket) {
+      return true;
+    } else {
+      return this.router.parseUrl('/');
+    }
+  }
+}

--- a/src/app/pages/checkout/checkout-page.module.ts
+++ b/src/app/pages/checkout/checkout-page.module.ts
@@ -10,6 +10,7 @@ import { CheckoutReviewPageModule } from '../checkout-review/checkout-review-pag
 import { CheckoutShippingPageModule } from '../checkout-shipping/checkout-shipping-page.module';
 
 import { CheckoutPageComponent } from './checkout-page.component';
+import { CheckoutPageGuard } from './checkout-page.guard';
 import { CheckoutProgressBarComponent } from './checkout-progress-bar/checkout-progress-bar.component';
 
 const checkoutPageRoutes: Routes = [
@@ -48,6 +49,7 @@ const checkoutPageRoutes: Routes = [
         redirectTo: 'address',
       },
     ],
+    canActivate: [CheckoutPageGuard],
   },
 ];
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Currently you can navigate to the checkout with a non-existent shopping cart via the address bar of the browser

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What Is the New Behavior?
Now the route is protected by a guard. Navigate to /checkout or any related childRoute without an existing basket will redirect you to the root url

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X ] No
