### PR TITLE
chore: pin usage of ubuntu focal

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as buildstep
+FROM ubuntu:focal as buildstep
 RUN apt-get update
 RUN apt-get install -y curl build-essential zlib1g-dev libpcre3-dev unzip wget uuid-dev sudo openssl libssl-dev
 RUN curl -kfL -sS https://ngxpagespeed.com/install > install.sh
@@ -13,7 +13,7 @@ COPY entrypoint.sh *.yaml /
 COPY 50x.html /usr/share/nginx/html/
 ADD https://github.com/hairyhenderson/gomplate/releases/download/v3.8.0/gomplate_linux-amd64-slim /gomplate
 
-FROM ubuntu:latest
+FROM ubuntu:focal
 RUN apt-get update && \
   apt-get install -y gettext-base libssl1.1 apache2-utils && \
   apt-get -y autoremove && \


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[X] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

NGinx build is broken due to new gcc compiler being available in `ubuntu:jammy` image

Steps to reproduce the behavior:

1. Instead of `ubuntu:latest` use `ubuntu:jammy` in `nginx/Dockerfile`
2. Run `docker build nginx --no-cache -t intershoppwa-nginx:latest`

Issue Number: Closes #1136 

## What Is the New Behavior?

NGinx build is not broken and finishes successfully.


[AB#76155](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76155)