### PR TITLE
fix: use feature subscription instead of static check in lazy components

### DIFF
--- a/schematics/src/lazy-component/factory.ts
+++ b/schematics/src/lazy-component/factory.ts
@@ -159,6 +159,8 @@ export function createLazyComponent(options: Options): Rule {
       );
     }
 
+    const guardDisplay = !isProject && !isShared && extension;
+
     operations.push(
       mergeWith(
         apply(url('./files'), [
@@ -167,11 +169,10 @@ export function createLazyComponent(options: Options): Rule {
             ...options,
             inputNames,
             originalPath,
-            extension,
             originalName,
             onChanges,
-            isProject,
             isShared,
+            guardDisplay,
             componentImportPath,
             declaringModule,
           }),
@@ -188,6 +189,10 @@ export function createLazyComponent(options: Options): Rule {
         ])
       )
     );
+
+    if (guardDisplay) {
+      operations.push(schematic('add-destroy', { project: options.project, name: `${options.path}/${options.name}` }));
+    }
 
     operations.push(applyLintFix());
 

--- a/schematics/src/lazy-component/factory_spec.ts
+++ b/schematics/src/lazy-component/factory_spec.ts
@@ -105,7 +105,7 @@ describe('Lazy Component Schematic', () => {
     });
 
     it('should check if extension is enabled', async () => {
-      expect(componentContent).toContain(".enabled('ext')");
+      expect(componentContent).toContain(".enabled$('ext')");
     });
 
     it('should generate right component selector', async () => {

--- a/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -6,8 +6,9 @@ import {
   <% if (onChanges === 'complex') { %>SimpleChange, SimpleChanges, <% } %>
 } from '@angular/core';
 
-<% if(!isProject && !isShared) { %>
+<% if(guardDisplay) { %>
   import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+  import { takeUntil } from 'rxjs/operators';
 <% } %>
 
 import type { <%= classify(originalName) %>Component as OriginalComponent } from '<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component';
@@ -37,33 +38,44 @@ export class <%= classify(name) %>Component implements OnInit <% if (inputNames.
   private component: ComponentRef<OriginalComponent>;
 
   constructor(
-    <% if(!isProject && !isShared) { %>private featureToggleService: FeatureToggleService,<% } %>
+    <% if(guardDisplay) { %>private featureToggleService: FeatureToggleService,<% } %>
     private injector: Injector
   ) {}
 
-  async ngOnInit() {
-    <% if(!isProject && !isShared) { %> if (this.featureToggleService.enabled('<%= camelize(extension) %>')) { <% } %>
-
-      const module = await import(`../..<% if(isShared) { %>/../shared<% } %>/<%= dasherize(declaringModule) %>.module`).then(m => m.<%= classify(declaringModule) %>Module);
-
-      const { <%= classify(originalName) %>Component: originalComponent } = await import('<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component');
-
-      const ngModuleRef = createNgModuleRef(module, this.injector);
-
-      this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
-    <% if (inputNames.length) { %>
-      this.ngOnChanges(
-        <% if (onChanges === 'complex') { %>{
-          <% for (let name of inputNames) { %>
-            <%= name %>: new SimpleChange(undefined, this.<%= name %>, true),
-          <% } %>
-          }
-        <% } %>
-      );
+  <% if(!guardDisplay) { %>async<% } %> ngOnInit() {
+    <% if(guardDisplay) { %> this.featureToggleService.enabled$('<%= camelize(guardDisplay) %>').pipe(takeUntil(this.destroy$)).subscribe(async enabled => {
+      if (enabled) {
     <% } %>
-      this.component.changeDetectorRef.markForCheck();
 
-    <% if(!isProject && !isShared){ %> } <% } %>
+      await this.renderComponent();
+
+    <% if(guardDisplay){ %>
+        } else {
+          this.anchor.clear();
+        }
+      })
+    <% } %>
+  }
+
+  private async renderComponent() {
+    const module = await import(`../..<% if(isShared) { %>/../shared<% } %>/<%= dasherize(declaringModule) %>.module`).then(m => m.<%= classify(declaringModule) %>Module);
+
+    const { <%= classify(originalName) %>Component: originalComponent } = await import('<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component');
+
+    const ngModuleRef = createNgModuleRef(module, this.injector);
+
+    this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
+  <% if (inputNames.length) { %>
+    this.ngOnChanges(
+      <% if (onChanges === 'complex') { %>{
+        <% for (let name of inputNames) { %>
+          <%= name %>: new SimpleChange(undefined, this.<%= name %>, true),
+        <% } %>
+        }
+      <% } %>
+    );
+  <% } %>
+    this.component.changeDetectorRef.markForCheck();
   }
 
 <% if (inputNames.length) { %>

--- a/src/app/core/utils/feature-toggle/feature-toggle.service.ts
+++ b/src/app/core/utils/feature-toggle/feature-toggle.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 
 import { getFeatures } from 'ish-core/store/core/configuration';
 
@@ -38,6 +38,9 @@ export class FeatureToggleService {
    * Asynchronously check if {@param feature} is active.
    */
   enabled$(feature: string): Observable<boolean> {
-    return this.featureToggles$.pipe(map(featureToggles => checkFeature(featureToggles, feature)));
+    return this.featureToggles$.pipe(
+      map(featureToggles => checkFeature(featureToggles, feature)),
+      distinctUntilChanged()
+    );
   }
 }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Lazy components use [`FeatureToggleService.enabled`](https://github.com/intershop/intershop-pwa/blob/4c8b891fa62b088e12127a0da9bcbe1a03fdd29e/src/app/core/utils/feature-toggle/feature-toggle.service.ts#L32) which does not work for lazy components on page load.

## What Is the New Behavior?

Lazy components use subscriptions to [`FeatureToggleService.enabled$`](https://github.com/intershop/intershop-pwa/blob/4c8b891fa62b088e12127a0da9bcbe1a03fdd29e/src/app/core/utils/feature-toggle/feature-toggle.service.ts#L40)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

wait for integration of #1122 
