### PR TITLE
fix: enable locale override for development mode

### DIFF
--- a/src/app/core/store/core/configuration/configuration.selectors.spec.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.spec.ts
@@ -19,6 +19,15 @@ import {
   getRestEndpoint,
 } from './configuration.selectors';
 
+// mock `isDevMode` to return `false`
+jest.mock('@angular/core', () => {
+  const originalModule = jest.requireActual('@angular/core');
+  return {
+    ...originalModule,
+    isDevMode: jest.fn(() => false),
+  };
+});
+
 describe('Configuration Selectors', () => {
   let store$: StoreWithSnapshots;
 

--- a/src/app/core/store/core/configuration/configuration.selectors.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.ts
@@ -1,3 +1,4 @@
+import { isDevMode } from '@angular/core';
 import { createSelector, createSelectorFactory, resultMemoize } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
 
@@ -59,10 +60,12 @@ export const getCurrentLocale = createSelector(
   internalDefaultLocale,
   getServerConfigParameter<string>('general.defaultLocale'),
   (available, requested, defaultLocale, configuredDefault) =>
-    available?.find(l => l === requested) ??
-    available?.find(l => l === configuredDefault) ??
-    available?.find(l => l === defaultLocale) ??
-    available?.[0]
+    isDevMode() && defaultLocale
+      ? defaultLocale
+      : available?.find(l => l === requested) ??
+        available?.find(l => l === configuredDefault) ??
+        available?.find(l => l === defaultLocale) ??
+        available?.[0]
 );
 
 export const getAvailableCurrencies = createSelector(

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -84,7 +84,7 @@ export interface Environment {
   // default device type used for initial page responses
   defaultDeviceType: DeviceType;
 
-  // default locale that is used as fallback if no default locale from the ICM REST call is available
+  // default locale that is used as fallback if no default locale from the ICM REST call is available (should only be set for local development)
   defaultLocale?: string;
 
   // configuration filtering available locales and their active currencies
@@ -139,7 +139,6 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
   },
   defaultProductListingViewType: 'grid',
   defaultDeviceType: 'mobile',
-  defaultLocale: 'en_US',
   multiSiteLocaleMap: {
     en_US: '/en',
     de_DE: '/de',


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

At the moment there is no easy way of configuring the PWA for a specific locale in `environment.development.ts`.

The default locale has to be either
- changed in the ICM
- be applied by navigating to the PWA with `;lang=...` (which does not work with SSO redirects)
- set in a full docker compose config

## What Is the New Behavior?

The already existing property `defaultLocale` can be set in `environment.development.ts` and it takes precedence in development mode.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76387](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76387)