### PR TITLE
fix: load product list again after a specified duration

### DIFF
--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -19,7 +19,7 @@ import {
 } from 'ish-core/store/shopping/filter';
 import { loadProductsForCategory, loadProductsForMaster } from 'ish-core/store/shopping/products';
 import { searchProducts } from 'ish-core/store/shopping/search';
-import { mapToPayload, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
+import { mapToPayload, throttleOrChanged, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 import { stringToFormParams } from 'ish-core/utils/url-form-params';
 
 import {
@@ -106,7 +106,7 @@ export class ProductListingEffects {
           })
         );
       }),
-      distinctUntilChanged(isEqual),
+      throttleOrChanged(5000),
       map(({ id, filters, sorting, page }) => loadMoreProductsForParams({ id, filters, sorting, page }))
     )
   );
@@ -115,7 +115,6 @@ export class ProductListingEffects {
     this.actions$.pipe(
       ofType(loadMoreProductsForParams),
       mapToPayload(),
-      distinctUntilChanged(isEqual),
       map(({ id, sorting, page, filters }) => {
         if (filters) {
           const searchParameter = filters;
@@ -133,8 +132,7 @@ export class ProductListingEffects {
           }
         }
       }),
-      whenTruthy(),
-      distinctUntilChanged(isEqual)
+      whenTruthy()
     )
   );
 

--- a/src/app/core/utils/operators.ts
+++ b/src/app/core/utils/operators.ts
@@ -1,5 +1,6 @@
 import { ofType } from '@ngrx/effects';
 import { Action, ActionCreator } from '@ngrx/store';
+import { isEqual } from 'lodash-es';
 import {
   MonoTypeOperatorFunction,
   NEVER,
@@ -11,7 +12,17 @@ import {
   throwError,
   connect,
 } from 'rxjs';
-import { buffer, catchError, distinctUntilChanged, filter, map, mergeAll, take, withLatestFrom } from 'rxjs/operators';
+import {
+  buffer,
+  catchError,
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeAll,
+  scan,
+  take,
+  withLatestFrom,
+} from 'rxjs/operators';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 
@@ -93,5 +104,28 @@ export function delayUntil<T>(notifier: Observable<unknown>): OperatorFunction<T
   return source =>
     source.pipe(
       connect(connected => concat(concat(connected, NEVER).pipe(buffer(notifier), take(1), mergeAll()), connected))
+    );
+}
+
+/**
+ * Throttle observable emissions for specified duration or until a new value was emitted
+ *
+ * Taken from https://stackoverflow.com/questions/53623221/rxjs-throttle-same-value-but-let-new-values-through
+ *
+ * @param duration specified time where observable emissions are ignored
+ * @param equals callback function to check if value changes changed
+ * @returns
+ */
+export function throttleOrChanged<T>(duration: number, equals: (a: T, b: T) => boolean = isEqual) {
+  return (source: Observable<T>) =>
+    source.pipe(
+      map(x => ({ val: x, time: Date.now(), keep: true })),
+      scan((acc, cur) => {
+        const diff = cur.time - acc.time;
+        const isSame = equals(acc.val, cur.val);
+        return diff > duration || (diff < duration && !isSame) ? { ...cur, keep: true } : { ...acc, keep: false };
+      }),
+      filter(x => x.keep),
+      map(x => x.val)
     );
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

If the PWA load a product list for given parameters, then its not possible to load the product list with the same parameters directly again. Nevertheless the PWA should manage the amount of product listing calls, because many related actions are triggered. (f.e. on a search page)



Issue Number: Closes #

## What Is the New Behavior?

A new rxjs operator "throttleOrChanged" is implemented. It will emit always new values, when the values (f.e search params) are changed. If this is not the case, then same values are ignored for a specified duration (5s is defined).

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information

How To Check?: 
1. Search with searchTerm: 'usb' --> Go To HomePage and redo the search after specified throttle time (5s)
2. Endless Scrolling on a search page should work. (Search with different offset parameter)