### PR TITLE
chore: remove useless schematics vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,11 +17,9 @@
   "extensions": [
     // general
     "eamodio.gitlens",
-    "coenraads.bracket-pair-colorizer",
     "vincaslt.highlight-matching-tag",
     // code assist
     "visualstudioexptteam.vscodeintellicode",
-    "cyrilletuzi.angular-schematics",
     "angular.ng-template",
     "mikael.angular-beastcode",
     "formulahendry.auto-rename-tag",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,6 @@
     "vincaslt.highlight-matching-tag",
     // code assist
     "visualstudioexptteam.vscodeintellicode",
-    "cyrilletuzi.angular-schematics",
     "angular.ng-template",
     "mikael.angular-beastcode",
     "formulahendry.auto-rename-tag",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,6 @@
 
   "git.rebaseWhenSync": true,
   "git.autoStash": true,
-  "ngschematics.schematics": ["intershop-schematics"],
   "typescript.tsdk": "node_modules/typescript/lib",
   "workbench.iconTheme": "vscode-icons",
 

--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -87,9 +87,6 @@ CREATE src/app/cms/components/cms-inventory/cms-inventory.component.spec.ts (795
 UPDATE src/app/cms/cms.module.ts (4956 bytes)
 ```
 
-> **Visual Studio Code Integration**  
-> For Visual Studio Code there is an extension that offers comfortable usage options for the schematics, see [Angular Schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics).
-
 ## Integration with an External CMS
 
 Since the Intershop PWA can integrate any other REST API in addition to the ICM REST API, it should not be a problem to integrate an external 3rd party CMS that provides an own REST API, instead of using the integrated ICM CMS.


### PR DESCRIPTION
The Angular Schematics extension does not support the "schematics" option anymore, probably due to monetization. 
I removed it until an alternative is found.

[AB#76390](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76390)