### PR TITLE
fix(schematics): make override schematic robust to path seperators

### DIFF
--- a/schematics/src/helpers/override/factory.ts
+++ b/schematics/src/helpers/override/factory.ts
@@ -1,6 +1,6 @@
 import { Rule, SchematicsException, chain } from '@angular-devkit/schematics';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
-import { normalize, sep } from 'path';
+import { normalize } from 'path';
 import { OverrideOptionsSchema as Options } from 'schemas/helpers/override/schema';
 
 import { copyFile } from '../../utils/filesystem';
@@ -20,15 +20,14 @@ export function override(options: Options): Rule {
     const workspace = await getWorkspace(host);
     const project = workspace.projects.get(options.project);
     const sourceRoot = project.sourceRoot;
-    const from = normalize(
-      `${
-        options.path
-          ? `${options.path}${sep}`
-          : !options.from?.startsWith(`${sourceRoot}${sep}app${sep}`)
-          ? `${sourceRoot}${sep}app${sep}`
-          : ''
-      }${options.from.replace(/\/$/, '')}`
-    );
+    const path = normalize(options.path ?? '')
+      .replace(/\\/g, '/')
+      .replace(/^\./, '');
+    let from = normalize(options.from).replace(/\\/g, '/');
+    from = `${path ? `${path}/` : !from.startsWith(`${sourceRoot}/app/`) ? `${sourceRoot}/app/` : ''}${from.replace(
+      /\/$/,
+      ''
+    )}`;
     if (!host.exists(from) || !from.endsWith('.ts')) {
       throw new SchematicsException('Input does not point to an existing TypeScript file.');
     }

--- a/schematics/src/helpers/override/factory.ts
+++ b/schematics/src/helpers/override/factory.ts
@@ -1,5 +1,6 @@
 import { Rule, SchematicsException, chain } from '@angular-devkit/schematics';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { normalize, sep } from 'path';
 import { OverrideOptionsSchema as Options } from 'schemas/helpers/override/schema';
 
 import { copyFile } from '../../utils/filesystem';
@@ -19,9 +20,15 @@ export function override(options: Options): Rule {
     const workspace = await getWorkspace(host);
     const project = workspace.projects.get(options.project);
     const sourceRoot = project.sourceRoot;
-    const from = `${
-      options.path ? `${options.path}/` : !options.from?.startsWith(`${sourceRoot}/app/`) ? `${sourceRoot}/app/` : ''
-    }${options.from.replace(/\/$/, '')}`;
+    const from = normalize(
+      `${
+        options.path
+          ? `${options.path}${sep}`
+          : !options.from?.startsWith(`${sourceRoot}${sep}app${sep}`)
+          ? `${sourceRoot}${sep}app${sep}`
+          : ''
+      }${options.from.replace(/\/$/, '')}`
+    );
     if (!host.exists(from) || !from.endsWith('.ts')) {
       throw new SchematicsException('Input does not point to an existing TypeScript file.');
     }

--- a/schematics/src/helpers/override/factory_spec.ts
+++ b/schematics/src/helpers/override/factory_spec.ts
@@ -282,4 +282,19 @@ describe('override Schematic', () => {
       ]
     `);
   });
+
+  it('should override file if path contains backslashes', async () => {
+    const tree = await runOverride({
+      from: 'core\\routing\\product.route.ts',
+      theme: 'b2b',
+      ts: true,
+    });
+
+    expect(tree.files.filter(x => x.includes('product.route'))).toMatchInlineSnapshot(`
+      Array [
+        "/src/app/core/routing/product.route.ts",
+        "/src/app/core/routing/product.route.b2b.ts",
+      ]
+    `);
+  });
 });

--- a/schematics/src/helpers/override/factory_spec.ts
+++ b/schematics/src/helpers/override/factory_spec.ts
@@ -283,7 +283,7 @@ describe('override Schematic', () => {
     `);
   });
 
-  it('should override file if path contains backslashes', async () => {
+  it('should override file if path is windows-styled', async () => {
     const tree = await runOverride({
       from: 'core\\routing\\product.route.ts',
       theme: 'b2b',


### PR DESCRIPTION
Currently, the override schematic only accepts paths with forward slashes.

Now, it also accepts paths with backslashes.

[AB#76433](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76433)