### PR TITLE
fix: cookie page guard should only use NgModal on browser

### DIFF
--- a/src/app/pages/cookies/cookies-page.guard.ts
+++ b/src/app/pages/cookies/cookies-page.guard.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { CanActivate, NavigationEnd, Router } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { filter, first } from 'rxjs/operators';
@@ -9,32 +10,38 @@ import { CookiesModalComponent } from './cookies-modal/cookies-modal.component';
 export class CookiesPageGuard implements CanActivate {
   private currentDialog: NgbModalRef;
 
-  constructor(private modalService: NgbModal, private router: Router) {}
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: string,
+    private modalService: NgbModal,
+    private router: Router
+  ) {}
 
   async canActivate() {
-    this.currentDialog = this.modalService.open(CookiesModalComponent, {
-      centered: true,
-      size: 'lg',
-      backdrop: 'static',
-    });
+    if (isPlatformBrowser(this.platformId)) {
+      this.currentDialog = this.modalService.open(CookiesModalComponent, {
+        centered: true,
+        size: 'lg',
+        backdrop: 'static',
+      });
 
-    const cookiesModalComponent = this.currentDialog.componentInstance as CookiesModalComponent;
+      const cookiesModalComponent = this.currentDialog.componentInstance as CookiesModalComponent;
 
-    // dialog closed
-    cookiesModalComponent.closeModal.pipe(first()).subscribe(() => {
-      this.currentDialog.dismiss();
-    });
-
-    // navigated away with link on dialog
-    this.router.events
-      .pipe(
-        filter(event => event instanceof NavigationEnd),
-        first()
-      )
-      .subscribe(() => {
+      // dialog closed
+      cookiesModalComponent.closeModal.pipe(first()).subscribe(() => {
         this.currentDialog.dismiss();
       });
 
-    return false;
+      // navigated away with link on dialog
+      this.router.events
+        .pipe(
+          filter(event => event instanceof NavigationEnd),
+          first()
+        )
+        .subscribe(() => {
+          this.currentDialog.dismiss();
+        });
+      return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

In a ssr+nginx setup the route: /cookies will show the error page of the nginx. The ssr container have the following log: 

![image](https://user-images.githubusercontent.com/44707835/166687678-425b6c97-0f0b-408e-ba5a-b1a3303c9329.png)

The cookie page guard should manage to open and close a modal to select the desired cookies. It should be clear, that modals are only available on browser and not on server side. (https://github.com/angular-slider/ngx-slider/issues/66)

Issue Number: Closes #

## What Is the New Behavior?

The cookie page guard manages the cookie modal only on browser side.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Reproduce: Go to demo page: https://intershoppwa.azurewebsites.net/cookies


[AB#76445](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76445)