### PR TITLE
fix: only update cost center when it actually changes

### DIFF
--- a/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.html
+++ b/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="(costCenterOptions$ | async)?.length" data-testing-id="cost-center-select">
+<ng-container *ngIf="fields$ | async as fields" data-testing-id="cost-center-select">
   <h3>{{ 'checkout.cost_center.select.heading' | translate }}</h3>
   <form [formGroup]="form">
     <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>

--- a/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.spec.ts
+++ b/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { EMPTY, of } from 'rxjs';
+import { BehaviorSubject, EMPTY, of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
@@ -63,54 +63,89 @@ describe('Basket Cost Center Selection Component', () => {
     expect(element.querySelector('select[data-testing-id=cost-center-select]')).toBeFalsy();
   });
 
-  it('should be rendered with correct option and no placeholder, when isBusinessCustomer is true and cost center options with one option are receiving', () => {
-    when(accountFacade.isBusinessCustomer$).thenReturn(of(true));
-    when(checkoutFacade.eligibleCostCenterSelectOptions$()).thenReturn(of([mockCostCenterOptions[0]]));
-    fixture.detectChanges();
+  describe('with isBusinessCustomer = true', () => {
+    beforeEach(() => {
+      when(accountFacade.isBusinessCustomer$).thenReturn(of(true));
+    });
+    it('should be rendered with correct option and no placeholder for single cost center option', () => {
+      when(checkoutFacade.eligibleCostCenterSelectOptions$()).thenReturn(of([mockCostCenterOptions[0]]));
+      fixture.detectChanges();
 
-    expect(element.querySelectorAll('formly-field')).toHaveLength(1);
-    expect(element.querySelector('formly-field').textContent).toMatchInlineSnapshot(`
-      "SelectFieldComponent: costCenter ish-select-field {
-        \\"label\\": \\"checkout.cost_center.select.label\\",
-        \\"required\\": true,
-        \\"hideRequiredMarker\\": true,
-        \\"options\\": [
-          {
-            \\"label\\": \\"Cost Center 1\\",
-            \\"value\\": \\"1\\"
-          }
-        ],
-        \\"placeholder\\": \\"\\",
-        \\"focus\\": false,
-        \\"disabled\\": false
-      }"
-    `);
-  });
+      expect(element.querySelectorAll('formly-field')).toHaveLength(1);
+      expect(element.querySelector('formly-field').textContent).toMatchInlineSnapshot(`
+        "SelectFieldComponent: costCenter ish-select-field {
+          \\"label\\": \\"checkout.cost_center.select.label\\",
+          \\"required\\": true,
+          \\"hideRequiredMarker\\": true,
+          \\"options\\": [
+            {
+              \\"label\\": \\"Cost Center 1\\",
+              \\"value\\": \\"1\\"
+            }
+          ],
+          \\"placeholder\\": \\"\\",
+          \\"focus\\": false,
+          \\"disabled\\": false
+        }"
+      `);
+    });
 
-  it('should be rendered with correct options and placeholder, when isBusinessCustomer is true and cost center options with multiple options are receiving', () => {
-    when(accountFacade.isBusinessCustomer$).thenReturn(of(true));
-    when(checkoutFacade.eligibleCostCenterSelectOptions$()).thenReturn(of(mockCostCenterOptions));
-    fixture.detectChanges();
-    expect(element.querySelectorAll('formly-field')).toHaveLength(1);
-    expect(element.querySelector('formly-field').textContent).toMatchInlineSnapshot(`
-      "SelectFieldComponent: costCenter ish-select-field {
-        \\"label\\": \\"checkout.cost_center.select.label\\",
-        \\"required\\": true,
-        \\"hideRequiredMarker\\": true,
-        \\"options\\": [
-          {
-            \\"label\\": \\"Cost Center 1\\",
-            \\"value\\": \\"1\\"
-          },
-          {
-            \\"label\\": \\"Cost Center 2\\",
-            \\"value\\": \\"2\\"
-          }
-        ],
-        \\"placeholder\\": \\"account.option.select.text\\",
-        \\"focus\\": false,
-        \\"disabled\\": false
-      }"
-    `);
+    it('should be rendered with correct options and placeholder for multiple cost center options', () => {
+      when(checkoutFacade.eligibleCostCenterSelectOptions$()).thenReturn(of(mockCostCenterOptions));
+      fixture.detectChanges();
+      expect(element.querySelectorAll('formly-field')).toHaveLength(1);
+      expect(element.querySelector('formly-field').textContent).toMatchInlineSnapshot(`
+        "SelectFieldComponent: costCenter ish-select-field {
+          \\"label\\": \\"checkout.cost_center.select.label\\",
+          \\"required\\": true,
+          \\"hideRequiredMarker\\": true,
+          \\"options\\": [
+            {
+              \\"label\\": \\"Cost Center 1\\",
+              \\"value\\": \\"1\\"
+            },
+            {
+              \\"label\\": \\"Cost Center 2\\",
+              \\"value\\": \\"2\\"
+            }
+          ],
+          \\"placeholder\\": \\"account.option.select.text\\",
+          \\"focus\\": false,
+          \\"disabled\\": false
+        }"
+      `);
+    });
+
+    it('should be rendered with correct options and no placeholder after cost center is selected', () => {
+      const subject$ = new BehaviorSubject(BasketMockData.getBasket());
+      when(checkoutFacade.basket$).thenReturn(subject$.asObservable());
+      when(checkoutFacade.eligibleCostCenterSelectOptions$()).thenReturn(of(mockCostCenterOptions));
+      fixture.detectChanges();
+      component.form.get('costCenter').setValue('2');
+      subject$.next({ ...BasketMockData.getBasket(), costCenter: '2' });
+      fixture.detectChanges();
+
+      expect(element.querySelectorAll('formly-field')).toHaveLength(1);
+      expect(element.querySelector('formly-field').textContent).toMatchInlineSnapshot(`
+        "SelectFieldComponent: costCenter ish-select-field {
+          \\"label\\": \\"checkout.cost_center.select.label\\",
+          \\"required\\": true,
+          \\"hideRequiredMarker\\": true,
+          \\"options\\": [
+            {
+              \\"label\\": \\"Cost Center 1\\",
+              \\"value\\": \\"1\\"
+            },
+            {
+              \\"label\\": \\"Cost Center 2\\",
+              \\"value\\": \\"2\\"
+            }
+          ],
+          \\"placeholder\\": \\"\\",
+          \\"focus\\": false,
+          \\"disabled\\": false
+        }"
+      `);
+    });
   });
 });

--- a/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.ts
+++ b/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.ts
@@ -59,7 +59,7 @@ export class BasketCostCenterSelectionComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(([costCenter, basket]) => {
-        if (costCenter !== basket.costCenter) {
+        if (costCenter !== basket.costCenter && !!costCenter) {
           this.checkoutFacade.updateBasketCostCenter(costCenter);
         }
       });

--- a/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.ts
+++ b/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, combineLatest } from 'rxjs';
 import { distinctUntilChanged, map, switchMap, take, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
@@ -39,7 +39,15 @@ export class BasketCostCenterSelectionComponent implements OnInit, OnDestroy {
       switchMap(() => this.checkoutFacade.eligibleCostCenterSelectOptions$())
     );
 
-    this.fields$ = this.costCenterOptions$.pipe(
+    this.fields$ = combineLatest([
+      this.costCenterOptions$,
+      // retrigger field render when cost center is updated (maybe we don't need the placeholder anymore)
+      this.checkoutFacade.basket$.pipe(
+        map(basket => basket?.costCenter),
+        distinctUntilChanged()
+      ),
+    ]).pipe(
+      map(([options]) => options),
       map(options => (options.length ? this.getFields(options) : undefined)),
       whenTruthy()
     );
@@ -82,6 +90,9 @@ export class BasketCostCenterSelectionComponent implements OnInit, OnDestroy {
   }
 
   private getFields(options: SelectOption[]): FormlyFieldConfig[] {
+    if (options.length === 1 && options[0].value && !this.model?.costCenter) {
+      this.model = { ...this.model, costCenter: options[0].value };
+    }
     return [
       {
         key: 'costCenter',
@@ -92,14 +103,6 @@ export class BasketCostCenterSelectionComponent implements OnInit, OnDestroy {
           hideRequiredMarker: true,
           options,
           placeholder: options.length > 1 && !this.model?.costCenter ? 'account.option.select.text' : undefined,
-        },
-        hooks: {
-          // set automatically a cost center at basket if there is only 1 cost center assigned to this user
-          onInit: () => {
-            if (options.length === 1 && options[0].value && !this.model?.costCenter) {
-              this.form.get('costCenter').setValue(options[0].value);
-            }
-          },
         },
       },
     ];


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently, when you navigate to the basket page and the user has only one cost center, the cost center is nevertheless reassigned and because of this, the basket is reloaded. This leads to certain error/information messages dissapearing.

## What Is the New Behavior?
Now, the cost center is only reassigned when it actually differs from the one already set in the basket.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76467](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76467)