### PR TITLE
chore: remove unnecessary jest mock

### DIFF
--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -61,10 +61,3 @@ Object.defineProperty(document.body.style, 'transform', {
     configurable: true,
   }),
 });
-
-// fix for TypeError, see https://github.com/telerik/kendo-angular/issues/1505#issuecomment-385882188
-Object.defineProperty(window, 'getComputedStyle', {
-  value: () => ({
-    getPropertyValue: () => '',
-  }),
-});


### PR DESCRIPTION
The workaround that was required to get jest running (described here https://github.com/telerik/kendo-angular/issues/1505#issuecomment-385882188) was apparently fixed in the JSDOM implementation.

All tests work without this manual mock now, so I have removed it.

[AB#76563](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76563)