### PR TITLE
feat: select displays fixed string for single option required fields

### DIFF
--- a/src/app/shared/formly/types/select-field/select-field.component.html
+++ b/src/app/shared/formly/types/select-field/select-field.component.html
@@ -1,18 +1,24 @@
-<select
-  [formControl]="formControl"
-  [compareWith]="to.compareWith ? to.compareWith : defaultOptions.templateOptions.compareWith"
-  [formlyAttributes]="field"
-  class="form-control"
-  [ngClass]="to.inputClass"
-  [attr.data-testing-id]="field.key"
->
-  <ng-container *ngIf="selectOptions && selectOptions | formlySelectOptions: field | async as opts">
-    <ng-container *ngIf="to._flatOptions">
-      <ng-container *ngFor="let opt of opts">
-        <option [value]="opt.value" [disabled]="opt.disabled">
-          {{ opt.label }}
-        </option>
+<ng-container *ngIf="selectOptions && selectOptions | formlySelectOptions: field | async as opts">
+  <ng-container *ngIf="!useFixedDisplay(opts); else fixedDisplay">
+    <select
+      [formControl]="formControl"
+      [compareWith]="to.compareWith ? to.compareWith : defaultOptions.templateOptions.compareWith"
+      [formlyAttributes]="field"
+      class="form-control"
+      [ngClass]="to.inputClass"
+      [attr.data-testing-id]="field.key"
+    >
+      <ng-container *ngIf="to._flatOptions">
+        <ng-container *ngFor="let opt of opts">
+          <option [value]="opt.value" [disabled]="opt.disabled">
+            {{ opt.label }}
+          </option>
+        </ng-container>
       </ng-container>
-    </ng-container>
+    </select>
   </ng-container>
-</select>
+
+  <ng-template #fixedDisplay>
+    {{ getFixedOption(opts).label }}
+  </ng-template>
+</ng-container>

--- a/src/app/shared/formly/types/select-field/select-field.component.spec.ts
+++ b/src/app/shared/formly/types/select-field/select-field.component.spec.ts
@@ -45,7 +45,10 @@ describe('Select Field Component', () => {
           templateOptions: {
             label: 'test label',
             required: true,
-            options: [{ value: 1, label: 'test' }],
+            options: [
+              { value: 1, label: 'test' },
+              { value: 2, label: 'test' },
+            ],
           },
         } as FormlyFieldConfig,
       ],
@@ -63,6 +66,57 @@ describe('Select Field Component', () => {
   });
 
   it('should be rendered after creation', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('ish-select-field > select')).toBeTruthy();
+  });
+  it('should be rendered as fixed string if required with only one option', () => {
+    component.testComponentInputs = {
+      fields: [
+        {
+          key: 'select',
+          type: 'ish-select-field',
+          templateOptions: {
+            label: 'test label',
+            required: true,
+            placeholder: 'test placeholder',
+            processedOptions: [
+              { value: 1, label: 'test' },
+              // mocks what the translate-select-options extension would return
+              { value: undefined, label: 'placeholder' },
+            ],
+          },
+        } as FormlyFieldConfig,
+      ],
+      form: new FormGroup({}),
+      model: {
+        select: undefined,
+      },
+    };
+    fixture.detectChanges();
+    expect(element.querySelector('ish-select-field > select')).toBeFalsy();
+  });
+  it('should not be rendered as fixed string if not required with only one option', () => {
+    component.testComponentInputs = {
+      fields: [
+        {
+          key: 'select',
+          type: 'ish-select-field',
+          templateOptions: {
+            label: 'test label',
+            placeholder: 'test placeholder',
+            processedOptions: [
+              { value: 1, label: 'test' },
+              // mocks what the translate-select-options extension would return
+              { value: undefined, label: 'placeholder' },
+            ],
+          },
+        } as FormlyFieldConfig,
+      ],
+      form: new FormGroup({}),
+      model: {
+        select: undefined,
+      },
+    };
     fixture.detectChanges();
     expect(element.querySelector('ish-select-field > select')).toBeTruthy();
   });

--- a/src/app/shared/formly/types/select-field/select-field.component.ts
+++ b/src/app/shared/formly/types/select-field/select-field.component.ts
@@ -3,6 +3,14 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
 
+// taken from formly's select-options.pipe.ts
+interface ISelectOption {
+  label: string;
+  disabled?: boolean;
+  value?: any;
+  group?: ISelectOption[];
+}
+
 /**
  * Type for a basic select field
  *
@@ -36,5 +44,13 @@ export class SelectFieldComponent extends FieldType<FieldTypeConfig> {
 
   get selectOptions() {
     return this.to.processedOptions ?? this.to.options;
+  }
+
+  useFixedDisplay(opts: ISelectOption[]): boolean {
+    return this.to.required ? (this.to.placeholder ? opts.length === 2 : opts.length === 1) : false;
+  }
+
+  getFixedOption(opts: ISelectOption[]): ISelectOption {
+    return this.to.placeholder ? opts[1] : opts[0];
   }
 }

--- a/src/app/shared/formly/types/select-field/select-field.component.ts
+++ b/src/app/shared/formly/types/select-field/select-field.component.ts
@@ -7,7 +7,7 @@ import { SelectOption } from 'ish-core/models/select-option/select-option.model'
 interface ISelectOption {
   label: string;
   disabled?: boolean;
-  value?: any;
+  value?: unknown;
   group?: ISelectOption[];
 }
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently, required select option fields with only one option will still show a (unnecessary) select box.

Issue Number: Closes #

## What Is the New Behavior?
Now, the select option field type shows a fixed string if there is only one (non-placeholder) option and it's required

## ToDo:
- [ ] add `:` after fixed display

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76576](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76576)