### PR TITLE
fix: preserve semicolons in query params

### DIFF
--- a/src/app/core/routing/pwa-url.serializer.spec.ts
+++ b/src/app/core/routing/pwa-url.serializer.spec.ts
@@ -29,9 +29,21 @@ describe('Pwa Url Serializer', () => {
     expect(result).toMatchInlineSnapshot(`"/path/a/b/c"`);
   });
 
-  it('should remove matrix parameters from and keep query params in URL', () => {
+  it('should remove multiple matrix parameters from URL', () => {
+    const tree = urlSerializer.parse('/path/a/b/c;matrix=value;matrix2=value2');
+    const result = urlSerializer.serialize(tree);
+    expect(result).toMatchInlineSnapshot(`"/path/a/b/c"`);
+  });
+
+  it('should remove matrix parameters and keep query params in URL', () => {
     const tree = urlSerializer.parse('/path/a/b/c;matrix=value?test=dummy&foo=bar');
     const result = urlSerializer.serialize(tree);
     expect(result).toMatchInlineSnapshot(`"/path/a/b/c?test=dummy&foo=bar"`);
+  });
+
+  it('should remove matrix parameters and keep query params in URL preserving semicolons in query params', () => {
+    const tree = urlSerializer.parse('/path/a/b/c;matrix=value?test=dummy%3btest&foo=bar');
+    const result = urlSerializer.serialize(tree);
+    expect(result).toMatchInlineSnapshot(`"/path/a/b/c?test=dummy;test&foo=bar"`);
   });
 });

--- a/src/app/core/routing/pwa-url.serializer.ts
+++ b/src/app/core/routing/pwa-url.serializer.ts
@@ -1,4 +1,22 @@
-import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+import { DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree } from '@angular/router';
+
+function removeMatrixParametersFromGroup(group: UrlSegmentGroup): UrlSegmentGroup {
+  return new UrlSegmentGroup(
+    group.segments.map(segment => new UrlSegment(segment.path, {})),
+    Object.entries(group.children).reduce(
+      (acc, [key, group]) => ({ ...acc, [key]: removeMatrixParametersFromGroup(group) }),
+      {}
+    )
+  );
+}
+
+function removeMatrixParameters(tree: UrlTree): UrlTree {
+  const newTree = new UrlTree();
+  newTree.root = removeMatrixParametersFromGroup(tree.root);
+  newTree.fragment = tree.fragment;
+  newTree.queryParams = tree.queryParams;
+  return newTree;
+}
 
 /**
  * Custom serializer for allowing parenthesis in URLs and removing matrix parameters
@@ -16,12 +34,10 @@ export class PWAUrlSerializer implements UrlSerializer {
   serialize(tree: UrlTree): string {
     return (
       this.defaultUrlSerializer
-        .serialize(tree)
+        .serialize(removeMatrixParameters(tree))
         // display parenthesis unencoded in URL
         .replace(/%28/g, '(')
         .replace(/%29/g, ')')
-        // remove matrix parameters
-        .replace(/;[^?]*/, '')
     );
   }
 }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The matrix param removal in [`PWAUrlSerializer`](https://github.com/intershop/intershop-pwa/blob/f7e0de7a9b68351f15a7d272b535e4034a29e2fa/src/app/core/routing/pwa-url.serializer.ts#L23-L24) is too greedy and also reacts on semicolons in query parameters.
In our case semicolons in query parameters are added in the SSO login state by the library `angular-oauth2-oidc` when logging in with a `returnUrl`.

## What Is the New Behavior?

Matrix param removal is not implemented by string manipulation using a regex, but instead by creating a `UrlTree` copy free of matrix parameters that is then serialized.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#76838](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/76838)