### PR TITLE
fix: window object should only be used on browser side

### DIFF
--- a/src/app/extensions/tracking/store/tracking-config/tracking-config.effects.ts
+++ b/src/app/extensions/tracking/store/tracking-config/tracking-config.effects.ts
@@ -1,4 +1,4 @@
-import { isPlatformServer } from '@angular/common';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Actions, createEffect } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
@@ -24,7 +24,7 @@ export class TrackingConfigEffects {
     store: Store,
     cookiesService: CookiesService
   ) {
-    if (cookiesService.cookieConsentFor('tracking')) {
+    if (isPlatformBrowser(this.platformId) && cookiesService.cookieConsentFor('tracking')) {
       store
         .pipe(
           select(getGTMToken),


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

If the tracking extension is enabled **AND for some reason the cookies consent check is removed (project customization to use a different cookies consent management tool)**, then the tracking-config.effect.ts will use the window object on server side if a gtmToken is found.

## What Is the New Behavior?

Making sure that the window object is only used on browser side independent from the potentially removed cookies consent handling.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#77211](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77211)