### PR TITLE
chore: add ci option to commitizen config

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -20,6 +20,10 @@ module.exports = {
     { value: 'build', name: 'build:    Anything build related' },
     { value: 'deps', name: 'deps:     Dependency updates' },
     {
+      value: 'ci',
+      name: 'ci:    Changes to the CI configuration files and scripts',
+    },
+    {
       value: 'chore',
       name: 'chore:    Anything else...',
     },


### PR DESCRIPTION
According to our docs, we follow conventional commits (which in turn follows the angular conventions).
Both allow a `ci` type for commit messages, but we don't.

Added a `ci` type.

[AB#77327](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77327)