### PR TITLE
Hybrid-demo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,77 +1,76 @@
-# export appropriate ICM_BASE_URL and use with
-# docker compose up --build
+# example docker compose that should provide a working hybrid approach for development
+# 'jshaukenb' and IPs needs to be replaced with the correct values
+# docker compose -f docker-compose_hybrid.yml up --build
 
 version: '3'
 services:
+  icm:
+    image: registry.intershop.de/ispwa/intershop7-devenv/hybrid-approach/a_responsive
+    environment:
+      - HOST=jmetznernb.localdev.intershop.de
+      - HTTP_PORT=5322
+      - HTTPS_PORT=5300
+      - SECURE_ONLY=true
+    ports:
+      - '5322:8081'
+      - '5323:8444'
+    stdin_open: true
+    tty: true
+    extra_hosts:
+      - 'jmetznernb.localdev.intershop.de:10.0.206.205'
+  #    restart: always
+
   pwa:
     build:
       context: .
       # dockerfile: Dockerfile_noSSR
       args:
         serviceWorker: 'false'
-        # activeThemes: b2b
+        activeThemes: b2b
         # activeThemes: b2c
     environment:
-      - LOGGING=on
-      - SOURCE_MAPS=on
-      - ICM_BASE_URL
-      # - PROXY_ICM=true
+      - ICM_BASE_URL=https://jmetznernb.localdev.intershop.de:5323
+      - SSL=true
+      - SSR_HYBRID=true
       - TRUST_ICM=true
-      # - PROMETHEUS=on
-      # - MULTI_SITE_LOCALE_MAP={"en_US":"/en","de_DE":"/de","fr_FR":"/fr"}
-
-  # <CDN-Example>
-  # add 127.0.0.1 mypwa.net to your hosts file and
-  # uncomment the following lines
-  #
-  #     - DEPLOY_URL=http://mypwa.net:4222
-  # cdn:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile_noSSR
-  #     args:
-  #       configuration: production
-  #       serviceWorker: 'false'
-  #       deployUrl: http://mypwa.net:4222
-  #   ports:
-  #     - '4222:4200'
-  #
-  # </CDN-Example>
+      - LOGGING=true
+    ports:
+      - '5301:4200'
+    extra_hosts:
+      - 'jmetznernb.localdev.intershop.de:10.0.206.205'
+  #    restart: always
 
   nginx:
     build: nginx
     depends_on:
       - pwa
     ports:
-      - '4200:80'
+      - '5300:443'
       # - '9113:9113'
     environment:
-      UPSTREAM_PWA: 'http://pwa:4200'
-      # DEBUG: 1
-      CACHE: 0
-      PAGESPEED: 0
-      SSR: 1
-      # PROMETHEUS: 1
-      # COMPRESSION: 0
-      # DEVICE_DETECTION: 0
-      # CACHING_IGNORE_PARAMS: |
-      #   params:
-      # MULTI_CHANNEL_SOURCE: env:///ASDF?type=application/yaml
-      # BASIC_AUTH: 'developer:!InterShop00!'
-      # BASIC_AUTH_IP_WHITELIST: |
-      #   # - 172.22.0.1
-      #   - 1.2.3.4
+      UPSTREAM_PWA: https://jmetznernb.localdev.intershop.de:5301
+      ICM_BASE_URL: https://jmetznernb.localdev.intershop.de:5323
+      LOGFORMAT: json
       MULTI_CHANNEL: |
         .+:
-          - baseHref: /en
-            channel: default
-            lang: en_US
-          - baseHref: /de
-            channel: default
-            lang: de_DE
-          - baseHref: /fr
-            channel: default
-            lang: fr_FR
-          - baseHref: /b2c
-            channel: default
-            theme: b2c
+          channel: inSPIRED-inTRONICS_Business-Site
+          application: '-'
+          theme: b2b
+    volumes:
+      - /home/jmetzner/work/server.crt:/etc/nginx/server.crt
+      - /home/jmetzner/work/server.key:/etc/nginx/server.key
+    extra_hosts:
+      - 'jmetznernb.localdev.intershop.de:10.0.206.205'
+  #    restart: always
+
+  solr:
+    image: solr:8
+    environment:
+      SOLR_OPTS: '$SOLR_OPTS -Dsolr.disableConfigSetsCreateAuthChecks=true'
+    ports:
+      - '8983:8983'
+      - '9983:9983'
+    command:
+      - 'solr-foreground'
+      - '-cloud'
+  #    restart: always

--- a/e2e/cypress/integration/specs/cms/server-html.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/cms/server-html.b2c.e2e-spec.ts
@@ -28,7 +28,7 @@ describe('Server Html', () => {
         },
         pagelets: [
           {
-            definitionQualifiedName: 'app_sf_base_cm:component.common.freeStyle.pagelet2-Component',
+            definitionQualifiedName: 'app_sf_responsive_cm:component.common.freeStyle.pagelet2-Component',
             link: {
               type: 'Link',
               uri: 'inSPIRED-inTRONICS-Site/-/cms/pagelets/test_foo_bar',
@@ -44,7 +44,7 @@ describe('Server Html', () => {
                   <div><a href="page://${_.pageId}">page</a></div>
                   <div><a href="route://${_.route}">route</a></div>
                   <img src="https://./?[ismediaobject]isfile://inSPIRED-Site/inTRONICS-b2c-responsive/inSPIRED-inTRONICS-b2c-responsive/en_US/logo%402x.png|/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS-b2c-responsive/inSPIRED-inTRONICS-b2c-responsive/en_US/logo%402x.png[/ismediaobject]" alt="" width="92" height="92" style="width: unset;" />`,
-                definitionQualifiedName: 'app_sf_base_cm:component.common.freeStyle.pagelet2-Component-HTML',
+                definitionQualifiedName: 'app_sf_responsive_cm:component.common.freeStyle.pagelet2-Component-HTML',
               },
             },
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@googlemaps/js-api-loader": "^1.14.3",
-        "@ng-bootstrap/ng-bootstrap": "^11.0.0",
+        "@ng-bootstrap/ng-bootstrap": "^11.0.1",
         "@ngrx/effects": "13.2.0",
         "@ngrx/entity": "13.2.0",
         "@ngrx/router-store": "13.2.0",
@@ -42,7 +42,7 @@
         "angular-oauth2-oidc": "13.0.1",
         "angular2-uuid": "^1.1.1",
         "angulartics2": "^12.1.0",
-        "bootstrap": "^4.0.0",
+        "bootstrap": "^4.6.1",
         "date-fns": "^2.28.0",
         "express": "^4.18.1",
         "express-http-proxy": "^1.6.3",
@@ -53,13 +53,13 @@
         "ng-recaptcha": "^9.0.0",
         "ngx-infinite-scroll": "^13.0.2",
         "ngx-toastr": "^14.3.0",
-        "rxjs": "~7.5.0",
+        "rxjs": "~7.5.5",
         "swiper": "^8.1.6",
-        "tslib": "^2.0.0",
+        "tslib": "^2.4.0",
         "typeface-roboto": "1.1.13",
         "typeface-roboto-condensed": "1.1.13",
         "xliff": "^6.0.3",
-        "zone.js": "~0.11.0"
+        "zone.js": "~0.11.5"
       },
       "devDependencies": {
         "@angular-builders/custom-webpack": "13.1.0",
@@ -85,7 +85,7 @@
         "@types/google.maps": "^3.49.1",
         "@types/jest": "^27.5.1",
         "@types/lodash-es": "^4.17.6",
-        "@types/node": "^16.0.0",
+        "@types/node": "^16.11.36",
         "@types/webpack": "^5.28.0",
         "@typescript-eslint/eslint-plugin": "5.26.0",
         "@typescript-eslint/parser": "5.26.0",
@@ -110,10 +110,10 @@
         "eslint-plugin-unused-imports": "^2.0.0",
         "husky": "^8.0.1",
         "intershop-schematics": "file:schematics",
-        "jest": "^27.0.0",
+        "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
         "jest-marbles": "^3.0.2",
-        "jest-preset-angular": "^11.0.0",
+        "jest-preset-angular": "^11.1.2",
         "json-schema-to-typescript": "^10.1.5",
         "lint-staged": "^12.4.2",
         "ng-mocks": "^13.5.2",
@@ -134,7 +134,7 @@
         "ts-mockito": "2.6.1",
         "ts-morph": "15.0.0",
         "ts-node": "~10.8.0",
-        "typescript": "~4.6.0"
+        "typescript": "~4.6.4"
       },
       "engines": {
         "node": ">=16.14.2",
@@ -142,6 +142,7 @@
       }
     },
     "eslint-rules": {
+      "name": "eslint-plugin-ish-custom-rules",
       "version": "0.0.1",
       "dev": true
     },
@@ -29116,6 +29117,7 @@
       }
     },
     "schematics": {
+      "name": "intershop-schematics",
       "version": "0.0.1",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -184,6 +184,11 @@
     "ts-node": "~10.8.0",
     "typescript": "~4.6.4"
   },
+  "overrides": {
+    "@trademe/ng-defer-load": {
+      "rxjs": "$rxjs"
+    }
+  },
   "lint-staged": {
     "docs/**/*.md": [
       "node docs/check-kb-labels",

--- a/schematics/src/cms-component/factory_spec.ts
+++ b/schematics/src/cms-component/factory_spec.ts
@@ -8,7 +8,7 @@ describe('CMS Component Schematic', () => {
   const schematicRunner = createSchematicRunner();
   const defaultOptions: Options = {
     name: 'foo',
-    definitionQualifiedName: 'app_sf_base_cm:component.common.foo.pagelet2-Component',
+    definitionQualifiedName: 'app_sf_responsive_cm:component.common.foo.pagelet2-Component',
     styleFile: false,
     module: undefined,
     export: false,
@@ -47,7 +47,7 @@ describe('CMS Component Schematic', () => {
           {
                 provide: CMS_COMPONENT,
                 useValue: {
-                  definitionQualifiedName: 'app_sf_base_cm:component.common.foo.pagelet2-Component',
+                  definitionQualifiedName: 'app_sf_responsive_cm:component.common.foo.pagelet2-Component',
                   class: CMSFooComponent,
                 },
                 multi: true,
@@ -96,7 +96,7 @@ describe('CMS Component Schematic', () => {
           {
                 provide: CMS_COMPONENT,
                 useValue: {
-                  definitionQualifiedName: 'app_sf_base_cm:component.common.foo.pagelet2-Component',
+                  definitionQualifiedName: 'app_sf_responsive_cm:component.common.foo.pagelet2-Component',
                   class: FooComponent,
                 },
                 multi: true,

--- a/src/app/core/models/content-pagelet/content-pagelet.mapper.spec.ts
+++ b/src/app/core/models/content-pagelet/content-pagelet.mapper.spec.ts
@@ -158,14 +158,14 @@ describe('Content Pagelet Mapper', () => {
 
   it('should have special handling for image pagelet configuration parmeters', () => {
     const input = {
-      definitionQualifiedName: 'app_sf_base_cm:component.common.image.pagelet2-Component',
+      definitionQualifiedName: 'app_sf_responsive_cm:component.common.image.pagelet2-Component',
       displayName: 'Brand Image 5',
       domain: 'domain',
       id: 'cmp_brandImage_5',
       configurationParameters: {
         Image: {
           value: 'inSPIRED-inTRONICS-b2c-responsive:/brands/adata.jpg',
-          definitionQualifiedName: 'app_sf_base_cm:component.common.image.pagelet2-Component-Image',
+          definitionQualifiedName: 'app_sf_responsive_cm:component.common.image.pagelet2-Component-Image',
         },
       },
     } as ContentPageletData;

--- a/src/app/pages/home/home-page.component.html
+++ b/src/app/pages/home/home-page.component.html
@@ -1,1 +1,1 @@
-<ish-content-include includeId="include.homepage.content.pagelet2-Include"></ish-content-include>
+<ish-content-include includeId="systempage.homepage.pagelet2-Page"></ish-content-include>

--- a/src/app/shared/cms/cms.module.ts
+++ b/src/app/shared/cms/cms.module.ts
@@ -6,6 +6,7 @@ import { CMSDialogComponent } from './components/cms-dialog/cms-dialog.component
 import { CMSFreestyleComponent } from './components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './components/cms-image/cms-image.component';
+import { CMSLandingPageComponent } from './components/cms-landing-page/cms-landing-page.component';
 import { CMSProductListCategoryComponent } from './components/cms-product-list-category/cms-product-list-category.component';
 import { CMSProductListFilterComponent } from './components/cms-product-list-filter/cms-product-list-filter.component';
 import { CMSProductListManualComponent } from './components/cms-product-list-manual/cms-product-list-manual.component';
@@ -94,6 +95,14 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
       useValue: {
         definitionQualifiedName: 'app_sf_responsive_cm:component.common.video.pagelet2-Component',
         class: CMSVideoComponent,
+      },
+      multi: true,
+    },
+    {
+      provide: CMS_COMPONENT,
+      useValue: {
+        definitionQualifiedName: 'app_sf_responsive_cm:component.shopping.landingPage.pagelet2-Component',
+        class: CMSLandingPageComponent,
       },
       multi: true,
     },

--- a/src/app/shared/cms/cms.module.ts
+++ b/src/app/shared/cms/cms.module.ts
@@ -20,7 +20,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.text.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.text.pagelet2-Component',
         class: CMSTextComponent,
       },
       multi: true,
@@ -28,7 +28,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.freeStyle.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.freeStyle.pagelet2-Component',
         class: CMSFreestyleComponent,
       },
       multi: true,
@@ -36,7 +36,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.container.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.container.pagelet2-Component',
         class: CMSContainerComponent,
       },
       multi: true,
@@ -44,7 +44,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.image.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.image.pagelet2-Component',
         class: CMSImageComponent,
       },
       multi: true,
@@ -52,7 +52,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.imageEnhanced.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.imageEnhanced.pagelet2-Component',
         class: CMSImageEnhancedComponent,
       },
       multi: true,
@@ -60,7 +60,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.carousel.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.carousel.pagelet2-Component',
         class: CMSCarouselComponent,
       },
       multi: true,
@@ -68,7 +68,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.productListManual.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.productListManual.pagelet2-Component',
         class: CMSProductListManualComponent,
       },
       multi: true,
@@ -76,7 +76,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.productListFilter.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.productListFilter.pagelet2-Component',
         class: CMSProductListFilterComponent,
       },
       multi: true,
@@ -84,7 +84,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.productListCategory.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.productListCategory.pagelet2-Component',
         class: CMSProductListCategoryComponent,
       },
       multi: true,
@@ -92,7 +92,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.video.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.video.pagelet2-Component',
         class: CMSVideoComponent,
       },
       multi: true,
@@ -100,7 +100,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.shopping.staticPage.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.shopping.staticPage.pagelet2-Component',
         class: CMSStaticPageComponent,
       },
       multi: true,
@@ -108,7 +108,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:pagevariant.standard.pagelet2-Pagevariant',
+        definitionQualifiedName: 'app_sf_responsive_cm:pagevariant.standard.pagelet2-Pagevariant',
         class: CMSStandardPageComponent,
       },
       multi: true,
@@ -116,7 +116,7 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
     {
       provide: CMS_COMPONENT,
       useValue: {
-        definitionQualifiedName: 'app_sf_base_cm:component.common.dialog.pagelet2-Component',
+        definitionQualifiedName: 'app_sf_responsive_cm:component.common.dialog.pagelet2-Component',
         class: CMSDialogComponent,
       },
       multi: true,

--- a/src/app/shared/cms/components/cms-carousel/__snapshots__/cms-carousel.component.spec.ts.snap
+++ b/src/app/shared/cms/components/cms-carousel/__snapshots__/cms-carousel.component.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Cms Carousel Component should be created 1`] = `
 <div ng-reflect-ng-class="foo-class" class="foo-class">
-  <ish-content-slot ng-reflect-wrapper="true" ng-reflect-slot="app_sf_base_cm:slot.carousel.i"
+  <ish-content-slot ng-reflect-wrapper="true" ng-reflect-slot="app_sf_responsive_cm:slot.carousel.i"
     ><div>
       <ngb-carousel
         tabindex="0"

--- a/src/app/shared/cms/components/cms-carousel/cms-carousel.component.html
+++ b/src/app/shared/cms/components/cms-carousel/cms-carousel.component.html
@@ -1,5 +1,9 @@
 <div *ngIf="pagelet" [ngClass]="pagelet.stringParam('CSSClass')">
-  <ish-content-slot [wrapper]="true" [slot]="'app_sf_base_cm:slot.carousel.items.pagelet2-Slot'" [pagelet]="pagelet">
+  <ish-content-slot
+    [wrapper]="true"
+    [slot]="'app_sf_responsive_cm:slot.carousel.items.pagelet2-Slot'"
+    [pagelet]="pagelet"
+  >
     <div [ngClass]="pagelet.stringParam('CarouselCSSClass')">
       <ngb-carousel
         #ngbCarousel

--- a/src/app/shared/cms/components/cms-carousel/cms-carousel.component.spec.ts
+++ b/src/app/shared/cms/components/cms-carousel/cms-carousel.component.spec.ts
@@ -36,7 +36,7 @@ describe('Cms Carousel Component', () => {
       slots: [
         {
           displayName: 'test',
-          definitionQualifiedName: 'app_sf_base_cm:slot.carousel.items.pagelet2-Slot',
+          definitionQualifiedName: 'app_sf_responsive_cm:slot.carousel.items.pagelet2-Slot',
           pageletIDs: ['slide1', 'slide2'],
         },
       ],

--- a/src/app/shared/cms/components/cms-carousel/cms-carousel.component.ts
+++ b/src/app/shared/cms/components/cms-carousel/cms-carousel.component.ts
@@ -40,7 +40,7 @@ export class CMSCarouselComponent implements CMSComponent, OnChanges, OnDestroy 
     }
     this.itemGridSize = (12 - (12 % this.slideItems)) / this.slideItems;
 
-    const slotPagelets = this.pagelet.slot('app_sf_base_cm:slot.carousel.items.pagelet2-Slot').pageletIDs;
+    const slotPagelets = this.pagelet.slot('app_sf_responsive_cm:slot.carousel.items.pagelet2-Slot').pageletIDs;
     this.pageletSlides = arraySlices(slotPagelets, this.slideItems);
 
     this.appRef.isStable

--- a/src/app/shared/cms/components/cms-container/cms-container.component.html
+++ b/src/app/shared/cms/components/cms-container/cms-container.component.html
@@ -10,3 +10,8 @@
     ></ish-content-pagelet>
   </ish-content-slot>
 </div>
+
+<!-- TODO: (CMS Component Configuration)
+  TrackingCode
+  TrackingScript
+-->

--- a/src/app/shared/cms/components/cms-container/cms-container.component.html
+++ b/src/app/shared/cms/components/cms-container/cms-container.component.html
@@ -1,5 +1,9 @@
 <div [ngClass]="containerClasses" class="content-container">
-  <ish-content-slot [wrapper]="true" [slot]="'app_sf_base_cm:slot.container.content.pagelet2-Slot'" [pagelet]="pagelet">
+  <ish-content-slot
+    [wrapper]="true"
+    [slot]="'app_sf_responsive_cm:slot.container.content.pagelet2-Slot'"
+    [pagelet]="pagelet"
+  >
     <ish-content-pagelet
       *ngFor="let slotPagelet of contentSlotPagelets"
       [pageletId]="slotPagelet"

--- a/src/app/shared/cms/components/cms-container/cms-container.component.spec.ts
+++ b/src/app/shared/cms/components/cms-container/cms-container.component.spec.ts
@@ -37,7 +37,7 @@ describe('Cms Container Component', () => {
       slots: [
         {
           displayName: 'test',
-          definitionQualifiedName: 'app_sf_base_cm:slot.container.content.pagelet2-Slot',
+          definitionQualifiedName: 'app_sf_responsive_cm:slot.container.content.pagelet2-Slot',
           pageletIDs: ['slide1', 'slide2'],
         },
       ],
@@ -56,7 +56,7 @@ describe('Cms Container Component', () => {
         class="content-container col-12 col-md-6 col-lg-4 float-left foo-class"
         ng-reflect-ng-class="col-12 col-md-6 col-lg-4 float"
       >
-        <ish-content-slot ng-reflect-wrapper="true" ng-reflect-slot="app_sf_base_cm:slot.container."
+        <ish-content-slot ng-reflect-wrapper="true" ng-reflect-slot="app_sf_responsive_cm:slot.container."
           ><ish-content-pagelet ng-reflect-pagelet-id="slide1"></ish-content-pagelet
           ><ish-content-pagelet ng-reflect-pagelet-id="slide2"></ish-content-pagelet
         ></ish-content-slot>

--- a/src/app/shared/cms/components/cms-container/cms-container.component.ts
+++ b/src/app/shared/cms/components/cms-container/cms-container.component.ts
@@ -15,7 +15,7 @@ export class CMSContainerComponent implements CMSComponent, OnChanges {
   containerClasses = '';
 
   ngOnChanges() {
-    let contentSlotPagelets = this.pagelet.slot('app_sf_base_cm:slot.container.content.pagelet2-Slot').pageletIDs;
+    let contentSlotPagelets = this.pagelet.slot('app_sf_responsive_cm:slot.container.content.pagelet2-Slot').pageletIDs;
     if (this.pagelet.hasParam('UpperBound')) {
       contentSlotPagelets = contentSlotPagelets.slice(0, this.pagelet.numberParam('UpperBound'));
     }

--- a/src/app/shared/cms/components/cms-dialog/cms-dialog.component.html
+++ b/src/app/shared/cms/components/cms-dialog/cms-dialog.component.html
@@ -5,4 +5,7 @@
   data-testing-id="dialog-content"
 ></div>
 
-<ish-content-slot [slot]="'app_sf_base_cm:slot.dialog.content.pagelet2-Slot'" [pagelet]="pagelet"></ish-content-slot>
+<ish-content-slot
+  [slot]="'app_sf_responsive_cm:slot.dialog.content.pagelet2-Slot'"
+  [pagelet]="pagelet"
+></ish-content-slot>

--- a/src/app/shared/cms/components/cms-dialog/cms-dialog.component.spec.ts
+++ b/src/app/shared/cms/components/cms-dialog/cms-dialog.component.spec.ts
@@ -67,7 +67,7 @@ describe('Cms Dialog Component', () => {
       slots: [
         {
           displayName: 'dialog',
-          definitionQualifiedName: 'app_sf_base_cm:slot.dialog.content.pagelet2-Slot',
+          definitionQualifiedName: 'app_sf_responsive_cm:slot.dialog.content.pagelet2-Slot',
           pageletIDs: ['dialogId'],
         },
       ],
@@ -77,7 +77,7 @@ describe('Cms Dialog Component', () => {
 
     expect(() => fixture.detectChanges()).not.toThrow();
     expect(element).toMatchInlineSnapshot(
-      `<ish-content-slot ng-reflect-slot="app_sf_base_cm:slot.dialog.con"></ish-content-slot>`
+      `<ish-content-slot ng-reflect-slot="app_sf_responsive_cm:slot.dialog.con"></ish-content-slot>`
     );
   });
 });

--- a/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.html
+++ b/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.html
@@ -1,0 +1,4 @@
+<ish-content-slot
+  [slot]="'app_sf_responsive_cm:slot.landingPage.content.pagelet2-Slot'"
+  [pagelet]="pagelet"
+></ish-content-slot>

--- a/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.spec.ts
+++ b/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ContentPagelet } from 'ish-core/models/content-pagelet/content-pagelet.model';
+import { ContentPageletView, createContentPageletView } from 'ish-core/models/content-view/content-view.model';
+
+import { CMSLandingPageComponent } from './cms-landing-page.component';
+
+describe('Cms Landing Page Component', () => {
+  let component: CMSLandingPageComponent;
+  let fixture: ComponentFixture<CMSLandingPageComponent>;
+  let element: HTMLElement;
+  let pageletView: ContentPageletView;
+  let pagelet: ContentPagelet;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CMSLandingPageComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    pagelet = {
+      domain: 'domain',
+      displayName: 'pagelet1',
+      definitionQualifiedName: 'fq',
+      id: 'id',
+      configurationParameters: {},
+    };
+    pageletView = createContentPageletView(pagelet);
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    component.pagelet = pageletView;
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+});

--- a/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.ts
+++ b/src/app/shared/cms/components/cms-landing-page/cms-landing-page.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+import { ContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { CMSComponent } from 'ish-shared/cms/models/cms-component/cms-component.model';
+
+/**
+ * The CMS Landing Page Component to render CMS managed content
+ * that is wrapped within a landing page component.
+ */
+@Component({
+  selector: 'ish-cms-landing-page',
+  templateUrl: './cms-landing-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CMSLandingPageComponent implements CMSComponent {
+  @Input() pagelet: ContentPageletView;
+}

--- a/src/app/shared/cms/components/cms-standard-page/cms-standard-page.component.html
+++ b/src/app/shared/cms/components/cms-standard-page/cms-standard-page.component.html
@@ -1,4 +1,4 @@
 <ish-content-slot
-  [slot]="'app_sf_base_cm:slot.pagevariant.content.pagelet2-Slot'"
+  [slot]="'app_sf_responsive_cm:slot.pagevariant.content.pagelet2-Slot'"
   [pagelet]="pagelet"
 ></ish-content-slot>

--- a/src/app/shared/cms/components/cms-static-page/cms-static-page.component.html
+++ b/src/app/shared/cms/components/cms-static-page/cms-static-page.component.html
@@ -12,7 +12,7 @@
         </div>
         <div class="marketing-area">
           <ish-content-slot
-            [slot]="'app_sf_base_cm:slot.marketing.sidePanel.pagelet2-Slot'"
+            [slot]="'app_sf_responsive_cm:slot.marketing.sidePanel.pagelet2-Slot'"
             [pagelet]="pagelet"
           ></ish-content-slot>
         </div>
@@ -21,11 +21,11 @@
         <ish-breadcrumb></ish-breadcrumb>
         <div class="marketing-area">
           <ish-content-slot
-            [slot]="'app_sf_base_cm:slot.marketing.base.pagelet2-Slot'"
+            [slot]="'app_sf_responsive_cm:slot.marketing.base.pagelet2-Slot'"
             [pagelet]="pagelet"
           ></ish-content-slot>
         </div>
-        <ish-content-slot [slot]="'app_sf_base_cm:slot.staticPage.content.pagelet2-Slot'" [pagelet]="pagelet">
+        <ish-content-slot [slot]="'app_sf_responsive_cm:slot.staticPage.content.pagelet2-Slot'" [pagelet]="pagelet">
         </ish-content-slot>
       </div>
     </ng-container>
@@ -35,11 +35,11 @@
         <ish-breadcrumb></ish-breadcrumb>
         <div class="marketing-area">
           <ish-content-slot
-            [slot]="'app_sf_base_cm:slot.marketing.base.pagelet2-Slot'"
+            [slot]="'app_sf_responsive_cm:slot.marketing.base.pagelet2-Slot'"
             [pagelet]="pagelet"
           ></ish-content-slot>
         </div>
-        <ish-content-slot [slot]="'app_sf_base_cm:slot.staticPage.content.pagelet2-Slot'" [pagelet]="pagelet">
+        <ish-content-slot [slot]="'app_sf_responsive_cm:slot.staticPage.content.pagelet2-Slot'" [pagelet]="pagelet">
         </ish-content-slot>
       </div>
     </ng-template>

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -43,6 +43,7 @@ import { CMSDialogComponent } from './cms/components/cms-dialog/cms-dialog.compo
 import { CMSFreestyleComponent } from './cms/components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './cms/components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './cms/components/cms-image/cms-image.component';
+import { CMSLandingPageComponent } from './cms/components/cms-landing-page/cms-landing-page.component';
 import { CMSProductListCategoryComponent } from './cms/components/cms-product-list-category/cms-product-list-category.component';
 import { CMSProductListFilterComponent } from './cms/components/cms-product-list-filter/cms-product-list-filter.component';
 import { CMSProductListManualComponent } from './cms/components/cms-product-list-manual/cms-product-list-manual.component';
@@ -186,6 +187,7 @@ const declaredComponents = [
   CMSFreestyleComponent,
   CMSImageComponent,
   CMSImageEnhancedComponent,
+  CMSLandingPageComponent,
   CMSProductListCategoryComponent,
   CMSProductListFilterComponent,
   CMSProductListManualComponent,

--- a/src/assets/mock-data/cms/includes/include.homepage.content.pagelet2-Include/get.json
+++ b/src/assets/mock-data/cms/includes/include.homepage.content.pagelet2-Include/get.json
@@ -10,7 +10,7 @@
   "pagelets": [
     {
       "type": "PageletRO",
-      "definitionQualifiedName": "app_sf_base_cm:component.common.freeStyle.pagelet2-Component",
+      "definitionQualifiedName": "app_sf_responsive_cm:component.common.freeStyle.pagelet2-Component",
       "link": {
         "type": "Link",
         "uri": "/inSPIRED-inTRONICS-Site/rest/cms/pagelets/cmp_homepage_mock_content",
@@ -25,7 +25,7 @@
         "HTML": {
           "value": "<div class=\"container\">\r\n<h1>Mock Content</h1>\r\n<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\r\n</div>",
           "type": "bc_pmc:types.pagelet2-Html",
-          "definitionQualifiedName": "app_sf_base_cm:component.common.freeStyle.pagelet2-Component-HTML"
+          "definitionQualifiedName": "app_sf_responsive_cm:component.common.freeStyle.pagelet2-Component-HTML"
         }
       }
     }


### PR DESCRIPTION
chore: remove obsolete CMS LandingPage rendering component (#1114)

* this is a pagelet model of the Responsive Starter Store and not part of the headless application type
* removed obsolete TODO

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
