### PR TITLE
feat: additional features extending defaults in multi-site

### DIFF
--- a/docs/guides/multi-site-configurations.md
+++ b/docs/guides/multi-site-configurations.md
@@ -44,6 +44,7 @@ All other properties are optional:
 - **application**: The ICM application
 - **identityProvider**: The active identity provider for this site
 - **features**: Comma-separated list of activated features
+- **addFeatures**: Comma-separated list of additional features extending defaults
 - **lang**: The default language as defined in the Angular CLI environment
 - **currency**: The default currency for this channel
 - **theme**: The theme used for the channel (see [Guide - Multiple Themes](./multiple-themes.md))

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -7,6 +7,7 @@
         {{- $lang := "default" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
         {{- $currency := "" }}{{ if (has . "currency") }}{{ $currency = join ( slice ";currency" .currency ) "=" }}{{ end }}
         {{- $features := "" }}{{ if (has . "features") }}{{ $features = join ( slice ";features" .features ) "=" }}{{ end }}
+        {{- $addFeatures := "" }}{{ if (has . "addFeatures") }}{{ $addFeatures = join ( slice ";addFeatures" .addFeatures ) "=" }}{{ end }}
         {{- $theme := "" }}{{ if (has . "theme") }}{{ $theme = join ( slice ";theme" .theme ) "=" }}{{ end }}
         {{- $baseHref := "/" }}{{ if (has . "baseHref") }}{{ $baseHref = .baseHref }}{{ end }}
         {{- $icmScheme := "" }}{{ if (has . "icmScheme") }}{{ $icmScheme = join ( slice "icmScheme" .icmScheme ) "=" }}{{ end }}
@@ -50,7 +51,7 @@
         rewrite '^(?!.*;identityProvider=.*)(.*)$' '$1;identityProvider={{ $identityProvider }}';
       {{ end }}
 
-        set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $features }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
+        set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $features }}{{ $addFeatures }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
 
         rewrite '^(.*)$' '$1$default_rewrite_params' break;
 

--- a/src/app/core/configurations/configuration.meta.ts
+++ b/src/app/core/configurations/configuration.meta.ts
@@ -18,6 +18,7 @@ class SimpleParamMap {
   }
 }
 
+// eslint-disable-next-line complexity
 function extractConfigurationParameters(state: ConfigurationState, paramMap: SimpleParamMap) {
   const keys: (keyof ConfigurationState)[] = ['channel', 'application', 'lang', 'currency', 'identityProvider'];
   const properties: Partial<ConfigurationState> = keys
@@ -37,6 +38,10 @@ function extractConfigurationParameters(state: ConfigurationState, paramMap: Sim
     } else {
       properties.features = paramMap.get<string>('features').split(/,/g);
     }
+  }
+
+  if (paramMap.has('addFeatures')) {
+    properties.addFeatures = paramMap.get<string>('addFeatures').split(/,/g);
   }
 
   if (paramMap.has('device')) {

--- a/src/app/core/store/core/configuration/configuration.reducer.ts
+++ b/src/app/core/store/core/configuration/configuration.reducer.ts
@@ -16,6 +16,7 @@ export interface ConfigurationState {
   identityProvider?: string;
   identityProviders?: { [id: string]: { type?: string; [key: string]: unknown } };
   features?: string[];
+  addFeatures?: string[];
   defaultLocale?: string;
   localeCurrencyOverride?: { [locale: string]: string | string[] };
   lang?: string;
@@ -33,6 +34,7 @@ const initialState: ConfigurationState = {
   channel: undefined,
   application: undefined,
   features: undefined,
+  addFeatures: [],
   defaultLocale: environment.defaultLocale,
   localeCurrencyOverride: environment.localeCurrencyOverride,
   lang: undefined,

--- a/src/app/core/store/core/configuration/configuration.selectors.spec.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.spec.ts
@@ -90,6 +90,20 @@ describe('Configuration Selectors', () => {
         expect(getFeatures(store$.state)).toIncludeAllMembers(['compare', 'recently']);
       });
     });
+
+    describe('after setting additional features', () => {
+      beforeEach(() => {
+        store$.dispatch(
+          applyConfiguration({
+            addFeatures: ['quoting'],
+          })
+        );
+      });
+
+      it('should have additional features active', () => {
+        expect(getFeatures(store$.state)).toIncludeAllMembers(['compare', 'recently', 'quoting']);
+      });
+    });
   });
 
   describe('after setting identity provider', () => {

--- a/src/app/core/store/core/configuration/configuration.selectors.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.ts
@@ -31,7 +31,9 @@ export const getICMStaticURL = createSelector(getConfigurationState, getICMAppli
 
 export const getICMBaseURL = createSelector(getConfigurationState, state => state.baseURL);
 
-export const getFeatures = createSelector(getConfigurationState, state => state.features);
+export const getFeatures = createSelector(getConfigurationState, state =>
+  state.features ? [...state.features, ...state.addFeatures] : undefined
+);
 
 const internalDefaultLocale = createSelector(getConfigurationState, state => state.defaultLocale);
 


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Using multi-site deployments, if you have a default feature list in the brand-specific environment.ts file, and on certain channels - but not all - you want to go live with another feature, it is currently required to repeat the whole feature list for all of those channels.

## What Is the New Behavior?

New property `addFeatures` in multi-site config, that allows adding additional features that extend the feature list for the specific channel.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#77608](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77608)