### PR TITLE
ci: fix demo server down

### DIFF
--- a/.github/workflows/demo-server-down.yml
+++ b/.github/workflows/demo-server-down.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Determine App Names
         run: |
-          if [[ -n ${{ github.event.pull_request.head.ref }} ]]
+          if [[ -n "${{ github.event.pull_request.head.ref }}" ]]
           then
             REF=${{ github.event.pull_request.head.ref }}
           else


### PR DESCRIPTION
Demo server down action was broken for `workflow_dispatch`. Works again

[AB#77632](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77632)