### PR TITLE
fix: content page not found when reloading a page with an authenticated user

### DIFF
--- a/src/app/core/store/content/pages/pages.effects.spec.ts
+++ b/src/app/core/store/content/pages/pages.effects.spec.ts
@@ -13,6 +13,7 @@ import { CMSService } from 'ish-core/services/cms/cms.service';
 import { ContentStoreModule } from 'ish-core/store/content/content-store.module';
 import { loadContentPageTreeSuccess } from 'ish-core/store/content/page-tree';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { pageTree } from 'ish-core/utils/dev/test-data-utils';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
@@ -57,7 +58,9 @@ describe('Pages Effects', () => {
     it('should send fail action when loading action via service is unsuccessful', done => {
       when(cmsServiceMock.getContentPage('dummy')).thenReturn(throwError(() => makeHttpError({ message: 'ERROR' })));
 
-      actions$ = of(loadContentPage({ contentPageId: 'dummy' }));
+      const action = loadContentPage({ contentPageId: 'dummy' });
+
+      actions$ = of(personalizationStatusDetermined, action);
 
       effects.loadContentPage$.subscribe(action => {
         verify(cmsServiceMock.getContentPage('dummy')).once();
@@ -72,10 +75,10 @@ describe('Pages Effects', () => {
     it('should not die when encountering an error', () => {
       when(cmsServiceMock.getContentPage('dummy')).thenReturn(throwError(() => makeHttpError({ message: 'ERROR' })));
 
-      actions$ = hot('a-a-a-a', { a: loadContentPage({ contentPageId: 'dummy' }) });
+      actions$ = hot('b-a-a', { a: loadContentPage({ contentPageId: 'dummy' }), b: personalizationStatusDetermined });
 
       expect(effects.loadContentPage$).toBeObservable(
-        cold('a-a-a-a', { a: loadContentPageFail({ error: makeHttpError({ message: 'ERROR' }) }) })
+        cold('--a-a', { a: loadContentPageFail({ error: makeHttpError({ message: 'ERROR' }) }) })
       );
     });
   });

--- a/src/app/core/store/content/pages/pages.effects.ts
+++ b/src/app/core/store/content/pages/pages.effects.ts
@@ -7,8 +7,14 @@ import { concatMap, map, mergeMap } from 'rxjs/operators';
 import { CMSService } from 'ish-core/services/cms/cms.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
-import { mapErrorToAction, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
+import {
+  mapErrorToAction,
+  mapToPayloadProperty,
+  useCombinedObservableOnAction,
+  whenTruthy,
+} from 'ish-core/utils/operators';
 
 import { loadContentPage, loadContentPageFail, loadContentPageSuccess } from './pages.actions';
 import { getBreadcrumbForContentPage } from './pages.selectors';
@@ -24,7 +30,7 @@ export class PagesEffects {
 
   loadContentPage$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(loadContentPage),
+      useCombinedObservableOnAction(this.actions$.pipe(ofType(loadContentPage)), personalizationStatusDetermined),
       mapToPayloadProperty('contentPageId'),
       mergeMap(contentPageId =>
         this.cmsService


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

When an authenticated user reloads a content page, then the "Page Not Found" component is rendered. The reason for this is, that the needed personalization call is dispatched after the content page call, which should use the pgid.

Issue Number: Closes #

## What Is the New Behavior?

The content page call is dispatched only after the personalization status is determined.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#77774](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77774)