### PR TITLE
fix: make default favicon accessible from root

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,14 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": ["src/assets"],
+            "assets": [
+              "src/assets",
+              {
+                "glob": "favicon.ico",
+                "input": "src/assets/themes/placeholder/img/",
+                "output": "/"
+              }
+            ],
             "scripts": [],
             "styles": ["src/styles/themes/placeholder/style.scss"],
             "stylePreprocessorOptions": {

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -147,7 +147,7 @@ server {
     }
 
     # respect cache entries of static assets
-    location ~* ^/(?!ngsw\.json)(ngx_pagespeed_beacon|metrics|assets|.*\.(js|css|ico|json|txt|webmanifest|woff|woff2))(.*)$ {
+    location ~* ^/(?!ngsw\.json)(ngx_pagespeed_beacon|metrics|assets|.*\.(js|css|json|txt|webmanifest|woff|woff2))(.*)$ {
         allow all;
         auth_basic off;
 

--- a/server.ts
+++ b/server.ts
@@ -300,6 +300,10 @@ export function app() {
       }
     });
   });
+  server.get(/.*\/favicon.ico.*/, (req, _, next) => {
+    req.url = req.originalUrl.replace(/[;?&].*$/, '').replace(/^.*\//g, '/');
+    next();
+  });
   server.get(
     '*.*',
     express.static(BROWSER_FOLDER, {

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -307,16 +307,29 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
     },
   });
 
-  const defaultThemePath = join('src', 'styles', 'themes', 'placeholder');
-  const newThemePath = join('src', 'styles', 'themes', theme);
+  ['styles', 'assets'].forEach(folder => {
+    const defaultThemePath = join('src', folder, 'themes', 'placeholder');
+    const newThemePath = join('src', folder, 'themes', theme);
 
-  traverse(
-    config,
-    v => typeof v === 'string' && v.includes(defaultThemePath),
-    (obj, key) => {
-      obj[key] = (obj[key] as string).replace(defaultThemePath, newThemePath);
-    }
-  );
+    traverse(
+      config,
+      v => typeof v === 'string' && v.includes(defaultThemePath),
+      (obj, key) => {
+        obj[key] = (obj[key] as string).replace(defaultThemePath, newThemePath);
+      }
+    );
+
+    const normalDefaultThemePath = defaultThemePath.replace(/\\/g, '/');
+    const normalNewThemePath = newThemePath.replace(/\\/g, '/');
+
+    traverse(
+      angularJsonConfig,
+      v => typeof v === 'string' && v.includes(normalDefaultThemePath),
+      (obj, key) => {
+        obj[key] = (obj[key] as string).replace(normalDefaultThemePath, normalNewThemePath);
+      }
+    );
+  });
 
   // set theme specific angular cache directory
   const cacheDir = join('.angular', 'cache');
@@ -389,17 +402,6 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
       const effectiveConfigPath = join(config.output.path, 'effective.config.json');
       logger.log('writing', logOutputFile(effectiveConfigPath));
       fs.writeFileSync(effectiveConfigPath, JSON.stringify(config, undefined, 2));
-
-      const normalDefaultThemePath = defaultThemePath.replace(/\\/g, '/');
-      const normalNewThemePath = newThemePath.replace(/\\/g, '/');
-
-      traverse(
-        angularJsonConfig,
-        v => typeof v === 'string' && v.includes(normalDefaultThemePath),
-        (obj, key) => {
-          obj[key] = (obj[key] as string).replace(normalDefaultThemePath, normalNewThemePath);
-        }
-      );
 
       Object.entries(angularCompilerPlugin.options.fileReplacements).map(([original, replacement]) => {
         angularJsonConfig.fileReplacements.push({


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Issue Number: Closes #1194

## What Is the New Behavior?

`favicon.ico` is accessible from website root.
If used with context path multi-site, only the default brand favicon can be chosen. If used with domain multi-site, the correct favicon is chosen automatically.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#77775](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77775)