### PR TITLE
fix: Invite page in ssr is not working

### DIFF
--- a/docs/concepts/sso.md
+++ b/docs/concepts/sso.md
@@ -28,6 +28,22 @@ For development purposes the configuration can be added to the Angular CLI envir
 For production, this configuration should be provided to the SSR process via environment variables (see [Building and Running Server-Side Rendering][ssr-startup]).
 The usage of identity providers can also be set in the multi-channel configuration (see [Building and Running nginx Docker Image][nginx-startup]).
 
+## Business cases
+
+### Create new user
+
+| Authentication Provider | Route in ICM email | Behavior of PWA                            |
+| ----------------------- | ------------------ | ------------------------------------------ |
+| ICM                     | /invite            | Redirect to /forgotPassword/updatePassword |
+| SSO                     | /invite            | Redirect to SSO provider                   |
+
+### User forgot password
+
+| Authentication Provider | Route in ICM email             | Behavior of PWA           |
+| ----------------------- | ------------------------------ | ------------------------- |
+| ICM                     | /forgotPassword/updatePassword | Show change password form |
+| SSO                     | /forgotPassword/updatePassword | Redirect to SSO provider  |
+
 # Further References
 
 - PWA

--- a/src/app/core/guards/identity-provider-password.guard.ts
+++ b/src/app/core/guards/identity-provider-password.guard.ts
@@ -8,7 +8,7 @@ export class IdentityProviderPasswordGuard implements CanActivate {
   constructor(private identityProviderFactory: IdentityProviderFactory) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    return this.identityProviderFactory.getType() !== 'ICM'
+    return this.identityProviderFactory.getType() !== 'ICM' && this.identityProviderFactory.getInstance().triggerInvite
       ? this.identityProviderFactory.getInstance().triggerInvite(route, state)
       : true;
   }

--- a/src/app/core/guards/identity-provider-password.guard.ts
+++ b/src/app/core/guards/identity-provider-password.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+
+import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+
+@Injectable({ providedIn: 'root' })
+export class IdentityProviderPasswordGuard implements CanActivate {
+  constructor(private identityProviderFactory: IdentityProviderFactory) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    return this.identityProviderFactory.getType() !== 'ICM'
+      ? this.identityProviderFactory.getInstance().triggerInvite(route, state)
+      : true;
+  }
+}

--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -58,6 +58,7 @@ export class IdentityProviderModule {
               intercept: (req: HttpRequest<unknown>, next: HttpHandler) => next.handle(req),
               triggerLogin: () => true,
               triggerLogout: () => true,
+              triggerInvite: () => true,
               getCapabilities: () => capabilities,
             }),
             getType: () => 'ICM',

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -57,6 +57,7 @@ export class IdentityProviderFactory {
         intercept: (req, next) => next.handle(req),
         triggerLogin: () => true,
         triggerLogout: () => true,
+        triggerInvite: () => true,
         getCapabilities: () => ({}),
       };
     }

--- a/src/app/pages/forgot-password/forgot-password-page.module.ts
+++ b/src/app/pages/forgot-password/forgot-password-page.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { IdentityProviderPasswordGuard } from 'ish-core/guards/identity-provider-password.guard';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { RequestReminderFormComponent } from './request-reminder-form/request-reminder-form.component';
@@ -16,6 +17,7 @@ const forgotPasswordPageRoutes: Routes = [
   {
     path: 'updatePassword',
     component: UpdatePasswordComponent,
+    canActivate: [IdentityProviderPasswordGuard],
   },
 ];
 


### PR DESCRIPTION
## PR Type

[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

When `/invite` route is being rendered in SSR context, the identity provider instance is missing a function object leading to errors later on.

When `forgotPasword/updatePassword` route is being rendered in SSR context, the system shows the Change Password page no matter what identity provider type is configured.

Issue Number: Closes #933

## What Is the New Behavior?

See documentation [sso.md](https://github.com/intershop/intershop-pwa/blob/fix/invite-page-in-ssr/docs/concepts/sso.md)

## Does this PR Introduce a Breaking Change?

[ ] Yes
[ X ] No

## Other Information


[AB#77778](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/77778)