### PR TITLE
chore: move xliff to dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "tslib": "^2.4.0",
         "typeface-roboto": "1.1.13",
         "typeface-roboto-condensed": "1.1.13",
-        "xliff": "^6.0.3",
         "zone.js": "~0.11.5"
       },
       "devDependencies": {
@@ -133,7 +132,8 @@
         "ts-mockito": "2.6.1",
         "ts-morph": "15.0.0",
         "ts-node": "~10.8.0",
-        "typescript": "~4.6.4"
+        "typescript": "~4.6.4",
+        "xliff": "^6.0.3"
       },
       "engines": {
         "node": ">=16.14.2",
@@ -25102,7 +25102,8 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -28932,6 +28933,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/xliff/-/xliff-6.0.3.tgz",
       "integrity": "sha512-rB51ayKqLvTXelucxp7Cl7e7iD2FN55QqUUfFqG5BHqnvIvrD/vQi7LqVFIMHucohP/fRuSVMsX+sYn6MzL/0A==",
+      "dev": true,
       "dependencies": {
         "xml-js": "1.6.11"
       }
@@ -28940,6 +28942,7 @@
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
       "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
       "dependencies": {
         "sax": "^1.2.4"
       },
@@ -47765,7 +47768,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "saxes": {
       "version": "5.0.1",
@@ -50683,6 +50687,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/xliff/-/xliff-6.0.3.tgz",
       "integrity": "sha512-rB51ayKqLvTXelucxp7Cl7e7iD2FN55QqUUfFqG5BHqnvIvrD/vQi7LqVFIMHucohP/fRuSVMsX+sYn6MzL/0A==",
+      "dev": true,
       "requires": {
         "xml-js": "1.6.11"
       }
@@ -50691,6 +50696,7 @@
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
       "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
       "requires": {
         "sax": "^1.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "tslib": "^2.4.0",
     "typeface-roboto": "1.1.13",
     "typeface-roboto-condensed": "1.1.13",
-    "xliff": "^6.0.3",
     "zone.js": "~0.11.5"
   },
   "devDependencies": {
@@ -181,7 +180,8 @@
     "ts-mockito": "2.6.1",
     "ts-morph": "15.0.0",
     "ts-node": "~10.8.0",
-    "typescript": "~4.6.4"
+    "typescript": "~4.6.4",
+    "xliff": "^6.0.3"
   },
   "lint-staged": {
     "docs/**/*.md": [


### PR DESCRIPTION
The xliff dependency is only used in a single script but was a normal dependency. Now it's a dev dependency.