### PR TITLE
test: adapt prices for e2e testing in B2C with the usage of ICM 7.10.38.11-LTS

### DIFF
--- a/e2e/cypress/integration/specs/checkout/basket-handling.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/basket-handling.b2c.e2e-spec.ts
@@ -21,7 +21,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
 };
 

--- a/e2e/cypress/integration/specs/checkout/register-before-checkout.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/register-before-checkout.b2c.e2e-spec.ts
@@ -12,7 +12,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
   address: {
     countryCode: 'DE',

--- a/e2e/cypress/integration/specs/checkout/shopping-anonymous.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/shopping-anonymous.b2c.e2e-spec.ts
@@ -18,7 +18,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
   address: {
     countryCode: 'DE',

--- a/e2e/cypress/integration/specs/checkout/shopping-prices.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/shopping-prices.b2c.e2e-spec.ts
@@ -13,9 +13,8 @@ const _ = {
   },
   product: {
     sku: '3468826',
-    priceNet: 19.5,
-    tax: 1.17,
-    shippingTax: 0.18,
+    priceGross: 19.5,
+    tax: 1.27,
   },
 };
 
@@ -27,21 +26,21 @@ describe('Price Display B2C', () => {
   });
 
   it('should display gross price on PDP', () => {
-    at(ProductDetailPage, page => page.price.should('contain', (_.product.priceNet + _.product.tax).toFixed(2)));
+    at(ProductDetailPage, page => page.price.should('contain', _.product.priceGross.toFixed(2)));
   });
 
   it('adding to cart should display with tax', () => {
     at(ProductDetailPage, page => {
       page.addProductToCart();
-      page.header.miniCart.total.should('contain', (_.product.priceNet + _.product.tax).toFixed(2));
+      page.header.miniCart.total.should('contain', _.product.priceGross.toFixed(2));
     });
   });
 
   it('should display tax on cart page', () => {
     at(ProductDetailPage, page => page.header.miniCart.goToCart());
     at(CartPage, page => {
-      page.subtotal.should('contain', (_.product.priceNet + _.product.tax).toFixed(2));
-      page.tax.should('contain', (_.product.tax + _.product.shippingTax).toFixed(2));
+      page.subtotal.should('contain', _.product.priceGross.toFixed(2));
+      page.tax.should('contain', _.product.tax.toFixed(2));
     });
   });
 
@@ -56,8 +55,8 @@ describe('Price Display B2C', () => {
   it('should see the same prices', () => {
     at(MyAccountPage, page => page.header.miniCart.goToCart());
     at(CartPage, page => {
-      page.subtotal.should('contain', (_.product.priceNet + _.product.tax).toFixed(2));
-      page.tax.should('contain', (_.product.tax + _.product.shippingTax).toFixed(2));
+      page.subtotal.should('contain', _.product.priceGross.toFixed(2));
+      page.tax.should('contain', _.product.tax.toFixed(2));
     });
   });
 });

--- a/e2e/cypress/integration/specs/checkout/shopping-user.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/checkout/shopping-user.b2c.e2e-spec.ts
@@ -25,7 +25,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
 };
 

--- a/e2e/cypress/integration/specs/shopping/browse-products-from-indexed-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/shopping/browse-products-from-indexed-page.b2c.e2e-spec.ts
@@ -9,7 +9,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
 };
 

--- a/e2e/cypress/integration/specs/shopping/browse-products-homepage-to-product-detail.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/shopping/browse-products-homepage-to-product-detail.b2c.e2e-spec.ts
@@ -12,7 +12,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
 };
 

--- a/e2e/cypress/integration/specs/shopping/search-category-routing.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/shopping/search-category-routing.b2c.e2e-spec.ts
@@ -8,7 +8,7 @@ const _ = {
   filter: {
     name: 'Brand',
     entryName: 'ManufacturerName_Microsoft',
-    results: 8,
+    results: 13,
   },
 };
 

--- a/e2e/cypress/integration/specs/system/change-language-family-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/change-language-family-page.b2c.e2e-spec.ts
@@ -10,8 +10,8 @@ const _ = {
   category: 'Cameras-Camcorders.585',
   product: {
     sku: '457595',
-    dollarPrice: '35.78',
-    euroPrice: '26,50',
+    dollarPrice: '33.75',
+    euroPrice: '25,00',
   },
 };
 

--- a/e2e/cypress/integration/specs/system/change-language-product-detail.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/change-language-product-detail.b2c.e2e-spec.ts
@@ -10,8 +10,8 @@ const _ = {
   category: 'Cameras-Camcorders.585',
   product: {
     sku: '457595',
-    dollarPrice: '35.78',
-    euroPrice: '26,50',
+    dollarPrice: '33.75',
+    euroPrice: '25,00',
   },
 };
 

--- a/e2e/cypress/integration/specs/system/change-language-search-result.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/change-language-search-result.b2c.e2e-spec.ts
@@ -9,8 +9,8 @@ const _ = {
   },
   product: {
     sku: '457595',
-    dollarPrice: '35.78',
-    euroPrice: '26,50',
+    dollarPrice: '33.75',
+    euroPrice: '25,00',
   },
   searchTerm: 'conversion lens',
 };

--- a/e2e/cypress/integration/specs/system/retain-basket-anonymous.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/retain-basket-anonymous.b2c.e2e-spec.ts
@@ -5,7 +5,7 @@ import { ProductDetailPage } from '../../pages/shopping/product-detail.page';
 const _ = {
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
 };
 

--- a/e2e/cypress/integration/specs/system/retain-basket-authenticated.b2c.e2e-spec.ts
+++ b/e2e/cypress/integration/specs/system/retain-basket-authenticated.b2c.e2e-spec.ts
@@ -20,7 +20,7 @@ const _ = {
   },
   product: {
     sku: '201807171',
-    price: 185.5,
+    price: 175.0,
   },
 };
 


### PR DESCRIPTION
Pricehandling was changed in the inSPIRED demo data from 'Net' to 'Gross' this resulted in failing e2e tests in B2C since other prices are displayed now. Adapted the prices to the new returned data.



[AB#78071](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78071)