### PR TITLE
fix: purgecss exeption for generated filter-layer CSS classes (#1204)

### DIFF
--- a/src/styles/pages/category/filter-panel.scss
+++ b/src/styles/pages/category/filter-panel.scss
@@ -45,6 +45,7 @@
   }
 }
 
+/* purgecss start ignore */
 .filter-group {
   position: relative;
   padding-bottom: $space-default;
@@ -117,7 +118,6 @@
 
       .filter-item-name,
       a.filter-item-name {
-        //font-weight: bold; // todo?
         color: $text-color-primary;
       }
 
@@ -202,6 +202,8 @@
     }
   }
 }
+
+/* purgecss end ignore */
 
 .filter-dropdown {
   position: relative;

--- a/src/styles/pages/category/product-list.scss
+++ b/src/styles/pages/category/product-list.scss
@@ -204,53 +204,6 @@
   }
 }
 
-.express-shop {
-  .product-img-thumbs {
-    width: auto;
-  }
-
-  .product-thumb-set {
-    margin-right: $space-default;
-  }
-}
-
-.product-image-container {
-  position: relative;
-
-  &:hover {
-    .express-shop-trigger {
-      display: block;
-    }
-  }
-}
-
-.express-shop-trigger {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: none;
-  width: 80px;
-  height: 80px;
-  margin: auto;
-  color: $text-color-inverse;
-  text-align: center;
-  cursor: pointer;
-  background-color: $CORPORATE-PRIMARY;
-  border-radius: 50%;
-  opacity: 0.93;
-
-  &:hover {
-    background-color: $CORPORATE-SECONDARY;
-  }
-
-  .ng-fa-icon {
-    padding: 25px 0;
-    font-size: 30px;
-  }
-}
-
 /* purgecss start ignore */
 
 .product-label {


### PR DESCRIPTION
* removed unused express-shop styles in addition

## PR Type

[x] Bugfix

## What Is the Current Behavior?

`filter-layer` CSS styles were remove "optimized" by purgecss.

Issue Number: Closes #1204

## What Is the New Behavior?

`filter-layer` CSS styles are now kept by the purgecss optimization.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#78108](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78108)