### PR TITLE
deps: use a fixed node.js version to prevent build issues with unknown versions

### DIFF
--- a/.github/workflows/automated-upgrade.yml
+++ b/.github/workflows/automated-upgrade.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+env:
+  NODE_VERSION: 16.16.0
+
 jobs:
   CancelPrevious:
     runs-on: ubuntu-latest
@@ -39,7 +42,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Create Upgrade Branch

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -6,6 +6,9 @@ on:
     # every sunday at midnight
     - cron: '0 0 * * 0'
 
+env:
+  NODE_VERSION: 16.16.0
+
 jobs:
   TestBed:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/**'
 
 env:
+  NODE_VERSION: 16.16.0
   ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8081
 
 jobs:
@@ -35,7 +36,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies
@@ -82,7 +83,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies
@@ -112,7 +113,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies
@@ -140,7 +141,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+env:
+  NODE_VERSION: 16.16.0
+
 jobs:
   Docs:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,8 +13,9 @@ on:
       - 'docs/**'
 
 env:
-  ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8081
+  NODE_VERSION: 16.16.0
   NODE_OPTIONS: --max_old_space_size=8192
+  ICM_BASE_URL: http://pwa-review.northeurope.cloudapp.azure.com:8081
 
 jobs:
   CancelPrevious:
@@ -38,7 +39,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies
@@ -69,7 +70,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Download Build Output

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+env:
+  NODE_VERSION: 16.16.0
+
 jobs:
   Updates:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**'
 
 env:
+  NODE_VERSION: 16.16.0
   NODE_OPTIONS: --max_old_space_size=8192
   JEST_MAX_WORKERS: 1
   CI: false
@@ -44,7 +45,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install root dependencies
@@ -64,7 +65,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - uses: 1arp/create-a-file-action@0.2
@@ -94,7 +95,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Run developer workflow
@@ -110,7 +111,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Run developer workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ kb_everyone
 
 **required Intershop Commerce Management version: 7.10.38.0-LTS**
 
+**required/tested Node.js version: 16.16.0 LTS (including npm 8.11.0)**
+
 ### Bug Fixes
 
 - dependencies and package-lock fixes (#1182) ([5f22ccc](https://github.com/intershop/intershop-pwa/commit/5f22ccc))
@@ -121,7 +123,7 @@ kb_everyone
 
 **required Intershop Commerce Management version: 7.10.38.0-LTS**
 
-**required/tested Node.js version: 16.14.2 - LTS (including npm 8.5.0)**
+**required/tested Node.js version: 16.14.2 LTS (including npm 8.5.0)**
 
 ### Features
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -9,6 +9,11 @@ kb_sync_latest_only
 
 ## 2.4 to 3.0
 
+With the 2.4.1 Hotfix we introduced a more fixed Node.js version handling to the version used and tested by us.
+We set Node.js 16.16.0 and npm 8.11.0 as our application runtime and package management versions.
+This is supposed to prevent unexpected build issues in the future but requires manual updating of Node.js to newer versions if tested successfully.
+Other Node.js versions might still work but you might get warnings regarding the projects recommended settings.
+
 The Intershop PWA 3.0 release includes a Jest Update to version 28, see also https://jestjs.io/docs/upgrading-to-jest28.
 The jest-marbles package has been replaced by jasmine-marbles.
 


### PR DESCRIPTION
* fixed to node.js 16.16.0 including npm 8.11.0

## PR Type

[x] Build-related changes

## What Is the Current Behavior?

docker and git actions use latest node.js 16 version that led to unexpected behavior

## What Is the New Behavior?

fixed node.js version does not introduce unexpected behavior/issues

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#78109](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78109)