### PR TITLE
fix: revert selector-not-notation behavior to overload Bootstrap standard sytles

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -20,6 +20,7 @@
     "no-duplicate-selectors": true,
     "property-no-vendor-prefix": true,
     "selector-no-vendor-prefix": true,
+    "selector-not-notation": "simple",
     "selector-pseudo-element-no-unknown": [
       true,
       { "ignorePseudoElements": ["ng-deep"] }

--- a/src/styles/components/footer/footer.scss
+++ b/src/styles/components/footer/footer.scss
@@ -37,7 +37,7 @@ footer {
 
   li {
     a,
-    a:not([href], [tabindex]) {
+    a:not([href]):not([tabindex]) {
       font-family: $font-family-condensedregular;
       color: $text-color-quaternary;
       text-decoration: none;

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -47,11 +47,11 @@ h4,
 }
 
 a,
-a:not([href], [tabindex]) {
+a:not([href]):not([tabindex]) {
   color: $CORPORATE-PRIMARY;
 }
 
-a:not([href], [tabindex]) {
+a:not([href]):not([tabindex]) {
   &:hover {
     color: $CORPORATE-SECONDARY;
   }

--- a/src/styles/pages/category/filter-row.scss
+++ b/src/styles/pages/category/filter-row.scss
@@ -109,7 +109,7 @@
   padding-right: $space-default;
 
   a,
-  a:not([href], [tabindex]) {
+  a:not([href]):not([tabindex]) {
     color: $text-color-primary;
     white-space: nowrap;
 


### PR DESCRIPTION
* the latest stylelint-config-standard update introduced the selector-not-notation rule with an incompatible standard configuration (https://github.com/stylelint/stylelint-config-standard/releases/tag/26.0.0)
* used the selector-not-notation with 'simple' option to keep previous ':not' notation style (https://stylelint.io/user-guide/rules/list/selector-not-notation/)

## PR Type

[x] Bugfix

## What Is the Current Behavior?

Wrong link color
![image](https://user-images.githubusercontent.com/50741106/179806288-20e330f1-e29d-40a9-a8be-85e67738c2bf.png)

## What Is the New Behavior?

Same styling as before the Angular 14 and dependencies update.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
