### PR TITLE
feat: interprets the relative URLs of pagelet parameters "bc_pmc:type…

### DIFF
--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.interface.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.interface.ts
@@ -1,5 +1,5 @@
 export interface ContentConfigurationParameterData {
   definitionQualifiedName: string;
   value: string | object;
-  type?: string;
+  type: string;
 }

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.interface.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.interface.ts
@@ -1,4 +1,5 @@
 export interface ContentConfigurationParameterData {
   definitionQualifiedName: string;
   value: string | object;
+  type?: string;
 }

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
@@ -60,26 +60,54 @@ describe('Content Configuration Parameter Mapper', () => {
     `);
   });
 
-  describe('postProcessFileReferences', () => {
-    it.each([
-      ['assets/pwa/pwa_home_teaser_1.jpg', 'assets/pwa/pwa_home_teaser_1.jpg', 'Image'],
-      [
-        'site:/pwa/pwa_home_teaser_1.jpg',
-        'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
-        'Image',
-      ],
-      [
-        'site:/pwa/pwa_home_teaser_1.jpg',
-        'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
-        'ImageXS',
-      ],
-      ['site:/pwa/pwa_home_teaser_1.jpg', 'site:/pwa/pwa_home_teaser_1.jpg', 'Other'],
-      ['site:/video/video.mp4', 'http://www.example.org/static/channel/-/site/de_DE/video/video.mp4', 'Video'],
-      ['https://www.youtube.com/watch?v=ABCDEFG', 'https://www.youtube.com/watch?v=ABCDEFG', 'Video'],
-    ])(`should transform %s to %s for key %s`, (input, expected, key) => {
-      expect(contentConfigurationParameterMapper.postProcessFileReferences({ [key]: input })).toEqual({
-        [key]: expected,
-      });
-    });
+  it('should handle ImageFileReferences', () => {
+    const input: { [name: string]: ContentConfigurationParameterData } = {
+      key1: {
+        definitionQualifiedName: 'name1',
+        value: 'assets/pwa/pwa_home_teaser_1.jpg',
+        type: 'bc_pmc:types.pagelet2-ImageFileRef',
+      },
+      key2: {
+        definitionQualifiedName: 'name2',
+        value: 'site:/pwa/pwa_home_teaser_1.jpg',
+        type: 'bc_pmc:types.pagelet2-ImageFileRef',
+      },
+      key3: {
+        definitionQualifiedName: 'name3',
+        value: 'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
+        type: 'bc_pmc:types.pagelet2-ImageFileRef',
+      },
+      key4: {
+        definitionQualifiedName: 'name4',
+        value: 'https://www.youtube.com/watch?v=ABCDEFG',
+        type: 'bc_pmc:types.pagelet2-ImageFileRef',
+      },
+      key5: {
+        definitionQualifiedName: 'name5',
+        value: [
+          'assets/pwa/pwa_home_teaser_1.jpg',
+          'site:/pwa/pwa_home_teaser_1.jpg',
+          'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
+          'https://www.youtube.com/watch?v=ABCDEFG',
+        ],
+        type: 'bc_pmc:types.pagelet2-ImageFileRef',
+      },
+    };
+
+    const result = contentConfigurationParameterMapper.fromData(input);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "key1": "assets/pwa/pwa_home_teaser_1.jpg",
+        "key2": "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+        "key3": "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+        "key4": "https://www.youtube.com/watch?v=ABCDEFG",
+        "key5": Array [
+          "assets/pwa/pwa_home_teaser_1.jpg",
+          "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+          "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+          "https://www.youtube.com/watch?v=ABCDEFG",
+        ],
+      }
+    `);
   });
 });

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
@@ -60,7 +60,7 @@ describe('Content Configuration Parameter Mapper', () => {
     `);
   });
 
-  it('should handle ImageFileReferences', () => {
+  it('should handle bc_pmc:types.pagelet2-ImageFileRef', () => {
     const input: { [name: string]: ContentConfigurationParameterData } = {
       key1: {
         definitionQualifiedName: 'name1',
@@ -91,6 +91,57 @@ describe('Content Configuration Parameter Mapper', () => {
           'https://www.youtube.com/watch?v=ABCDEFG',
         ],
         type: 'bc_pmc:types.pagelet2-ImageFileRef',
+      },
+    };
+
+    const result = contentConfigurationParameterMapper.fromData(input);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "key1": "assets/pwa/pwa_home_teaser_1.jpg",
+        "key2": "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+        "key3": "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+        "key4": "https://www.youtube.com/watch?v=ABCDEFG",
+        "key5": Array [
+          "assets/pwa/pwa_home_teaser_1.jpg",
+          "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+          "http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg",
+          "https://www.youtube.com/watch?v=ABCDEFG",
+        ],
+      }
+    `);
+  });
+
+  it('should handle bc_pmc:types.pagelet2-FileRef', () => {
+    const input: { [name: string]: ContentConfigurationParameterData } = {
+      key1: {
+        definitionQualifiedName: 'name1',
+        value: 'assets/pwa/pwa_home_teaser_1.jpg',
+        type: 'bc_pmc:types.pagelet2-FileRef',
+      },
+      key2: {
+        definitionQualifiedName: 'name2',
+        value: 'site:/pwa/pwa_home_teaser_1.jpg',
+        type: 'bc_pmc:types.pagelet2-FileRef',
+      },
+      key3: {
+        definitionQualifiedName: 'name3',
+        value: 'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
+        type: 'bc_pmc:types.pagelet2-FileRef',
+      },
+      key4: {
+        definitionQualifiedName: 'name4',
+        value: 'https://www.youtube.com/watch?v=ABCDEFG',
+        type: 'bc_pmc:types.pagelet2-FileRef',
+      },
+      key5: {
+        definitionQualifiedName: 'name5',
+        value: [
+          'assets/pwa/pwa_home_teaser_1.jpg',
+          'site:/pwa/pwa_home_teaser_1.jpg',
+          'http://www.example.org/static/channel/-/site/de_DE/pwa/pwa_home_teaser_1.jpg',
+          'https://www.youtube.com/watch?v=ABCDEFG',
+        ],
+        type: 'bc_pmc:types.pagelet2-FileRef',
       },
     };
 

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.spec.ts
@@ -35,14 +35,17 @@ describe('Content Configuration Parameter Mapper', () => {
       key1: {
         definitionQualifiedName: 'name1',
         value: '1',
+        type: 'set-id:types.pagelet2-name',
       },
       key2: {
         definitionQualifiedName: 'name2',
         value: 'hello',
+        type: 'set-id:types.pagelet2-name',
       },
       key3: {
         definitionQualifiedName: 'name3',
         value: ['hello', 'world'],
+        type: 'set-id:types.pagelet2-name',
       },
     };
 

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
@@ -45,6 +45,10 @@ export class ContentConfigurationParameterMapper {
     return encodeURI(`${this.staticURL}/${split[0]}/${this.lang}${split[1]}`);
   }
 
+  /**
+   * TODO: Make this method use name-based plugin mechanism to delegate post processing of
+   * configuration parameter data to specific handler.
+   */
   private postProcessData(data: ContentConfigurationParameterData): string | object | number {
     switch (data.type) {
       case 'bc_pmc:types.pagelet2-ImageFileRef':

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
@@ -31,7 +31,7 @@ export class ContentConfigurationParameterMapper {
     return configurationParameters;
   }
 
-  resolveStaticURL(value: string): string {
+  private resolveStaticURL(value: string): string {
     if (value.startsWith('http')) {
       return value;
     }
@@ -45,7 +45,7 @@ export class ContentConfigurationParameterMapper {
     return encodeURI(`${this.staticURL}/${split[0]}/${this.lang}${split[1]}`);
   }
 
-  postProcessData(data: ContentConfigurationParameterData): string | object | number {
+  private postProcessData(data: ContentConfigurationParameterData): string | object | number {
     switch (data.type) {
       case 'bc_pmc:types.pagelet2-ImageFileRef':
       case 'bc_pmc:types.pagelet2-FileRef':

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
@@ -24,7 +24,7 @@ export class ContentConfigurationParameterMapper {
 
     if (data) {
       configurationParameters = Object.entries(data)
-        .map(([key, value]) => ({ [key]: this.postProcessConfigurationParameterValue(value) }))
+        .map(([key, value]) => ({ [key]: this.postProcessData(value) }))
         .reduce((acc, val) => ({ ...acc, ...val }));
     }
 
@@ -45,7 +45,7 @@ export class ContentConfigurationParameterMapper {
     return encodeURI(`${this.staticURL}/${split[0]}/${this.lang}${split[1]}`);
   }
 
-  postProcessConfigurationParameterValue(data: ContentConfigurationParameterData): string | object | number {
+  postProcessData(data: ContentConfigurationParameterData): string | object | number {
     switch (data.type) {
       case 'bc_pmc:types.pagelet2-ImageFileRef':
       case 'bc_pmc:types.pagelet2-FileRef':

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
@@ -48,6 +48,7 @@ export class ContentConfigurationParameterMapper {
   postProcessConfigurationParameterValue(data: ContentConfigurationParameterData): string | object | number {
     switch (data.type) {
       case 'bc_pmc:types.pagelet2-ImageFileRef':
+      case 'bc_pmc:types.pagelet2-FileRef':
         if (Array.isArray(data.value)) {
           return data.value.map(x => this.resolveStaticURL(x));
         } else {

--- a/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
+++ b/src/app/core/models/content-configuration-parameter/content-configuration-parameter.mapper.ts
@@ -24,34 +24,37 @@ export class ContentConfigurationParameterMapper {
 
     if (data) {
       configurationParameters = Object.entries(data)
-        .map(([key, value]) => ({ [key]: value.value }))
+        .map(([key, value]) => ({ [key]: this.postProcessConfigurationParameterValue(value) }))
         .reduce((acc, val) => ({ ...acc, ...val }));
     }
-
-    this.postProcessFileReferences(configurationParameters);
 
     return configurationParameters;
   }
 
-  /**
-   * TODO: make this dependant on the type of the configuration parameter once the CMS REST API provides this information
-   * for now filter all configuration parameters that start with 'Image' or 'Video'
-   * and where the value does not start with 'http' but contains ':/'
-   + if the filter matches convert the CMS REST API value in a full server URL to the configured file
-   */
-  postProcessFileReferences(data: ContentConfigurationParameters): ContentConfigurationParameters {
-    Object.keys(data)
-      .filter(
-        key =>
-          (key.startsWith('Image') || key.startsWith('Video')) &&
-          data[key] &&
-          !data[key].toString().startsWith('http') &&
-          data[key].toString().includes(':/')
-      )
-      .forEach(key => {
-        const split = data[key].toString().split(':');
-        data[key] = encodeURI(`${this.staticURL}/${split[0]}/${this.lang}${split[1]}`);
-      });
-    return data;
+  resolveStaticURL(value: string): string {
+    if (value.startsWith('http')) {
+      return value;
+    }
+
+    if (!value.includes(':/')) {
+      return value;
+    }
+
+    const split = value.split(':');
+
+    return encodeURI(`${this.staticURL}/${split[0]}/${this.lang}${split[1]}`);
+  }
+
+  postProcessConfigurationParameterValue(data: ContentConfigurationParameterData): string | object | number {
+    switch (data.type) {
+      case 'bc_pmc:types.pagelet2-ImageFileRef':
+        if (Array.isArray(data.value)) {
+          return data.value.map(x => this.resolveStaticURL(x));
+        } else {
+          return this.resolveStaticURL(data.value.toString());
+        }
+      default:
+        return data.value;
+    }
   }
 }

--- a/src/app/core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper.spec.ts
+++ b/src/app/core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper.spec.ts
@@ -40,6 +40,7 @@ describe('Content Pagelet Entry Point Mapper', () => {
             key1: {
               definitionQualifiedName: 'fq',
               value: 'hallo 1',
+              type: 'set-id:types.pagelet2-name',
             },
           },
           slots: {
@@ -56,6 +57,7 @@ describe('Content Pagelet Entry Point Mapper', () => {
                     key11: {
                       definitionQualifiedName: 'fq',
                       value: 'test',
+                      type: 'set-id:types.pagelet2-name',
                     },
                   },
                 },

--- a/src/app/core/models/content-pagelet/content-pagelet.mapper.spec.ts
+++ b/src/app/core/models/content-pagelet/content-pagelet.mapper.spec.ts
@@ -166,6 +166,7 @@ describe('Content Pagelet Mapper', () => {
         Image: {
           value: 'inSPIRED-inTRONICS-b2c-responsive:/brands/adata.jpg',
           definitionQualifiedName: 'app_sf_base_cm:component.common.image.pagelet2-Component-Image',
+          type: 'bc_pmc:types.pagelet2-ImageFileRef',
         },
       },
     } as ContentPageletData;

--- a/src/app/core/models/content-pagelet/content-pagelet.mapper.spec.ts
+++ b/src/app/core/models/content-pagelet/content-pagelet.mapper.spec.ts
@@ -35,6 +35,7 @@ describe('Content Pagelet Mapper', () => {
         key: {
           definitionQualifiedName: 'quali',
           value: 'test',
+          type: 'set-id:types.pagelet2-name',
         },
       },
     };
@@ -53,6 +54,7 @@ describe('Content Pagelet Mapper', () => {
         key: {
           definitionQualifiedName: 'quali',
           value: 'test',
+          type: 'set-id:types.pagelet2-name',
         },
       },
       slots: {
@@ -78,6 +80,7 @@ describe('Content Pagelet Mapper', () => {
         key: {
           definitionQualifiedName: 'quali',
           value: 'test',
+          type: 'set-id:types.pagelet2-name',
         },
       },
       slots: {
@@ -106,6 +109,7 @@ describe('Content Pagelet Mapper', () => {
                 key1: {
                   definitionQualifiedName: 'fq',
                   value: 'test-key1',
+                  type: 'set-id:types.pagelet2-name',
                 },
               },
               slots: {
@@ -122,6 +126,7 @@ describe('Content Pagelet Mapper', () => {
                         key3: {
                           definitionQualifiedName: 'fq',
                           value: '1',
+                          type: 'set-id:types.pagelet2-name',
                         },
                       },
                     },
@@ -134,10 +139,12 @@ describe('Content Pagelet Mapper', () => {
             key1: {
               definitionQualifiedName: 'name1',
               value: 'hallo',
+              type: 'set-id:types.pagelet2-name',
             },
             key2: {
               definitionQualifiedName: 'name2',
               value: ['hallo', 'welt'],
+              type: 'set-id:types.pagelet2-name',
             },
           },
         },


### PR DESCRIPTION
…s.pagelet2-ImageFileRef" generically

Until now only parameter that starts with image or video were interpreted
Now any parameter that
extends "bc_pmc:types.pagelet2-ImageFileRef" will be interpreted

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
