### PR TITLE
fix: prevent linting for running schematics with dry-run option

### DIFF
--- a/schematics/src/utils/lint-fix.ts
+++ b/schematics/src/utils/lint-fix.ts
@@ -23,6 +23,10 @@ const registerLintAtEnd = once((root: string) => {
 
 export function applyLintFix(): Rule {
   return tree => {
+    // do nothing for option --dry-run
+    if (process.argv.some(arg => arg === '--dry-run')) {
+      return;
+    }
     // Only include files that have been touched.
     tree.actions
       .map(action => action.path.substring(1))


### PR DESCRIPTION
## PR Type
[x] Bugfix

## What Is the Current Behavior?
Issue Number: Closes #1221

Running intershop schematics with the --dry-run option results in errors because of the appended prettier check that fails for non existing files.

## What Is the New Behavior?
Prevent the additional formatting checks with prettier for dry runs so no errors occur.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No


[AB#78477](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78477)