### PR TITLE
fix: display confirmation page returning from redirect after checkout

### DIFF
--- a/src/app/pages/checkout/checkout-page.module.ts
+++ b/src/app/pages/checkout/checkout-page.module.ts
@@ -20,21 +20,25 @@ const checkoutPageRoutes: Routes = [
     children: [
       {
         path: 'address',
+        canActivate: [CheckoutPageGuard],
         data: { checkoutStep: 1 },
         component: CheckoutAddressPageModule.component,
       },
       {
         path: 'shipping',
+        canActivate: [CheckoutPageGuard],
         data: { checkoutStep: 2 },
         component: CheckoutShippingPageModule.component,
       },
       {
         path: 'payment',
+        canActivate: [CheckoutPageGuard],
         data: { checkoutStep: 3 },
         component: CheckoutPaymentPageModule.component,
       },
       {
         path: 'review',
+        canActivate: [CheckoutPageGuard],
         data: { checkoutStep: 4 },
         component: CheckoutReviewPageModule.component,
       },
@@ -49,7 +53,6 @@ const checkoutPageRoutes: Routes = [
         redirectTo: 'address',
       },
     ],
-    canActivate: [CheckoutPageGuard],
   },
 ];
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user pays with a redirect after checkout payment method (e.g. online pay) he is routed to an empty basket page after returning from the redirect of the external payment provider.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
He is routed to the order confirmation page after returns from redirect after checkout.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


[ ] Yes
[x] No

## Other Information
This issue occurred because the checkout guard expects a basket, but it doesn't exist after order creation. The guard has been removed from checkout receipt page.



[AB#78502](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78502)