### PR TITLE
chore(eslint): allow underscore variable names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -99,7 +99,11 @@
           {
             "selector": "variable",
             "modifiers": ["const"],
-            "format": ["camelCase", "UPPER_CASE"]
+            "format": ["camelCase", "UPPER_CASE"],
+            "filter": {
+              "regex": "_",
+              "match": false
+            }
           },
           {
             "selector": "typeLike",


### PR DESCRIPTION
Currently, vars are allowed to be unused when they're named `_`. However, `_` is not an allowed variable name so there will be another ESLint exception isntead.

=> Fixed

[AB#78545](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78545)