### PR TITLE
chore: remove outdated eslint ignore comment

### DIFF
--- a/src/app/core/state-management.module.ts
+++ b/src/app/core/state-management.module.ts
@@ -24,7 +24,6 @@ import { storeDevtoolsModule } from './store/store-devtools.module';
     storeDevtoolsModule, // disable the Store Devtools in production (https://ngrx.io/guide/store-devtools/recipes/exclude)
   ],
   providers: [
-    /* eslint-disable @angular-eslint/sort-ngmodule-metadata-arrays */
     { provide: APP_INITIALIZER, useFactory: ngrxStateTransfer, deps: [TransferState, Store, Actions], multi: true },
   ],
 })


### PR DESCRIPTION
the comment was only necessary because of the rule's wrong behaviour.

This is fixed with https://github.com/angular-eslint/angular-eslint/pull/1001

=> comment removed

[AB#78616](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78616)