### PR TITLE
fix: unnecessary emissions of the getCurrentBasket selector if the ba…

### DIFF
--- a/src/app/core/store/customer/basket/basket.selectors.ts
+++ b/src/app/core/store/customer/basket/basket.selectors.ts
@@ -8,9 +8,15 @@ import { BasketView, createBasketView } from 'ish-core/models/basket/basket.mode
 import { getCustomerState } from 'ish-core/store/customer/customer-store';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
+import { BasketState } from './basket.reducer';
+
 const getBasketState = createSelector(getCustomerState, state => state?.basket);
 
-export const getBasketValidationResults = createSelector(getBasketState, (basket): BasketValidationResultType => {
+const getInternalBasket = createSelector(getBasketState, basket => basket.basket);
+
+export const getBasketValidationResults = createSelectorFactory<object, BasketValidationResultType>(projector =>
+  resultMemoize(projector, isEqual)
+)(getBasketState, (basket: BasketState): BasketValidationResultType => {
   if (!basket || !basket.validationResults) {
     return;
   }
@@ -33,10 +39,10 @@ export const getBasketValidationResults = createSelector(getBasketState, (basket
 export const getBasketInfo = createSelector(getBasketState, basket => basket.info);
 
 export const getCurrentBasket = createSelector(
-  getBasketState,
+  getInternalBasket,
   getBasketValidationResults,
   getBasketInfo,
-  (basket, validationResults, basketInfo): BasketView => createBasketView(basket.basket, validationResults, basketInfo)
+  (basket, validationResults, basketInfo): BasketView => createBasketView(basket, validationResults, basketInfo)
 );
 
 export const getSubmittedBasket = createSelector(


### PR DESCRIPTION
…sket loading state changes

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

If the basket loading state changes the getCurrentBasket selector always emits a value even if the basket doesn't change. This leads, inter alia, to a further rendering of the basket item list after a basket item quantity has been changed, a basket item has been deleted or maybe other actions like assigning a cost center to basket and so on.
After entering a basket item quantity on basket page the original quantity is displayed shortly during the basket update (loading).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The getCurrentBasket item only emits a value if the basket object, the basket validation or info changes but not if the loading state changes. 
After updating a basket item quantity on basket page the entered quantity remains in the input field.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#78637](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78637)