### PR TITLE
fix: correct selector for custom components in projects generated by …

### DIFF
--- a/schematics/customization/add/index.js
+++ b/schematics/customization/add/index.js
@@ -21,8 +21,10 @@ execSync(`npx ncp src/styles/themes/b2b src/styles/themes/${theme} --stopOnErr`)
 // replace in angular.json
 const angularJson = parse(fs.readFileSync('./angular.json', { encoding: 'UTF-8' }));
 const project = angularJson.defaultProject;
-console.log('setting prefix for new components to "custom"');
-angularJson.projects[project].prefix = 'custom';
+console.log('setting prefix for new components to "custom" for all projects');
+for (const project in angularJson.projects) {
+  angularJson.projects[project].prefix = 'custom';
+}
 
 const architect = angularJson.projects[project].architect;
 architect.build.configurations[theme] = {};


### PR DESCRIPTION
…schematics

## PR Type
[x] Bugfix

## What Is the Current Behavior?
If you create new components in the projects folder, e.g. in the organization-management, the component selector prefix 'ish' is used.

Issue Number: Closes #977

## What Is the New Behavior?
The prefix of the new components is 'custom' for components generated in projects.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No

[AB#78738](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78738)