### PR TITLE
fix: prevent directory traversal on SSR

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -280,15 +280,19 @@ export function app() {
   server.get(/\/.*\.(js|css)$/, (req, res) => {
     // remove all parameters
     const path = req.originalUrl.substring(1).replace(/[;?&].*$/, '');
-
-    fs.readFile(join(BROWSER_FOLDER, path), { encoding: 'utf-8' }, (err, data) => {
-      if (err) {
-        res.sendStatus(404);
-      } else {
-        res.set('Content-Type', `${path.endsWith('css') ? 'text/css' : 'application/javascript'}; charset=UTF-8`);
-        res.send(setDeployUrlInFile(DEPLOY_URL, path, data));
-      }
-    });
+    const filename = join(BROWSER_FOLDER, path);
+    if (filename.startsWith(BROWSER_FOLDER)) {
+      fs.readFile(filename, { encoding: 'utf-8' }, (err, data) => {
+        if (err) {
+          res.sendStatus(404);
+        } else {
+          res.set('Content-Type', `${path.endsWith('css') ? 'text/css' : 'application/javascript'}; charset=UTF-8`);
+          res.send(setDeployUrlInFile(DEPLOY_URL, path, data));
+        }
+      });
+    } else {
+      res.sendStatus(404);
+    }
   });
   server.get(/\/ngsw\.json/, (_, res) => {
     fs.readFile(join(BROWSER_FOLDER, 'ngsw.json'), { encoding: 'utf-8' }, (err, data) => {


### PR DESCRIPTION
## PR Type

[X] Bugfix

## What Is the Current Behavior?

It is possible to get file contents from the underlying container files system by passing a relative file system path behind any `.js` or `.css` resource url (valid for PWA 1.0 to 2.1.0).

### For example: ###

https://host/.js?/../../../../etc/hosts would potentially leak the contents of file `/etc/hosts`

## What Is the New Behavior?

You'll get a 404 when trying to breakout of the server determined `BROWSER_FOLDER`.
(This is already fixed with 2.1.0 but this fix adds an additional check to prevent the unwanted behavior)

## Does this PR Introduce a Breaking Change?

[X] No

## Other Information

https://nodejs.org/en/knowledge/file-system/security/introduction/#preventing-directory-traversal

[AB#78766](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78766)