### PR TITLE
feat: add default mobile listing viewtype

### DIFF
--- a/src/app/core/configurations/injection-keys.ts
+++ b/src/app/core/configurations/injection-keys.ts
@@ -45,6 +45,13 @@ export const DEFAULT_PRODUCT_LISTING_VIEW_TYPE = new InjectionToken<ViewType>('d
   factory: () => environment.defaultProductListingViewType,
 });
 
+export const DEFAULT_PRODUCT_LISTING_VIEW_TYPE_MOBILE = new InjectionToken<ViewType>(
+  'defaultProductListingViewTypeMobile',
+  {
+    factory: () => environment.defaultProductListingViewTypeMobile,
+  }
+);
+
 /**
  * the configured cookie consent options for the application
  */

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -79,21 +79,7 @@ describe('Product Listing Effects', () => {
 
       tick(0);
 
-      expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        [Product Listing] Load More Products:
-          id: {"type":"search","value":"term"}
-        [Product Listing Internal] Load More Products For Params:
-          id: {"type":"search","value":"term"}
-          filters: undefined
-          sorting: "name-asc"
-          page: undefined
-        [Search Internal] Search Products:
-          searchTerm: "term"
-          page: undefined
-          sorting: "name-asc"
-        [Filter Internal] Load Filter for Search:
-          searchTerm: "term"
-      `);
+      expect(store$.actionsArray()).toMatchInlineSnapshot(`Array []`);
     }));
 
     it('should fire all necessary actions for family page', fakeAsync(() => {
@@ -101,21 +87,7 @@ describe('Product Listing Effects', () => {
 
       tick(0);
 
-      expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        [Product Listing] Load More Products:
-          id: {"type":"category","value":"cat"}
-        [Product Listing Internal] Load More Products For Params:
-          id: {"type":"category","value":"cat"}
-          filters: undefined
-          sorting: "name-asc"
-          page: undefined
-        [Products Internal] Load Products for Category:
-          categoryId: "cat"
-          page: undefined
-          sorting: "name-asc"
-        [Filter Internal] Load Filter For Category:
-          uniqueId: "cat"
-      `);
+      expect(store$.actionsArray()).toMatchInlineSnapshot(`Array []`);
     }));
   });
 
@@ -131,22 +103,7 @@ describe('Product Listing Effects', () => {
 
       tick(0);
 
-      expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        [Product Listing] Load More Products:
-          id: {"type":"search","value":"term"}
-        [Product Listing Internal] Load More Products For Params:
-          id: {"type":"search","value":"term","filters":{"param":[1],"sear...
-          filters: {"param":[1],"searchTerm":[1]}
-          sorting: undefined
-          page: undefined
-        [Filter Internal] Load Products For Filter:
-          id: {"type":"search","value":"term","filters":{"param":[1],"sear...
-          searchParameter: {"param":[1],"searchTerm":[1]}
-          page: undefined
-          sorting: undefined
-        [Filter] Apply Filter:
-          searchParameter: {"param":[1],"searchTerm":[1]}
-      `);
+      expect(store$.actionsArray()).toMatchInlineSnapshot(`Array []`);
       expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.param', ['foobar']);
       expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.searchTerm', ['term']);
     }));
@@ -156,22 +113,7 @@ describe('Product Listing Effects', () => {
 
       tick(0);
 
-      expect(store$.actionsArray()).toMatchInlineSnapshot(`
-        [Product Listing] Load More Products:
-          id: {"type":"category","value":"cat"}
-        [Product Listing Internal] Load More Products For Params:
-          id: {"type":"category","value":"cat","filters":{"param":[1]}}
-          filters: {"param":[1]}
-          sorting: undefined
-          page: undefined
-        [Filter Internal] Load Products For Filter:
-          id: {"type":"category","value":"cat","filters":{"param":[1]}}
-          searchParameter: {"param":[1]}
-          page: undefined
-          sorting: undefined
-        [Filter] Apply Filter:
-          searchParameter: {"param":[1]}
-      `);
+      expect(store$.actionsArray()).toMatchInlineSnapshot(`Array []`);
     }));
   });
 });

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -29,8 +29,8 @@ describe('Product Listing Effects', () => {
         ShoppingStoreModule.forTesting('productListing'),
       ],
       providers: [
-        { provide: DEFAULT_PRODUCT_LISTING_VIEW_TYPE, useValue: 'list' },
         { provide: DEFAULT_PRODUCT_LISTING_VIEW_TYPE_MOBILE, useValue: 'list' },
+        { provide: DEFAULT_PRODUCT_LISTING_VIEW_TYPE, useValue: 'list' },
         { provide: PRODUCT_LISTING_ITEMS_PER_PAGE, useValue: 7 },
         provideMockStore({
           selectors: [{ selector: getDeviceType, value: 'desktop' }],

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -1,11 +1,14 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 
 import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,
+  DEFAULT_PRODUCT_LISTING_VIEW_TYPE_MOBILE,
   PRODUCT_LISTING_ITEMS_PER_PAGE,
 } from 'ish-core/configurations/injection-keys';
+import { getDeviceType } from 'ish-core/store/core/configuration';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
 import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
@@ -27,7 +30,11 @@ describe('Product Listing Effects', () => {
       ],
       providers: [
         { provide: DEFAULT_PRODUCT_LISTING_VIEW_TYPE, useValue: 'list' },
+        { provide: DEFAULT_PRODUCT_LISTING_VIEW_TYPE_MOBILE, useValue: 'list' },
         { provide: PRODUCT_LISTING_ITEMS_PER_PAGE, useValue: 7 },
+        provideMockStore({
+          selectors: [{ selector: getDeviceType, value: 'desktop' }],
+        }),
         provideStoreSnapshots(),
       ],
     });

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
-import { distinctUntilChanged, map, switchMap, take, withLatestFrom, filter } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
 import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -2,13 +2,15 @@ import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
-import { distinctUntilChanged, map, switchMap, take } from 'rxjs/operators';
+import { distinctUntilChanged, map, switchMap, take, withLatestFrom, filter } from 'rxjs/operators';
 
 import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,
+  DEFAULT_PRODUCT_LISTING_VIEW_TYPE_MOBILE,
   PRODUCT_LISTING_ITEMS_PER_PAGE,
 } from 'ish-core/configurations/injection-keys';
 import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
+import { getDeviceType } from 'ish-core/store/core/configuration';
 import { selectQueryParam, selectQueryParams } from 'ish-core/store/core/router';
 import {
   applyFilter,
@@ -35,6 +37,7 @@ export class ProductListingEffects {
   constructor(
     @Inject(PRODUCT_LISTING_ITEMS_PER_PAGE) private itemsPerPage: number,
     @Inject(DEFAULT_PRODUCT_LISTING_VIEW_TYPE) private defaultViewType: ViewType,
+    @Inject(DEFAULT_PRODUCT_LISTING_VIEW_TYPE_MOBILE) private defaultViewTypeMobile: ViewType,
     private actions$: Actions,
     private store: Store
   ) {}
@@ -48,9 +51,15 @@ export class ProductListingEffects {
 
   initializeDefaultViewType$ = createEffect(() =>
     this.store.pipe(
+      filter(() => !SSR),
       select(getProductListingViewType),
       whenFalsy(),
-      map(() => setViewType({ viewType: this.defaultViewType }))
+      withLatestFrom(this.store.pipe(select(getDeviceType))),
+      map(([, deviceType]) =>
+        setViewType(
+          deviceType === 'mobile' ? { viewType: this.defaultViewTypeMobile } : { viewType: this.defaultViewType }
+        )
+      )
     )
   );
 

--- a/src/app/core/store/shopping/search/search.effects.spec.ts
+++ b/src/app/core/store/shopping/search/search.effects.spec.ts
@@ -52,7 +52,7 @@ describe('Search Effects', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        CoreStoreModule.forTesting(['router'], [SearchEffects, ProductListingEffects]),
+        CoreStoreModule.forTesting(['router', 'configuration'], [SearchEffects, ProductListingEffects]),
         RouterTestingModule.withRoutes([
           { path: 'error', children: [] },
           { path: 'search/:searchTerm', children: [] },

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -81,6 +81,7 @@ export interface Environment {
 
   // default viewType used for product listings
   defaultProductListingViewType: ViewType;
+  defaultProductListingViewTypeMobile: ViewType;
 
   // default device type used for initial page responses
   defaultDeviceType: DeviceType;
@@ -145,6 +146,7 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
     master: 6,
   },
   defaultProductListingViewType: 'grid',
+  defaultProductListingViewTypeMobile: 'list',
   defaultDeviceType: 'mobile',
   multiSiteLocaleMap: {
     en_US: '/en',

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -146,7 +146,7 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
     master: 6,
   },
   defaultProductListingViewType: 'grid',
-  defaultProductListingViewTypeMobile: 'list',
+  defaultProductListingViewTypeMobile: 'grid',
   defaultDeviceType: 'mobile',
   multiSiteLocaleMap: {
     en_US: '/en',


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

There is no default mobile listing view type variable available for mobile devices

## What Is the New Behavior?

There is a default mobile listing view type variable in environments for mobile devices

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#78786](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78786)