### PR TITLE
fix: respect navigation root when displaying the breadcrumb of cms pages

### DIFF
--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -48,6 +48,12 @@ export class CMSFacade {
     return this.store.pipe(select(getContentPageTree(rootId)));
   }
 
+  /**
+   *
+   * @param rootId is taken into consideration as first element of breadcrumb for content page
+   *
+   * NOTE: use 'COMPLETE' as value of rootId to get complete available page path as breadcrumb
+   */
   setBreadcrumbForContentPage(rootId: string): void {
     this.store.dispatch(setBreadcrumbForContentPage({ rootId }));
   }

--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -8,7 +8,11 @@ import { CategoryHelper } from 'ish-core/models/category/category.helper';
 import { getContentInclude, loadContentInclude } from 'ish-core/store/content/includes';
 import { getContentPageTree, loadContentPageTree } from 'ish-core/store/content/page-tree';
 import { getContentPagelet } from 'ish-core/store/content/pagelets';
-import { getContentPageLoading, getSelectedContentPage } from 'ish-core/store/content/pages';
+import {
+  getContentPageLoading,
+  getSelectedContentPage,
+  setBreadcrumbForContentPage,
+} from 'ish-core/store/content/pages';
 import { getParametersProductList, loadParametersProductListFilter } from 'ish-core/store/content/parameters';
 import { getViewContext, loadViewContextEntrypoint } from 'ish-core/store/content/viewcontexts';
 import { getPGID } from 'ish-core/store/customer/user';
@@ -42,6 +46,10 @@ export class CMSFacade {
   contentPageTree$(rootId: string, depth: number) {
     this.store.dispatch(loadContentPageTree({ rootId, depth }));
     return this.store.pipe(select(getContentPageTree(rootId)));
+  }
+
+  setBreadcrumbForContentPage(rootId: string): void {
+    this.store.dispatch(setBreadcrumbForContentPage({ rootId }));
   }
 
   parameterProductListFilter$(categoryId?: string, productFilter?: string, scope?: string, amount?: number) {

--- a/src/app/core/store/content/pages/pages.actions.ts
+++ b/src/app/core/store/content/pages/pages.actions.ts
@@ -12,3 +12,8 @@ export const loadContentPageSuccess = createAction(
   '[Content Page API] Load Content Page Success',
   payload<{ page: ContentPageletEntryPoint; pagelets: ContentPagelet[] }>()
 );
+
+export const setBreadcrumbForContentPage = createAction(
+  '[Content Page Internal] Set Breadcrumb For Content Page',
+  payload<{ rootId: string }>()
+);

--- a/src/app/core/store/content/pages/pages.effects.ts
+++ b/src/app/core/store/content/pages/pages.effects.ts
@@ -67,8 +67,12 @@ export class PagesEffects {
       ofType(setBreadcrumbForContentPage),
       mapToPayloadProperty('rootId'),
       // eslint-disable-next-line rxjs/no-unsafe-switchmap
-      switchMap(rootId => this.store.pipe(select(getBreadcrumbForContentPage(rootId)))),
-      map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+      switchMap(rootId =>
+        this.store.pipe(
+          select(getBreadcrumbForContentPage(rootId)),
+          map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
+        )
+      )
     )
   );
 }

--- a/src/app/core/store/content/pages/pages.effects.ts
+++ b/src/app/core/store/content/pages/pages.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { from } from 'rxjs';
-import { concatMap, map, mergeMap } from 'rxjs/operators';
+import { concatMap, map, mergeMap, switchMap } from 'rxjs/operators';
 
 import { CMSService } from 'ish-core/services/cms/cms.service';
 import { selectRouteParam } from 'ish-core/store/core/router';
@@ -16,7 +16,12 @@ import {
   whenTruthy,
 } from 'ish-core/utils/operators';
 
-import { loadContentPage, loadContentPageFail, loadContentPageSuccess } from './pages.actions';
+import {
+  loadContentPage,
+  loadContentPageFail,
+  loadContentPageSuccess,
+  setBreadcrumbForContentPage,
+} from './pages.actions';
 import { getBreadcrumbForContentPage } from './pages.selectors';
 
 @Injectable()
@@ -58,8 +63,11 @@ export class PagesEffects {
   );
 
   setBreadcrumbForContentPage$ = createEffect(() =>
-    this.store.pipe(select(getBreadcrumbForContentPage)).pipe(
-      whenTruthy(),
+    this.actions$.pipe(
+      ofType(setBreadcrumbForContentPage),
+      mapToPayloadProperty('rootId'),
+      // eslint-disable-next-line rxjs/no-unsafe-switchmap
+      switchMap(rootId => this.store.pipe(select(getBreadcrumbForContentPage(rootId)))),
       map(breadcrumbData => setBreadcrumbData({ breadcrumbData }))
     )
   );

--- a/src/app/core/store/content/pages/pages.selectors.ts
+++ b/src/app/core/store/content/pages/pages.selectors.ts
@@ -42,7 +42,7 @@ export const getBreadcrumbForContentPage = (rootId: string) =>
         breadcrumbData = [];
       }
 
-      // determine breadcrumb data infpagetree information is available for the selected content page
+      // determine breadcrumb data pagetree information is available for the selected content page
       if (pagetree.nodes[contentPage?.id]) {
         pagetree.nodes[contentPage.id].path.forEach((item, i, path) => {
           // check if we are at the wanted path element for the root

--- a/src/app/core/store/content/pages/pages.selectors.ts
+++ b/src/app/core/store/content/pages/pages.selectors.ts
@@ -42,7 +42,7 @@ export const getBreadcrumbForContentPage = (rootId: string) =>
         breadcrumbData = [];
       }
 
-      // determine breadcrumb data pagetree information is available for the selected content page
+      // determine if pagetree information is available for the selected content page
       if (pagetree.nodes[contentPage?.id]) {
         pagetree.nodes[contentPage.id].path.forEach((item, i, path) => {
           // check if we are at the wanted path element for the root

--- a/src/app/core/store/content/pages/pages.selectors.ts
+++ b/src/app/core/store/content/pages/pages.selectors.ts
@@ -25,14 +25,43 @@ export const getSelectedContentPage = createSelector(getPageEntities, selectRout
   createContentPageletEntryPointView(pages[id])
 );
 
-export const getBreadcrumbForContentPage = createSelectorFactory<object, BreadcrumbItem[]>(projector =>
-  resultMemoize(projector, isEqual)
-)(getPageTree, getSelectedContentPage, (pagetree: ContentPageTree, contentPage: ContentPageletEntryPointView) =>
-  pagetree.nodes[contentPage?.id]
-    ? (pagetree.nodes[contentPage.id].path.map((item, i, path) => ({
-        key: pagetree.nodes[item].name,
-        link:
-          i !== path.length - 1 ? generateContentPageUrl(createContentPageTreeView(pagetree, item, item)) : undefined,
-      })) as BreadcrumbItem[])
-    : ([{ key: contentPage?.displayName }] as BreadcrumbItem[])
-);
+export const getBreadcrumbForContentPage = (rootId: string) =>
+  createSelectorFactory<object, BreadcrumbItem[]>(projector => resultMemoize(projector, isEqual))(
+    getSelectedContentPage,
+    getPageTree,
+    (contentPage: ContentPageletEntryPointView, pagetree: ContentPageTree) => {
+      // set default breadcrumb data: just the selected content page name
+      let breadcrumbData = [{ key: contentPage?.displayName }] as BreadcrumbItem[];
+      // initialize root flag (no root yet)
+      let gotRoot = false;
+
+      // if 'COMPLETE' is used as rootId the complete available page path is returned as breadcrumb data
+      // (in case we have no explicit root information but the full path is wanted)
+      if (rootId === 'COMPLETE') {
+        gotRoot = true;
+        breadcrumbData = [];
+      }
+
+      // determine breadcrumb data infpagetree information is available for the selected content page
+      if (pagetree.nodes[contentPage?.id]) {
+        pagetree.nodes[contentPage.id].path.forEach((item, i, path) => {
+          // check if we are at the wanted path element for the root
+          if (item === rootId) {
+            gotRoot = true;
+            breadcrumbData = [];
+          }
+          // push breadcrumb data once we have a root
+          if (gotRoot) {
+            breadcrumbData.push({
+              key: pagetree.nodes[item].name,
+              link:
+                i !== path.length - 1
+                  ? generateContentPageUrl(createContentPageTreeView(pagetree, item, item))
+                  : undefined,
+            });
+          }
+        });
+      }
+      return breadcrumbData;
+    }
+  );

--- a/src/app/shared/cms/components/cms-static-page/cms-static-page.component.ts
+++ b/src/app/shared/cms/components/cms-static-page/cms-static-page.component.ts
@@ -29,5 +29,8 @@ export class CMSStaticPageComponent implements CMSComponent, OnChanges {
         this.pagelet.numberParam('NavigationDepth')
       );
     }
+
+    // explicitly set breadcrumb data for content pages that use the Static Content Page Component
+    this.cmsFacade.setBreadcrumbForContentPage(this.pagelet?.stringParam('NavigationRoot'));
   }
 }


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

The breadcrumb of cms pages contains always the whole path of the page tree even if a deferring navigation root is defined.

## What Is the New Behavior?

The display of the cms breadcrumb respects the defined navigation root.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No

## Other Information


[AB#78918](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/78918)