### PR TITLE
fix: add missing translation key for company information on registration page

### DIFF
--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -314,7 +314,7 @@ export class RegistrationFormConfigurationService {
         type: 'ish-registration-heading-field',
         templateOptions: {
           headingSize: 'h2',
-          heading: 'Company Information',
+          heading: 'account.register.company_information.heading',
           showRequiredInfo: true,
         },
       },

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -337,6 +337,7 @@
   "account.quotes.widget.view_all_quotes.link": "Alle Preisangebote anzeigen",
   "account.register.address.headding": "Adresse",
   "account.register.address.message": "Um bei der Bestellung Zeit zu sparen, geben Sie unten Ihre Hauptadressen für Rechnung und Lieferung an. Die Informationen werden gespeichert, sodass Sie sie bei zukünftigen Bestellungen nicht mehr jedes Mal erneut eingeben müssen.",
+  "account.register.company_information.heading": "Firmeninformationen",
   "account.register.complete_heading": "Vervollständigen Sie Ihr Benutzerkonto",
   "account.register.confirm_leave_modal.body": "Sie haben den Registrierungsvorgang noch nicht abgeschlossen. Wenn Sie die Seite verlassen, gehen alle Informationen verloren. Wollen Sie wirklich fortfahren?",
   "account.register.confirm_leave_modal.cancel_button": "Zurückkehren",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -337,6 +337,7 @@
   "account.quotes.widget.view_all_quotes.link": "View All Quotes",
   "account.register.address.headding": "Address",
   "account.register.address.message": "To save time when placing an order, please provide your primary invoice or shipping address below. We will store this information so you won't have to enter it again.",
+  "account.register.company_information.heading": "Company Information",
   "account.register.complete_heading": "Complete your Account",
   "account.register.confirm_leave_modal.body": "You have not completed the registration process yet. If you leave the page, all information will be lost. Are you sure you want to continue?",
   "account.register.confirm_leave_modal.cancel_button": "Go back",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -337,6 +337,7 @@
   "account.quotes.widget.view_all_quotes.link": "Afficher tous les devis",
   "account.register.address.headding": "Adresse",
   "account.register.address.message": "Pour gagner du temps lors de la commande, veuillez indiquer votre adresse de facturation ou de livraison ci-dessous. Nous conserverons ces informations afin que vous n’ayez pas à les saisir à nouveau.",
+  "account.register.company_information.heading": "Informations sur la société",
   "account.register.complete_heading": "Complétez votre compte",
   "account.register.confirm_leave_modal.body": "Vous n'avez pas encore terminé le processus d'enregistrement. Si vous quittez la page, toutes les informations seront perdues. Êtes-vous sûr de vouloir continuer ?",
   "account.register.confirm_leave_modal.cancel_button": "Retourner",


### PR DESCRIPTION

## PR Type

[x] Bugfix



## What Is the New Behavior?

- The missing translation key for 'Company Information' has been added on registration page.

## Does this PR Introduce a Breaking Change?


[x] No

## Other Information


[AB#79014](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79014)