### PR TITLE
fix: add fallbackLocales to show translations even if there is no connection to the server

### DIFF
--- a/src/app/core/store/core/configuration/configuration.reducer.ts
+++ b/src/app/core/store/core/configuration/configuration.reducer.ts
@@ -18,6 +18,7 @@ export interface ConfigurationState {
   features?: string[];
   addFeatures?: string[];
   defaultLocale?: string;
+  defaultLocales?: string[];
   localeCurrencyOverride?: { [locale: string]: string | string[] };
   lang?: string;
   currency?: string;
@@ -36,6 +37,7 @@ const initialState: ConfigurationState = {
   features: undefined,
   addFeatures: [],
   defaultLocale: environment.defaultLocale,
+  defaultLocales: environment.defaultLocales,
   localeCurrencyOverride: environment.localeCurrencyOverride,
   lang: undefined,
   currency: undefined,

--- a/src/app/core/store/core/configuration/configuration.reducer.ts
+++ b/src/app/core/store/core/configuration/configuration.reducer.ts
@@ -18,7 +18,7 @@ export interface ConfigurationState {
   features?: string[];
   addFeatures?: string[];
   defaultLocale?: string;
-  defaultLocales?: string[];
+  fallbackLocales?: string[];
   localeCurrencyOverride?: { [locale: string]: string | string[] };
   lang?: string;
   currency?: string;
@@ -37,7 +37,7 @@ const initialState: ConfigurationState = {
   features: undefined,
   addFeatures: [],
   defaultLocale: environment.defaultLocale,
-  defaultLocales: environment.defaultLocales,
+  fallbackLocales: environment.fallbackLocales,
   localeCurrencyOverride: environment.localeCurrencyOverride,
   lang: undefined,
   currency: undefined,

--- a/src/app/core/store/core/configuration/configuration.selectors.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.ts
@@ -37,13 +37,17 @@ export const getFeatures = createSelector(getConfigurationState, state =>
 
 const internalDefaultLocale = createSelector(getConfigurationState, state => state.defaultLocale);
 
+const internalDefaultAvailableLocales = createSelector(getConfigurationState, state => state.defaultLocales);
+
 const internalCurrencyFilter = createSelector(getConfigurationState, state => state.localeCurrencyOverride);
 
 /**
  * locales configured in ICM
  */
-export const getAvailableLocales = createSelector(getServerConfigParameter<string[]>('general.locales'), activated =>
-  activated?.length ? activated : undefined
+export const getAvailableLocales = createSelector(
+  internalDefaultAvailableLocales,
+  getServerConfigParameter<string[]>('general.locales'),
+  (defaultLocales, activated) => (activated?.length ? activated : defaultLocales)
 );
 
 const internalRequestedLocale = createSelector(getConfigurationState, state => state.lang);

--- a/src/app/core/store/core/configuration/configuration.selectors.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.ts
@@ -37,7 +37,7 @@ export const getFeatures = createSelector(getConfigurationState, state =>
 
 const internalDefaultLocale = createSelector(getConfigurationState, state => state.defaultLocale);
 
-const internalDefaultAvailableLocales = createSelector(getConfigurationState, state => state.defaultLocales);
+const internalFallbackLocales = createSelector(getConfigurationState, state => state.fallbackLocales);
 
 const internalCurrencyFilter = createSelector(getConfigurationState, state => state.localeCurrencyOverride);
 
@@ -45,9 +45,9 @@ const internalCurrencyFilter = createSelector(getConfigurationState, state => st
  * locales configured in ICM
  */
 export const getAvailableLocales = createSelector(
-  internalDefaultAvailableLocales,
+  internalFallbackLocales,
   getServerConfigParameter<string[]>('general.locales'),
-  (defaultLocales, activated) => (activated?.length ? activated : defaultLocales)
+  (fallbackLocales, serverLocales) => (serverLocales?.length ? serverLocales : fallbackLocales)
 );
 
 const internalRequestedLocale = createSelector(getConfigurationState, state => state.lang);

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -87,8 +87,9 @@ export interface Environment {
 
   // default locale that is used as fallback if no default locale from the ICM REST call is available (should only be set for local development)
   defaultLocale?: string;
-  // default locales if the locales from the configurations REST call are not available, to show error pages in the requested language.
-  defaultLocales?: string[];
+
+  // fallback locales if the locales from the configurations REST call are not available/not responding (to have a working translation functionality with the translations provided as source code)
+  fallbackLocales?: string[];
 
   // configuration filtering available locales and their active currencies
   localeCurrencyOverride?: { [locale: string]: string | string[] };
@@ -148,7 +149,7 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
   },
   defaultProductListingViewType: 'grid',
   defaultDeviceType: 'mobile',
-  defaultLocales: ['en_US', 'de_DE', 'fr_FR'],
+  fallbackLocales: ['en_US', 'de_DE', 'fr_FR'],
   multiSiteLocaleMap: {
     en_US: '/en',
     de_DE: '/de',

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -87,6 +87,8 @@ export interface Environment {
 
   // default locale that is used as fallback if no default locale from the ICM REST call is available (should only be set for local development)
   defaultLocale?: string;
+  // default locales if the locales from the configurations REST call are not available, to show error pages in the requested language.
+  defaultLocales?: string[];
 
   // configuration filtering available locales and their active currencies
   localeCurrencyOverride?: { [locale: string]: string | string[] };
@@ -146,6 +148,7 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
   },
   defaultProductListingViewType: 'grid',
   defaultDeviceType: 'mobile',
+  defaultLocales: ['en_US', 'de_DE', 'fr_FR'],
   multiSiteLocaleMap: {
     en_US: '/en',
     de_DE: '/de',


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Precondition: the pwa cannot connect to the ICM server, e.g. because of a wrong base URL

-    without SSR (multichannel configuration) - if the user requests a page in German (route parameter lang=de_DE) the error page will be shown in English
-    with multichannel config: The translations of the json files are not returned all texts are missing in the page (missing translation is shown)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The error page is shown in the requested locale if the server doesn't respond



## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#79145](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79145)
[AB#78921](https://dev.azure.com/intershop-com/Products/_workitems/edit/78921)