### PR TITLE
fix: do not override favicon if requested from assets

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -304,7 +304,7 @@ export function app() {
       }
     });
   });
-  server.get(/.*\/favicon.ico.*/, (req, _, next) => {
+  server.get(/^(?!\/assets\/).*\/favicon.ico.*/, (req, _, next) => {
     req.url = req.originalUrl.replace(/[;?&].*$/, '').replace(/^.*\//g, '/');
     next();
   });


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Issue Number: Closes #1257

## What Is the New Behavior?

Favicon path is no longer modified if directly requested via assets.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#79152](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79152)