### PR TITLE
fix: use product price api for retail sets and product master

### DIFF
--- a/src/app/core/models/price-item/price-item.helper.ts
+++ b/src/app/core/models/price-item/price-item.helper.ts
@@ -32,6 +32,12 @@ export class PriceItemHelper {
       scaledPrices: priceDetails?.prices?.scaledPrices?.map(priceItem =>
         PriceItemHelper.selectScaledPriceType(priceItem, type)
       ),
+      minSalePrice: PriceItemHelper.selectType(priceDetails?.prices?.minSalePrice, type),
+      minListPrice: PriceItemHelper.selectType(priceDetails?.prices?.minListPrice, type),
+      maxSalePrice: PriceItemHelper.selectType(priceDetails?.prices?.maxSalePrice, type),
+      maxListPrice: PriceItemHelper.selectType(priceDetails?.prices?.maxListPrice, type),
+      summedUpSalePrice: PriceItemHelper.selectType(priceDetails?.prices?.summedUpSalePrice, type),
+      summedUpListPrice: PriceItemHelper.selectType(priceDetails?.prices?.summedUpListPrice, type),
     };
   }
 }

--- a/src/app/core/models/price/price.helper.ts
+++ b/src/app/core/models/price/price.helper.ts
@@ -27,6 +27,7 @@ export class PriceHelper {
     }
   }
 
+  // not-dead-code
   static min(p1: Price, p2: Price): Price {
     PriceHelper.sanityChecks(p1, p2);
     return {

--- a/src/app/core/models/price/price.model.ts
+++ b/src/app/core/models/price/price.model.ts
@@ -11,9 +11,15 @@ export interface ScaledPrice extends Price {
 }
 
 export interface Pricing {
-  listPrice: Price;
-  salePrice: Price;
-  scaledPrices: ScaledPrice[];
+  listPrice?: Price;
+  salePrice?: Price;
+  scaledPrices?: ScaledPrice[];
+  minSalePrice?: Price;
+  minListPrice?: Price;
+  maxSalePrice?: Price;
+  maxListPrice?: Price;
+  summedUpSalePrice?: Price;
+  summedUpListPrice?: Price;
 }
 
 export * from './price.helper';

--- a/src/app/core/models/product-prices/product-prices.interface.ts
+++ b/src/app/core/models/product-prices/product-prices.interface.ts
@@ -3,8 +3,14 @@ import { PriceItemData } from 'ish-core/models/price-item/price-item.interface';
 export interface ProductPriceDetailsData {
   sku: string;
   prices: {
-    SalePrice: ProductPriceItemData[];
-    ListPrice: ProductPriceItemData[];
+    SalePrice?: ProductPriceItemData[];
+    ListPrice?: ProductPriceItemData[];
+    MinSalePrice?: ProductPriceItemData[];
+    MinListPrice?: ProductPriceItemData[];
+    MaxSalePrice?: ProductPriceItemData[];
+    MaxListPrice?: ProductPriceItemData[];
+    SummedUpSalePrice?: ProductPriceItemData[];
+    SummedUpListPrice?: ProductPriceItemData[];
   };
 }
 

--- a/src/app/core/models/product-prices/product-prices.mapper.spec.ts
+++ b/src/app/core/models/product-prices/product-prices.mapper.spec.ts
@@ -42,6 +42,10 @@ describe('Product Prices Mapper', () => {
               "net": 1,
               "type": "PriceItem",
             },
+            "maxListPrice": undefined,
+            "maxSalePrice": undefined,
+            "minListPrice": undefined,
+            "minSalePrice": undefined,
             "salePrice": Object {
               "currency": "USD",
               "gross": 2,
@@ -57,6 +61,8 @@ describe('Product Prices Mapper', () => {
                 "type": "PriceItem",
               },
             ],
+            "summedUpListPrice": undefined,
+            "summedUpSalePrice": undefined,
           },
           "sku": "abc",
         }
@@ -96,6 +102,10 @@ describe('Product Prices Mapper', () => {
               "net": 1,
               "type": "PriceItem",
             },
+            "maxListPrice": undefined,
+            "maxSalePrice": undefined,
+            "minListPrice": undefined,
+            "minSalePrice": undefined,
             "salePrice": Object {
               "currency": "USD",
               "gross": 2,
@@ -111,6 +121,8 @@ describe('Product Prices Mapper', () => {
                 "type": "PriceItem",
               },
             ],
+            "summedUpListPrice": undefined,
+            "summedUpSalePrice": undefined,
           },
           "sku": "abc",
         }

--- a/src/app/core/models/product-prices/product-prices.mapper.ts
+++ b/src/app/core/models/product-prices/product-prices.mapper.ts
@@ -39,6 +39,13 @@ export class ProductPricesMapper {
         salePrice: getSinglePrice(data?.prices?.SalePrice) ?? getSinglePrice(data?.prices?.ListPrice),
         listPrice: getSinglePrice(data?.prices?.ListPrice),
         scaledPrices,
+        minSalePrice: getSinglePrice(data?.prices?.MinSalePrice) ?? getSinglePrice(data?.prices?.MinListPrice),
+        minListPrice: getSinglePrice(data?.prices?.MinListPrice),
+        maxSalePrice: getSinglePrice(data?.prices?.MaxSalePrice) ?? getSinglePrice(data?.prices?.MaxListPrice),
+        maxListPrice: getSinglePrice(data?.prices?.MaxListPrice),
+        summedUpSalePrice:
+          getSinglePrice(data?.prices?.SummedUpSalePrice) ?? getSinglePrice(data?.prices?.SummedUpListPrice),
+        summedUpListPrice: getSinglePrice(data?.prices?.SummedUpListPrice),
       },
     };
   }

--- a/src/app/core/models/product-prices/product-prices.model.ts
+++ b/src/app/core/models/product-prices/product-prices.model.ts
@@ -3,8 +3,14 @@ import { PriceItem, ScaledPriceItem } from 'ish-core/models/price-item/price-ite
 export interface ProductPriceDetails {
   sku: string;
   prices: {
-    salePrice: PriceItem;
-    listPrice: PriceItem;
-    scaledPrices: ScaledPriceItem[];
+    salePrice?: PriceItem;
+    listPrice?: PriceItem;
+    scaledPrices?: ScaledPriceItem[];
+    minSalePrice?: PriceItem;
+    minListPrice?: PriceItem;
+    maxSalePrice?: PriceItem;
+    maxListPrice?: PriceItem;
+    summedUpSalePrice?: PriceItem;
+    summedUpListPrice?: PriceItem;
   };
 }

--- a/src/app/core/models/product/product.helper.spec.ts
+++ b/src/app/core/models/product/product.helper.spec.ts
@@ -2,7 +2,6 @@ import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
-import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 
 import { ProductDataStub } from './product.interface';
 import { Product, ProductCompletenessLevel, ProductHelper } from './product.model';
@@ -183,73 +182,6 @@ describe('Product Helper', () => {
       [true, { failed: true }],
     ])(`should return %s when supplying product '%j'`, (expected, product: Product) => {
       expect(ProductHelper.isReadyForDisplay(product, ProductCompletenessLevel.List)).toEqual(expected);
-    });
-  });
-
-  describe('calculatePriceRange()', () => {
-    it('should return empty object when no products are supplied', () => {
-      expect(ProductHelper.calculatePriceRange(undefined, undefined, undefined)).toBeEmpty();
-      expect(ProductHelper.calculatePriceRange([], [], undefined)).toBeEmpty();
-    });
-
-    it('should return the single object if only one element is supplied', () => {
-      const product = { sku: '1' } as Product;
-      const productPrice = {
-        sku: '1',
-        prices: { salePrice: { gross: 1, currency: 'EUR' } },
-      } as ProductPriceDetails;
-      expect(ProductHelper.calculatePriceRange([product], [productPrice], 'gross')).toEqual(productPrice);
-    });
-
-    it('should calculate a range when multiple elements are supplied', () => {
-      const product1 = { sku: '1' } as Product;
-      const productPrice1 = {
-        sku: '1',
-        prices: { salePrice: { gross: 1, currency: 'EUR' }, listPrice: { gross: 2, currency: 'EUR' } },
-      } as ProductPriceDetails;
-
-      const product2 = { sku: '2' } as Product;
-      const productPrice2 = {
-        sku: '2',
-        prices: { salePrice: { gross: 3, currency: 'EUR' }, listPrice: { gross: 4, currency: 'EUR' } },
-      } as ProductPriceDetails;
-
-      const product3 = { sku: '3' } as Product;
-      const productPrice3 = {
-        sku: '3',
-        prices: { salePrice: { gross: 5, currency: 'EUR' }, listPrice: { gross: 6, currency: 'EUR' } },
-      } as ProductPriceDetails;
-
-      expect(
-        ProductHelper.calculatePriceRange(
-          [product1, product2, product3],
-          [productPrice1, productPrice2, productPrice3],
-          'gross'
-        )
-      ).toMatchInlineSnapshot(`
-        Object {
-          "minListPrice": Object {
-            "currency": "EUR",
-            "type": "Money",
-            "value": 2,
-          },
-          "minSalePrice": Object {
-            "currency": "EUR",
-            "type": "Money",
-            "value": 1,
-          },
-          "summedUpListPrice": Object {
-            "currency": "EUR",
-            "type": "Money",
-            "value": 12,
-          },
-          "summedUpSalePrice": Object {
-            "currency": "EUR",
-            "type": "Money",
-            "value": 9,
-          },
-        }
-      `);
     });
   });
 

--- a/src/app/core/models/product/product.helper.ts
+++ b/src/app/core/models/product/product.helper.ts
@@ -2,9 +2,6 @@ import { intersection } from 'lodash-es';
 
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
 import { Image } from 'ish-core/models/image/image.model';
-import { PriceItemHelper } from 'ish-core/models/price-item/price-item.helper';
-import { PriceHelper } from 'ish-core/models/price/price.model';
-import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 
 import {
@@ -26,13 +23,6 @@ export enum ProductCompletenessLevel {
   Detail = 3,
   List = 2,
 }
-
-// not-dead-code
-export type ProductPrices = Partial<
-  Pick<ProductRetailSet, 'minListPrice' | 'minSalePrice' | 'summedUpListPrice' | 'summedUpSalePrice'>
-> &
-  Partial<Pick<VariationProductMaster, 'minListPrice' | 'minSalePrice' | 'maxListPrice' | 'maxSalePrice'>> &
-  Partial<Pick<ProductPriceDetails, 'prices'>>;
 
 export class ProductHelper {
   /**
@@ -136,35 +126,6 @@ export class ProductHelper {
       return product.attributeGroups[attributeGroupId].attributes;
     }
     return;
-  }
-
-  // not-dead-code
-  static calculatePriceRange(
-    products: Product[],
-    productPrices: ProductPriceDetails[],
-    priceType: 'gross' | 'net'
-  ): ProductPrices {
-    if ((!products || !products.length) && (!productPrices || !productPrices.length)) {
-      return {};
-    } else if (products.length === 1) {
-      return productPrices.find(price => price.sku === products[0].sku);
-    } else {
-      const prices = products.map(p => productPrices.find(productPrice => productPrice.sku === p.sku));
-      return {
-        minListPrice: prices
-          .map(p => PriceItemHelper.selectType(p?.prices?.listPrice, priceType))
-          .reduce(PriceHelper.min),
-        minSalePrice: prices
-          .map(p => PriceItemHelper.selectType(p?.prices?.salePrice, priceType))
-          .reduce(PriceHelper.min),
-        summedUpListPrice: prices
-          .map(p => PriceItemHelper.selectType(p?.prices?.listPrice, priceType))
-          .reduce(PriceHelper.sum),
-        summedUpSalePrice: prices
-          .map(p => PriceItemHelper.selectType(p?.prices?.salePrice, priceType))
-          .reduce(PriceHelper.sum),
-      };
-    }
   }
 
   /**

--- a/src/app/core/models/product/product.interface.ts
+++ b/src/app/core/models/product/product.interface.ts
@@ -41,19 +41,9 @@ export interface ProductData {
   stepOrderQuantity?: number;
   packingUnit: string;
 
-  // If Variation Master and Retail Set {
-  minListPrice?: PriceData;
-  maxListPrice?: PriceData;
-  minSalePrice?: PriceData;
-  maxSalePrice?: PriceData;
-  // }
   variationAttributeValues?: VariationAttribute[];
   variableVariationAttributes?: VariationAttribute[];
   partOfRetailSet: boolean;
-  // If  Retail Set {
-  summedUpListPrice?: PriceData;
-  summedUpSalePrice?: PriceData;
-  // }
 
   attachments?: AttachmentData[];
   variations?: unknown;

--- a/src/app/core/models/product/product.mapper.ts
+++ b/src/app/core/models/product/product.mapper.ts
@@ -8,7 +8,6 @@ import { CategoryData } from 'ish-core/models/category/category.interface';
 import { CategoryMapper } from 'ish-core/models/category/category.mapper';
 import { ImageMapper } from 'ish-core/models/image/image.mapper';
 import { Link } from 'ish-core/models/link/link.model';
-import { PriceMapper } from 'ish-core/models/price/price.mapper';
 import { SeoAttributesMapper } from 'ish-core/models/seo-attributes/seo-attributes.mapper';
 
 import { SkuQuantityType } from './product.helper';
@@ -249,10 +248,6 @@ export class ProductMapper {
     if (data.productMaster) {
       return {
         ...product,
-        minListPrice: PriceMapper.fromData(data.minListPrice),
-        minSalePrice: PriceMapper.fromData(data.minSalePrice),
-        maxListPrice: PriceMapper.fromData(data.maxListPrice),
-        maxSalePrice: PriceMapper.fromData(data.maxSalePrice),
         variationAttributeValues: data.variationAttributeValues,
         type: 'VariationProductMaster',
       };
@@ -272,10 +267,6 @@ export class ProductMapper {
       return {
         ...product,
         type: 'RetailSet',
-        minListPrice: PriceMapper.fromData(data.minListPrice),
-        minSalePrice: PriceMapper.fromData(data.minSalePrice),
-        summedUpListPrice: PriceMapper.fromData(data.summedUpListPrice),
-        summedUpSalePrice: PriceMapper.fromData(data.summedUpSalePrice),
       };
     } else {
       return product;

--- a/src/app/core/models/product/product.model.ts
+++ b/src/app/core/models/product/product.model.ts
@@ -2,7 +2,6 @@ import { Attachment } from 'ish-core/models/attachment/attachment.model';
 import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.model';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
 import { Image } from 'ish-core/models/image/image.model';
-import { Price } from 'ish-core/models/price/price.model';
 import { VariationAttribute } from 'ish-core/models/product-variation/variation-attribute.model';
 import { SeoAttributes } from 'ish-core/models/seo-attributes/seo-attributes.model';
 
@@ -45,18 +44,10 @@ export interface VariationProduct extends Product {
 export interface VariationProductMaster extends Product {
   type: 'VariationProductMaster';
   variationAttributeValues?: VariationAttribute[];
-  minListPrice?: Price;
-  minSalePrice?: Price;
-  maxListPrice?: Price;
-  maxSalePrice?: Price;
 }
 
 export interface ProductRetailSet extends Product {
   type: 'RetailSet';
-  minListPrice: Price;
-  minSalePrice: Price;
-  summedUpListPrice: Price;
-  summedUpSalePrice: Price;
 }
 
 export interface ProductBundle extends Product {

--- a/src/app/shared/components/product/product-price/product-price.component.ts
+++ b/src/app/shared/components/product/product-price/product-price.component.ts
@@ -43,11 +43,11 @@ export class ProductPriceComponent implements OnInit {
         isListPriceLessThanSalePrice: prices.listPrice?.value < prices.salePrice?.value,
         priceSavings: prices.listPrice && prices.salePrice && PriceHelper.diff(prices.listPrice, prices.salePrice),
         lowerPrice:
-          (ProductHelper.isMasterProduct(product) || ProductHelper.isRetailSet(product)) && product.minSalePrice,
+          (ProductHelper.isMasterProduct(product) || ProductHelper.isRetailSet(product)) && prices.minSalePrice,
         upperPrice: ProductHelper.isMasterProduct(product)
-          ? product.maxSalePrice
+          ? prices.maxSalePrice
           : ProductHelper.isRetailSet(product)
-          ? product.summedUpSalePrice
+          ? prices.summedUpSalePrice
           : undefined,
       }))
     );


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Retail sets and product masters use the old product REST API to display prices ranges. This should be replaced with the new product price REST api. 

Issue Number: Closes #

## What Is the New Behavior?

The new product price REST API is used.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#79168](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79168)