### PR TITLE
fix: render product descriptions with images properly

### DIFF
--- a/src/app/core/directives/server-html.directive.spec.ts
+++ b/src/app/core/directives/server-html.directive.spec.ts
@@ -58,7 +58,8 @@ describe('Server Html Directive', () => {
         changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class TestComponent {
-        html = `<img src="https://./?[ismediaobject]isfile://inSPIRED-Site/inTRONICS-b2c-responsive/inSPIRED-inTRONICS-b2c-responsive/en_US/logo%402x.png|/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS-b2c-responsive/inSPIRED-inTRONICS-b2c-responsive/en_US/logo%402x.png[/ismediaobject]" alt="" width="92" height="92" style="width: unset;" />`;
+        html = `<img src="https://./?[ismediaobject]isfile://inSPIRED-Site/inTRONICS_Business/inSPIRED/en_US/logo.png|/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS_Business/inSPIRED/en_US/logo.png[/ismediaobject]" alt="logo" width="100" height="100"/>
+          <img src="/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS_Business/inSPIRED/en_US/logo.png" alt="logo" width="100" height="100"/>`;
       }
 
       const appFacade = mock(AppFacade);
@@ -82,11 +83,16 @@ describe('Server Html Directive', () => {
       expect(element).toMatchInlineSnapshot(`
         <div>
           <img
-            src="http://example.org/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS-b2c-responsive/inSPIRED-inTRONICS-b2c-responsive/en_US/logo%402x.png"
-            alt=""
-            width="92"
-            height="92"
-            style="width: unset"
+            src="http://example.org/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS_Business/inSPIRED/en_US/logo.png"
+            alt="logo"
+            width="100"
+            height="100"
+          />
+          <img
+            src="http://example.org/INTERSHOP/static/WFS/inSPIRED-Site/inTRONICS_Business/inSPIRED/en_US/logo.png"
+            alt="logo"
+            width="100"
+            height="100"
           />
         </div>
       `);

--- a/src/app/core/directives/server-html.directive.ts
+++ b/src/app/core/directives/server-html.directive.ts
@@ -62,8 +62,10 @@ export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnC
     const regex = /.*\[ismediaobject\](.*?)\[\/ismediaobject\].*/;
     if (regex.test(src)) {
       const [, ismediaobjectContent] = regex.exec(src);
-      const links = ismediaobjectContent.split('|');
-      return this.appFacade.icmBaseUrl + links[links.length - 1];
+      const mediaObjectSrc = ismediaobjectContent.split('|')[1];
+      return this.appFacade.icmBaseUrl + mediaObjectSrc;
+    } else if (src.startsWith('/INTERSHOP/')) {
+      return this.appFacade.icmBaseUrl + src;
     } else {
       return src;
     }

--- a/src/app/extensions/compare/pages/compare/product-compare-list/product-compare-list.component.html
+++ b/src/app/extensions/compare/pages/compare/product-compare-list/product-compare-list.component.html
@@ -74,7 +74,9 @@
 
           <tr>
             <th>{{ 'product.short_description.label' | translate }}</th>
-            <td *ngFor="let product of visibleProducts">{{ product.shortDescription }}</td>
+            <td *ngFor="let product of visibleProducts">
+              <div [ishServerHtml]="product.shortDescription"></div>
+            </td>
           </tr>
 
           <tr>

--- a/src/app/extensions/compare/pages/compare/product-compare-list/product-compare-list.component.spec.ts
+++ b/src/app/extensions/compare/pages/compare/product-compare-list/product-compare-list.component.spec.ts
@@ -7,6 +7,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { FeatureToggleDirective } from 'ish-core/directives/feature-toggle.directive';
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { AttributeToStringPipe } from 'ish-core/models/attribute/attribute.pipe';
 import { ProductView, createProductView } from 'ish-core/models/product-view/product-view.model';
@@ -80,6 +81,7 @@ describe('Product Compare List Component', () => {
         MockComponent(ProductPriceComponent),
         MockDirective(FeatureToggleDirective),
         MockDirective(ProductContextDirective),
+        MockDirective(ServerHtmlDirective),
         MockPipe(AttributeToStringPipe),
         ProductCompareListComponent,
       ],

--- a/src/app/pages/product/product-detail-info/product-detail-info.component.html
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.html
@@ -3,7 +3,7 @@
     <li [ngbNavItem]="'DESCRIPTION'" data-testing-id="product-description-tab">
       <a ngbNavLink>{{ 'product.description.heading' | translate }}</a>
       <ng-template ngbNavContent>
-        <div [innerHTML]="product.longDescription"></div>
+        <div [ishServerHtml]="product.longDescription"></div>
       </ng-template>
     </li>
 

--- a/src/app/pages/product/product-detail-info/product-detail-info.component.spec.ts
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
+import { MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
@@ -23,7 +25,7 @@ describe('Product Detail Info Component', () => {
 
     await TestBed.configureTestingModule({
       imports: [FeatureToggleModule.forTesting('rating'), NgbNavModule, TranslateModule.forRoot()],
-      declarations: [ProductDetailInfoComponent],
+      declarations: [MockDirective(ServerHtmlDirective), ProductDetailInfoComponent],
       providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }],
     }).compileComponents();
   });

--- a/src/app/pages/product/product-detail-info/product-detail-info.component.spec.ts
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.spec.ts
@@ -21,6 +21,7 @@ describe('Product Detail Info Component', () => {
   beforeEach(async () => {
     context = mock(ProductContextFacade);
     when(context.select('product')).thenReturn(of({ sku: '123' } as ProductView));
+    when(context.select('sku')).thenReturn(of('123'));
     when(context.select('variationCount')).thenReturn(of(0));
 
     await TestBed.configureTestingModule({

--- a/src/app/pages/product/product-detail-info/product-detail-info.component.ts
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { Observable, map } from 'rxjs';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { Observable, Subject, map, takeUntil } from 'rxjs';
 
 import { ProductContextDisplayProperties, ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
@@ -9,19 +9,33 @@ import { ProductView } from 'ish-core/models/product-view/product-view.model';
   templateUrl: './product-detail-info.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProductDetailInfoComponent implements OnInit {
+export class ProductDetailInfoComponent implements OnInit, OnDestroy {
   product$: Observable<ProductView>;
   isVariationMaster$: Observable<boolean>;
-  active = 'DESCRIPTION';
+  active = 'DESCRIPTION'; // default product tab
+
+  private destroy$ = new Subject<void>();
 
   constructor(private context: ProductContextFacade) {}
 
   ngOnInit() {
     this.product$ = this.context.select('product');
+
+    // when routing between products reset the opened product tab to the default tab
+    this.context
+      .select('sku')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => (this.active = 'DESCRIPTION'));
+
     this.isVariationMaster$ = this.context.select('variationCount').pipe(map(variationCount => !!variationCount));
   }
 
   configuration$(key: keyof ProductContextDisplayProperties) {
     return this.context.select('displayProperties', key);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/shared/components/product/product-row/product-row.component.html
+++ b/src/app/shared/components/product/product-row/product-row.component.html
@@ -15,9 +15,11 @@
 
         <ish-product-id></ish-product-id>
 
-        <div *ngIf="configuration$('description') | async" class="product-description">
-          {{ product.shortDescription }}
-        </div>
+        <div
+          *ngIf="configuration$('description') | async"
+          class="product-description"
+          [ishServerHtml]="product.shortDescription"
+        ></div>
 
         <ish-product-promotion displayType="simpleWithDetail"></ish-product-promotion>
 

--- a/src/app/shared/components/product/product-row/product-row.component.spec.ts
+++ b/src/app/shared/components/product/product-row/product-row.component.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anyString, instance, mock, when } from 'ts-mockito';
 
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
@@ -60,6 +61,7 @@ describe('Product Row Component', () => {
         MockComponent(ProductPromotionComponent),
         MockComponent(ProductQuantityComponent),
         MockComponent(ProductShipmentComponent),
+        MockDirective(ServerHtmlDirective),
         ProductRowComponent,
       ],
       providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }],


### PR DESCRIPTION
* use `ishServerHtml` directive to handle embedded image resources

## PR Type

[x] Bugfix


## What Is the Current Behavior?

* Product descriptions (short or long) are not always rendered as HTML and are not rendered with specific treatment for server side images and ICM specific link notation.
* The `ishServerHtml` directive does not handle ICM embedded images without `ismediaobject` notation. TinyMCE embedding  format after update just uses simple relative URLs in the Intershop static file system
* Directly navigating between different product detail pages does not reset a previously selected product detail tab (default would be the description tab).

## What Is the New Behavior?

* Product descriptions (short or long) are rendered with specific treatment for server side images and ICM specific link notation using the `ishServerHtml` directive.
* The `ishServerHtml` directive handles ICM embedded images without `ismediaobject` notation.
* When navigating between different product detail pages the selected product detail tab is reset to the product description.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#79244](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79244)