### PR TITLE
feat: CMS navigation components (link, page, category)

### DIFF
--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -109,6 +109,24 @@ The [`PreviewInterceptor`](../../src/app/core/interceptors/preview.interceptor.t
 
 To end a preview session and to delete the saved `PreviewContextID` in the browser session storage, use the _Finish Preview_ button of the _Design View_ configuration.
 
+## Navigation CMS Components
+
+With the Intershop PWA release 5.1.0 three new CMS rendering components are introduced that can be used to extend the main navigation.
+
+| Component           | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| Navigation Category | Renders a main navigation entry based on the selected category with optional sub navigation. |
+| Navigation Link     | Renders a main navigation entry to the given link with optional sub navigation.              |
+| Navigation Page     | Renders a main navigation entry based on the selected page with optional sub navigation.     |
+
+The according content models, to configure these new components in the ICM backoffice, are part of `icm-as-customization-headless:1.7.0` (ICM 11.9.0).
+They are all assignable to the _Header - Navigation_ include and can be combined to extend the main navigation.
+It would also be possible to completely configure the main navigation with these components without the default main navigation by only rendering the `<ish-lazy-content-include includeId="include.header.navigation.pagelet2-Include"/>` in the `HeaderNavigationComponent`.
+To fulfill such a requirement the source code needs to be adapted accordingly.
+
+All three component allow the configuration of additional freestyle HTML that is rendered within the sub navigation layer.
+The root element as well as the depth of the sub navigation tree is configurable for the _Navigation Category_ and the _Navigation Page_ component.
+
 ## Integration with an External CMS
 
 Since the Intershop PWA can integrate any other REST API in addition to the ICM REST API, it should not be a problem to integrate an external 3rd party CMS that provides an own REST API, instead of using the integrated ICM CMS.

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -23,6 +23,9 @@ In addition the `'messageToMerchant'` environment feature toggle option needs to
 To address an Angular hydration issue ([#1585](https://github.com/intershop/intershop-pwa/pull/1585)) the `header` component rendering was changed and in addition a `HeaderType` was introduced for the standard header types `['simple', 'error', 'checkout']`.
 If in a project other header types are used these header types and the rendering needs to be adapted accordingly.
 
+With the introduction of the new [navigation CMS components](../concepts/cms-integration.md#navigation-cms-components) it became necessary to adapt the main navigation styling.
+The styling can no longer rely on child selectors (`>`) since the CMS manged components introduce a lot of additional HTML tags around the styling relevant `li` tags.
+
 ## From 4.2 to 5.0
 
 Starting with the Intershop PWA 5.0 we develop and test against an Intershop Commerce Management 11 server.

--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -6,7 +6,7 @@ import { delay, switchMap, tap } from 'rxjs/operators';
 import { CallParameters } from 'ish-core/models/call-parameters/call-parameters.model';
 import { CategoryHelper } from 'ish-core/models/category/category.helper';
 import { getContentInclude, loadContentInclude } from 'ish-core/store/content/includes';
-import { getContentPageTree, loadContentPageTree } from 'ish-core/store/content/page-tree';
+import { getCompleteContentPageTree, getContentPageTree, loadContentPageTree } from 'ish-core/store/content/page-tree';
 import { getContentPagelet } from 'ish-core/store/content/pagelets';
 import {
   getContentPageLoading,
@@ -46,6 +46,12 @@ export class CMSFacade {
   contentPageTree$(rootId: string, depth: number) {
     this.store.dispatch(loadContentPageTree({ rootId, depth }));
     return this.store.pipe(select(getContentPageTree(rootId)));
+  }
+
+  completeContentPageTree$(rootId: string, depth: number) {
+    // fetch only the depth that is actually needed, depth=0 returns already the next child level
+    this.store.dispatch(loadContentPageTree({ rootId, depth: depth > 0 ? depth - 1 : 0 }));
+    return this.store.pipe(select(getCompleteContentPageTree(rootId, depth)));
   }
 
   /**

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -14,8 +14,10 @@ import {
   getCategory,
   getCategoryIdByRefId,
   getNavigationCategories,
+  getNavigationCategoryTree,
   getSelectedCategory,
   loadCategoryByRef,
+  loadCategoryTree,
   loadTopLevelCategories,
 } from 'ish-core/store/shopping/categories';
 import { getAvailableFilter } from 'ish-core/store/shopping/filter';
@@ -69,8 +71,14 @@ export class ShoppingFacade {
     }
     return this.store.pipe(
       select(getNavigationCategories(uniqueId)),
+      // prevent to display an empty navigation bar after login/logout);
       filter(categories => !!categories?.length)
-    ); // prevent to display an empty navigation bar after login/logout);
+    );
+  }
+
+  navigationCategoryTree$(categoryRef: string, depth: number) {
+    this.store.dispatch(loadCategoryTree({ categoryRef, depth }));
+    return this.store.pipe(select(getNavigationCategoryTree(categoryRef, depth)));
   }
 
   // PRODUCT

--- a/src/app/core/models/content-view/content-view.helper.ts
+++ b/src/app/core/models/content-view/content-view.helper.ts
@@ -17,7 +17,7 @@ export class ContentViewHelper {
   }
 
   /**
-   * determine whether the a given configuration parameter of the given configuration parameter container
+   * determine whether the given configuration parameter of the given configuration parameter container
    * contains a link value that is supposed to be handled as a routerLink or not (external link)
    *
    * @param configParamView

--- a/src/app/core/models/navigation-category/navigation-category.model.ts
+++ b/src/app/core/models/navigation-category/navigation-category.model.ts
@@ -3,4 +3,5 @@ export interface NavigationCategory {
   name: string;
   url: string;
   hasChildren: boolean;
+  children?: NavigationCategory[];
 }

--- a/src/app/core/services/categories/categories.service.spec.ts
+++ b/src/app/core/services/categories/categories.service.spec.ts
@@ -24,6 +24,9 @@ describe('Categories Service', () => {
     when(apiServiceMock.get('categories/dummyid/dummysubid', anything())).thenReturn(
       of({ categoryPath: [{ id: 'blubb' }] } as CategoryData)
     );
+    when(apiServiceMock.get('categories/dummyid@cat', anything())).thenReturn(
+      of({ categoryPath: [{ id: 'blubb' }] } as CategoryData)
+    );
     TestBed.configureTestingModule({
       providers: [{ provide: ApiService, useFactory: () => instance(apiServiceMock) }, provideMockStore()],
     });
@@ -43,7 +46,7 @@ describe('Categories Service', () => {
       expect(capture(apiServiceMock.get).last()[0].toString()).toMatchInlineSnapshot(`"categories"`);
       const options: AvailableOptions = capture(apiServiceMock.get).last()[1];
       expect(options.params.toString()).toMatchInlineSnapshot(
-        `"imageView=NO-IMAGE&view=tree&limit=1&omitHasOnlineProducts=true"`
+        `"view=tree&limit=1&omitHasOnlineProducts=true&imageView=NO-IMAGE"`
       );
     });
 
@@ -94,6 +97,19 @@ describe('Categories Service', () => {
     it('should call underlying ApiService categories/id when asked to resolve a subcategory by id', () => {
       categoriesService.getCategory('dummyid/dummysubid');
       verify(apiServiceMock.get('categories/dummyid/dummysubid', anything())).once();
+    });
+  });
+
+  describe('getCategoryTree()', () => {
+    it('should call ApiService "categories" when called', () => {
+      categoriesService.getCategoryTree('dummyid@cat', 1);
+      verify(apiServiceMock.get('categories/dummyid@cat', anything())).once();
+
+      expect(capture(apiServiceMock.get).last()[0].toString()).toMatchInlineSnapshot(`"categories/dummyid@cat"`);
+      const options: AvailableOptions = capture(apiServiceMock.get).last()[1];
+      expect(options.params.toString()).toMatchInlineSnapshot(
+        `"view=tree&limit=1&omitHasOnlineProducts=true&imageView=NO-IMAGE"`
+      );
     });
   });
 });

--- a/src/app/core/store/content/page-tree/page-tree.selectors.ts
+++ b/src/app/core/store/content/page-tree/page-tree.selectors.ts
@@ -1,10 +1,12 @@
-import { createSelector, createSelectorFactory, resultMemoize } from '@ngrx/store';
+import { createSelector, createSelectorFactory, defaultMemoize, resultMemoize } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
 
 import {
   ContentPageTreeView,
+  createCompleteContentPageTreeView,
   createContentPageTreeView,
 } from 'ish-core/models/content-page-tree-view/content-page-tree-view.model';
+import { ContentPageTreeHelper } from 'ish-core/models/content-page-tree/content-page-tree.helper';
 import { ContentPageTree } from 'ish-core/models/content-page-tree/content-page-tree.model';
 import { getContentState } from 'ish-core/store/content/content-store';
 import { selectRouteParam } from 'ish-core/store/core/router';
@@ -25,3 +27,19 @@ export const getContentPageTree = (rootId: string) =>
     selectRouteParam('contentPageId'),
     (pagetree: ContentPageTree, contentPageId: string) => createContentPageTreeView(pagetree, rootId, contentPageId)
   );
+
+/**
+ * Get the complete content page tree (all branches) for the given root to the given depth.
+ *
+ * @param rootId  The Id of the root content page of the tree
+ * @returns       The complete content page tree
+ */
+export const getCompleteContentPageTree = (rootId: string, depth: number) =>
+  createSelectorFactory<object, ContentPageTreeView>(projector =>
+    defaultMemoize(projector, ContentPageTreeHelper.equals, isEqual)
+  )(getPageTree, (tree: ContentPageTree): ContentPageTreeView => {
+    if (!rootId) {
+      return;
+    }
+    return createCompleteContentPageTreeView(ContentPageTreeHelper.subTree(tree, rootId), rootId, depth);
+  });

--- a/src/app/core/store/shopping/categories/categories.actions.ts
+++ b/src/app/core/store/shopping/categories/categories.actions.ts
@@ -12,6 +12,16 @@ export const loadTopLevelCategoriesSuccess = createAction(
   payload<{ categories: CategoryTree }>()
 );
 
+export const loadCategoryTree = createAction(
+  '[Categories Internal] Load a specific category tree',
+  payload<{ categoryRef: string; depth: number }>()
+);
+
+export const loadCategoryTreeSuccess = createAction(
+  '[Categories API] Load a specific category tree success',
+  payload<{ categories: CategoryTree }>()
+);
+
 export const loadCategory = createAction('[Categories Internal] Load Category', payload<{ categoryId: string }>());
 
 export const loadCategoryFail = createAction('[Categories API] Load Category Fail', httpError());

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -17,6 +17,7 @@ import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-stat
 import { InjectSingle } from 'ish-core/utils/injection';
 import {
   mapErrorToAction,
+  mapToPayload,
   mapToPayloadProperty,
   useCombinedObservableOnAction,
   whenTruthy,
@@ -27,6 +28,8 @@ import {
   loadCategoryByRef,
   loadCategoryFail,
   loadCategorySuccess,
+  loadCategoryTree,
+  loadCategoryTreeSuccess,
   loadTopLevelCategories,
   loadTopLevelCategoriesFail,
   loadTopLevelCategoriesSuccess,
@@ -113,6 +116,18 @@ export class CategoriesEffects {
           map(categories => loadTopLevelCategoriesSuccess({ categories })),
           mapErrorToAction(loadTopLevelCategoriesFail)
         )
+      )
+    )
+  );
+
+  loadCategoryTree$ = createEffect(() =>
+    this.actions$.pipe(
+      useCombinedObservableOnAction(this.actions$.pipe(ofType(loadCategoryTree)), personalizationStatusDetermined),
+      mapToPayload(),
+      switchMap(({ categoryRef, depth }) =>
+        this.categoryService
+          .getCategoryTree(categoryRef, depth)
+          .pipe(map(categories => loadCategoryTreeSuccess({ categories })))
       )
     )
   );

--- a/src/app/core/store/shopping/categories/categories.reducer.ts
+++ b/src/app/core/store/shopping/categories/categories.reducer.ts
@@ -2,7 +2,12 @@ import { createReducer, on } from '@ngrx/store';
 
 import { CategoryTree, CategoryTreeHelper } from 'ish-core/models/category-tree/category-tree.model';
 
-import { loadCategoryFail, loadCategorySuccess, loadTopLevelCategoriesSuccess } from './categories.actions';
+import {
+  loadCategoryFail,
+  loadCategorySuccess,
+  loadCategoryTreeSuccess,
+  loadTopLevelCategoriesSuccess,
+} from './categories.actions';
 
 export interface CategoriesState {
   categories: CategoryTree;
@@ -14,7 +19,7 @@ const initialState: CategoriesState = {
 
 function mergeCategories(
   state: CategoriesState,
-  action: ReturnType<typeof loadTopLevelCategoriesSuccess | typeof loadCategorySuccess>
+  action: ReturnType<typeof loadTopLevelCategoriesSuccess | typeof loadCategorySuccess | typeof loadCategoryTreeSuccess>
 ) {
   const loadedTree = action.payload.categories;
   const categories = CategoryTreeHelper.merge(state.categories, loadedTree);
@@ -32,5 +37,5 @@ export const categoriesReducer = createReducer(
       ...state,
     })
   ),
-  on(loadCategorySuccess, loadTopLevelCategoriesSuccess, mergeCategories)
+  on(loadCategorySuccess, loadCategoryTreeSuccess, loadTopLevelCategoriesSuccess, mergeCategories)
 );

--- a/src/app/core/store/shopping/categories/categories.selectors.spec.ts
+++ b/src/app/core/store/shopping/categories/categories.selectors.spec.ts
@@ -15,6 +15,7 @@ import {
   loadCategory,
   loadCategoryFail,
   loadCategorySuccess,
+  loadCategoryTreeSuccess,
   loadTopLevelCategoriesSuccess,
 } from './categories.actions';
 import {
@@ -23,6 +24,7 @@ import {
   getCategoryEntities,
   getCategoryIdByRefId,
   getNavigationCategories,
+  getNavigationCategoryTree,
   getSelectedCategory,
 } from './categories.selectors';
 
@@ -190,12 +192,14 @@ describe('Categories Selectors', () => {
         expect(getNavigationCategories(undefined)(store$.state)).toMatchInlineSnapshot(`
           [
             {
+              "children": undefined,
               "hasChildren": true,
               "name": "name_A",
               "uniqueId": "A",
               "url": "/name_a-ctgA",
             },
             {
+              "children": undefined,
               "hasChildren": false,
               "name": "name_B",
               "uniqueId": "B",
@@ -209,12 +213,14 @@ describe('Categories Selectors', () => {
         expect(getNavigationCategories('A')(store$.state)).toMatchInlineSnapshot(`
           [
             {
+              "children": undefined,
               "hasChildren": true,
               "name": "name_A.1",
               "uniqueId": "A.1",
               "url": "/name_a/name_a.1-ctgA.1",
             },
             {
+              "children": undefined,
               "hasChildren": false,
               "name": "name_A.2",
               "uniqueId": "A.2",
@@ -228,12 +234,14 @@ describe('Categories Selectors', () => {
         expect(getNavigationCategories('A.1')(store$.state)).toMatchInlineSnapshot(`
           [
             {
+              "children": undefined,
               "hasChildren": false,
               "name": "name_A.1.a",
               "uniqueId": "A.1.a",
               "url": "/name_a/name_a.1/name_a.1.a-ctgA.1.a",
             },
             {
+              "children": undefined,
               "hasChildren": false,
               "name": "name_A.1.b",
               "uniqueId": "A.1.b",
@@ -245,6 +253,149 @@ describe('Categories Selectors', () => {
 
       it('should be empty when selecting leaves', () => {
         expect(getNavigationCategories('A.1.a')(store$.state)).toBeEmpty();
+      });
+    });
+  });
+
+  describe('loading category tree', () => {
+    beforeEach(() => {
+      const cA = { name: 'name_A', uniqueId: 'A', categoryRef: 'A@cat', categoryPath: ['A'] } as Category;
+      const cA1 = { name: 'name_A.1', uniqueId: 'A.1', categoryRef: 'A.1@cat', categoryPath: ['A', 'A.1'] } as Category;
+      const cA1a = {
+        name: 'name_A.1.a',
+        uniqueId: 'A.1.a',
+        categoryRef: 'A.1.a@cat',
+        categoryPath: ['A', 'A.1', 'A.1.a'],
+      } as Category;
+      const cA1b = {
+        name: 'name_A.1.b',
+        uniqueId: 'A.1.b',
+        categoryRef: 'A.1.b@cat',
+        categoryPath: ['A', 'A.1', 'A.1.b'],
+      } as Category;
+      const cA2 = { name: 'name_A.2', uniqueId: 'A.2', categoryRef: 'A.2@cat', categoryPath: ['A', 'A.2'] } as Category;
+      store$.dispatch(loadCategoryTreeSuccess({ categories: categoryTree([cA, cA1, cA1a, cA1b, cA2]) }));
+    });
+
+    describe('selecting navigation category tree', () => {
+      it('should select only the category tree root', () => {
+        expect(getNavigationCategoryTree('A@cat', 0)(store$.state)).toMatchInlineSnapshot(`
+          {
+            "children": undefined,
+            "hasChildren": true,
+            "name": "name_A",
+            "uniqueId": "A",
+            "url": "/name_a-ctgA",
+          }
+        `);
+      });
+
+      it('should select the category tree with only one level', () => {
+        expect(getNavigationCategoryTree('A@cat', 1)(store$.state)).toMatchInlineSnapshot(`
+          {
+            "children": [
+              {
+                "children": undefined,
+                "hasChildren": true,
+                "name": "name_A.1",
+                "uniqueId": "A.1",
+                "url": "/name_a/name_a.1-ctgA.1",
+              },
+              {
+                "children": undefined,
+                "hasChildren": false,
+                "name": "name_A.2",
+                "uniqueId": "A.2",
+                "url": "/name_a/name_a.2-ctgA.2",
+              },
+            ],
+            "hasChildren": true,
+            "name": "name_A",
+            "uniqueId": "A",
+            "url": "/name_a-ctgA",
+          }
+        `);
+      });
+
+      it('should select the whole category tree', () => {
+        expect(getNavigationCategoryTree('A@cat', 2)(store$.state)).toMatchInlineSnapshot(`
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": undefined,
+                    "hasChildren": false,
+                    "name": "name_A.1.a",
+                    "uniqueId": "A.1.a",
+                    "url": "/name_a/name_a.1/name_a.1.a-ctgA.1.a",
+                  },
+                  {
+                    "children": undefined,
+                    "hasChildren": false,
+                    "name": "name_A.1.b",
+                    "uniqueId": "A.1.b",
+                    "url": "/name_a/name_a.1/name_a.1.b-ctgA.1.b",
+                  },
+                ],
+                "hasChildren": true,
+                "name": "name_A.1",
+                "uniqueId": "A.1",
+                "url": "/name_a/name_a.1-ctgA.1",
+              },
+              {
+                "children": undefined,
+                "hasChildren": false,
+                "name": "name_A.2",
+                "uniqueId": "A.2",
+                "url": "/name_a/name_a.2-ctgA.2",
+              },
+            ],
+            "hasChildren": true,
+            "name": "name_A",
+            "uniqueId": "A",
+            "url": "/name_a-ctgA",
+          }
+        `);
+      });
+
+      it('should select sub category tree when deeper sub category is selected', () => {
+        expect(getNavigationCategoryTree('A.1@cat', 2)(store$.state)).toMatchInlineSnapshot(`
+          {
+            "children": [
+              {
+                "children": undefined,
+                "hasChildren": false,
+                "name": "name_A.1.a",
+                "uniqueId": "A.1.a",
+                "url": "/name_a/name_a.1/name_a.1.a-ctgA.1.a",
+              },
+              {
+                "children": undefined,
+                "hasChildren": false,
+                "name": "name_A.1.b",
+                "uniqueId": "A.1.b",
+                "url": "/name_a/name_a.1/name_a.1.b-ctgA.1.b",
+              },
+            ],
+            "hasChildren": true,
+            "name": "name_A.1",
+            "uniqueId": "A.1",
+            "url": "/name_a/name_a.1-ctgA.1",
+          }
+        `);
+      });
+
+      it('should select only the root category if it has no subcategories', () => {
+        expect(getNavigationCategoryTree('A.2@cat', 2)(store$.state)).toMatchInlineSnapshot(`
+          {
+            "children": undefined,
+            "hasChildren": false,
+            "name": "name_A.2",
+            "uniqueId": "A.2",
+            "url": "/name_a/name_a.2-ctgA.2",
+          }
+        `);
       });
     });
   });

--- a/src/app/shared/cms/cms.module.ts
+++ b/src/app/shared/cms/cms.module.ts
@@ -6,6 +6,7 @@ import { CMSDialogComponent } from './components/cms-dialog/cms-dialog.component
 import { CMSFreestyleComponent } from './components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './components/cms-image/cms-image.component';
+import { CMSNavigationLinkComponent } from './components/cms-navigation-link/cms-navigation-link.component';
 import { CMSProductListCategoryComponent } from './components/cms-product-list-category/cms-product-list-category.component';
 import { CMSProductListFilterComponent } from './components/cms-product-list-filter/cms-product-list-filter.component';
 import { CMSProductListManualComponent } from './components/cms-product-list-manual/cms-product-list-manual.component';
@@ -127,6 +128,14 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
       useValue: {
         definitionQualifiedName: 'app_sf_base_cm:component.common.dialog.pagelet2-Component',
         class: CMSDialogComponent,
+      },
+      multi: true,
+    },
+    {
+      provide: CMS_COMPONENT,
+      useValue: {
+        definitionQualifiedName: 'app_sf_base_cm:component.navigation.link.pagelet2-Component',
+        class: CMSNavigationLinkComponent,
       },
       multi: true,
     },

--- a/src/app/shared/cms/cms.module.ts
+++ b/src/app/shared/cms/cms.module.ts
@@ -7,6 +7,7 @@ import { CMSFreestyleComponent } from './components/cms-freestyle/cms-freestyle.
 import { CMSImageEnhancedComponent } from './components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './components/cms-image/cms-image.component';
 import { CMSNavigationLinkComponent } from './components/cms-navigation-link/cms-navigation-link.component';
+import { CMSNavigationPageComponent } from './components/cms-navigation-page/cms-navigation-page.component';
 import { CMSProductListCategoryComponent } from './components/cms-product-list-category/cms-product-list-category.component';
 import { CMSProductListFilterComponent } from './components/cms-product-list-filter/cms-product-list-filter.component';
 import { CMSProductListManualComponent } from './components/cms-product-list-manual/cms-product-list-manual.component';
@@ -136,6 +137,14 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
       useValue: {
         definitionQualifiedName: 'app_sf_base_cm:component.navigation.link.pagelet2-Component',
         class: CMSNavigationLinkComponent,
+      },
+      multi: true,
+    },
+    {
+      provide: CMS_COMPONENT,
+      useValue: {
+        definitionQualifiedName: 'app_sf_base_cm:component.navigation.page.pagelet2-Component',
+        class: CMSNavigationPageComponent,
       },
       multi: true,
     },

--- a/src/app/shared/cms/cms.module.ts
+++ b/src/app/shared/cms/cms.module.ts
@@ -6,6 +6,7 @@ import { CMSDialogComponent } from './components/cms-dialog/cms-dialog.component
 import { CMSFreestyleComponent } from './components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './components/cms-image/cms-image.component';
+import { CMSNavigationCategoryComponent } from './components/cms-navigation-category/cms-navigation-category.component';
 import { CMSNavigationLinkComponent } from './components/cms-navigation-link/cms-navigation-link.component';
 import { CMSNavigationPageComponent } from './components/cms-navigation-page/cms-navigation-page.component';
 import { CMSProductListCategoryComponent } from './components/cms-product-list-category/cms-product-list-category.component';
@@ -145,6 +146,14 @@ import { CMS_COMPONENT } from './configurations/injection-keys';
       useValue: {
         definitionQualifiedName: 'app_sf_base_cm:component.navigation.page.pagelet2-Component',
         class: CMSNavigationPageComponent,
+      },
+      multi: true,
+    },
+    {
+      provide: CMS_COMPONENT,
+      useValue: {
+        definitionQualifiedName: 'app_sf_base_cm:component.navigation.category.pagelet2-Component',
+        class: CMSNavigationCategoryComponent,
       },
       multi: true,
     },

--- a/src/app/shared/cms/components/cms-navigation-category/cms-navigation-category.component.html
+++ b/src/app/shared/cms/components/cms-navigation-category/cms-navigation-category.component.html
@@ -1,0 +1,62 @@
+<!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
+<!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
+<ng-container *ngIf="categoryTree$ | async as category">
+  <li
+    #subMenu
+    [class]="'dropdown ' + pagelet.stringParam('CSSClass', '')"
+    [ngClass]="{ open: isOpened(category.uniqueId) }"
+    (mouseenter)="subMenuShow(subMenu)"
+    (mouseleave)="subMenuHide(subMenu)"
+    (click)="subMenuHide(subMenu)"
+  >
+    <a [routerLink]="category.url" [ngStyle]="{ width: !showSubMenu(category.children?.length) ? '100%' : '' }">
+      <ng-container *ngIf="pagelet.hasParam('DisplayName'); else noDisplayName">
+        {{ pagelet.stringParam('DisplayName') }}
+      </ng-container>
+      <ng-template #noDisplayName>
+        {{ category.name }}
+      </ng-template>
+    </a>
+
+    <ng-container *ngIf="showSubMenu(category.children?.length)">
+      <a class="dropdown-toggle" (click)="toggleOpen(category.uniqueId)">
+        <fa-icon *ngIf="isOpened(category.uniqueId); else closed" [icon]="['fas', 'minus']" />
+        <ng-template #closed><fa-icon [icon]="['fas', 'plus']" /></ng-template>
+      </a>
+
+      <ng-container
+        [ngTemplateOutlet]="treeNodeTemplate"
+        [ngTemplateOutletContext]="{ treeNode: category, depth: 1 }"
+      />
+
+      <!-- the recursively used template to render the tree nodes -->
+      <ng-template #treeNodeTemplate let-treeNode="treeNode" let-depth="depth">
+        <ul class="category-level{{ depth }}" [ngClass]="{ 'dropdown-menu': depth === 1 }">
+          <li
+            *ngFor="let node of treeNode.children"
+            class="main-navigation-level{{ depth }}-item"
+            [ngClass]="{ open: isOpened(node.uniqueId) }"
+          >
+            <a [routerLink]="node.url" [ngStyle]="{ width: !node.children?.length ? '100%' : '' }">
+              {{ node.name }}
+            </a>
+            <ng-container *ngIf="node.children?.length">
+              <a class="dropdown-toggle" (click)="toggleOpen(node.uniqueId)">
+                <fa-icon *ngIf="isOpened(node.uniqueId); else closed" [icon]="['fas', 'minus']" />
+                <ng-template #closed><fa-icon [icon]="['fas', 'plus']" /></ng-template>
+              </a>
+              <ng-container
+                [ngTemplateOutlet]="treeNodeTemplate"
+                [ngTemplateOutletContext]="{ treeNode: node, depth: depth + 1 }"
+              />
+            </ng-container>
+          </li>
+
+          <li *ngIf="pagelet.hasParam('SubNavigationHTML') && depth === 1" class="sub-navigation-content">
+            <div [ishServerHtml]="pagelet.stringParam('SubNavigationHTML')"></div>
+          </li>
+        </ul>
+      </ng-template>
+    </ng-container>
+  </li>
+</ng-container>

--- a/src/app/shared/cms/components/cms-navigation-category/cms-navigation-category.component.spec.ts
+++ b/src/app/shared/cms/components/cms-navigation-category/cms-navigation-category.component.spec.ts
@@ -1,0 +1,246 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { MockComponent, MockDirective } from 'ng-mocks';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+import { createContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { NavigationCategory } from 'ish-core/models/navigation-category/navigation-category.model';
+
+import { CMSNavigationCategoryComponent } from './cms-navigation-category.component';
+
+describe('Cms Navigation Category Component', () => {
+  let component: CMSNavigationCategoryComponent;
+  let fixture: ComponentFixture<CMSNavigationCategoryComponent>;
+  let element: HTMLElement;
+  let shoppingFacade: ShoppingFacade;
+
+  const pagelet = {
+    definitionQualifiedName: 'dqn',
+    id: 'id',
+    displayName: 'name',
+    domain: 'domain',
+    configurationParameters: {
+      Category: 'A@1',
+      SubNavigationDepth: 0,
+    },
+  };
+
+  const categoryTree_0 = { uniqueId: 'A', name: 'Cat A', url: '/cat/A' } as NavigationCategory;
+
+  const categoryTree_1 = {
+    uniqueId: 'A',
+    name: 'Cat A',
+    url: '/cat/A',
+    children: [
+      { uniqueId: 'A_1', name: 'Cat A1', url: '/cat/A.A_1' },
+      { uniqueId: 'A_2', name: 'Cat A2', url: '/cat/A.A_2' },
+      { uniqueId: 'A_3', name: 'Cat A3', url: '/cat/A.A_3' },
+    ],
+  } as NavigationCategory;
+
+  const categoryTree_2 = {
+    uniqueId: 'A',
+    name: 'Cat A',
+    url: '/cat/A',
+    children: [
+      {
+        uniqueId: 'A_1',
+        name: 'Cat A1',
+        url: '/cat/A.A_1',
+        children: [{ uniqueId: 'A_1_a', name: 'Cat A1 a', url: '/cat/A.A_1.A_1_a' }],
+      },
+    ],
+  } as NavigationCategory;
+
+  beforeEach(async () => {
+    shoppingFacade = mock(ShoppingFacade);
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [
+        CMSNavigationCategoryComponent,
+        MockComponent(FaIconComponent),
+        MockDirective(ServerHtmlDirective),
+      ],
+      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CMSNavigationCategoryComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    when(shoppingFacade.navigationCategoryTree$(anything(), 0)).thenReturn(of(categoryTree_0));
+    when(shoppingFacade.navigationCategoryTree$(anything(), 1)).thenReturn(of(categoryTree_1));
+    when(shoppingFacade.navigationCategoryTree$(anything(), 2)).thenReturn(of(categoryTree_2));
+    when(shoppingFacade.navigationCategoryTree$(anything(), 3)).thenReturn(of(categoryTree_0));
+  });
+
+  it('should be created', () => {
+    component.pagelet = createContentPageletView(pagelet);
+    component.ngOnChanges();
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a ng-reflect-router-link="/cat/A" style="width: 100%" href="/cat/A"> Cat A </a>
+      </li>
+    `);
+  });
+
+  it('should render an Alternative Display Name and a CSS Class if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        DisplayName: 'Navigation Category',
+        CSSClass: 'nav-cat',
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown nav-cat">
+        <a ng-reflect-router-link="/cat/A" style="width: 100%" href="/cat/A"> Navigation Category </a>
+      </li>
+    `);
+  });
+
+  it('should render Subnavigation HTML if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: { ...pagelet.configurationParameters, SubNavigationHTML: '<span>Hello Category</span>' },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a ng-reflect-router-link="/cat/A" href="/cat/A"> Cat A </a
+        ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="sub-navigation-content">
+            <div ng-reflect-ish-server-html="<span>Hello Category</span>"></div>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should render category tree and Subnavigation HTML if both are set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 2,
+        SubNavigationHTML: '<span>Hello Category</span>',
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a ng-reflect-router-link="/cat/A" href="/cat/A"> Cat A </a
+        ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="main-navigation-level1-item">
+            <a ng-reflect-router-link="/cat/A.A_1" href="/cat/A.A_1"> Cat A1 </a
+            ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+            <ul class="category-level2">
+              <li class="main-navigation-level2-item">
+                <a ng-reflect-router-link="/cat/A.A_1.A_1_a" style="width: 100%" href="/cat/A.A_1.A_1_a">
+                  Cat A1 a
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li class="sub-navigation-content">
+            <div ng-reflect-ish-server-html="<span>Hello Category</span>"></div>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should render a category tree with Subnavigation Depth of 1 if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 1,
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a ng-reflect-router-link="/cat/A" href="/cat/A"> Cat A </a
+        ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="main-navigation-level1-item">
+            <a ng-reflect-router-link="/cat/A.A_1" style="width: 100%" href="/cat/A.A_1"> Cat A1 </a>
+          </li>
+          <li class="main-navigation-level1-item">
+            <a ng-reflect-router-link="/cat/A.A_2" style="width: 100%" href="/cat/A.A_2"> Cat A2 </a>
+          </li>
+          <li class="main-navigation-level1-item">
+            <a ng-reflect-router-link="/cat/A.A_3" style="width: 100%" href="/cat/A.A_3"> Cat A3 </a>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should render a category tree with Subnavigation Depth of 2 if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 2,
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a ng-reflect-router-link="/cat/A" href="/cat/A"> Cat A </a
+        ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="main-navigation-level1-item">
+            <a ng-reflect-router-link="/cat/A.A_1" href="/cat/A.A_1"> Cat A1 </a
+            ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+            <ul class="category-level2">
+              <li class="main-navigation-level2-item">
+                <a ng-reflect-router-link="/cat/A.A_1.A_1_a" style="width: 100%" href="/cat/A.A_1.A_1_a">
+                  Cat A1 a
+                </a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should not render a sub naviagtion if category has no children even if Subnavigation Depth is set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 3,
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a ng-reflect-router-link="/cat/A" style="width: 100%" href="/cat/A"> Cat A </a>
+      </li>
+    `);
+  });
+});

--- a/src/app/shared/cms/components/cms-navigation-category/cms-navigation-category.component.ts
+++ b/src/app/shared/cms/components/cms-navigation-category/cms-navigation-category.component.ts
@@ -1,0 +1,63 @@
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+import { ContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { NavigationCategory } from 'ish-core/models/navigation-category/navigation-category.model';
+import { CMSComponent } from 'ish-shared/cms/models/cms-component/cms-component.model';
+
+@Component({
+  selector: 'ish-cms-navigation-category',
+  templateUrl: './cms-navigation-category.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CMSNavigationCategoryComponent implements CMSComponent, OnChanges {
+  @Input({ required: true }) pagelet: ContentPageletView;
+
+  categoryTree$: Observable<NavigationCategory>;
+
+  private openedCategories: string[] = [];
+
+  constructor(private shoppingFacade: ShoppingFacade) {}
+
+  ngOnChanges(): void {
+    if (this.pagelet?.hasParam('Category')) {
+      this.categoryTree$ = this.shoppingFacade.navigationCategoryTree$(
+        this.pagelet.stringParam('Category'),
+        this.pagelet.numberParam('SubNavigationDepth', 0)
+      );
+    }
+  }
+
+  showSubMenu(childCount: number) {
+    return (this.pagelet.hasParam('SubNavigationDepth') &&
+      this.pagelet.numberParam('SubNavigationDepth') > 0 &&
+      childCount) ||
+      this.pagelet.hasParam('SubNavigationHTML')
+      ? true
+      : false;
+  }
+
+  subMenuShow(subMenu: HTMLElement) {
+    subMenu.classList.add('hover');
+  }
+
+  subMenuHide(subMenu: HTMLElement) {
+    subMenu.classList.remove('hover');
+  }
+
+  /**
+   * Indicate if specific content page is expanded.
+   */
+  isOpened(uniqueId: string): boolean {
+    return this.openedCategories.includes(uniqueId);
+  }
+
+  /**
+   * Toggle content page open state.
+   */
+  toggleOpen(uniqueId: string) {
+    const index = this.openedCategories.findIndex(id => id === uniqueId);
+    index > -1 ? this.openedCategories.splice(index, 1) : this.openedCategories.push(uniqueId);
+  }
+}

--- a/src/app/shared/cms/components/cms-navigation-link/cms-navigation-link.component.html
+++ b/src/app/shared/cms/components/cms-navigation-link/cms-navigation-link.component.html
@@ -1,0 +1,41 @@
+<!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
+<!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
+<ng-container *ngIf="pagelet?.hasParam('Link')">
+  <li
+    #subMenu
+    [class]="'dropdown ' + pagelet.stringParam('CSSClass', '')"
+    [ngClass]="{ open: opened }"
+    (mouseenter)="subMenuShow(subMenu)"
+    (mouseleave)="subMenuHide(subMenu)"
+    (click)="subMenuHide(subMenu)"
+  >
+    <ng-container *ngIf="isRouterLink(pagelet, 'Link'); else externalLink">
+      <a
+        [routerLink]="routerLink(pagelet, 'Link')"
+        [ngStyle]="{ width: !pagelet.hasParam('SubNavigationHTML') ? '100%' : '' }"
+      >
+        {{ pagelet.stringParam('LinkText') }}
+      </a>
+    </ng-container>
+    <ng-template #externalLink>
+      <a
+        [href]="pagelet.stringParam('Link')"
+        [ngStyle]="{ width: !pagelet.hasParam('SubNavigationHTML') ? '100%' : '' }"
+      >
+        {{ pagelet.stringParam('LinkText') }}
+      </a>
+    </ng-template>
+
+    <ng-container *ngIf="pagelet.hasParam('SubNavigationHTML')">
+      <a class="dropdown-toggle" (click)="toggleOpen()">
+        <fa-icon *ngIf="opened; else closed" [icon]="['fas', 'minus']" />
+        <ng-template #closed><fa-icon [icon]="['fas', 'plus']" /></ng-template>
+      </a>
+      <ul class="category-level1 dropdown-menu">
+        <li class="sub-navigation-content">
+          <div [ishServerHtml]="pagelet.stringParam('SubNavigationHTML')"></div>
+        </li>
+      </ul>
+    </ng-container>
+  </li>
+</ng-container>

--- a/src/app/shared/cms/components/cms-navigation-link/cms-navigation-link.component.spec.ts
+++ b/src/app/shared/cms/components/cms-navigation-link/cms-navigation-link.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { MockComponent, MockDirective } from 'ng-mocks';
+
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { createContentPageletView } from 'ish-core/models/content-view/content-view.model';
+
+import { CMSNavigationLinkComponent } from './cms-navigation-link.component';
+
+describe('Cms Navigation Link Component', () => {
+  let component: CMSNavigationLinkComponent;
+  let fixture: ComponentFixture<CMSNavigationLinkComponent>;
+  let element: HTMLElement;
+
+  const pagelet = {
+    definitionQualifiedName: 'dqn',
+    id: 'id',
+    displayName: 'name',
+    domain: 'domain',
+    configurationParameters: {
+      Link: 'route://home',
+      LinkText: 'Home',
+      CSSClass: 'nav-link',
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [CMSNavigationLinkComponent, MockComponent(FaIconComponent), MockDirective(ServerHtmlDirective)],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CMSNavigationLinkComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it('should be created', () => {
+    component.pagelet = createContentPageletView(pagelet);
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown nav-link">
+        <a ng-reflect-router-link="/home" style="width: 100%" href="/home"> Home </a>
+      </li>
+    `);
+  });
+
+  it('should render external link if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: { ...pagelet.configurationParameters, Link: 'https://test.com', LinkText: 'External' },
+    });
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(
+      `<li class="dropdown nav-link"><a href="https://test.com" style="width: 100%"> External </a></li>`
+    );
+  });
+
+  it('should render Sub Navigation HTML if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: { ...pagelet.configurationParameters, SubNavigationHTML: '<span>Hello World</span>' },
+    });
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown nav-link">
+        <a ng-reflect-router-link="/home" href="/home"> Home </a
+        ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="sub-navigation-content">
+            <div ng-reflect-ish-server-html="<span>Hello World</span>"></div>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+});

--- a/src/app/shared/cms/components/cms-navigation-link/cms-navigation-link.component.ts
+++ b/src/app/shared/cms/components/cms-navigation-link/cms-navigation-link.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+import { ContentViewHelper } from 'ish-core/models/content-view/content-view.helper';
+import { ContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { CMSComponent } from 'ish-shared/cms/models/cms-component/cms-component.model';
+
+@Component({
+  selector: 'ish-cms-navigation-link',
+  templateUrl: './cms-navigation-link.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CMSNavigationLinkComponent implements CMSComponent {
+  @Input({ required: true }) pagelet: ContentPageletView;
+
+  opened = false;
+
+  isRouterLink = ContentViewHelper.isRouterLink;
+  routerLink = ContentViewHelper.getRouterLink;
+
+  subMenuShow(subMenu: HTMLElement) {
+    subMenu.classList.add('hover');
+  }
+
+  subMenuHide(subMenu: HTMLElement) {
+    subMenu.classList.remove('hover');
+  }
+
+  toggleOpen() {
+    this.opened = !this.opened;
+  }
+}

--- a/src/app/shared/cms/components/cms-navigation-page/cms-navigation-page.component.html
+++ b/src/app/shared/cms/components/cms-navigation-page/cms-navigation-page.component.html
@@ -1,0 +1,62 @@
+<!-- eslint-disable @angular-eslint/template/interactive-supports-focus -->
+<!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
+<ng-container *ngIf="pageTree$ | async as page">
+  <li
+    #subMenu
+    [class]="'dropdown ' + pagelet.stringParam('CSSClass', '')"
+    [ngClass]="{ open: isOpened(page.contentPageId) }"
+    (mouseenter)="subMenuShow(subMenu)"
+    (mouseleave)="subMenuHide(subMenu)"
+    (click)="subMenuHide(subMenu)"
+  >
+    <a
+      [routerLink]="page | ishContentPageRoute"
+      [ngStyle]="{ width: !showSubMenu(page.children.length) ? '100%' : '' }"
+    >
+      <ng-container *ngIf="pagelet.hasParam('DisplayName'); else noDisplayName">
+        {{ pagelet.stringParam('DisplayName') }}
+      </ng-container>
+      <ng-template #noDisplayName>
+        {{ page.name }}
+      </ng-template>
+    </a>
+
+    <ng-container *ngIf="showSubMenu(page.children.length)">
+      <a class="dropdown-toggle" (click)="toggleOpen(page.contentPageId)">
+        <fa-icon *ngIf="isOpened(page.contentPageId); else closed" [icon]="['fas', 'minus']" />
+        <ng-template #closed><fa-icon [icon]="['fas', 'plus']" /></ng-template>
+      </a>
+
+      <ng-container [ngTemplateOutlet]="treeNodeTemplate" [ngTemplateOutletContext]="{ treeNode: page, depth: 1 }" />
+
+      <!-- the recursively used template to render the tree nodes -->
+      <ng-template #treeNodeTemplate let-treeNode="treeNode" let-depth="depth">
+        <ul class="category-level{{ depth }}" [ngClass]="{ 'dropdown-menu': depth === 1 }">
+          <li
+            *ngFor="let node of treeNode.children"
+            class="main-navigation-level{{ depth }}-item"
+            [ngClass]="{ open: isOpened(node.contentPageId) }"
+          >
+            <a [routerLink]="node | ishContentPageRoute" [ngStyle]="{ width: !node.children.length ? '100%' : '' }">
+              {{ node.name }}
+            </a>
+            <ng-container *ngIf="node.children.length">
+              <a class="dropdown-toggle" (click)="toggleOpen(node.contentPageId)">
+                <fa-icon *ngIf="isOpened(node.contentPageId); else closed" [icon]="['fas', 'minus']" />
+                <ng-template #closed><fa-icon [icon]="['fas', 'plus']" /></ng-template>
+              </a>
+              <ng-container
+                [ngTemplateOutlet]="treeNodeTemplate"
+                [ngTemplateOutletContext]="{ treeNode: node, depth: depth + 1 }"
+              />
+            </ng-container>
+          </li>
+
+          <li *ngIf="pagelet.hasParam('SubNavigationHTML') && depth === 1" class="sub-navigation-content">
+            <div [ishServerHtml]="pagelet.stringParam('SubNavigationHTML')"></div>
+          </li>
+        </ul>
+      </ng-template>
+    </ng-container>
+  </li>
+</ng-container>

--- a/src/app/shared/cms/components/cms-navigation-page/cms-navigation-page.component.spec.ts
+++ b/src/app/shared/cms/components/cms-navigation-page/cms-navigation-page.component.spec.ts
@@ -1,0 +1,222 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { CMSFacade } from 'ish-core/facades/cms.facade';
+import { createCompleteContentPageTreeView } from 'ish-core/models/content-page-tree-view/content-page-tree-view.model';
+import { ContentPageTree } from 'ish-core/models/content-page-tree/content-page-tree.model';
+import { createContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { ContentPageRoutePipe } from 'ish-core/routing/content-page/content-page-route.pipe';
+
+import { CMSNavigationPageComponent } from './cms-navigation-page.component';
+
+describe('Cms Navigation Page Component', () => {
+  let component: CMSNavigationPageComponent;
+  let fixture: ComponentFixture<CMSNavigationPageComponent>;
+  let element: HTMLElement;
+  let cmsFacade: CMSFacade;
+
+  const pagelet = {
+    definitionQualifiedName: 'dqn',
+    id: 'id',
+    displayName: 'name',
+    domain: 'domain',
+    configurationParameters: {
+      Page: 'ebene_1',
+      SubNavigationDepth: 0,
+    },
+  };
+
+  const pageTree: ContentPageTree = {
+    rootIds: ['ebene_1'],
+    edges: {
+      ebene_1: ['ebene_2'],
+      ebene_2: ['ebene_3', 'ebene_3a', 'ebene_3b'],
+      ebene_3: ['ebene_4'],
+    },
+    nodes: {
+      ebene_1: {
+        name: 'Ebene 1',
+        path: ['ebene_1'],
+        contentPageId: 'ebene_1',
+      },
+      ebene_2: {
+        name: 'Ebene 2',
+        path: ['ebene_1', 'ebene_2'],
+        contentPageId: 'ebene_2',
+      },
+      ebene_3: {
+        name: 'Ebene 3',
+        path: ['ebene_1', 'ebene_2', 'ebene_3'],
+        contentPageId: 'ebene_3',
+      },
+      ebene_3a: {
+        name: 'Ebene 3a',
+        path: ['ebene_1', 'ebene_2', 'ebene_3a'],
+        contentPageId: 'ebene_3a',
+      },
+      ebene_3b: {
+        name: 'Ebene 3b',
+        path: ['ebene_1', 'ebene_2', 'ebene_3b'],
+        contentPageId: 'ebene_3b',
+      },
+      ebene_4: {
+        name: 'Ebene 4',
+        path: ['ebene_1', 'ebene_2', 'ebene_3', 'ebene_4'],
+        contentPageId: 'ebene_4',
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    cmsFacade = mock(CMSFacade);
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [
+        CMSNavigationPageComponent,
+        MockComponent(FaIconComponent),
+        MockDirective(ServerHtmlDirective),
+        MockPipe(ContentPageRoutePipe),
+      ],
+      providers: [{ provide: CMSFacade, useFactory: () => instance(cmsFacade) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CMSNavigationPageComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    when(cmsFacade.completeContentPageTree$(anything(), 0)).thenReturn(
+      of(createCompleteContentPageTreeView(pageTree, 'ebene_1', 0))
+    );
+    when(cmsFacade.completeContentPageTree$(anything(), 1)).thenReturn(
+      of(createCompleteContentPageTreeView(pageTree, 'ebene_1', 1))
+    );
+    when(cmsFacade.completeContentPageTree$(anything(), 3)).thenReturn(
+      of(createCompleteContentPageTreeView(pageTree, 'ebene_1', 3))
+    );
+    when(cmsFacade.completeContentPageTree$(anything(), 2)).thenReturn(
+      of(createCompleteContentPageTreeView(pageTree, 'ebene_4', 2))
+    );
+  });
+
+  it('should be created', () => {
+    component.pagelet = createContentPageletView(pagelet);
+    component.ngOnChanges();
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(element).toMatchInlineSnapshot(`<li class="dropdown"><a style="width: 100%"> Ebene 1 </a></li>`);
+  });
+
+  it('should render an Alternative Display Name and a CSS Class if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        DisplayName: 'Navigation Page',
+        CSSClass: 'nav-page',
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(
+      `<li class="dropdown nav-page"><a style="width: 100%"> Navigation Page </a></li>`
+    );
+  });
+
+  it('should render Subnavigation HTML if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: { ...pagelet.configurationParameters, SubNavigationHTML: '<span>Hello Page</span>' },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a> Ebene 1 </a><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="sub-navigation-content">
+            <div ng-reflect-ish-server-html="<span>Hello Page</span>"></div>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should render page tree and Subnavigation HTML if both are set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 1,
+        SubNavigationHTML: '<span>Hello Page</span>',
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a> Ebene 1 </a><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="main-navigation-level1-item"><a style="width: 100%"> Ebene 2 </a></li>
+          <li class="sub-navigation-content">
+            <div ng-reflect-ish-server-html="<span>Hello Page</span>"></div>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should render a page tree with Subnavigation Depth of 3 if set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 3,
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <li class="dropdown">
+        <a> Ebene 1 </a><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+        <ul class="category-level1 dropdown-menu">
+          <li class="main-navigation-level1-item">
+            <a> Ebene 2 </a><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+            <ul class="category-level2">
+              <li class="main-navigation-level2-item">
+                <a> Ebene 3 </a
+                ><a class="dropdown-toggle"><fa-icon ng-reflect-icon="fas,plus"></fa-icon></a>
+                <ul class="category-level3">
+                  <li class="main-navigation-level3-item"><a style="width: 100%"> Ebene 4 </a></li>
+                </ul>
+              </li>
+              <li class="main-navigation-level2-item"><a style="width: 100%"> Ebene 3a </a></li>
+              <li class="main-navigation-level2-item"><a style="width: 100%"> Ebene 3b </a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    `);
+  });
+
+  it('should not render a sub naviagtion if page has no children even if Subnavigation Depth is set', () => {
+    component.pagelet = createContentPageletView({
+      ...pagelet,
+      configurationParameters: {
+        ...pagelet.configurationParameters,
+        SubNavigationDepth: 2,
+      },
+    });
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`<li class="dropdown"><a style="width: 100%"> Ebene 4 </a></li>`);
+  });
+});

--- a/src/app/shared/cms/components/cms-navigation-page/cms-navigation-page.component.ts
+++ b/src/app/shared/cms/components/cms-navigation-page/cms-navigation-page.component.ts
@@ -1,0 +1,63 @@
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { CMSFacade } from 'ish-core/facades/cms.facade';
+import { ContentPageTreeView } from 'ish-core/models/content-page-tree-view/content-page-tree-view.model';
+import { ContentPageletView } from 'ish-core/models/content-view/content-view.model';
+import { CMSComponent } from 'ish-shared/cms/models/cms-component/cms-component.model';
+
+@Component({
+  selector: 'ish-cms-navigation-page',
+  templateUrl: './cms-navigation-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CMSNavigationPageComponent implements CMSComponent, OnChanges {
+  @Input({ required: true }) pagelet: ContentPageletView;
+
+  pageTree$: Observable<ContentPageTreeView>;
+
+  private openedPages: string[] = [];
+
+  constructor(private cmsFacade: CMSFacade) {}
+
+  ngOnChanges(): void {
+    if (this.pagelet?.hasParam('Page')) {
+      this.pageTree$ = this.cmsFacade.completeContentPageTree$(
+        this.pagelet.stringParam('Page'),
+        this.pagelet.numberParam('SubNavigationDepth', 0)
+      );
+    }
+  }
+
+  showSubMenu(childCount: number) {
+    return (this.pagelet.hasParam('SubNavigationDepth') &&
+      this.pagelet.numberParam('SubNavigationDepth') > 0 &&
+      childCount) ||
+      this.pagelet.hasParam('SubNavigationHTML')
+      ? true
+      : false;
+  }
+
+  subMenuShow(subMenu: HTMLElement) {
+    subMenu.classList.add('hover');
+  }
+
+  subMenuHide(subMenu: HTMLElement) {
+    subMenu.classList.remove('hover');
+  }
+
+  /**
+   * Indicate if specific content page is expanded.
+   */
+  isOpened(uniqueId: string): boolean {
+    return this.openedPages.includes(uniqueId);
+  }
+
+  /**
+   * Toggle content page open state.
+   */
+  toggleOpen(uniqueId: string) {
+    const index = this.openedPages.findIndex(id => id === uniqueId);
+    index > -1 ? this.openedPages.splice(index, 1) : this.openedPages.push(uniqueId);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -46,6 +46,7 @@ import { CMSFreestyleComponent } from './cms/components/cms-freestyle/cms-freest
 import { CMSImageEnhancedComponent } from './cms/components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './cms/components/cms-image/cms-image.component';
 import { CMSNavigationLinkComponent } from './cms/components/cms-navigation-link/cms-navigation-link.component';
+import { CMSNavigationPageComponent } from './cms/components/cms-navigation-page/cms-navigation-page.component';
 import { CMSProductListCategoryComponent } from './cms/components/cms-product-list-category/cms-product-list-category.component';
 import { CMSProductListFilterComponent } from './cms/components/cms-product-list-filter/cms-product-list-filter.component';
 import { CMSProductListManualComponent } from './cms/components/cms-product-list-manual/cms-product-list-manual.component';
@@ -201,6 +202,7 @@ const declaredComponents = [
   CMSImageComponent,
   CMSImageEnhancedComponent,
   CMSNavigationLinkComponent,
+  CMSNavigationPageComponent,
   CMSProductListCategoryComponent,
   CMSProductListFilterComponent,
   CMSProductListManualComponent,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -45,6 +45,7 @@ import { CMSDialogComponent } from './cms/components/cms-dialog/cms-dialog.compo
 import { CMSFreestyleComponent } from './cms/components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './cms/components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './cms/components/cms-image/cms-image.component';
+import { CMSNavigationLinkComponent } from './cms/components/cms-navigation-link/cms-navigation-link.component';
 import { CMSProductListCategoryComponent } from './cms/components/cms-product-list-category/cms-product-list-category.component';
 import { CMSProductListFilterComponent } from './cms/components/cms-product-list-filter/cms-product-list-filter.component';
 import { CMSProductListManualComponent } from './cms/components/cms-product-list-manual/cms-product-list-manual.component';
@@ -199,6 +200,7 @@ const declaredComponents = [
   CMSFreestyleComponent,
   CMSImageComponent,
   CMSImageEnhancedComponent,
+  CMSNavigationLinkComponent,
   CMSProductListCategoryComponent,
   CMSProductListFilterComponent,
   CMSProductListManualComponent,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -45,6 +45,7 @@ import { CMSDialogComponent } from './cms/components/cms-dialog/cms-dialog.compo
 import { CMSFreestyleComponent } from './cms/components/cms-freestyle/cms-freestyle.component';
 import { CMSImageEnhancedComponent } from './cms/components/cms-image-enhanced/cms-image-enhanced.component';
 import { CMSImageComponent } from './cms/components/cms-image/cms-image.component';
+import { CMSNavigationCategoryComponent } from './cms/components/cms-navigation-category/cms-navigation-category.component';
 import { CMSNavigationLinkComponent } from './cms/components/cms-navigation-link/cms-navigation-link.component';
 import { CMSNavigationPageComponent } from './cms/components/cms-navigation-page/cms-navigation-page.component';
 import { CMSProductListCategoryComponent } from './cms/components/cms-product-list-category/cms-product-list-category.component';
@@ -201,6 +202,7 @@ const declaredComponents = [
   CMSFreestyleComponent,
   CMSImageComponent,
   CMSImageEnhancedComponent,
+  CMSNavigationCategoryComponent,
   CMSNavigationLinkComponent,
   CMSNavigationPageComponent,
   CMSProductListCategoryComponent,

--- a/src/app/shell/header/header-navigation/header-navigation.component.html
+++ b/src/app/shell/header/header-navigation/header-navigation.component.html
@@ -2,10 +2,10 @@
 <!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
 <ul class="navbar-nav main-navigation-list">
   <li
-    *ngFor="let category of categories$ | async"
+    *ngFor="let category of categories$ | async; first as isFirst"
     #subMenu
     class="dropdown"
-    [ngClass]="{ open: isOpened(category.uniqueId) }"
+    [ngClass]="{ open: isOpened(category.uniqueId), first: isFirst }"
     (mouseenter)="subMenuShow(subMenu)"
     (mouseleave)="subMenuHide(subMenu)"
     (click)="subMenuHide(subMenu)"

--- a/src/app/shell/header/header-navigation/header-navigation.component.spec.ts
+++ b/src/app/shell/header/header-navigation/header-navigation.component.spec.ts
@@ -45,7 +45,7 @@ describe('Header Navigation Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
     expect(element).toMatchInlineSnapshot(`
       <ul class="navbar-nav main-navigation-list">
-        <li class="dropdown">
+        <li class="dropdown first">
           <a
             class="main-navigation-link"
             ng-reflect-router-link="/cat/A"

--- a/src/styles/components/header/main-navigation.scss
+++ b/src/styles/components/header/main-navigation.scss
@@ -23,6 +23,7 @@
       }
 
       li {
+        float: none;
         list-style: none;
 
         &.open ul {
@@ -49,23 +50,24 @@
           float: left;
           width: calc(100% - #{$toggler-width});
           padding: $space-default ($grid-gutter-width * 0.5) !important;
-          font-size: $font-size-menu-item-mobile;
+          font-size: $font-size-navbar-item-mobile;
           line-height: 1.3125rem;
+          color: $text-color-inverse;
+          background: $CORPORATE-PRIMARY;
+          border-bottom: $border-width-default solid $border-color-default;
         }
-      }
 
-      li.open {
-        .category-level1,
-        .category-level2,
-        .category-level3,
-        .category-level4 {
-          width: 100%;
-          padding: 0;
-          margin: 0;
+        &.open {
+          .category-level1,
+          .category-level2,
+          .category-level3,
+          .category-level4 {
+            width: 100%;
+            padding: 0;
+            margin: 0;
+          }
         }
-      }
 
-      > li {
         &.dropdown {
           padding: 0;
           background: none;
@@ -73,13 +75,6 @@
 
         ul > li {
           float: none;
-        }
-        // Navbar Items
-        > a {
-          font-size: $font-size-navbar-item-mobile;
-          color: $text-color-inverse;
-          background: $CORPORATE-PRIMARY;
-          border-bottom: $border-width-default solid $border-color-default;
         }
       }
       // Menu Items
@@ -89,7 +84,9 @@
       .category-level4 {
         > li > a {
           font-size: $font-size-sub-menu-item-mobile;
+          color: $text-color-primary;
           text-transform: capitalize;
+          background-color: $color-inverse;
           border-bottom: $border-width-default solid $border-color-light;
         }
 
@@ -139,19 +136,22 @@
   }
 
   .main-navigation-list {
+    display: block;
+
     a {
       font-size: $font-size-navbar-item;
       color: $text-color-primary;
     }
 
-    > li {
+    li {
       line-height: 40px;
 
       &.dropdown {
         position: static;
+        float: left;
         padding: 0 10px;
 
-        &:first-child {
+        &.first {
           padding-left: 0;
         }
 
@@ -226,6 +226,7 @@
 
             ul {
               padding: 0;
+              padding-left: $space-default;
               margin: 0;
             }
 
@@ -282,6 +283,16 @@
 
 @include media-breakpoint-down(sm) {
   @include mobile-navigation;
+}
+
+.sub-navigation-content {
+  padding: 0 !important;
+  margin: 0 !important;
+  clear: both;
+
+  @media (max-width: $screen-xs-max) {
+    padding: $space-default !important;
+  }
 }
 
 /* purgecss end ignore */


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the New Behavior?

Introduce new CMS components that can be used to extend the main navigation.
* simple link with optional flyout HTML
* page link with optional sub pages navigation and flyout HTML
* category link with optional sub category navigation and flyout HTML

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

* some main navigation styling adaptions were needed
* the needed pagelet models will be available with ICM 11 (`icm-as-customization-headless:1.7.0`)


[AB#79464](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79464)