### PR TITLE
chore: remove lazy components on synchronize

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -15,7 +15,6 @@ then
 
   if [ "$INTERSHOP_PWA_AUTO_INSTALL" = "true" ]
   then
-    git clean -xdf src/**/lazy-* projects/**/lazy-*
     npm install
   fi
 fi

--- a/schematics/src/helpers/lazy-components/factory.ts
+++ b/schematics/src/helpers/lazy-components/factory.ts
@@ -1,45 +1,96 @@
-import { Rule, SchematicsException, chain, schematic } from '@angular-devkit/schematics';
+import { Rule, SchematicsException, Tree, chain, schematic } from '@angular-devkit/schematics';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
+import * as cp from 'child_process';
+import * as path from 'path';
 import { PWALazyComponentsOptionsSchema as Options } from 'schemas/helpers/lazy-components/schema';
+
+async function createNewComponents(host: Tree, options: Options) {
+  const workspace = await getWorkspace(host);
+  const project = workspace.projects.get(options.project);
+
+  const operations: Rule[] = [];
+
+  const fileVisitor = (file: string) => {
+    if (file.endsWith('.component.ts')) {
+      const componentContent = host.read(file).toString('utf-8');
+      if (componentContent.includes('@GenerateLazyComponent')) {
+        operations.push(schematic('lazy-component', { ...options, path: file.substring(1) }));
+      }
+    }
+    try {
+      host.getDir(file).visit(fileVisitor);
+    } catch (err) {
+      // do nothing
+    }
+  };
+
+  const extensionsRoot = `/${project.sourceRoot}/app/extensions`;
+  host.getDir(extensionsRoot).subdirs.forEach(extension => {
+    const sharedComponentFolder = `${extensionsRoot}/${extension}/shared`;
+    host.getDir(sharedComponentFolder).visit(fileVisitor);
+  });
+
+  const projectsRoot = `/projects`;
+  host.getDir(projectsRoot).subdirs.forEach(projectName => {
+    const sharedComponentFolder = `${projectsRoot}/${projectName}/src/app/components`;
+    host.getDir(sharedComponentFolder).visit(fileVisitor);
+  });
+
+  const sharedRoot = `/src/app/shared`;
+  host.getDir(sharedRoot).visit(fileVisitor);
+
+  return operations;
+}
+
+async function deleteOldComponents() {
+  const operations: Rule[] = [];
+
+  if (process.env.CI !== 'true') {
+    let gitAvailable = false;
+    try {
+      cp.execSync('git --version');
+      gitAvailable = true;
+    } catch (error) {
+      console.warn('Git is not installed. Skipping deletion.');
+    }
+
+    if (gitAvailable) {
+      cp.execSync('git clean -dnx')
+        .toString()
+        .split('\n')
+        .map(line => {
+          const splits = line.split(/\s/);
+          return splits[splits.length - 1];
+        })
+        .filter(file => path.basename(file)?.startsWith('lazy-'))
+        .forEach(file => {
+          operations.push(tree => {
+            try {
+              console.log(tree.get(file));
+              tree.delete(file);
+            } catch (error) {
+              tree.getDir(file).subfiles.forEach(subfile => {
+                tree.delete(`${file}/${subfile}`);
+              });
+            }
+          });
+        });
+    }
+  }
+
+  return operations;
+}
 
 export function createLazyComponents(options: Options): Rule {
   return async host => {
     if (!options.project) {
       throw new SchematicsException('Option (project) is required.');
     }
-    const workspace = await getWorkspace(host);
-    const project = workspace.projects.get(options.project);
-    const operations: Rule[] = [];
 
-    const fileVisitor = (file: string) => {
-      if (file.endsWith('.component.ts')) {
-        const componentContent = host.read(file).toString('utf-8');
-        if (componentContent.includes('@GenerateLazyComponent')) {
-          operations.push(schematic('lazy-component', { ...options, path: file.substring(1) }));
-        }
-      }
-      try {
-        host.getDir(file).visit(fileVisitor);
-      } catch (err) {
-        // do nothing
-      }
-    };
+    const oldComponents = await deleteOldComponents();
 
-    const extensionsRoot = `/${project.sourceRoot}/app/extensions`;
-    host.getDir(extensionsRoot).subdirs.forEach(extension => {
-      const sharedComponentFolder = `${extensionsRoot}/${extension}/shared`;
-      host.getDir(sharedComponentFolder).visit(fileVisitor);
-    });
+    const newComponents = await createNewComponents(host, options);
 
-    const projectsRoot = `/projects`;
-    host.getDir(projectsRoot).subdirs.forEach(projectName => {
-      const sharedComponentFolder = `${projectsRoot}/${projectName}/src/app/components`;
-      host.getDir(sharedComponentFolder).visit(fileVisitor);
-    });
-
-    const sharedRoot = `/src/app/shared`;
-    host.getDir(sharedRoot).visit(fileVisitor);
-
-    return chain(operations);
+    return chain([...oldComponents, ...newComponents]);
   };
 }

--- a/schematics/src/utils/lint-fix.ts
+++ b/schematics/src/utils/lint-fix.ts
@@ -29,6 +29,7 @@ export function applyLintFix(): Rule {
     }
     // Only include files that have been touched.
     tree.actions
+      .filter(action => action.kind !== 'd')
       .map(action => action.path.substring(1))
       .filter(path => path.endsWith('.ts') || path.endsWith('.html'))
       .forEach(file => {


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

Lazy Components are not removed before npm script `synchronize-lazy-components`. It can happen that removed components are still there after synchronization.

## What Is the New Behavior?

Script uses `git clean` to remove components.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#79486](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79486)