### PR TITLE
refactor: injection token type safety

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -270,7 +270,7 @@
             {
               "importNamePattern": ".*",
               "name": ".*environments/environment.*",
-              "filePattern": "^.*/app/((?!(app(.server)?.module|core/store/core/configuration/configuration\\.reducer|core/utils/state-transfer/state-properties\\.service|injection-keys)\\.ts).)*$",
+              "filePattern": "^.*/app/((?!(app(.server)?.module|core/store/core/configuration/configuration\\.reducer|core/utils/state-transfer/state-properties\\.service|core/utils/injection)\\.ts).)*$",
               "message": "Importing environment is not allowed. Inject needed properties instead."
             },
             {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -675,6 +675,7 @@
         "ish-custom-rules/use-correct-component-overrides": "warn",
         "ish-custom-rules/use-jest-extended-matchers-in-tests": "warn",
         "ish-custom-rules/use-ssr-variable-instead-of-platform-id": "warn",
+        "ish-custom-rules/use-type-safe-injection-token": "warn",
         "ish-custom-rules/require-formly-code-documentation": "warn",
         "jest/no-commented-out-tests": "warn",
         "jest/no-disabled-tests": "warn",

--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -181,6 +181,7 @@ toastr
 topseller
 transpiled
 tsquery
+typeof
 uncommit
 undiscounted
 unflatten

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -18,34 +18,35 @@ In addition, the PWA, when run with Angular Universal, consists of a server-side
 ### Angular CLI Environments
 
 The standard way of configuring an Angular Application can be done by managing multiple environment files that are part of the project's source tree, usually located in _src/environments._ To choose one configuration, you have to supply the parameter when building the Angular Application.
-The file _angular.json_ defines how the correct environment file is swapped in for the corresponding environment.
-See [Configuring application environments](https://angular.io/guide/build#configure-environment-specific-defaults) for further information.
+See [Guide - Building and Running Server-Side Rendering](../guides/ssr-startup.md) and [Configuring application environments](https://angular.io/guide/build#configure-environment-specific-defaults) for further information.
 
-Properties supplied with environment files should not be accessed directly in artifacts other than modules.
+Properties supplied with environment files should not be accessed directly in artifacts.
 Instead, you need to provide them via `InjectionToken`s to be used in components, pipes or services.
-The `InjectionToken` can be used to access a certain property later on:
+Standard `InjectionToken`s are defined in [`injection-keys.ts`](../../src/app/core/configurations/injection-keys.ts).
+To create new keys for the standard PWA, use this file; project customizations should create their own file next to it.
+
+First extend the [`environment.model`](../../src/environments/environment.model.ts) to support your new property.
+Then define an `InjectionToken` that can be used to access a certain property later on:
 
 ```typescript
-export const PROPERTY = new InjectionToken<string>('property');
-
-@NgModule({
-  providers: [{ provide: PROPERTY, useValue: environment.property }],
-})
-export class SomeModule {}
+export const PROPERTY = createEnvironmentInjectionToken('property');
 ```
 
-**Property consumer**
+The new token is automatically initialized with the default value from the Angular CLI environment files.
+To override it in tests, you can provide it in the `TestBed` configuration.
+
+To inject the property with dependency injection use the helper [`InjectSingle`](../../src/app/core/utils/injection.ts) to properly inherit type information:
 
 ```typescript
 import { Inject } from '@angular/core'
-import { PROPERTY } from '../injection-keys'
+
+import { PROPERTY } from 'ish-core/configurations/injection-keys'
+import { InjectSingle } from 'ish-core/utils/injection';
 
 ...
 
-constructor(@Inject(PROPERTY) private property: string)
+constructor(@Inject(PROPERTY) private property: InjectSingle<typeof PROPERTY>)
 ```
-
-It is good practice to never write those properties at runtime.
 
 As can be seen here, only build-time and deploy-time configuration parameter can be supplied this way.
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -109,6 +109,12 @@ Obsolete functionality that is no longer needed with the current state of the In
 We recommend to use the Action Group Creator to create store actions now.
 Therefore the corresponding store schematic for the action creation has been adapted.
 
+We added some helper methods to improve the use of dependency injection.
+Use the method `createEnvironmentInjectionToken` now to define new injection keys for environment variables in the injection-keys.ts.
+If you want to inject a token use the methods `injectSingle` and `injectMultiple` to secure the type safety of your injected variables (except for angular core tokens, which are forced to a type).
+There is a new linting rule `useTypeSafeInjectionTokenRule` that enforces the usage of these methods.
+Find more information in the [Configuration Concept](../concepts/configuration.md#angular-cli-environments)
+
 ## 3.2 to 3.3
 
 To improve the accessibility of the PWA in regards to more elements being tab focusable a lot of `[routerLink]="[]"` where added to links that previously did not have a link reference.

--- a/eslint-rules/src/rules/use-type-safe-injection-token.ts
+++ b/eslint-rules/src/rules/use-type-safe-injection-token.ts
@@ -1,0 +1,96 @@
+import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+const messages = {
+  USE_STANDARD_TYPE: 'Use correct type for injection token.',
+  USE_INFERRED_TYPE: 'Use inferred type of injection token.',
+  USE_INFERRED_TYPE_APPLY: 'Use inferred type with `{{expected}}`.',
+};
+
+const standardTokens = {
+  APP_BASE_HREF: 'string',
+  LOCALE_ID: 'string',
+  DOCUMENT: 'Document',
+};
+
+const HAS_INJECT_DECORATOR = ':has(Decorator[expression.callee.name="Inject"])';
+
+const useTypeSafeInjectionTokenRule: TSESLint.RuleModule<keyof typeof messages> = {
+  defaultOptions: undefined,
+  meta: {
+    docs: {
+      description:
+        'Injection tokens in angular should inherit type information from the token itself to prevent using a wrong type where it is injected. By using `InjectSingle` or `InjectMultiple` the type of the token is inferred and can be used to type the injected value.',
+      recommended: 'warn',
+      url: '',
+      suggestion: true,
+    },
+    messages,
+    type: 'problem',
+    schema: [],
+    hasSuggestions: true,
+  },
+  create: context => ({
+    [`TSParameterProperty${HAS_INJECT_DECORATOR},Identifier${HAS_INJECT_DECORATOR}`]: (
+      node: TSESTree.TSParameterProperty | TSESTree.Identifier
+    ) => {
+      const injectDecorator = node.decorators.find(
+        decorator =>
+          decorator.expression?.type === TSESTree.AST_NODE_TYPES.CallExpression &&
+          decorator.expression.callee?.type === TSESTree.AST_NODE_TYPES.Identifier &&
+          decorator.expression.callee.name === 'Inject' &&
+          decorator.expression.arguments.length === 1 &&
+          decorator.expression.arguments[0].type === TSESTree.AST_NODE_TYPES.Identifier
+      );
+      if (injectDecorator) {
+        const token = ((injectDecorator.expression as TSESTree.CallExpression).arguments[0] as TSESTree.Identifier)
+          .name;
+
+        const identifier = node.type === TSESTree.AST_NODE_TYPES.TSParameterProperty ? node.parameter : node;
+
+        const typeText = context.getSourceCode().getText(identifier.typeAnnotation.typeAnnotation);
+
+        if (standardTokens[token]) {
+          const expected = standardTokens[token];
+
+          if (typeText !== expected) {
+            context.report({
+              node: identifier,
+              messageId: 'USE_STANDARD_TYPE',
+              suggest: [
+                {
+                  fix: fixer => fixer.replaceTextRange(identifier.typeAnnotation.typeAnnotation.range, expected),
+                  messageId: 'USE_STANDARD_TYPE',
+                  data: { expected },
+                },
+              ],
+            });
+          }
+        } else {
+          const expectedSingle = `InjectSingle<typeof ${token}>`;
+          const expectedMulti = `InjectMultiple<typeof ${token}>`;
+
+          if (typeText !== expectedSingle && typeText !== expectedMulti) {
+            context.report({
+              node: identifier,
+              messageId: 'USE_INFERRED_TYPE',
+              suggest: [
+                {
+                  fix: fixer => fixer.replaceTextRange(identifier.typeAnnotation.typeAnnotation.range, expectedSingle),
+                  messageId: 'USE_INFERRED_TYPE_APPLY',
+                  data: { expected: expectedSingle },
+                },
+                {
+                  fix: fixer => fixer.replaceTextRange(identifier.typeAnnotation.typeAnnotation.range, expectedMulti),
+                  messageId: 'USE_INFERRED_TYPE_APPLY',
+                  data: { expected: expectedMulti },
+                },
+              ],
+            });
+          }
+        }
+      }
+    },
+  }),
+};
+
+export default useTypeSafeInjectionTokenRule;

--- a/eslint-rules/tests/use-type-safe-injection-token.spec.ts
+++ b/eslint-rules/tests/use-type-safe-injection-token.spec.ts
@@ -1,0 +1,87 @@
+import useTypeSafeInjectionTokenRule from '../src/rules/use-type-safe-injection-token';
+
+import testRule from './rule-tester';
+
+function cleanWhitespace(str: string) {
+  return str
+    .split('\n')
+    .map(line => line.trim())
+    .join('\n');
+}
+
+testRule(useTypeSafeInjectionTokenRule, {
+  valid: [
+    {
+      name: 'should not report on correctly typed injection',
+      code: `class Test {
+        constructor(
+          private test: string,
+          @Inject(TOKEN) private token: InjectSingle<typeof TOKEN>
+        ) {}
+      }`,
+    },
+    {
+      name: 'should not report on correctly typed standard token',
+      code: `class Test {
+        constructor(
+          @Inject(APP_BASE_HREF) baseHref: string
+        ) {}
+      }`,
+    },
+    {
+      name: 'should not report on string tokens',
+      code: `class Test {
+        constructor(@Inject('token') token: unknown) {}
+      }`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'should report on incorrectly typed injection',
+      code: cleanWhitespace(`class Test {
+        constructor(@Inject(TOKEN) token: unknown) {}
+      }`),
+      errors: [
+        {
+          messageId: 'USE_INFERRED_TYPE',
+          suggestions: [
+            {
+              messageId: 'USE_INFERRED_TYPE_APPLY',
+              data: { expected: 'InjectSingle<typeof TOKEN>' },
+              output: cleanWhitespace(`class Test {
+                constructor(@Inject(TOKEN) token: InjectSingle<typeof TOKEN>) {}
+              }`),
+            },
+            {
+              messageId: 'USE_INFERRED_TYPE_APPLY',
+              data: { expected: 'InjectMultiple<typeof TOKEN>' },
+              output: cleanWhitespace(`class Test {
+                constructor(@Inject(TOKEN) token: InjectMultiple<typeof TOKEN>) {}
+              }`),
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'should report on incorrectly typed standard token',
+      code: cleanWhitespace(`class Test {
+        constructor(@Inject(APP_BASE_HREF) token: unknown) {}
+      }`),
+      errors: [
+        {
+          messageId: 'USE_STANDARD_TYPE',
+          suggestions: [
+            {
+              messageId: 'USE_STANDARD_TYPE',
+              data: { expected: 'string' },
+              output: cleanWhitespace(`class Test {
+                constructor(@Inject(APP_BASE_HREF) token: string) {}
+              }`),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/src/app/core/configurations/injection-keys.ts
+++ b/src/app/core/configurations/injection-keys.ts
@@ -1,16 +1,11 @@
 import { InjectionToken } from '@angular/core';
 
-import { CookieConsentOptions } from 'ish-core/models/cookies/cookies.model';
-import { PriceUpdateType } from 'ish-core/models/price/price.model';
-import { DataRetentionPolicy } from 'ish-core/utils/meta-reducers';
-
-import { environment } from '../../../environments/environment';
-import { Environment } from '../../../environments/environment.model';
+import { createEnvironmentInjectionToken } from 'ish-core/utils/injection';
 
 /**
  * Array of paths that always use mocked data
  */
-export const API_MOCK_PATHS = new InjectionToken<string[]>('apiMockPaths', { factory: () => environment.apiMockPaths });
+export const API_MOCK_PATHS = createEnvironmentInjectionToken('apiMockPaths');
 
 /**
  * If 'username' login name is used for registration, if 'email' the email is used as login name (default: 'email')
@@ -22,71 +17,46 @@ export const USER_REGISTRATION_LOGIN_TYPE = new InjectionToken<string>('userRegi
 /**
  * The maximum subcategories level depth rendered in the main navigation
  */
-export const MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH = new InjectionToken<number>(
-  'mainNavigationMaxSubCategoriesDepth',
-  { factory: () => environment.mainNavigationMaxSubCategoriesDepth }
+export const MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH = createEnvironmentInjectionToken(
+  'mainNavigationMaxSubCategoriesDepth'
 );
 
 /**
  * global definition of the product listing page size
  */
-export const PRODUCT_LISTING_ITEMS_PER_PAGE = new InjectionToken<Environment['productListingItemsPerPage']>(
-  'productListingItemsPerPage',
-  {
-    factory: () => environment.productListingItemsPerPage,
-  }
-);
+export const PRODUCT_LISTING_ITEMS_PER_PAGE = createEnvironmentInjectionToken('productListingItemsPerPage');
 
 /**
  * default definition of the product listing view type
  */
-export const DEFAULT_PRODUCT_LISTING_VIEW_TYPE = new InjectionToken<Environment['defaultProductListingViewType']>(
-  'defaultProductListingViewType',
-  {
-    factory: () => environment.defaultProductListingViewType,
-  }
-);
+export const DEFAULT_PRODUCT_LISTING_VIEW_TYPE = createEnvironmentInjectionToken('defaultProductListingViewType');
 
 /**
  * the configured cookie consent options for the application
  */
-export const COOKIE_CONSENT_OPTIONS = new InjectionToken<CookieConsentOptions>('cookieConsentOptions', {
-  factory: () => environment.cookieConsentOptions,
-});
+export const COOKIE_CONSENT_OPTIONS = createEnvironmentInjectionToken('cookieConsentOptions');
 
 /**
  * the configured data retention policy for the application
  */
-export const DATA_RETENTION_POLICY = new InjectionToken<DataRetentionPolicy>('dataRetentionPolicy', {
-  factory: () => environment.dataRetention,
-});
+export const DATA_RETENTION_POLICY = createEnvironmentInjectionToken('dataRetention');
 
 /**
  * the configured price update policy for the application
  */
-export const PRICE_UPDATE = new InjectionToken<PriceUpdateType>('priceUpdate', {
-  factory: () => environment.priceUpdate,
-});
+export const PRICE_UPDATE = createEnvironmentInjectionToken('priceUpdate');
 
 /**
  * the configured theme color
  */
-export const THEME_COLOR = new InjectionToken<string>('themeColor', {
-  factory: () => environment.themeColor,
-});
+export const THEME_COLOR = createEnvironmentInjectionToken('themeColor');
 
 /*
  * global definition of the Bootstrap grid system breakpoint widths
  */
 
-export const SMALL_BREAKPOINT_WIDTH = new InjectionToken<number>('smallBreakpointWidth', {
-  factory: () => environment.smallBreakpointWidth,
-});
+export const SMALL_BREAKPOINT_WIDTH = createEnvironmentInjectionToken('smallBreakpointWidth');
 
-export const MEDIUM_BREAKPOINT_WIDTH = new InjectionToken<number>('mediumBreakpointWidth', {
-  factory: () => environment.mediumBreakpointWidth,
-});
+export const MEDIUM_BREAKPOINT_WIDTH = createEnvironmentInjectionToken('mediumBreakpointWidth');
 
-export const LARGE_BREAKPOINT_WIDTH = new InjectionToken<number>('largeBreakpointWidth', {
-  factory: () => environment.largeBreakpointWidth,
-});
+export const LARGE_BREAKPOINT_WIDTH = createEnvironmentInjectionToken('largeBreakpointWidth');

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -5,7 +5,6 @@ import { debounce, filter, map, pairwise, startWith, switchMap, tap } from 'rxjs
 
 import { PRICE_UPDATE } from 'ish-core/configurations/injection-keys';
 import { PriceItemHelper } from 'ish-core/models/price-item/price-item.helper';
-import { PriceUpdateType } from 'ish-core/models/price/price.model';
 import { ProductListingID } from 'ish-core/models/product-listing/product-listing.model';
 import { ProductCompletenessLevel, ProductHelper } from 'ish-core/models/product/product.model';
 import { selectRouteParam } from 'ish-core/store/core/router';
@@ -41,12 +40,13 @@ import {
 import { getPromotion, getPromotions, loadPromotion } from 'ish-core/store/shopping/promotions';
 import { getSearchTerm, getSuggestSearchResults, suggestSearch } from 'ish-core/store/shopping/search';
 import { toObservable } from 'ish-core/utils/functions';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 
 /* eslint-disable @typescript-eslint/member-ordering */
 @Injectable({ providedIn: 'root' })
 export class ShoppingFacade {
-  constructor(private store: Store, @Inject(PRICE_UPDATE) private priceUpdate: PriceUpdateType) {}
+  constructor(private store: Store, @Inject(PRICE_UPDATE) private priceUpdate: InjectSingle<typeof PRICE_UPDATE>) {}
 
   // CATEGORY
 

--- a/src/app/core/interceptors/mock.interceptor.ts
+++ b/src/app/core/interceptors/mock.interceptor.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 
 import { API_MOCK_PATHS } from 'ish-core/configurations/injection-keys';
 import { getRestEndpoint } from 'ish-core/store/core/configuration';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 const MOCK_DATA_ROOT = './assets/mock-data';
 
@@ -15,7 +16,7 @@ const MOCK_DATA_ROOT = './assets/mock-data';
 export class MockInterceptor implements HttpInterceptor {
   private restEndpoint: string;
 
-  constructor(@Inject(API_MOCK_PATHS) private apiMockPaths: string[], store: Store) {
+  constructor(@Inject(API_MOCK_PATHS) private apiMockPaths: InjectSingle<typeof API_MOCK_PATHS>, store: Store) {
     store.pipe(select(getRestEndpoint)).subscribe(data => (this.restEndpoint = data));
   }
 

--- a/src/app/core/models/price/price.model.ts
+++ b/src/app/core/models/price/price.model.ts
@@ -1,5 +1,3 @@
-export type PriceUpdateType = 'stable' | 'always';
-
 export interface Price {
   type: 'Money';
   value: number;

--- a/src/app/core/store/core/configuration/configuration.effects.ts
+++ b/src/app/core/store/core/configuration/configuration.effects.ts
@@ -12,6 +12,7 @@ import { NGRX_STATE_SK } from 'ish-core/configurations/ngrx-state-transfer';
 import { SSR_LOCALE } from 'ish-core/configurations/state-keys';
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 import { LocalizationsService } from 'ish-core/services/localizations/localizations.service';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { distinctCompareWith, mapToPayload, whenTruthy } from 'ish-core/utils/operators';
 import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
 
@@ -30,8 +31,8 @@ export class ConfigurationEffects {
     private store: Store,
     private stateProperties: StatePropertiesService,
     private transferState: TransferState,
-    @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: number,
-    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: number,
+    @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>,
+    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
     @Inject(DOCUMENT) document: Document,
     translateService: TranslateService,
     appRef: ApplicationRef,

--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -14,6 +14,7 @@ import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
 import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { loadMoreProducts } from 'ish-core/store/shopping/product-listing';
 import { HttpStatusCodeService } from 'ish-core/utils/http-status-code/http-status-code.service';
+import { InjectSingle } from 'ish-core/utils/injection';
 import {
   mapErrorToAction,
   mapToPayloadProperty,
@@ -43,7 +44,8 @@ export class CategoriesEffects {
     private actions$: Actions,
     private store: Store,
     private categoryService: CategoriesService,
-    @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH) private mainNavigationMaxSubCategoriesDepth: number,
+    @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH)
+    private mainNavigationMaxSubCategoriesDepth: InjectSingle<typeof MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH>,
     private httpStatusCodeService: HttpStatusCodeService
   ) {}
 

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,
   PRODUCT_LISTING_ITEMS_PER_PAGE,
 } from 'ish-core/configurations/injection-keys';
-import { DeviceType, ViewType } from 'ish-core/models/viewtype/viewtype.types';
+import { ViewType } from 'ish-core/models/viewtype/viewtype.types';
 import { getDeviceType } from 'ish-core/store/core/configuration';
 import { selectQueryParam, selectQueryParams } from 'ish-core/store/core/router';
 import {
@@ -20,6 +20,7 @@ import {
 } from 'ish-core/store/shopping/filter';
 import { loadProductsForCategory, loadProductsForMaster } from 'ish-core/store/shopping/products';
 import { searchProducts } from 'ish-core/store/shopping/search';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { mapToPayload, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 import { stringToFormParams } from 'ish-core/utils/url-form-params';
 
@@ -34,9 +35,9 @@ import { getProductListingViewType } from './product-listing.selectors';
 @Injectable()
 export class ProductListingEffects {
   constructor(
-    @Inject(PRODUCT_LISTING_ITEMS_PER_PAGE) private itemsPerPage: number,
+    @Inject(PRODUCT_LISTING_ITEMS_PER_PAGE) private itemsPerPage: InjectSingle<typeof PRODUCT_LISTING_ITEMS_PER_PAGE>,
     @Inject(DEFAULT_PRODUCT_LISTING_VIEW_TYPE)
-    private defaultViewType: ViewType | Partial<Record<DeviceType, ViewType>>,
+    private defaultViewType: InjectSingle<typeof DEFAULT_PRODUCT_LISTING_VIEW_TYPE>,
     private actions$: Actions,
     private store: Store
   ) {}

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -4,7 +4,8 @@ import { TransferState } from '@angular/platform-browser';
 
 import { COOKIE_CONSENT_OPTIONS } from 'ish-core/configurations/injection-keys';
 import { COOKIE_CONSENT_VERSION } from 'ish-core/configurations/state-keys';
-import { CookieConsentOptions, CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
+import { CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 interface CookiesOptions {
   path?: string;
@@ -23,7 +24,7 @@ interface CookiesOptions {
 @Injectable({ providedIn: 'root' })
 export class CookiesService {
   constructor(
-    @Inject(COOKIE_CONSENT_OPTIONS) private cookieConsentOptions: CookieConsentOptions,
+    @Inject(COOKIE_CONSENT_OPTIONS) private cookieConsentOptions: InjectSingle<typeof COOKIE_CONSENT_OPTIONS>,
     private transferState: TransferState,
     @Inject(APP_BASE_HREF) private baseHref: string,
     @Inject(DOCUMENT) private document: Document

--- a/src/app/core/utils/http-error/login-user.error-handler.ts
+++ b/src/app/core/utils/http-error/login-user.error-handler.ts
@@ -4,12 +4,15 @@ import { Inject, Injectable } from '@angular/core';
 import { USER_REGISTRATION_LOGIN_TYPE } from 'ish-core/configurations/injection-keys';
 import { SpecialHttpErrorHandler } from 'ish-core/interceptors/icm-error-mapper.interceptor';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 /* eslint-disable @typescript-eslint/ban-types */
 
 @Injectable()
 export class LoginUserErrorHandler implements SpecialHttpErrorHandler {
-  constructor(@Inject(USER_REGISTRATION_LOGIN_TYPE) public loginType: string) {}
+  constructor(
+    @Inject(USER_REGISTRATION_LOGIN_TYPE) public loginType: InjectSingle<typeof USER_REGISTRATION_LOGIN_TYPE>
+  ) {}
 
   test(error: HttpErrorResponse): boolean {
     return (error.status === 401 || error.status === 403) && error.url.includes('token');

--- a/src/app/core/utils/http-status-code/http-status-code.service.ts
+++ b/src/app/core/utils/http-status-code/http-status-code.service.ts
@@ -1,11 +1,12 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { Router } from '@angular/router';
 import { RESPONSE } from '@nguniversal/express-engine/tokens';
-import { Response } from 'express';
+
+import { InjectSingle } from 'ish-core/utils/injection';
 
 @Injectable({ providedIn: 'root' })
 export class HttpStatusCodeService {
-  constructor(private router: Router, @Optional() @Inject(RESPONSE) private response: Response) {}
+  constructor(private router: Router, @Optional() @Inject(RESPONSE) private response: InjectSingle<typeof RESPONSE>) {}
 
   /**
    * set status for SSR response

--- a/src/app/core/utils/injection.ts
+++ b/src/app/core/utils/injection.ts
@@ -4,6 +4,16 @@ import { environment } from '../../../environments/environment';
 import { Environment } from '../../../environments/environment.model';
 
 /**
+ * Wrapper for type safe injection of injection tokens supplied without `multi: true`
+ */
+export type InjectSingle<T> = T extends InjectionToken<infer U> ? U : never;
+
+/**
+ * Wrapper for type safe injection of injection tokens supplied with `multi: true`
+ */
+export type InjectMultiple<T> = T extends InjectionToken<infer U> ? U[] : never;
+
+/**
  * Create an injection token for environment.ts properties
  */
 export function createEnvironmentInjectionToken<K extends keyof Environment>(key: K) {

--- a/src/app/core/utils/injection.ts
+++ b/src/app/core/utils/injection.ts
@@ -1,0 +1,13 @@
+import { InjectionToken } from '@angular/core';
+
+import { environment } from '../../../environments/environment';
+import { Environment } from '../../../environments/environment.model';
+
+/**
+ * Create an injection token for environment.ts properties
+ */
+export function createEnvironmentInjectionToken<K extends keyof Environment>(key: K) {
+  return new InjectionToken<Environment[K]>(key, {
+    factory: () => environment[key],
+  });
+}

--- a/src/app/core/utils/injection.ts
+++ b/src/app/core/utils/injection.ts
@@ -4,12 +4,12 @@ import { environment } from '../../../environments/environment';
 import { Environment } from '../../../environments/environment.model';
 
 /**
- * Wrapper for type safe injection of injection tokens supplied without `multi: true`
+ * Wrapper for type safe injection of injection tokens supplied WITHOUT `multi: true`
  */
 export type InjectSingle<T> = T extends InjectionToken<infer U> ? U : never;
 
 /**
- * Wrapper for type safe injection of injection tokens supplied with `multi: true`
+ * Wrapper for type safe injection of injection tokens supplied WITH `multi: true`
  */
 export type InjectMultiple<T> = T extends InjectionToken<infer U> ? U[] : never;
 

--- a/src/app/core/utils/theme/theme.service.ts
+++ b/src/app/core/utils/theme/theme.service.ts
@@ -4,6 +4,7 @@ import { TransferState } from '@angular/platform-browser';
 
 import { THEME_COLOR } from 'ish-core/configurations/injection-keys';
 import { NGRX_STATE_SK } from 'ish-core/configurations/ngrx-state-transfer';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 /**
  * Service to add the configured/selected theme’s meta in the HTML’s head.
@@ -13,7 +14,7 @@ export class ThemeService {
   constructor(
     @Inject(DOCUMENT) private document: Document,
     private transferState: TransferState,
-    @Inject(THEME_COLOR) private themeColor: string
+    @Inject(THEME_COLOR) private themeColor: InjectSingle<typeof THEME_COLOR>
   ) {}
 
   private trySetAttribute(selector: string, attribute: string, value: string) {

--- a/src/app/core/utils/translate/fallback-missing-translation-handler.ts
+++ b/src/app/core/utils/translate/fallback-missing-translation-handler.ts
@@ -12,6 +12,7 @@ import { EMPTY, concat, defer, iif, of } from 'rxjs';
 import { filter, first, map, tap } from 'rxjs/operators';
 
 import { getSpecificServerTranslation, loadSingleServerTranslation } from 'ish-core/store/core/configuration';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export const FALLBACK_LANG = new InjectionToken<string>('fallbackTranslateLanguage');
@@ -23,7 +24,7 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
     private translateCompiler: TranslateCompiler,
     private translateParser: TranslateParser,
     private errorHandler: ErrorHandler,
-    @Inject(FALLBACK_LANG) private fallback: string,
+    @Inject(FALLBACK_LANG) private fallback: InjectSingle<typeof FALLBACK_LANG>,
     private store: Store
   ) {}
 

--- a/src/app/core/utils/translate/icm-translate-loader.ts
+++ b/src/app/core/utils/translate/icm-translate-loader.ts
@@ -6,6 +6,7 @@ import { combineLatest, defer, from, iif, of } from 'rxjs';
 import { catchError, map, shareReplay, tap } from 'rxjs/operators';
 
 import { LocalizationsService } from 'ish-core/services/localizations/localizations.service';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 import { Translations } from './translations.type';
 
@@ -21,7 +22,7 @@ export class ICMTranslateLoader implements TranslateLoader {
   constructor(
     private transferState: TransferState,
     private localizations: LocalizationsService,
-    @Inject(LOCAL_TRANSLATIONS) private localTranslations: LocalTranslations
+    @Inject(LOCAL_TRANSLATIONS) private localTranslations: InjectSingle<typeof LOCAL_TRANSLATIONS>
   ) {}
 
   getTranslation = memoize(lang => {

--- a/src/app/extensions/compare/store/compare-store.module.ts
+++ b/src/app/extensions/compare/store/compare-store.module.ts
@@ -5,7 +5,8 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { DataRetentionPolicy, dataRetentionMeta } from 'ish-core/utils/meta-reducers';
+import { InjectSingle } from 'ish-core/utils/injection';
+import { dataRetentionMeta } from 'ish-core/utils/meta-reducers';
 
 import { CompareState } from './compare-store';
 import { CompareEffects } from './compare/compare.effects';
@@ -23,7 +24,7 @@ export class DefaultCompareStoreConfig implements StoreConfig<CompareState> {
 
   constructor(
     @Inject(APP_BASE_HREF) private appBaseHref: string,
-    @Inject(DATA_RETENTION_POLICY) private dataRetention: DataRetentionPolicy
+    @Inject(DATA_RETENTION_POLICY) private dataRetention: InjectSingle<typeof DATA_RETENTION_POLICY>
   ) {}
 }
 

--- a/src/app/extensions/recently/store/recently-store.module.ts
+++ b/src/app/extensions/recently/store/recently-store.module.ts
@@ -5,7 +5,8 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { DataRetentionPolicy, dataRetentionMeta } from 'ish-core/utils/meta-reducers';
+import { InjectSingle } from 'ish-core/utils/injection';
+import { dataRetentionMeta } from 'ish-core/utils/meta-reducers';
 
 import { RecentlyState } from './recently-store';
 import { RecentlyEffects } from './recently/recently.effects';
@@ -25,7 +26,7 @@ export class DefaultRecentlyStoreConfig implements StoreConfig<RecentlyState> {
 
   constructor(
     @Inject(APP_BASE_HREF) private appBaseHref: string,
-    @Inject(DATA_RETENTION_POLICY) private dataRetention: DataRetentionPolicy
+    @Inject(DATA_RETENTION_POLICY) private dataRetention: InjectSingle<typeof DATA_RETENTION_POLICY>
   ) {}
 }
 

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -6,7 +6,6 @@ import { routerNavigatedAction, routerNavigationAction } from '@ngrx/router-stor
 import { Store, select } from '@ngrx/store';
 import { REQUEST } from '@nguniversal/express-engine/tokens';
 import { TranslateService } from '@ngx-translate/core';
-import { Request } from 'express';
 import { isEqual } from 'lodash-es';
 import { Subject, combineLatest, merge, race } from 'rxjs';
 import { distinctUntilChanged, filter, map, switchMap, takeWhile, tap } from 'rxjs/operators';
@@ -24,6 +23,7 @@ import { getAvailableLocales, getCurrentLocale } from 'ish-core/store/core/confi
 import { ofUrl, selectRouteData, selectRouteParam } from 'ish-core/store/core/router';
 import { getSelectedCategory } from 'ish-core/store/shopping/categories/categories.selectors';
 import { getSelectedProduct } from 'ish-core/store/shopping/products';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { mapToProperty, whenTruthy } from 'ish-core/utils/operators';
 
 @Injectable()
@@ -35,7 +35,7 @@ export class SeoEffects {
     private titleService: Title,
     private translate: TranslateService,
     @Inject(DOCUMENT) private doc: Document,
-    @Optional() @Inject(REQUEST) private request: Request,
+    @Optional() @Inject(REQUEST) private request: InjectSingle<typeof REQUEST>,
     @Inject(APP_BASE_HREF) private baseHref: string,
     private appRef: ApplicationRef
   ) {}

--- a/src/app/extensions/store-locator/services/stores-map/stores-map.service.ts
+++ b/src/app/extensions/store-locator/services/stores-map/stores-map.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { Loader } from '@googlemaps/js-api-loader';
 import { Store, select } from '@ngrx/store';
 
+import { InjectSingle } from 'ish-core/utils/injection';
+
 import { StoreLocationHelper } from '../../models/store-location/store-location.helper';
 import { StoreLocation } from '../../models/store-location/store-location.model';
 import { getGMAKey } from '../../store/store-locator-config';
@@ -17,7 +19,10 @@ export class StoresMapService {
   private infoWindow: google.maps.InfoWindow;
   private entries: { store: StoreLocation; marker: google.maps.Marker }[] = [];
 
-  constructor(private store: Store, @Inject(STORE_MAP_ICON_CONFIGURATION) private icons: IconConfiguration) {}
+  constructor(
+    private store: Store,
+    @Inject(STORE_MAP_ICON_CONFIGURATION) private icons: InjectSingle<typeof STORE_MAP_ICON_CONFIGURATION>
+  ) {}
 
   initialize(container: HTMLElement) {
     this.store.pipe(select(getGMAKey)).subscribe((gmaKey: string) => {

--- a/src/app/extensions/tacton/store/tacton-store.module.ts
+++ b/src/app/extensions/tacton/store/tacton-store.module.ts
@@ -5,7 +5,8 @@ import { ActionReducerMap, StoreConfig, StoreModule } from '@ngrx/store';
 import { pick } from 'lodash-es';
 
 import { DATA_RETENTION_POLICY } from 'ish-core/configurations/injection-keys';
-import { DataRetentionPolicy, dataRetentionMeta } from 'ish-core/utils/meta-reducers';
+import { InjectSingle } from 'ish-core/utils/injection';
+import { dataRetentionMeta } from 'ish-core/utils/meta-reducers';
 
 import { ProductConfigurationEffects } from './product-configuration/product-configuration.effects';
 import { productConfigurationReducer } from './product-configuration/product-configuration.reducer';
@@ -31,7 +32,7 @@ export class DefaultTactonStoreConfig implements StoreConfig<TactonState> {
 
   constructor(
     @Inject(APP_BASE_HREF) private appBaseHref: string,
-    @Inject(DATA_RETENTION_POLICY) private dataRetention: DataRetentionPolicy
+    @Inject(DATA_RETENTION_POLICY) private dataRetention: InjectSingle<typeof DATA_RETENTION_POLICY>
   ) {}
 }
 

--- a/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.ts
@@ -4,6 +4,7 @@ import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
 import { ProductContextDisplayProperties } from 'ish-core/facades/product-context.facade';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { GenerateLazyComponent } from 'ish-core/utils/module-loader/generate-lazy-component.decorator';
 
 import { WishlistsFacade } from '../../facades/wishlists.facade';
@@ -32,8 +33,8 @@ export class WishlistWidgetComponent implements OnInit {
 
   constructor(
     private wishlistsFacade: WishlistsFacade,
-    @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: number,
-    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: number
+    @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
+    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>
   ) {
     this.tileConfiguration = {
       addToWishlist: false,

--- a/src/app/pages/cookies/cookies-modal/cookies-modal.component.ts
+++ b/src/app/pages/cookies/cookies-modal/cookies-modal.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Inject, OnInit, Output } from '@angular/core';
 
 import { COOKIE_CONSENT_OPTIONS } from 'ish-core/configurations/injection-keys';
-import { CookieConsentOptions, CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
+import { CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
 import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 /**
  * Cookies Modal Component
@@ -19,7 +20,7 @@ export class CookiesModalComponent implements OnInit {
   selectedIds: { [id: string]: boolean } = {};
 
   constructor(
-    @Inject(COOKIE_CONSENT_OPTIONS) public cookieConsentOptions: CookieConsentOptions,
+    @Inject(COOKIE_CONSENT_OPTIONS) public cookieConsentOptions: InjectSingle<typeof COOKIE_CONSENT_OPTIONS>,
     private cookiesService: CookiesService
   ) {}
 

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -8,6 +8,7 @@ import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/config
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { mapToProperty } from 'ish-core/utils/operators';
 
 SwiperCore.use([Navigation, Pagination]);
@@ -59,8 +60,8 @@ export class ProductLinksCarouselComponent {
   swiperConfig: SwiperOptions;
 
   constructor(
-    @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: number,
-    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: number,
+    @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
+    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>,
     private shoppingFacade: ShoppingFacade,
     private state: RxState<{
       products: string[];

--- a/src/app/shared/components/login/login-form/login-form.component.ts
+++ b/src/app/shared/components/login/login-form/login-form.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { USER_REGISTRATION_LOGIN_TYPE } from 'ish-core/configurations/injection-keys';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 /**
@@ -39,7 +40,10 @@ export class LoginFormComponent implements OnInit {
 
   fields: FormlyFieldConfig[];
 
-  constructor(@Inject(USER_REGISTRATION_LOGIN_TYPE) public loginType: string, private accountFacade: AccountFacade) {}
+  constructor(
+    @Inject(USER_REGISTRATION_LOGIN_TYPE) public loginType: InjectSingle<typeof USER_REGISTRATION_LOGIN_TYPE>,
+    private accountFacade: AccountFacade
+  ) {}
 
   ngOnInit() {
     this.loginError$ = this.accountFacade.userError$;

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -6,6 +6,7 @@ import {
   MEDIUM_BREAKPOINT_WIDTH,
   SMALL_BREAKPOINT_WIDTH,
 } from 'ish-core/configurations/injection-keys';
+import { InjectSingle } from 'ish-core/utils/injection';
 import { ProductItemDisplayType } from 'ish-shared/components/product/product-item/product-item.component';
 
 SwiperCore.use([Pagination, Navigation]);
@@ -29,9 +30,9 @@ export class ProductsListComponent implements OnChanges {
   swiperConfig: SwiperOptions;
 
   constructor(
-    @Inject(SMALL_BREAKPOINT_WIDTH) private smallBreakpointWidth: number,
-    @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: number,
-    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: number
+    @Inject(SMALL_BREAKPOINT_WIDTH) private smallBreakpointWidth: InjectSingle<typeof SMALL_BREAKPOINT_WIDTH>,
+    @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>,
+    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>
   ) {
     this.swiperConfig = {
       direction: 'horizontal',

--- a/src/app/shared/formly-address-forms/configurations/address-form-configuration.provider.ts
+++ b/src/app/shared/formly-address-forms/configurations/address-form-configuration.provider.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 
+import { InjectMultiple } from 'ish-core/utils/injection';
+
 import { AddressFormConfiguration } from './address-form.configuration';
 
 export const ADDRESS_FORM_CONFIGURATION = new InjectionToken<AddressFormConfiguration>('Address Form Factory');
@@ -10,7 +12,9 @@ export const ADDRESS_FORM_CONFIGURATION = new InjectionToken<AddressFormConfigur
  */
 @Injectable()
 export class AddressFormConfigurationProvider {
-  constructor(@Inject(ADDRESS_FORM_CONFIGURATION) private configurations: AddressFormConfiguration[]) {}
+  constructor(
+    @Inject(ADDRESS_FORM_CONFIGURATION) private configurations: InjectMultiple<typeof ADDRESS_FORM_CONFIGURATION>
+  ) {}
 
   /**
    * gets the appropriate address configuration for the given countryCode and configuration

--- a/src/app/shared/formly/field-library/field-library.ts
+++ b/src/app/shared/formly/field-library/field-library.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { mergeWith } from 'lodash-es';
 
+import { InjectMultiple } from 'ish-core/utils/injection';
 import { FieldLibraryConfiguration } from 'ish-shared/formly/field-library/configurations/field-library-configuration';
 
 export const FIELD_LIBRARY_CONFIGURATION = new InjectionToken<FieldLibraryConfiguration>(
@@ -18,9 +19,9 @@ export const FIELD_LIBRARY_CONFIGURATION_GROUP = new InjectionToken<Configuratio
 export class FieldLibrary {
   constructor(
     @Inject(FIELD_LIBRARY_CONFIGURATION)
-    fieldLibraryConfigurations: FieldLibraryConfiguration[],
+    fieldLibraryConfigurations: InjectMultiple<typeof FIELD_LIBRARY_CONFIGURATION>,
     @Inject(FIELD_LIBRARY_CONFIGURATION_GROUP)
-    fieldLibraryConfigurationGroups: ConfigurationGroup[]
+    fieldLibraryConfigurationGroups: InjectMultiple<typeof FIELD_LIBRARY_CONFIGURATION_GROUP>
   ) {
     // create configuration dictionary from array
     this.configurations = fieldLibraryConfigurations?.reduce((acc, curr) => ({ ...acc, [curr.id]: curr }), {}) ?? {};

--- a/src/app/shell/header/header-navigation/header-navigation.component.ts
+++ b/src/app/shell/header/header-navigation/header-navigation.component.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH } from 'ish-core/configurations/injection-keys';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { NavigationCategory } from 'ish-core/models/navigation-category/navigation-category.model';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 @Component({
   selector: 'ish-header-navigation',
@@ -19,7 +20,8 @@ export class HeaderNavigationComponent implements OnInit {
 
   constructor(
     private shoppingFacade: ShoppingFacade,
-    @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH) public mainNavigationMaxSubCategoriesDepth: number
+    @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH)
+    public mainNavigationMaxSubCategoriesDepth: InjectSingle<typeof MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH>
   ) {}
 
   ngOnInit() {

--- a/src/app/shell/header/sub-category-navigation/sub-category-navigation.component.ts
+++ b/src/app/shell/header/sub-category-navigation/sub-category-navigation.component.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH } from 'ish-core/configurations/injection-keys';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { NavigationCategory } from 'ish-core/models/navigation-category/navigation-category.model';
+import { InjectSingle } from 'ish-core/utils/injection';
 
 /**
  * The Sub Category Navigation Component displays second level category navigation.
@@ -24,7 +25,8 @@ export class SubCategoryNavigationComponent implements OnInit {
 
   constructor(
     private shoppingFacade: ShoppingFacade,
-    @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH) public mainNavigationMaxSubCategoriesDepth: number
+    @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH)
+    public mainNavigationMaxSubCategoriesDepth: InjectSingle<typeof MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH>
   ) {}
 
   ngOnInit() {

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -1,6 +1,5 @@
 import { Auth0Config } from 'ish-core/identity-provider/auth0.identity-provider';
 import { CookieConsentOptions } from 'ish-core/models/cookies/cookies.model';
-import { PriceUpdateType } from 'ish-core/models/price/price.model';
 import { DeviceType, ViewType } from 'ish-core/models/viewtype/viewtype.types';
 import { DataRetentionPolicy } from 'ish-core/utils/meta-reducers';
 import { MultiSiteLocaleMap } from 'ish-core/utils/multi-site/multi-site.service';
@@ -131,7 +130,7 @@ export interface Environment {
    * - 'always': fetch fresh price information all the time
    * - 'stable': only fetch prices once per application lifetime
    */
-  priceUpdate: PriceUpdateType;
+  priceUpdate: 'stable' | 'always';
 }
 
 export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

- Usage of `InjectionToken` is not done in a type safe way.
- Type declarations are duplicated to places where they are needed.

## What Is the New Behavior?

- Type safety is done via inference (except for angular core tokens, which are forced to a type).
- inspired by [this blog post](https://nick-r-favero.medium.com/simple-type-safety-for-angular-inject-93ffce60e655) (only first step done as second step doesn't work for external injection token and also hides a bit too much)

## Does this PR Introduce a Breaking Change?

Completely downwards-compatible. No need to wait for another major release.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#79498](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79498)