### PR TITLE
fix(eslint-rules): repair ban-imports-file-pattern rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -241,9 +241,9 @@
               "message": "Modules should only aggregate deeper lying artifacts."
             },
             {
-              "name": "^(?!.*\\.(module|guard)$)\\.\\..*$",
+              "name": "^(?!.*\\.(module|guard|service)$)\\.\\..*$",
               "filePattern": ".*-routing\\.module\\.ts",
-              "message": "Modules should only aggregate deeper lying artifacts."
+              "message": "Routing modules should only aggregate deeper lying artifacts."
             },
             {
               "name": ".*/extensions/.*",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -218,10 +218,16 @@
               "message": "use star imports only for aggregation of deeper lying imports"
             },
             {
-              "importNamePattern": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|pick)$).*",
+              "importNamePattern": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|pick|differenceBy|unionBy|mergeWith)$).*",
               "name": "lodash.*",
-              "filePattern": "^(?!.*.spec.ts$).*.ts$",
-              "message": "importing (range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|pick) from lodash is forbidden"
+              "filePattern": "^.*/src/app/(?!.*\\.spec\\.ts$).*\\.ts$",
+              "message": "importing this operator from lodash is forbidden"
+            },
+            {
+              "importNamePattern": "^omit$",
+              "name": "lodash.*",
+              "filePattern": "^.*/src/app/(?!.*\\.spec\\.ts$).*\\.ts$",
+              "message": "use omit from 'ish-core/utils/functions'"
             },
             {
               "importNamePattern": "CookiesService",

--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../.eslintrc.json",
+  "extends": "../.eslintrc.json",
   "overrides": [
     {
       "files": ["*.ts"],
@@ -23,6 +23,7 @@
         ],
         "@typescript-eslint/no-unused-expressions": "off",
         "ban/ban": "off",
+        "ish-custom-rules/ban-imports-file-pattern": "off",
         "ish-custom-rules/project-structure": [
           "warn",
           {
@@ -30,7 +31,8 @@
             "pathPatterns": [
               ".*/e2e/framework/.*/*\\.ts",
               ".*/e2e/pages/.*\\.(module|page|dialog)\\.ts",
-              ".*/e2e/specs/\\w+/[^/]*\\.e2e-spec\\.ts"
+              ".*/e2e/specs/\\w+/[^/]*\\.e2e-spec\\.ts",
+              ".*/e2e/cypress.*\\.ts"
             ]
           }
         ],

--- a/eslint-rules/src/rules/ban-imports-file-pattern.ts
+++ b/eslint-rules/src/rules/ban-imports-file-pattern.ts
@@ -49,7 +49,7 @@ const banImportsFilePatternRule: TSESLint.RuleModule<keyof typeof messages, [Rul
       rules.forEach(rule => {
         if (
           new RegExp(rule.filePattern).test(normalizePath(context.getFilename())) &&
-          node.source.value === rule.name &&
+          new RegExp(rule.name).test(node.source.value) &&
           checkValidityOfSpecifiers(node.specifiers, rule.importNamePattern, rule.starImport)
         ) {
           context.report({

--- a/eslint-rules/tests/ban-imports-file-pattern.spec.ts
+++ b/eslint-rules/tests/ban-imports-file-pattern.spec.ts
@@ -52,7 +52,33 @@ testRule(banImportsFilePatternRule, {
       ],
     },
     {
-      name: 'should report when detecting disallowed start pattern',
+      name: 'should report on file included in file pattern',
+      filename: 'test.component.spec.ts',
+      options: [
+        [
+          {
+            importNamePattern: 'environment',
+            name: '.*environments\\/environment',
+            filePattern: '^.*\\.ts$',
+            message: 'Test Message',
+          },
+        ],
+      ],
+      code: `
+        import { environment } from '../environments/environment';
+      `,
+      errors: [
+        {
+          messageId: 'banImportsFilePatternError',
+          data: {
+            message: 'Test Message',
+          },
+          type: AST_NODE_TYPES.ImportDeclaration,
+        },
+      ],
+    },
+    {
+      name: 'should report when detecting disallowed star pattern',
       filename: 'test.component.ts',
       options: [
         [

--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -17,7 +17,7 @@ import { BasketValidation, BasketValidationScopeType } from 'ish-core/models/bas
 import { BasketBaseData, BasketData } from 'ish-core/models/basket/basket.interface';
 import { BasketMapper } from 'ish-core/models/basket/basket.mapper';
 import { Basket } from 'ish-core/models/basket/basket.model';
-import { ErrorFeedback, HttpError } from 'ish-core/models/http-error/http-error.model';
+import { ErrorFeedback } from 'ish-core/models/http-error/http-error.model';
 import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
 import { LineItemMapper } from 'ish-core/models/line-item/line-item.mapper';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
@@ -330,11 +330,11 @@ export class BasketService {
    * @param   items       The list of product SKU and quantity pairs to be added to the basket.
    * @returns lineItems   The list of line items, that have been added to the basket.
    *          info        Info responded by the server.
-   *          error       Errors responded by the server.
+   *          errors      Errors responded by the server.
    */
   addItemsToBasket(
     items: SkuQuantityType[]
-  ): Observable<{ lineItems: LineItem[]; info: BasketInfo[]; error: HttpError }> {
+  ): Observable<{ lineItems: LineItem[]; info: BasketInfo[]; errors: ErrorFeedback[] }> {
     if (!items) {
       return throwError(() => new Error('addItemsToBasket() called without items'));
     }
@@ -355,7 +355,7 @@ export class BasketService {
         map(payload => ({
           lineItems: payload.data.map(item => LineItemMapper.fromData(item)),
           info: BasketInfoMapper.fromInfo({ infos: payload.infos }),
-          error: payload.errors ? { name: 'HttpErrorResponse', errors: payload.errors } : undefined,
+          errors: payload.errors,
         }))
       );
   }

--- a/src/app/core/store/customer/basket/basket-items.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.spec.ts
@@ -91,7 +91,7 @@ describe('Basket Items Effects', () => {
   describe('addItemsToBasket$', () => {
     beforeEach(() => {
       when(basketServiceMock.addItemsToBasket(anything())).thenReturn(
-        of({ lineItems: [], info: undefined, error: undefined })
+        of({ lineItems: [], info: undefined, errors: undefined })
       );
     });
 

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -6,7 +6,7 @@ import { Attribute } from 'ish-core/models/attribute/attribute.model';
 import { BasketInfo } from 'ish-core/models/basket-info/basket-info.model';
 import { BasketValidation, BasketValidationScopeType } from 'ish-core/models/basket-validation/basket-validation.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
-import { HttpError } from 'ish-core/models/http-error/http-error.model';
+import { ErrorFeedback } from 'ish-core/models/http-error/http-error.model';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
@@ -85,7 +85,7 @@ export const addItemsToBasketFail = createAction('[Basket API] Add Items To Bask
 
 export const addItemsToBasketSuccess = createAction(
   '[Basket API] Add Items To Basket Success',
-  payload<{ lineItems: LineItem[]; info: BasketInfo[]; error?: HttpError }>()
+  payload<{ lineItems: LineItem[]; info: BasketInfo[]; errors?: ErrorFeedback[] }>()
 );
 
 export const mergeBasketInProgress = createAction('[Basket API] Merge two baskets in progress');

--- a/src/app/core/store/customer/basket/basket.reducer.ts
+++ b/src/app/core/store/customer/basket/basket.reducer.ts
@@ -228,7 +228,7 @@ export const basketReducer = createReducer(
     ...state,
     basket: { ...state.basket, lineItems: unionBy(action.payload.lineItems, state.basket.lineItems ?? [], 'id') },
     info: action.payload.info,
-    error: action.payload.error,
+    error: action.payload.errors ? { name: 'HttpErrorResponse', errors: action.payload.errors } : undefined,
     lastTimeProductAdded: new Date().getTime(),
     submittedBasket: undefined,
   })),

--- a/src/app/shared/formly/field-library/library-config-replacement.extension.ts
+++ b/src/app/shared/formly/field-library/library-config-replacement.extension.ts
@@ -1,5 +1,6 @@
 import { FormlyExtension, FormlyFieldConfig } from '@ngx-formly/core';
-import { omit } from 'lodash-es';
+
+import { omit } from 'ish-core/utils/functions';
 
 import { FieldLibrary } from './field-library';
 


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

In the process of migrating to eslint (#836), the rule ban-imports-file-pattern rule lost its ability to support regex patterns in the `name` field, which left some of the migrated configuration without effect.

## What Is the New Behavior?

- `name` supports patterns again
- applied rules or changed configuration

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#79500](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79500)