### PR TITLE
fix: rework category completeness computation

### DIFF
--- a/src/app/core/models/category/category.mapper.spec.ts
+++ b/src/app/core/models/category/category.mapper.spec.ts
@@ -81,17 +81,41 @@ describe('Category Mapper', () => {
     it('should return -1 for falsy inputs', () => {
       expect(categoryMapper.computeCompleteness(undefined)).toEqual(-1);
     });
-    it('should return 0 for input from top level call', () => {
+    it('should return 0 for input from category path categories', () => {
       expect(categoryMapper.computeCompleteness({ uri: 'some' } as CategoryData)).toEqual(0);
     });
-    it('should return 1 for input from subcategories from category call', () => {
-      expect(categoryMapper.computeCompleteness({ uri: 'some', images: [{}] } as CategoryData)).toEqual(1);
+    it('should return 1 for input from sub categories', () => {
+      expect(categoryMapper.computeCompleteness({ uri: 'some', categoryRef: 'some@demo' } as CategoryData)).toEqual(1);
     });
-    it('should return 2 for input from categories call', () => {
-      expect(categoryMapper.computeCompleteness({ images: [{}], categoryPath: [{}, {}] } as CategoryData)).toEqual(2);
+    it('should return 2 for root categories from top level categories call', () => {
+      expect(
+        categoryMapper.computeCompleteness({
+          uri: 'some',
+          categoryRef: 'some@demo',
+          categoryPath: [{}],
+        } as CategoryData)
+      ).toEqual(2);
     });
-    it('should return 3 for input from categories call with root categories', () => {
-      expect(categoryMapper.computeCompleteness({ categoryPath: [{}], attributes: [] } as CategoryData)).toEqual(3);
+    it('should return 2 for sub categories from categories call', () => {
+      expect(
+        categoryMapper.computeCompleteness({
+          uri: 'some',
+          categoryRef: 'some@demo',
+          images: [{}],
+          categoryPath: [{}, {}],
+        } as CategoryData)
+      ).toEqual(2);
+    });
+    it('should return 3 for input from categories call', () => {
+      expect(
+        categoryMapper.computeCompleteness({
+          uri: 'some',
+          categoryRef: 'some@demo',
+          images: [{}],
+          categoryPath: [{}, {}],
+          seoAttributes: {},
+        } as CategoryData)
+      ).toEqual(3);
     });
   });
 

--- a/src/app/core/models/category/category.mapper.ts
+++ b/src/app/core/models/category/category.mapper.ts
@@ -70,20 +70,20 @@ export class CategoryMapper {
     // adjust CategoryCompletenessLevel.Max accordingly
     let count = 0;
 
-    if (!categoryData.uri) {
-      // returned subcategories and elements from the top-level category call contain uri
-      count++;
-    }
-    if (categoryData.images) {
-      // images are not supplied with top level category call
-      count++;
-    }
-    if (categoryData.attributes) {
-      // attributes are not supplied for subcategories
+    if (categoryData.categoryRef) {
+      // category path categories do not contain a categoryRef
       count++;
     }
     if (categoryData.categoryPath && categoryData.categoryPath.length === 1) {
       // root categories have no images but a single-entry categoryPath
+      count++;
+    }
+    if (categoryData.images) {
+      // images are supplied for sub categories in the category details call
+      count++;
+    }
+    if (categoryData.seoAttributes) {
+      // seo attributes are only supplied with the category details call
       count++;
     }
 


### PR DESCRIPTION
so more complete data overwrites less complete one

* categoryRef was missing for categories that should already have this information

## PR Type

[x] Bugfix

## What Is the Current Behavior?

For some category levels (second level) after the initial load of the category main navigation tree the `categoryRef` information is missing. 
The information is part of the REST response but it is somehow not mapped/copied right to the state management.
After a category details call it is available in the state.

## What Is the New Behavior?

Category Completeness Level is calculated considering more relevant response information to have better distinct completeness levels for merging the correct category information.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#79621](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79621)