### PR TITLE
feat: add "no server side rendering" guard to protect routes that should not be rendered in SSR

### DIFF
--- a/src/app/core/guards/no-server-side-rendering.guard.ts
+++ b/src/app/core/guards/no-server-side-rendering.guard.ts
@@ -5,7 +5,7 @@ import { CanActivate, Router } from '@angular/router';
  * guards a route against server side rendering (e.g. if the logic requires information only available in browser rendering)
  */
 @Injectable({ providedIn: 'root' })
-export class ServerSideRenderingGuard implements CanActivate {
+export class NoServerSideRenderingGuard implements CanActivate {
   constructor(private router: Router) {}
 
   canActivate() {

--- a/src/app/core/guards/server-side-rendering.guard.ts
+++ b/src/app/core/guards/server-side-rendering.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+
+/**
+ * guards a route against server side rendering (e.g. if the logic requires information only available in browser rendering)
+ */
+@Injectable({ providedIn: 'root' })
+export class ServerSideRenderingGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate() {
+    // prevent any handling in the server side rendering (SSR) and instead show loading
+    if (SSR) {
+      return this.router.parseUrl('/loading');
+    }
+
+    // if not in SSR just return true and continue
+    return true;
+  }
+}

--- a/src/app/pages/checkout/checkout-page.module.ts
+++ b/src/app/pages/checkout/checkout-page.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { ServerSideRenderingGuard } from 'ish-core/guards/server-side-rendering.guard';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { CheckoutAddressPageModule } from '../checkout-address/checkout-address-page.module';
@@ -44,6 +45,7 @@ const checkoutPageRoutes: Routes = [
       },
       {
         path: 'receipt',
+        canActivate: [ServerSideRenderingGuard],
         data: { checkoutStep: 5 },
         component: CheckoutReceiptPageModule.component,
       },

--- a/src/app/pages/checkout/checkout-page.module.ts
+++ b/src/app/pages/checkout/checkout-page.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { ServerSideRenderingGuard } from 'ish-core/guards/server-side-rendering.guard';
+import { NoServerSideRenderingGuard } from 'ish-core/guards/no-server-side-rendering.guard';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { CheckoutAddressPageModule } from '../checkout-address/checkout-address-page.module';
@@ -17,6 +17,7 @@ import { CheckoutProgressBarComponent } from './checkout-progress-bar/checkout-p
 const checkoutPageRoutes: Routes = [
   {
     path: '',
+    canActivate: [NoServerSideRenderingGuard],
     component: CheckoutPageComponent,
     children: [
       {
@@ -45,7 +46,6 @@ const checkoutPageRoutes: Routes = [
       },
       {
         path: 'receipt',
-        canActivate: [ServerSideRenderingGuard],
         data: { checkoutStep: 5 },
         component: CheckoutReceiptPageModule.component,
       },


### PR DESCRIPTION
* used for the checkout receipt page that should only be rendered in the users browser

## PR Type

[x] Feature

## What Is the Current Behavior?

Currently the checkout receipt page is not protected by any guard. It is rendered on the server side as well as on the browser side. Since some information is missing on the server side, e.g. authentication (apiToken cookie) and user information, the needed data cannot be fetched and only an empty page can be rendered.
With the relatively simple logic of the standard checkout receipt page this is not a big problem and the page is rendered as a more or less empty page without errors in SSR and returned to the browser that will than render the page with the full content since here the needed user authentication is available.

In projects though it can happen that more information is handled for this page and it can happen that this is not implemented in a SSR safe way resulting in errors or timeouts.

## What Is the New Behavior?

With the introduced `NoServerSideRenderingGuard` it is now possible to protect certain routes from being rendered at all in SSR and instead returning a simple loading animation page. Back in the browser this page will then be completely rendered without problems.
This functionality is used to protect all checkout pages from being rendered in SSR.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#79644](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79644)