### PR TITLE
fix: replace server encoded whitespace '+' with '%20'

### DIFF
--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
@@ -56,7 +56,7 @@ export class FilterNavigationMapper {
               selected: facet.selected,
               displayName: facet.displayValue || undefined,
               searchParameter: {
-                ...stringToFormParams(facet.link.uri.split('?')[1] || ''),
+                ...stringToFormParams(facet.link.uri.split('?')[1]?.replace(/\+/g, '%20') || ''),
                 category,
               },
               level: facet.level || 0,


### PR DESCRIPTION
## PR Type

[ x ] Bugfix

## What Is the Current Behavior?

If a filter facet contains a whitespace, than the ICM will encode it to '+' with the application/x-www-form-urlencoded type. This is not compatible to the url encoding on browser side, which replace a whitespace with '%20'.


## What Is the New Behavior?

Before the encoded string will be decoded on browser side, each '+' character in the string will be replaced with '%20'.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#79710](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79710)