### PR TITLE
fix: update product information, add attributes even if the completen…

### DIFF
--- a/src/app/core/models/product/product.helper.spec.ts
+++ b/src/app/core/models/product/product.helper.spec.ts
@@ -336,6 +336,7 @@ describe('Product Helper', () => {
       } as Product;
       stubProduct = {
         sku: '110',
+        longDescription: 'additional info',
         completenessLevel: 0,
         name: 'Stub Product',
         available: false,
@@ -366,6 +367,7 @@ describe('Product Helper', () => {
         Object {
           "available": false,
           "completenessLevel": 0,
+          "longDescription": "additional info",
           "name": "Stub Product",
           "sku": "110",
         }
@@ -402,6 +404,7 @@ describe('Product Helper', () => {
           "available": false,
           "availableStock": undefined,
           "completenessLevel": 3,
+          "longDescription": "additional info",
           "manufacturer": "Detail Manufacturer",
           "name": "Detail Product",
           "shortDescription": "The best product",

--- a/src/app/core/models/product/product.helper.ts
+++ b/src/app/core/models/product/product.helper.ts
@@ -180,8 +180,10 @@ export class ProductHelper {
     if (!product.completenessLevel || newProduct.completenessLevel >= product.completenessLevel) {
       return newProduct as AllProductTypes;
     }
+    // if the newProduct information has a lower completeness level merge attributes and
     // always update dynamic product information with the new product information (e.g. availability)
     product = {
+      ...newProduct,
       ...product,
       // list of product properties that should be updated
       available: newProduct.available ?? product.available,

--- a/src/app/core/store/shopping/products/products.selectors.spec.ts
+++ b/src/app/core/store/shopping/products/products.selectors.spec.ts
@@ -102,7 +102,7 @@ describe('Products Selectors', () => {
         store$.dispatch(loadProductSuccess({ product: newProd }));
 
         expect(getProductEntities(store$.state)).toEqual({
-          [prod.sku]: { ...prod, available: false, availableStock: undefined },
+          [prod.sku]: { ...prod, available: false, manufacturer: 'Microsoft', availableStock: undefined },
         });
       });
     });


### PR DESCRIPTION
…ess level of the incoming product is lower than the existing one

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

Precondition: Advanced variation handling is switched off for this channel in the ICM back office.

## What Is the Current Behavior?

If the user navigates to a category page ( product list) and changes the variation attribute of a variation product, the product is not updated, the default variation product is still shown instead of the selected product.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

The right product is shown after changing the variation attribute on product list.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#79718](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79718)