### PR TITLE
refactor: use current basket REST api for quote related basket functionality

### DIFF
--- a/src/app/core/services/basket/basket.service.spec.ts
+++ b/src/app/core/services/basket/basket.service.spec.ts
@@ -297,4 +297,31 @@ describe('Basket Service', () => {
       done();
     });
   });
+  it("should add a quote to the basket if 'addQuoteToBasket' is called", done => {
+    when(apiService.post(anything(), anything(), anything())).thenReturn(of({}));
+
+    basketService.addQuoteToBasket('quoteId').subscribe(() => {
+      verify(apiService.post(anything(), anything(), anything())).once();
+      const [path, body] = capture(apiService.post).last();
+      expect(path).toMatchInlineSnapshot(`"baskets/current/quotes"`);
+      expect(body).toMatchInlineSnapshot(`
+        Object {
+          "calculated": true,
+          "id": "quoteId",
+        }
+      `);
+      done();
+    });
+  });
+
+  it("should delete a quote from the basket if 'deleteQuoteFromBasket' is called", done => {
+    when(apiService.delete(anything(), anything())).thenReturn(of({}));
+
+    basketService.deleteQuoteFromBasket('quoteId').subscribe(() => {
+      verify(apiService.delete(anything(), anything())).once();
+      const [path] = capture(apiService.delete).last();
+      expect(path).toMatchInlineSnapshot(`"baskets/current/quotes/quoteId"`);
+      done();
+    });
+  });
 });

--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -514,7 +514,7 @@ export class BasketService {
   }
 
   /**
-   * Create a custom attribute on the currently used basket. Default attribute type is 'String'.
+   * Creates a custom attribute on the currently used basket. Default attribute type is 'String'.
    *
    * @param attr   The custom attribute
    * @returns      The custom attribute
@@ -533,7 +533,7 @@ export class BasketService {
   }
 
   /**
-   * Update a custom attribute on the currently used basket. Default attribute type is 'String'.
+   * Updates a custom attribute on the currently used basket. Default attribute type is 'String'.
    *
    * @param attribute   The custom attribute
    * @returns           The custom attribute
@@ -552,7 +552,7 @@ export class BasketService {
   }
 
   /**
-   * Delete a custom attribute from the currently used basket.
+   * Deletes a custom attribute from the currently used basket.
    *
    * @param attributeName The name of the custom attribute
    */
@@ -563,5 +563,45 @@ export class BasketService {
     return this.currentBasketEndpoint().delete(`attributes/${attributeName}`, {
       headers: this.basketHeaders,
     });
+  }
+
+  /**
+   * Adds all items of a quote to the current basket.
+   *
+   * @param quoteId   The id of the quote that should be added to the basket.
+   * @returns         The info message if present.
+   */
+  addQuoteToBasket(quoteId: string): Observable<string> {
+    if (!quoteId) {
+      return throwError(() => new Error('addQuoteToBasket() called without quoteId'));
+    }
+
+    return this.currentBasketEndpoint()
+      .post(
+        `quotes`,
+        { id: quoteId, calculated: true },
+        {
+          headers: this.basketHeaders,
+        }
+      )
+      .pipe(map(({ infos }) => infos?.[0]?.message));
+  }
+
+  /**
+   * Deletes all items of a quote from the current basket.
+   *
+   * @param quoteId   The id of the quote whose items should be deleted from the basket.
+   * @returns         The info message if present.
+   */
+  deleteQuoteFromBasket(quoteId: string): Observable<BasketInfo[]> {
+    if (!quoteId) {
+      return throwError(() => new Error('deleteQuoteFromBasket() called without quoteId'));
+    }
+
+    return this.currentBasketEndpoint()
+      .delete(`quotes/${quoteId}`, {
+        headers: this.basketHeaders,
+      })
+      .pipe(map(BasketInfoMapper.fromInfo));
   }
 }

--- a/src/app/extensions/quoting/services/quoting/quoting.service.spec.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.spec.ts
@@ -147,29 +147,6 @@ describe('Quoting Service', () => {
     });
   });
 
-  describe('addQuoteToBasket', () => {
-    beforeEach(() => {
-      when(apiService.post(anything(), anything())).thenReturn(of({}));
-    });
-
-    it('should use basket API for adding quotes to basket', done => {
-      quotingService.addQuoteToBasket('basketId', 'quoteID').subscribe({
-        next: () => {
-          verify(apiService.post(anything(), anything())).once();
-          const [path, body] = capture(apiService.post).last();
-          expect(path).toMatchInlineSnapshot(`"baskets/basketId/items"`);
-          expect(body).toMatchInlineSnapshot(`
-            Object {
-              "quoteID": "quoteID",
-            }
-          `);
-        },
-        error: fail,
-        complete: done,
-      });
-    });
-  });
-
   describe('createQuoteRequestFromQuote', () => {
     beforeEach(() => {
       when(apiService.post(anything(), anything(), anything())).thenReturn(of({ type: 'QuoteRequest' }));

--- a/src/app/extensions/quoting/services/quoting/quoting.service.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.ts
@@ -95,11 +95,6 @@ export class QuotingService {
       .pipe(map(data => this.quoteMapper.fromData(data, 'Quote')));
   }
 
-  addQuoteToBasket(basketId: string, quoteID: string) {
-    // ToDo: remove parameter basketId and delegate addQuoteToBasket to the basket service if the basket REST api 1.0 provides this functionality, see #70533
-    return this.apiService.post(`baskets/${basketId}/items`, { quoteID }).pipe(map(() => quoteID));
-  }
-
   createQuoteRequestFromQuote(quoteID: string) {
     return this.apiService
       .b2bUserEndpoint()

--- a/src/app/extensions/quoting/store/quoting/quoting.actions.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.actions.ts
@@ -50,6 +50,8 @@ export const deleteQuotingEntitySuccess = createAction(
 );
 
 export const deleteQuoteFromBasket = createAction('[Quoting] Delete Quote From Basket', payload<IdPayloadType>());
+export const deleteQuoteFromBasketSuccess = createAction('[Quoting API] Delete Quote From Basket Success');
+export const deleteQuoteFromBasketFail = createAction('[Quoting API] Delete Quote From Basket Fail');
 
 export const rejectQuote = createAction('[Quoting] Reject Quote', payload<IdPayloadType>());
 

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
@@ -5,13 +5,15 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { Observable, noop, of } from 'rxjs';
-import { delay } from 'rxjs/operators';
+import { Observable, noop, of, throwError } from 'rxjs';
+import { delay, toArray } from 'rxjs/operators';
 import { anyString, anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
 
-import { Basket, BasketView } from 'ish-core/models/basket/basket.model';
+import { BasketInfo } from 'ish-core/models/basket-info/basket-info.model';
+import { Basket } from 'ish-core/models/basket/basket.model';
 import { BasketService } from 'ish-core/services/basket/basket.service';
-import { getCurrentBasket, getCurrentBasketId } from 'ish-core/store/customer/basket';
+import { getCurrentBasketId } from 'ish-core/store/customer/basket';
+import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 
 import { QuoteRequest, QuoteStub } from '../../models/quoting/quoting.model';
 import { QuotingService } from '../../services/quoting/quoting.service';
@@ -178,7 +180,7 @@ describe('Quoting Effects', () => {
 
   describe('addQuoteToBasket$', () => {
     beforeEach(() => {
-      when(quotingService.addQuoteToBasket(anything(), anything())).thenReturn(of(''));
+      when(basketService.addQuoteToBasket(anything())).thenReturn(of(''));
     });
 
     describe('with basket', () => {
@@ -190,7 +192,7 @@ describe('Quoting Effects', () => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
         effects.addQuoteToBasket$.subscribe(() => {
-          verify(quotingService.addQuoteToBasket('basketID', 'quoteID')).once();
+          verify(basketService.addQuoteToBasket('quoteID')).once();
           verify(basketService.createBasket()).never();
           done();
         });
@@ -207,7 +209,7 @@ describe('Quoting Effects', () => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
         effects.addQuoteToBasket$.subscribe(() => {
-          verify(quotingService.addQuoteToBasket('basketID', 'quoteID')).once();
+          verify(basketService.addQuoteToBasket('quoteID')).once();
           verify(basketService.createBasket()).once();
           done();
         });
@@ -381,50 +383,37 @@ describe('Quoting Effects', () => {
   });
 
   describe('deleteQuoteFromBasket$', () => {
-    it('should dispatch deleteBasketItem action for quote related item', done => {
+    beforeEach(() => {
+      when(basketService.deleteQuoteFromBasket(anything())).thenReturn(
+        of([{ message: 'delete Message' } as BasketInfo])
+      );
+    });
+
+    it('should dispatch deleteQuoteFromBasketSuccess action if successful', done => {
       actions$ = of(deleteQuoteFromBasket({ id: 'QUOTE' }));
 
-      store$.overrideSelector(getCurrentBasket, {
-        lineItems: [
-          { id: '1' },
-          { id: '2', quote: 'QUOTE' },
-          { id: '3', quote: 'QUOTE' },
-          { id: '4', quote: 'QUOTE2' },
-        ],
-      } as BasketView);
-
-      effects.deleteQuoteFromBasket$.subscribe(action => {
+      effects.deleteQuoteFromBasket$.pipe(toArray()).subscribe(action => {
+        verify(basketService.deleteQuoteFromBasket('QUOTE')).once();
         expect(action).toMatchInlineSnapshot(`
-          [Basket] Delete Basket Item:
-            itemId: "2"
+          [Basket Internal] Load Basket
+          [Quoting API] Delete Quote From Basket Success
+          [Message] Success Toast:
+            message: "delete Message"
         `);
         done();
       });
     });
 
-    it('should do nothing when quote is not in the basket', done => {
+    it('should dispatch deleteQuoteFromBasketFail action if an error occurs', done => {
+      const error = makeHttpError({ status: 401, code: 'feld' });
+      when(basketService.deleteQuoteFromBasket(anything())).thenReturn(throwError(() => error));
+
       actions$ = of(deleteQuoteFromBasket({ id: 'QUOTE' }));
 
-      store$.overrideSelector(getCurrentBasket, {
-        lineItems: [{ id: '1' }],
-      } as BasketView);
-
-      effects.deleteQuoteFromBasket$.subscribe({
-        next: fail,
-        error: fail,
-        complete: done,
-      });
-    });
-
-    it('should do nothing when there is no basket', done => {
-      actions$ = of(deleteQuoteFromBasket({ id: 'QUOTE' }));
-
-      store$.overrideSelector(getCurrentBasket, undefined);
-
-      effects.deleteQuoteFromBasket$.subscribe({
-        next: fail,
-        error: fail,
-        complete: done,
+      effects.deleteQuoteFromBasket$.subscribe(action => {
+        verify(basketService.deleteQuoteFromBasket('QUOTE')).once();
+        expect(action).toMatchInlineSnapshot(`[Quoting API] Delete Quote From Basket Fail`);
+        done();
       });
     });
   });


### PR DESCRIPTION


<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The outdated basket 0.1 REST api is used to add a quote to basket. A quote is deleted from basket by deleting the first quote item from basket.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The basket REST api 1.x is used to add a quote to basket and delete a quote from basket.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The store actions AddQuoteToBasket and DeleteQuoteFromBasket remain unchanged. only the corresponding quote effects have been adapted. 
The method AddQuoteToBasket has been moved from the quoting.service to the basket service.

[ ] Yes
[x] No

## Other Information


[AB#79744](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79744)