### PR TITLE
Feature/show inactiveflag costcenteruser

### DIFF
--- a/docs/guides/formly.md
+++ b/docs/guides/formly.md
@@ -267,6 +267,7 @@ Template option `inputClass`: These css class(es) will be added to all input/sel
 | ish-captcha-field    | Includes the `<ish-lazy-captcha>` component and adds the relevant `formControls` to the form | `topic`: Topic that will be passed to the Captcha component.                                                                  |
 | ish-radio-field      | Basic radio input                                                                            | ----                                                                                                                          |
 | ish-plain-text-field | Only display the form value                                                                  | ----                                                                                                                          |
+| ish-html-text-field  | Only display the form value as html                                                          | ----                                                                                                                          |
 
 ### Wrappers
 

--- a/docs/guides/formly.md
+++ b/docs/guides/formly.md
@@ -55,7 +55,7 @@ Your template should look something like this:
 ### FormlyFieldConfig
 
 The `FormlyFieldConfig` class allows you to define a number of parameters that change the way a Formly field behaves.
-For a comprehensive overview of properties, refer to the [official documentation](https://formly.dev/guide/properties-options).
+For a comprehensive overview of properties, refer to the [official documentation](https://formly.dev/docs/guide/properties-options).
 A configuration for a form containing only a basic input field could be defined like this:
 
 ```typescript
@@ -181,7 +181,7 @@ FormlyModule.forChild({
 
 ### Validation
 
-There are many options when it comes to [adding custom validation to formly forms](https://formly.dev/guide/validation).
+There are many options when it comes to [adding custom validation to formly forms](https://formly.dev/docs/guide/validation).
 
 The PWA comes with some predefined custom validators which can be found in [special-validators.ts](../../src/app/shared/forms/validators/special-validators.ts).
 These can be added directly to the `validators.validation` property of a `FormlyFieldConfig`.

--- a/projects/organization-management/src/app/components/cost-center-users-list/cost-center-users-list.component.html
+++ b/projects/organization-management/src/app/components/cost-center-users-list/cost-center-users-list.component.html
@@ -22,6 +22,9 @@
           <ng-container *ishHasNotRole="'APP_B2B_ACCOUNT_OWNER'">
             {{ buyer.firstName }} {{ buyer.lastName }}
           </ng-container>
+          <span *ngIf="buyer.active === false" class="input-help">
+            <br />{{ 'account.user.list.status.inactive' | translate }}
+          </span>
         </td>
       </ng-container>
 

--- a/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.ts
+++ b/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
+import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subject, merge } from 'rxjs';
 import { take, takeUntil, withLatestFrom } from 'rxjs/operators';
 
@@ -50,7 +51,11 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
 
   private destroy$ = new Subject<void>();
 
-  constructor(private appFacade: AppFacade, private organizationManagementFacade: OrganizationManagementFacade) {}
+  constructor(
+    private appFacade: AppFacade,
+    private organizationManagementFacade: OrganizationManagementFacade,
+    private translateService: TranslateService
+  ) {}
 
   ngOnInit() {
     this.loading$ = this.organizationManagementFacade.costCentersLoading$;
@@ -59,7 +64,6 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
       this.organizationManagementFacade.usersError$
     );
     this.buyers$ = this.organizationManagementFacade.costCenterUnassignedBuyers$();
-
     // set model and form fields
     this.buyers$
       .pipe(withLatestFrom(this.appFacade.currentCurrency$), take(1), takeUntil(this.destroy$))
@@ -70,10 +74,13 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
   }
 
   getModel(buyers: B2bUser[], currency: string) {
+    const inactivetext = this.translateService.instant('account.user.list.status.inactive');
     return {
       addBuyers: buyers.map(buyer => ({
         selected: false,
-        name: `${buyer.firstName} ${buyer.lastName}`,
+        name: `${buyer.firstName} ${buyer.lastName} ${
+          !buyer.active ? `<p class="input-help">${inactivetext}</p>` : ''
+        } `,
         login: buyer.login,
         budgetValue: undefined,
         currency,
@@ -102,7 +109,7 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
             },
             {
               key: 'name',
-              type: 'ish-plain-text-field',
+              type: 'ish-html-text-field',
               className: 'col-11 col-sm-10 col-md-3 list-item pb-0',
               templateOptions: {
                 inputClass: 'col-form-label pb-0',

--- a/src/app/shared/formly/dev/testing/formly-testing.module.ts
+++ b/src/app/shared/formly/dev/testing/formly-testing.module.ts
@@ -42,6 +42,9 @@ class TextInputFieldComponent extends FieldType {}
 @Component({ template: 'PlainTextFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class PlainTextFieldComponent extends FieldType {}
 
+@Component({ template: 'HtmlTextFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
+class HtmlTextFieldComponent extends FieldType {}
+
 @Component({ template: 'EmailFieldComponent: {{ field.key }} {{ field.type }} {{ to | json }}' })
 class EmailFieldComponent extends FieldType {}
 
@@ -74,6 +77,7 @@ class DatePickerFieldComponent extends FieldType {}
     DummyWrapperComponent,
     EmailFieldComponent,
     FieldsetFieldComponent,
+    HtmlTextFieldComponent,
     PasswordFieldComponent,
     PhoneFieldComponent,
     PlainTextFieldComponent,
@@ -92,7 +96,11 @@ class DatePickerFieldComponent extends FieldType {}
         },
         {
           name: 'ish-plain-text-field',
-          component: TextInputFieldComponent,
+          component: PlainTextFieldComponent,
+        },
+        {
+          name: 'ish-html-text-field',
+          component: HtmlTextFieldComponent,
         },
         {
           name: 'ish-fieldset-field',

--- a/src/app/shared/formly/types/html-text-field/html-text-field.component.html
+++ b/src/app/shared/formly/types/html-text-field/html-text-field.component.html
@@ -1,0 +1,1 @@
+<div [ngClass]="to.inputClass ? to.inputClass : 'col-form-label'" [innerHtml]="textValue"></div>

--- a/src/app/shared/formly/types/html-text-field/html-text-field.component.spec.ts
+++ b/src/app/shared/formly/types/html-text-field/html-text-field.component.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+
+import { FormlyTestingComponentsModule } from 'ish-shared/formly/dev/testing/formly-testing-components.module';
+import { FormlyTestingContainerComponent } from 'ish-shared/formly/dev/testing/formly-testing-container/formly-testing-container.component';
+
+import { HtmlTextFieldComponent } from './html-text-field.component';
+
+describe('Html Text Field Component', () => {
+  let component: FormlyTestingContainerComponent;
+  let fixture: ComponentFixture<FormlyTestingContainerComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HtmlTextFieldComponent],
+      imports: [
+        FormlyModule.forRoot({
+          types: [
+            {
+              name: 'ish-html-text-field',
+              component: HtmlTextFieldComponent,
+            },
+          ],
+        }),
+        FormlyTestingComponentsModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    const testComponentInputs = {
+      fields: [
+        {
+          key: 'displayValue',
+          type: 'ish-html-text-field',
+          templateOptions: {
+            label: 'test label',
+          },
+        } as FormlyFieldConfig,
+      ],
+      form: new FormGroup({}),
+      model: {
+        displayValue: 'testValue',
+      },
+    };
+    fixture = TestBed.createComponent(FormlyTestingContainerComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.testComponentInputs = testComponentInputs;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should be rendered after creation', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('ish-html-text-field > div.col-form-label')).toBeTruthy();
+  });
+});

--- a/src/app/shared/formly/types/html-text-field/html-text-field.component.ts
+++ b/src/app/shared/formly/types/html-text-field/html-text-field.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+
+/**
+ * Type to display a html text value with optional styling
+ *
+ * @templateOption **inputClass** a class that will be used to style the div around the text
+ */
+@Component({
+  selector: 'ish-html-text-field',
+  templateUrl: './html-text-field.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HtmlTextFieldComponent extends FieldType {
+  get textValue() {
+    return this.form.get(this.field.key as string)?.value;
+  }
+}

--- a/src/app/shared/formly/types/types.module.ts
+++ b/src/app/shared/formly/types/types.module.ts
@@ -23,6 +23,7 @@ import { DatePickerFieldComponent } from './date-picker-field/date-picker-field.
 import { IshDatepickerI18n } from './date-picker-field/ish-datepicker-i18n';
 import { LocalizedParserFormatter } from './date-picker-field/localized-parser-formatter';
 import { FieldsetFieldComponent } from './fieldset-field/fieldset-field.component';
+import { HtmlTextFieldComponent } from './html-text-field/html-text-field.component';
 import { PlainTextFieldComponent } from './plain-text-field/plain-text-field.component';
 import { RadioFieldComponent } from './radio-field/radio-field.component';
 import { SelectFieldComponent } from './select-field/select-field.component';
@@ -34,6 +35,7 @@ const fieldComponents = [
   CheckboxFieldComponent,
   DatePickerFieldComponent,
   FieldsetFieldComponent,
+  HtmlTextFieldComponent,
   PlainTextFieldComponent,
   RadioFieldComponent,
   SelectFieldComponent,
@@ -61,6 +63,11 @@ const fieldComponents = [
         {
           name: 'ish-plain-text-field',
           component: PlainTextFieldComponent,
+          wrappers: ['form-field-horizontal'],
+        },
+        {
+          name: 'ish-html-text-field',
+          component: HtmlTextFieldComponent,
           wrappers: ['form-field-horizontal'],
         },
         {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ x] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
In the cost center management of the MyAccount section it is not visible, if a cost center user is inactive.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #958

## What Is the New Behavior?
The inactive status for a cost center user is shown.
## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x] No

## Other Information


[AB#79878](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/79878)

active flag for costcenteruser available starting ICM version 7.10.38.15-LTS-dev3 