### PR TITLE
feat: add configurable product attributes

### DIFF
--- a/src/app/core/services/products-attributes/products-attributes.service.spec.ts
+++ b/src/app/core/services/products-attributes/products-attributes.service.spec.ts
@@ -1,0 +1,289 @@
+import { TestBed } from '@angular/core/testing';
+import { instance, mock, when } from 'ts-mockito';
+
+import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+
+import {
+  AdditionnalsProductAttributesProvider,
+  ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER,
+  ProductAttributeScope,
+  ProductsAttributesService,
+} from './products-attributes.service';
+
+describe('Products Attributes Service', () => {
+  let productsAttributesService: ProductsAttributesService;
+  let featureToggleService: FeatureToggleService;
+
+  describe('without product attributes providers', () => {
+    beforeEach(() => {
+      featureToggleService = mock(FeatureToggleService);
+      TestBed.configureTestingModule({
+        providers: [{ provide: FeatureToggleService, useFactory: () => instance(featureToggleService) }],
+      });
+
+      productsAttributesService = TestBed.inject(ProductsAttributesService);
+    });
+
+    it("should get default data when 'getAttributes(ProductAttributeScope.ALL)' is called", () => {
+      expect(productsAttributesService.getAttributes(ProductAttributeScope.ALL)).toMatchInlineSnapshot(
+        `"attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+      );
+    });
+
+    it("should get default data when 'getAttributes()' is called without parameters", () => {
+      expect(productsAttributesService.getAttributes()).toMatchInlineSnapshot(
+        `"attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+      );
+    });
+
+    it("should get default list data when 'getAttributes(ProductAttributeScope.LIST)' is called", () => {
+      expect(productsAttributesService.getAttributes(ProductAttributeScope.LIST)).toMatchInlineSnapshot(
+        `"availability,defaultCategory,image,inStock,manufacturer,mastered,maxOrderQuantity,minOrderQuantity,packingUnit,productMaster,productMasterSKU,promotions,retailSet,roundedAverageRating,sku,stepOrderQuantity"`
+      );
+    });
+  });
+
+  describe('with product attributes providers', () => {
+    class ProviderUniqValue implements AdditionnalsProductAttributesProvider {
+      getAdditionnalsAttributes(_scope: ProductAttributeScope): string[] {
+        return ['A'];
+      }
+    }
+
+    class ProviderMultipleValue implements AdditionnalsProductAttributesProvider {
+      getAdditionnalsAttributes(_scope: ProductAttributeScope): string[] {
+        return ['B', 'C'];
+      }
+    }
+
+    class ProviderRepeatValue implements AdditionnalsProductAttributesProvider {
+      getAdditionnalsAttributes(_scope: ProductAttributeScope): string[] {
+        return ['C', 'B', 'A'];
+      }
+    }
+
+    class ProviderListValue implements AdditionnalsProductAttributesProvider {
+      getAdditionnalsAttributes(scope: ProductAttributeScope): string[] {
+        switch (scope) {
+          case ProductAttributeScope.LIST:
+            return ['LIST1', 'LIST2'];
+          default:
+            return [];
+        }
+      }
+    }
+
+    beforeEach(() => {
+      featureToggleService = mock(FeatureToggleService);
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderListValue, multi: true },
+          { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderMultipleValue, multi: true },
+          { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderRepeatValue, multi: true },
+          { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderUniqValue, multi: true },
+          { provide: FeatureToggleService, useFactory: () => instance(featureToggleService) },
+        ],
+      });
+
+      productsAttributesService = TestBed.inject(ProductsAttributesService);
+    });
+
+    it("should get extra data when 'getAttributes(ProductAttributeScope.ALL)' is called", () => {
+      expect(productsAttributesService.getAttributes(ProductAttributeScope.ALL)).toMatchInlineSnapshot(
+        `"A,B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+      );
+    });
+
+    it("should get extra data when 'getAttributes()' is called without parameters", () => {
+      expect(productsAttributesService.getAttributes()).toMatchInlineSnapshot(
+        `"A,B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+      );
+    });
+
+    it("should get extra list data when 'getAttributes(ProductAttributeScope.LIST)' is called", () => {
+      expect(productsAttributesService.getAttributes(ProductAttributeScope.LIST)).toMatchInlineSnapshot(
+        `"A,B,C,LIST1,LIST2,availability,defaultCategory,image,inStock,manufacturer,mastered,maxOrderQuantity,minOrderQuantity,packingUnit,productMaster,productMasterSKU,promotions,retailSet,roundedAverageRating,sku,stepOrderQuantity"`
+      );
+    });
+  });
+
+  describe('with featured scope product attributes providers', () => {
+    class ProviderUniqValue implements AdditionnalsProductAttributesProvider {
+      feature = 'A';
+      getAdditionnalsAttributes(_scope: ProductAttributeScope): string[] {
+        return ['A'];
+      }
+    }
+
+    class ProviderMultipleValue implements AdditionnalsProductAttributesProvider {
+      feature = 'B';
+      getAdditionnalsAttributes(_scope: ProductAttributeScope): string[] {
+        return ['B', 'C'];
+      }
+    }
+
+    class ProviderRepeatValue implements AdditionnalsProductAttributesProvider {
+      feature = 'C';
+      getAdditionnalsAttributes(_scope: ProductAttributeScope): string[] {
+        return ['C', 'B', 'A'];
+      }
+    }
+
+    class ProviderListValue implements AdditionnalsProductAttributesProvider {
+      feature = 'A';
+      getAdditionnalsAttributes(scope: ProductAttributeScope): string[] {
+        switch (scope) {
+          case ProductAttributeScope.LIST:
+            return ['LIST1', 'LIST2'];
+          default:
+            return [];
+        }
+      }
+    }
+    describe('and feature A activated', () => {
+      beforeEach(() => {
+        featureToggleService = mock(FeatureToggleService);
+        when(featureToggleService.enabled('A')).thenReturn(true);
+
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderListValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderMultipleValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderRepeatValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderUniqValue, multi: true },
+            { provide: FeatureToggleService, useFactory: () => instance(featureToggleService) },
+          ],
+        });
+        productsAttributesService = TestBed.inject(ProductsAttributesService);
+      });
+
+      it("should get extra data when 'getAttributes(ProductAttributeScope.ALL)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.ALL)).toMatchInlineSnapshot(
+          `"A,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra data when 'getAttributes()' is called without parameters", () => {
+        expect(productsAttributesService.getAttributes()).toMatchInlineSnapshot(
+          `"A,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra list data when 'getAttributes(ProductAttributeScope.LIST)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.LIST)).toMatchInlineSnapshot(
+          `"A,LIST1,LIST2,availability,defaultCategory,image,inStock,manufacturer,mastered,maxOrderQuantity,minOrderQuantity,packingUnit,productMaster,productMasterSKU,promotions,retailSet,roundedAverageRating,sku,stepOrderQuantity"`
+        );
+      });
+    });
+
+    describe('and feature B activated', () => {
+      beforeEach(() => {
+        featureToggleService = mock(FeatureToggleService);
+        when(featureToggleService.enabled('B')).thenReturn(true);
+
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderListValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderMultipleValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderRepeatValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderUniqValue, multi: true },
+            { provide: FeatureToggleService, useFactory: () => instance(featureToggleService) },
+          ],
+        });
+        productsAttributesService = TestBed.inject(ProductsAttributesService);
+      });
+
+      it("should get extra data when 'getAttributes(ProductAttributeScope.ALL)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.ALL)).toMatchInlineSnapshot(
+          `"B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra data when 'getAttributes()' is called without parameters", () => {
+        expect(productsAttributesService.getAttributes()).toMatchInlineSnapshot(
+          `"B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra list data when 'getAttributes(ProductAttributeScope.LIST)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.LIST)).toMatchInlineSnapshot(
+          `"B,C,availability,defaultCategory,image,inStock,manufacturer,mastered,maxOrderQuantity,minOrderQuantity,packingUnit,productMaster,productMasterSKU,promotions,retailSet,roundedAverageRating,sku,stepOrderQuantity"`
+        );
+      });
+    });
+
+    describe('and feature C activated', () => {
+      beforeEach(() => {
+        featureToggleService = mock(FeatureToggleService);
+        when(featureToggleService.enabled('C')).thenReturn(true);
+
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderListValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderMultipleValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderRepeatValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderUniqValue, multi: true },
+            { provide: FeatureToggleService, useFactory: () => instance(featureToggleService) },
+          ],
+        });
+        productsAttributesService = TestBed.inject(ProductsAttributesService);
+      });
+
+      it("should get extra data when 'getAttributes(ProductAttributeScope.ALL)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.ALL)).toMatchInlineSnapshot(
+          `"A,B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra data when 'getAttributes()' is called without parameters", () => {
+        expect(productsAttributesService.getAttributes()).toMatchInlineSnapshot(
+          `"A,B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra list data when 'getAttributes(ProductAttributeScope.LIST)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.LIST)).toMatchInlineSnapshot(
+          `"A,B,C,availability,defaultCategory,image,inStock,manufacturer,mastered,maxOrderQuantity,minOrderQuantity,packingUnit,productMaster,productMasterSKU,promotions,retailSet,roundedAverageRating,sku,stepOrderQuantity"`
+        );
+      });
+    });
+
+    describe('and feature A,B,C activated', () => {
+      beforeEach(() => {
+        featureToggleService = mock(FeatureToggleService);
+        when(featureToggleService.enabled('A')).thenReturn(true);
+        when(featureToggleService.enabled('B')).thenReturn(true);
+        when(featureToggleService.enabled('C')).thenReturn(true);
+
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderListValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderMultipleValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderRepeatValue, multi: true },
+            { provide: ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, useClass: ProviderUniqValue, multi: true },
+            { provide: FeatureToggleService, useFactory: () => instance(featureToggleService) },
+          ],
+        });
+        productsAttributesService = TestBed.inject(ProductsAttributesService);
+      });
+
+      it("should get extra data when 'getAttributes(ProductAttributeScope.ALL)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.ALL)).toMatchInlineSnapshot(
+          `"A,B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra data when 'getAttributes()' is called without parameters", () => {
+        expect(productsAttributesService.getAttributes()).toMatchInlineSnapshot(
+          `"A,B,C,attachments,attributeGroups,availability,availableGiftMessages,availableGiftWraps,availableStock,availableWarranties,bundles,crosssells,currencyCode,defaultCategory,endOfLife,images,inStock,lastOrderDate,listPrice,longDescription,manufacturer,mastered,maxListPrice,maxOrderQuantity,maxSalePrice,minListPrice,minOrderQuantity,minSalePrice,name,packingUnit,partOfRetailSet,price,productBundle,productMaster,productMasterSKU,productName,productTypes,promotions,readyForShipmentMax,readyForShipmentMin,retailSet,reviews,roundedAverageRating,salePrice,shippingMethods,shortDescription,sku,stepOrderQuantity,summedUpListPrice,summedUpSalePrice,supplierSKU,variableVariationAttributes,variationAttributeValues,variations"`
+        );
+      });
+
+      it("should get extra list data when 'getAttributes(ProductAttributeScope.LIST)' is called", () => {
+        expect(productsAttributesService.getAttributes(ProductAttributeScope.LIST)).toMatchInlineSnapshot(
+          `"A,B,C,LIST1,LIST2,availability,defaultCategory,image,inStock,manufacturer,mastered,maxOrderQuantity,minOrderQuantity,packingUnit,productMaster,productMasterSKU,promotions,retailSet,roundedAverageRating,sku,stepOrderQuantity"`
+        );
+      });
+    });
+  });
+});

--- a/src/app/core/services/products-attributes/products-attributes.service.ts
+++ b/src/app/core/services/products-attributes/products-attributes.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, InjectionToken, Injector } from '@angular/core';
+
+import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+
+/**
+ * Type of products attributes.
+ */
+export enum ProductAttributeScope {
+  /**
+   * All availables attributes from the application
+   */
+  ALL,
+  /**
+   * Attributes that should be diplayed on product listing
+   */
+  LIST,
+}
+
+/**
+ * Provider to declare additionnals production attributes on extensions
+ */
+export interface AdditionnalsProductAttributesProvider {
+  /**
+   * Fetch additionnals attributes when the product will be fetch with the REST API
+   *
+   * @returns A list of attributes name
+   * @param scope Type of products attributes
+   */
+  getAdditionnalsAttributes(scope: ProductAttributeScope): string[];
+
+  feature?: string;
+}
+
+/**
+ * Main declaration of the product attribute provider.
+ * 'additionnalsProductAttributesProvider' as internal id
+ */
+export const ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER = new InjectionToken<AdditionnalsProductAttributesProvider>(
+  'additionnalsProductAttributesProvider'
+);
+
+/**
+ * All attributes that can be fetched (currently retreived on product page)
+ */
+const DEFAULT_ALL_ATTRIBUTES = [
+  'productName',
+  'shortDescription',
+  'longDescription',
+  'sku',
+  'availability',
+  'retailSet',
+  'inStock',
+  'availableStock',
+  'productMaster',
+  'productMasterSKU',
+  'mastered',
+  'shippingMethods',
+  'reviews',
+  'roundedAverageRating',
+  'readyForShipmentMin',
+  'readyForShipmentMax',
+  'minOrderQuantity',
+  'variationAttributeValues',
+  'productBundle',
+  'manufacturer',
+  'listPrice',
+  'salePrice',
+  'images',
+  'defaultCategory',
+  'attachments',
+  'variations',
+  'crosssells',
+  'variableVariationAttributes',
+  'bundles',
+  'partOfRetailSet',
+  'price',
+  'minListPrice',
+  'maxListPrice',
+  'minSalePrice',
+  'maxSalePrice',
+  'summedUpListPrice',
+  'summedUpSalePrice',
+  'availableWarranties',
+  'availableGiftWraps',
+  'availableGiftMessages',
+  'endOfLife',
+  'lastOrderDate',
+  'maxOrderQuantity',
+  'stepOrderQuantity',
+  'currencyCode',
+  'sku',
+  'name',
+  'attributeGroups',
+  'productTypes',
+  'packingUnit',
+  'promotions',
+  'supplierSKU',
+];
+
+/**
+ * All attributes that can be fetched on product listing page
+ */
+const DEFAULT_LIST_ATTRIBUTES = [
+  'sku',
+  'availability',
+  'manufacturer',
+  'image',
+  'minOrderQuantity',
+  'maxOrderQuantity',
+  'stepOrderQuantity',
+  'inStock',
+  'promotions',
+  'packingUnit',
+  'mastered',
+  'productMaster',
+  'productMasterSKU',
+  'roundedAverageRating',
+  'retailSet',
+  'defaultCategory',
+];
+
+/**
+ * The Products Attributes Service handles attributes fetched with the 'products' REST API.
+ */
+@Injectable({ providedIn: 'root' })
+export class ProductsAttributesService {
+  private allAttributes: string;
+  private listAttributes: string;
+
+  constructor(private injector: Injector, private featureToggleService: FeatureToggleService) {
+    const externalProvider = this.injector
+      .get<AdditionnalsProductAttributesProvider[]>(ADDITIONNALS_PRODUCT_ATTRIBUTES_PROVIDER, [])
+      .filter(p => (p.feature ? this.featureToggleService.enabled(p.feature) : true));
+
+    this.allAttributes = this.compactAttributesList(
+      DEFAULT_ALL_ATTRIBUTES,
+      this.getAdditionnalAttributes(externalProvider, ProductAttributeScope.ALL)
+    );
+    this.listAttributes = this.compactAttributesList(
+      DEFAULT_LIST_ATTRIBUTES,
+      this.getAdditionnalAttributes(externalProvider, ProductAttributeScope.LIST)
+    );
+  }
+
+  private compactAttributesList(defaultAttributes: string[], additionnalsAttributes: string[]) {
+    const uniqAttrs = new Set<string>([...defaultAttributes, ...additionnalsAttributes]);
+    return [...uniqAttrs].sort().join(',');
+  }
+
+  private getAdditionnalAttributes(providers: AdditionnalsProductAttributesProvider[], scope: ProductAttributeScope) {
+    return providers.reduce((prev, current) => [...prev, ...current.getAdditionnalsAttributes(scope)], []);
+  }
+
+  /**
+   * Get the list of attributes to fetch from a given scope
+   *
+   * @param scope Type of products attributes
+   * @returns All attribute names joined by a comma
+   */
+  getAttributes(scope?: ProductAttributeScope): string {
+    switch (scope) {
+      case ProductAttributeScope.LIST:
+        return this.listAttributes;
+      default:
+        return this.allAttributes;
+    }
+  }
+}

--- a/src/app/core/services/products/products-list-attributes.ts
+++ b/src/app/core/services/products/products-list-attributes.ts
@@ -1,1 +1,0 @@
-export default 'sku,availability,manufacturer,image,minOrderQuantity,maxOrderQuantity,stepOrderQuantity,inStock,promotions,packingUnit,mastered,productMaster,productMasterSKU,roundedAverageRating,retailSet,defaultCategory';

--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -5,6 +5,7 @@ import { anyString, anything, capture, instance, mock, verify, when } from 'ts-m
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { Product } from 'ish-core/models/product/product.model';
 import { ApiService, AvailableOptions } from 'ish-core/services/api/api.service';
+import { ProductsAttributesService } from 'ish-core/services/products-attributes/products-attributes.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { ProductListingEffects } from 'ish-core/store/shopping/product-listing/product-listing.effects';
 import { ShoppingStoreModule } from 'ish-core/store/shopping/shopping-store.module';
@@ -16,6 +17,7 @@ describe('Products Service', () => {
   let productsService: ProductsService;
   let apiServiceMock: ApiService;
   let appFacadeMock: AppFacade;
+  let productAttributesService: ProductsAttributesService;
 
   const productSku = 'SKU';
   const categoryId = 'CategoryID';
@@ -65,7 +67,7 @@ describe('Products Service', () => {
   beforeEach(() => {
     apiServiceMock = mock(ApiService);
     appFacadeMock = mock(AppFacade);
-
+    productAttributesService = mock(ProductsAttributesService);
     TestBed.configureTestingModule({
       imports: [
         CoreStoreModule.forTesting(['configuration'], [ProductListingEffects]),
@@ -74,6 +76,7 @@ describe('Products Service', () => {
       providers: [
         { provide: ApiService, useFactory: () => instance(apiServiceMock) },
         { provide: AppFacade, useFactory: () => instance(appFacadeMock) },
+        { provide: ProductsAttributesService, useFactory: () => instance(productAttributesService) },
       ],
     });
     productsService = TestBed.inject(ProductsService);

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -20,18 +20,25 @@ import {
   VariationProductMaster,
 } from 'ish-core/models/product/product.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import {
+  ProductAttributeScope,
+  ProductsAttributesService,
+} from 'ish-core/services/products-attributes/products-attributes.service';
 import { omit } from 'ish-core/utils/functions';
 import { mapToProperty } from 'ish-core/utils/operators';
 import { URLFormParams, appendFormParamsToHttpParams } from 'ish-core/utils/url-form-params';
-
-import STUB_ATTRS from './products-list-attributes';
 
 /**
  * The Products Service handles the interaction with the 'products' REST API.
  */
 @Injectable({ providedIn: 'root' })
 export class ProductsService {
-  constructor(private apiService: ApiService, private productMapper: ProductMapper, private appFacade: AppFacade) {}
+  constructor(
+    private apiService: ApiService,
+    private productMapper: ProductMapper,
+    private appFacade: AppFacade,
+    private productAttributesService: ProductsAttributesService
+  ) {}
 
   /**
    * Get the full Product data for the given Product SKU.
@@ -44,7 +51,9 @@ export class ProductsService {
       return throwError(() => new Error('getProduct() called without a sku'));
     }
 
-    const params = new HttpParams().set('allImages', 'true');
+    const params = new HttpParams()
+      .set('allImages', 'true')
+      .set('attrs', this.productAttributesService.getAttributes(ProductAttributeScope.ALL));
 
     return this.apiService
       .get<ProductData>(`products/${sku}`, { sendSPGID: true, params })
@@ -70,7 +79,7 @@ export class ProductsService {
     }
 
     let params = new HttpParams()
-      .set('attrs', STUB_ATTRS)
+      .set('attrs', this.productAttributesService.getAttributes(ProductAttributeScope.ALL))
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('amount', amount.toString())
       .set('offset', offset.toString())
@@ -126,7 +135,7 @@ export class ProductsService {
       .set('searchTerm', searchTerm)
       .set('amount', amount.toString())
       .set('offset', offset.toString())
-      .set('attrs', STUB_ATTRS)
+      .set('attrs', this.productAttributesService.getAttributes(ProductAttributeScope.LIST))
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
     if (sortKey) {
@@ -171,7 +180,7 @@ export class ProductsService {
       .set('MasterSKU', masterSKU)
       .set('amount', amount.toString())
       .set('offset', offset.toString())
-      .set('attrs', STUB_ATTRS)
+      .set('attrs', this.productAttributesService.getAttributes(ProductAttributeScope.LIST))
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
     if (sortKey) {
@@ -202,7 +211,7 @@ export class ProductsService {
     let params = new HttpParams()
       .set('amount', amount ? amount.toString() : '')
       .set('offset', offset.toString())
-      .set('attrs', STUB_ATTRS)
+      .set('attrs', this.productAttributesService.getAttributes(ProductAttributeScope.LIST))
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
     if (sortKey) {


### PR DESCRIPTION
An attempt to make product defaut easily overridable was mande on ticket #1098.
However, this change only affects the product listing.
It is not possible to easily add an attribute globally on all the products of the site (and the api rest on the backoffice side is quite rigid). 
This modificationintroduces a service which allows to solve this problem more easily and also to make this configuration parameterizable at the level of an extension by using the \"FeatureToggleService\".

BREAKING CHANGES:
products-list-attribute.ts no longer provide default export

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
