### PR TITLE
fix: display filter navigation after page refresh (F5)

### DIFF
--- a/src/app/core/store/shopping/filter/filter.effects.spec.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.spec.ts
@@ -9,6 +9,7 @@ import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { FilterService } from 'ish-core/services/filter/filter.service';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { setProductListingPageSize } from 'ish-core/store/shopping/product-listing';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 
@@ -80,7 +81,8 @@ describe('Filter Effects', () => {
   describe('loadAvailableFilters$', () => {
     it('should call the filterService for LoadFilterForCategories action', done => {
       const action = loadFilterForCategory({ uniqueId: 'c' });
-      actions$ = of(action);
+
+      actions$ = of(personalizationStatusDetermined, action);
 
       effects.loadAvailableFilters$.subscribe(() => {
         verify(filterServiceMock.getFilterForCategory(anything())).once();
@@ -90,7 +92,7 @@ describe('Filter Effects', () => {
 
     it('should call the filterService for loadFilterForSearch action', done => {
       const action = loadFilterForSearch({ searchTerm: 'c' });
-      actions$ = of(action);
+      actions$ = of(personalizationStatusDetermined, action);
 
       effects.loadAvailableFilters$.subscribe(() => {
         verify(filterServiceMock.getFilterForSearch(anything())).once();
@@ -100,7 +102,7 @@ describe('Filter Effects', () => {
 
     it('should call the filterService for loadFilterForMaster action', done => {
       const action = loadFilterForMaster({ masterSKU: 'c' });
-      actions$ = of(action);
+      actions$ = of(personalizationStatusDetermined, action);
 
       effects.loadAvailableFilters$.subscribe(() => {
         verify(filterServiceMock.getFilterForMaster(anything())).once();
@@ -111,8 +113,8 @@ describe('Filter Effects', () => {
     it('should map to action of type LoadFilterSuccess', () => {
       const action = loadFilterForCategory({ uniqueId: 'c' });
       const completion = loadFilterSuccess({ filterNavigation: filterNav });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = hot('b-a-a-a', { a: action, b: personalizationStatusDetermined });
+      const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadAvailableFilters$).toBeObservable(expected$);
     });
@@ -120,8 +122,8 @@ describe('Filter Effects', () => {
     it('should map invalid request to action of type LoadFilterFail', () => {
       const action = loadFilterForCategory({ uniqueId: 'invalid' });
       const completion = loadFilterFail({ error: makeHttpError({ message: 'invalid' }) });
-      actions$ = hot('-a-a-a', { a: action });
-      const expected$ = cold('-c-c-c', { c: completion });
+      actions$ = hot('b-a-a-a', { a: action, b: personalizationStatusDetermined });
+      const expected$ = cold('--c-c-c', { c: completion });
 
       expect(effects.loadAvailableFilters$).toBeObservable(expected$);
     });
@@ -137,11 +139,11 @@ describe('Filter Effects', () => {
 
       actions$ = merge(
         // go to master 1
-        of(loadFilterForMaster({ masterSKU: 'master1' })),
+        of(personalizationStatusDetermined, loadFilterForMaster({ masterSKU: 'master1' })),
         // go to category
-        of(loadFilterForCategory({ uniqueId: 'category' })).pipe(delay(300)),
+        of(personalizationStatusDetermined, loadFilterForCategory({ uniqueId: 'category' })).pipe(delay(300)),
         // go to master 2 before category filters are loaded
-        of(loadFilterForMaster({ masterSKU: 'master2' })).pipe(delay(500))
+        of(personalizationStatusDetermined, loadFilterForMaster({ masterSKU: 'master2' })).pipe(delay(500))
       );
 
       let lastAction;

--- a/src/app/core/store/shopping/filter/filter.effects.ts
+++ b/src/app/core/store/shopping/filter/filter.effects.ts
@@ -3,7 +3,8 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { map, mergeMap, switchMap } from 'rxjs/operators';
 
 import { FilterService } from 'ish-core/services/filter/filter.service';
-import { mapErrorToAction, mapToPayload } from 'ish-core/utils/operators';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
+import { delayUntil, mapErrorToAction, mapToPayload } from 'ish-core/utils/operators';
 
 import {
   applyFilter,
@@ -23,6 +24,7 @@ export class FilterEffects {
   loadAvailableFilters$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadFilterForCategory, loadFilterForSearch, loadFilterForMaster),
+      delayUntil(this.actions$.pipe(ofType(personalizationStatusDetermined))),
       map(action => {
         switch (action.type) {
           case loadFilterForCategory.type:

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
-import { distinctUntilChanged, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
 import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,
@@ -92,6 +92,10 @@ export class ProductListingEffects {
         let initialPage = page; // scope variable (reset after first usage)
         return this.store.pipe(
           select(selectQueryParams),
+          // filter router changes which have nothing to do with product lists like login
+          filter(
+            params => !!params?.filters || !!params?.sorting || !!params?.page || Object.keys(params)?.length === 0
+          ),
           map(params => {
             const filters = params.filters
               ? {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
1. If a logged in user navigates to a category family page with filter navigation and presses F5 (page refresh) the category page is displayed without filter navigation.
2. If an anonymous user selects a filter on a family page and clicks the login link the filter gets lost.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1232, #468

## What Is the New Behavior?
1. The filter navigation is displayed after refreshing the page.
2. The filter remains unchanged if a user clicks login.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#80062](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80062)