### PR TITLE
fix: show mini cart animation after add quote to cart

### DIFF
--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -571,7 +571,7 @@ export class BasketService {
    * @param quoteId   The id of the quote that should be added to the basket.
    * @returns         The info message if present.
    */
-  addQuoteToBasket(quoteId: string): Observable<string> {
+  addQuoteToBasket(quoteId: string): Observable<BasketInfo[]> {
     if (!quoteId) {
       return throwError(() => new Error('addQuoteToBasket() called without quoteId'));
     }
@@ -584,7 +584,7 @@ export class BasketService {
           headers: this.basketHeaders,
         }
       )
-      .pipe(map(({ infos }) => infos?.[0]?.message));
+      .pipe(map(BasketInfoMapper.fromInfo));
   }
 
   /**

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.spec.ts
@@ -180,7 +180,7 @@ describe('Quoting Effects', () => {
 
   describe('addQuoteToBasket$', () => {
     beforeEach(() => {
-      when(basketService.addQuoteToBasket(anything())).thenReturn(of(''));
+      when(basketService.addQuoteToBasket(anything())).thenReturn(of(undefined));
     });
 
     describe('with basket', () => {
@@ -188,13 +188,24 @@ describe('Quoting Effects', () => {
         store$.overrideSelector(getCurrentBasketId, 'basketID');
       });
 
-      it('should directly add quote to basket via quoting service', done => {
+      it('should directly add quote to basket via basket service', done => {
         actions$ = of(addQuoteToBasket({ id: 'quoteID' }));
 
-        effects.addQuoteToBasket$.subscribe(() => {
-          verify(basketService.addQuoteToBasket('quoteID')).once();
-          verify(basketService.createBasket()).never();
-          done();
+        effects.addQuoteToBasket$.pipe(toArray()).subscribe({
+          next: actions => {
+            verify(basketService.addQuoteToBasket('quoteID')).once();
+            verify(basketService.createBasket()).never();
+            expect(actions).toMatchInlineSnapshot(`
+              [Basket API] Add Items To Basket Success:
+                lineItems: []
+                info: undefined
+              [Basket Internal] Load Basket
+              [Quoting API] Add Quote To Basket Success:
+                id: "quoteID"
+              `);
+          },
+          error: fail,
+          complete: done,
         });
       });
     });

--- a/src/app/extensions/quoting/store/quoting/quoting.effects.ts
+++ b/src/app/extensions/quoting/store/quoting/quoting.effects.ts
@@ -9,7 +9,7 @@ import { BasketService } from 'ish-core/services/basket/basket.service';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { selectRouteParam, selectUrl } from 'ish-core/store/core/router';
 import { setBreadcrumbData } from 'ish-core/store/core/viewconf';
-import { getCurrentBasketId, loadBasket } from 'ish-core/store/customer/basket';
+import { addItemsToBasketSuccess, getCurrentBasketId, loadBasket } from 'ish-core/store/customer/basket';
 import {
   mapErrorToAction,
   mapToPayload,
@@ -149,7 +149,11 @@ export class QuotingEffects {
             !basketId ? this.basketService.createBasket().pipe(map(basket => basket.id)) : of(basketId)
           ),
           concatMap(() => this.basketService.addQuoteToBasket(quoteId)),
-          mergeMap(() => [loadBasket(), addQuoteToBasketSuccess({ id: quoteId })]),
+          mergeMap(info => [
+            addItemsToBasketSuccess({ lineItems: [], info }), //  update lastTimeProductAdded in the basket state
+            loadBasket(),
+            addQuoteToBasketSuccess({ id: quoteId }),
+          ]),
           mapErrorToAction(loadQuotingFail)
         )
       )


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
After a user has added a quote to cart there is no mini cart animation.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1041

## What Is the New Behavior?
The mini cart animation is shown if a user add a quote to cart.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#80072](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80072)