### PR TITLE
chore: made pinned version handling more robust in upgrade PWA script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,11 +19,19 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "name": "Clean up Localizations",
+      "name": "Cleanup Localizations",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/scripts/clean-up-localizations",
-      "args": [],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "Upgrade PWA",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/scripts/upgrade-pwa",
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"


### PR DESCRIPTION
* pinned Formly 5 and Jest 28 version
* add launch configuration for upgrade-pwa script

## New Behavior

The upgrade-pwa script no longer "downgrades" the pinned versions before trying to upgrade the dependencies. With this approach the whole automatic upgrade would no longer work. Besides that it does not seem to be a plausible approach to downgrade. So the downgrade is removed but the check for the kept pinned versions is still done at the end.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#80166](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80166)