### PR TITLE
fix: product list after a logged in user clicked a filter navigation link on family page

### DIFF
--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
@@ -46,8 +46,9 @@ export class FilterNavigationMapper {
   private mapFacetData(filterData: FilterData) {
     return filterData.filterEntries
       ? filterData.filterEntries.reduce((acc, facet) => {
-          const category = facet.link.uri.includes('/categories/')
-            ? [facet.link.uri.split('/productfilters')[0].split('/categories/')[1]]
+          const uri = this.removeSpgidFromUri(facet.link.uri);
+          const category = uri.includes('/categories/')
+            ? [uri.split('/productfilters')[0].split('/categories/')[1]]
             : undefined;
           if (facet.name !== 'Show all') {
             acc.push({
@@ -69,5 +70,16 @@ export class FilterNavigationMapper {
           return acc;
         }, [])
       : [];
+  }
+
+  private removeSpgidFromUri(uri: string): string {
+    if (!uri?.includes(';spgid')) {
+      return uri;
+    }
+
+    const pgidStart = uri.indexOf(';spgid');
+    const pgidEnd = uri.indexOf('/', pgidStart);
+
+    return uri.replace(uri.substring(pgidStart, pgidEnd), '');
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Filter navigation in product lists after category navigation (not search) does not work as expected if the user is logged in (displays too many products and not the expected filtered list). 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
Filter navigation in product lists does work the same for logged in and not logged in users. 

## Steps to Reproduce the Issue

1.  Go to https://intershoppwa.azurewebsites.net/
2.  Log in
3.  Go to Computers
4.  Select Tablets
5.  Select Acer
6.  Select filter Price >= $ 1000 

instead of presenting only 1 filtered item the list becomes large .

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
#AB80168