### PR TITLE
Bump nginx and nginx prometheus exporter

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.20
+FROM nginx:1.22
 RUN apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils libnss3-tools
 COPY nginx.conf /etc/nginx/nginx.conf
@@ -11,7 +11,7 @@ ADD https://github.com/hairyhenderson/gomplate/releases/download/v3.8.0/gomplate
 RUN chmod 700 /gomplate
 ADD https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 /usr/bin/mkcert
 RUN chmod 700 /usr/bin/mkcert
-COPY --from=nginx/nginx-prometheus-exporter:0.10.0 /usr/bin/nginx-prometheus-exporter /nginx-prometheus-exporter
+COPY --from=nginx/nginx-prometheus-exporter:0.11.0 /usr/bin/nginx-prometheus-exporter /nginx-prometheus-exporter
 ENV CACHE=on
 ENV COMPRESSION=on
 ENV DEVICE_DETECTION=on


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ X ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently we use:
- nginx:1.20
- nginx-prometheus-exporter:0.10.0

## What Is the New Behavior?

We will use:
- nginx:1.22
- nginx-prometheus-exporter:0.11.0

## Does this PR Introduce a Breaking Change?

[ ] Yes
[ X ] No

## Other Information
[Release page of prometheus-exporter](https://github.com/nginxinc/nginx-prometheus-exporter/releases/tag/v0.11.0)
[Release page of nginx](https://nginx.org/en/CHANGES-1.22)

