### PR TITLE
fix: add matrix parameter spgid to promotion REST calls 

### DIFF
--- a/src/app/core/services/promotions/promotions.service.spec.ts
+++ b/src/app/core/services/promotions/promotions.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { Promotion } from 'ish-core/models/promotion/promotion.model';
 import { ApiService } from 'ish-core/services/api/api.service';
@@ -39,10 +39,11 @@ describe('Promotions Service', () => {
   });
 
   it("should get Promotion data when 'getPromotion' is called", done => {
-    when(apiServiceMock.get(`promotions/PROMO_UUID`)).thenReturn(of(promotionMockData));
+    when(apiServiceMock.get(anything(), anything())).thenReturn(of(promotionMockData));
+
     promotionsService.getPromotion('PROMO_UUID').subscribe(data => {
       expect(data.id).toEqual('PROMO_UUID');
-      verify(apiServiceMock.get(`promotions/PROMO_UUID`)).once();
+      verify(apiServiceMock.get(`promotions/PROMO_UUID`, anything())).once();
       done();
     });
   });

--- a/src/app/core/services/promotions/promotions.service.ts
+++ b/src/app/core/services/promotions/promotions.service.ts
@@ -19,6 +19,8 @@ export class PromotionsService {
       return throwError(() => new Error('getPromotion() called without a id'));
     }
 
-    return this.apiService.get<Promotion>(`promotions/${id}`);
+    return this.apiService.get<Promotion>(`promotions/${id}`, {
+      sendSPGID: true,
+    });
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If a promotion is only valid for registered customers the get /promotions/id REST call ends up with a 404 (not found)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The matrix parameter spgid is added to the promotions REST call, so the REST call returns data without errors even if the promotion is only valid for registered users.

## Steps to repeat
1. Create a promotion in the ICM backoffice that is only valid for registered users, e.g.
  'Registered_1_37_off_for_5816351' inTRONICS Business promotion (1.37 value off for SKU 5816351 for registered users)
2. Clear pagecache
3. Login into the pwa b2b storefront
4. search for product 5816351 and check the network protocol
-> the get promotions/Registered_1_37_off_for_5816351 call shows a 404 error

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#80536](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80536)
[AB#80473](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80473)