### PR TITLE
fix: display login modal after authentication token has expired

### DIFF
--- a/src/app/core/guards/login.guard.ts
+++ b/src/app/core/guards/login.guard.ts
@@ -38,6 +38,7 @@ export class LoginGuard implements CanActivate {
 
     const loginModalComponent = this.currentDialog.componentInstance as LoginModalComponent;
     loginModalComponent.loginMessageKey = route.queryParamMap.get('messageKey');
+    loginModalComponent.detectChanges();
 
     // dialog closed
     loginModalComponent.closeModal.pipe(first()).subscribe(() => {

--- a/src/app/shared/components/login/login-modal/login-modal.component.html
+++ b/src/app/shared/components/login/login-modal/login-modal.component.html
@@ -7,6 +7,7 @@
       [title]="'dialog.close.text' | translate"
       [attr.aria-label]="'dialog.close.text' | translate"
       (click)="hide()"
+      ngbAutofocus
     >
       <span aria-hidden="true">&times;</span>
     </button>

--- a/src/app/shared/components/login/login-modal/login-modal.component.ts
+++ b/src/app/shared/components/login/login-modal/login-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'ish-login-modal',
@@ -8,6 +8,12 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 export class LoginModalComponent {
   @Input() loginMessageKey: string;
   @Output() closeModal = new EventEmitter<void>();
+
+  constructor(private cdRef: ChangeDetectorRef) {}
+
+  detectChanges() {
+    this.cdRef.detectChanges();
+  }
 
   hide() {
     this.closeModal.emit();


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## Precondition

SSR is switched on (production mode)

## What Is the Current Behavior?
After a user logged in and the authentication token expired an empty login modal is displayed. If the user clicks inside the modal the content of the modal is shown.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1280 

## What Is the New Behavior?
The login modal is displayed with content immediately after the authentication token has expired.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#80567](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80567)