### PR TITLE
fix: entry and display of the email address during the checkout process of an anonymous user

### DIFF
--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-detail-page.component.html
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-detail-page.component.html
@@ -46,7 +46,7 @@
     <div class="row d-flex">
       <!-- Invoice Address -->
       <ish-info-box heading="checkout.widget.billing-address.heading" class="infobox-wrapper col-md-6">
-        <ish-address [address]="requisition.invoiceToAddress"></ish-address>
+        <ish-address [address]="requisition.invoiceToAddress" [displayEmail]="true"></ish-address>
       </ish-info-box>
 
       <!-- Payment Method -->

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
@@ -54,6 +54,8 @@ describe('Checkout Address Anonymous Component', () => {
       additionalAddressAttributes: fb.group({
         email: new FormControl('', Validators.required),
         taxationID: new FormControl(''),
+      }),
+      shipOptions: fb.group({
         shipOption: new FormControl('shipToInvoiceAddress'),
       }),
       invoiceAddress: fb.group({
@@ -125,8 +127,10 @@ describe('Checkout Address Anonymous Component', () => {
   it('should create address for valid invoice address form', () => {
     component.form.get('additionalAddressAttributes').setValue({
       taxationID: '',
-      shipOption: 'shipToInvoiceAddress',
       email: 'test@intershop.de',
+    });
+    component.form.get('shipOptions').setValue({
+      shipOption: 'shipToInvoiceAddress',
     });
 
     component.submitAddressForm();

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.ts
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.ts
@@ -64,8 +64,11 @@ export class CheckoutAddressAnonymousComponent implements OnChanges {
 
     this.addressForm.control.get('additionalAddressAttributes').setValue({
       taxationID: '',
-      shipOption: 'shipToInvoiceAddress',
       email: '',
+    });
+
+    this.addressForm.control.get('shipOptions').setValue({
+      shipOption: 'shipToInvoiceAddress',
     });
 
     this.submitted = false;
@@ -88,7 +91,7 @@ export class CheckoutAddressAnonymousComponent implements OnChanges {
     };
 
     const shippingAddress =
-      this.form.get('additionalAddressAttributes').value.shipOption === 'shipToInvoiceAddress'
+      this.form.get('shipOptions').value.shipOption === 'shipToInvoiceAddress'
         ? undefined
         : this.form.get('shippingAddress').value.address;
 
@@ -114,6 +117,6 @@ export class CheckoutAddressAnonymousComponent implements OnChanges {
   }
 
   get isShippingAddressFormExpanded() {
-    return this.form && this.form.get('additionalAddressAttributes').value.shipOption === 'shipToDifferentAddress';
+    return this.form && this.form.get('shipOptions').value.shipOption === 'shipToDifferentAddress';
   }
 }

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.html
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.html
@@ -11,12 +11,12 @@
 </ish-formly-address-form>
 
 <!-- Taxation ID and Email address input field-->
-<formly-form [form]="form" [fields]="addressFields" [options]="addressOptions"></formly-form>
+<formly-form [form]="attributesForm" [fields]="attributesFields"></formly-form>
 
 <!-- Shipping Address Selection Radio boxes-->
 <div class="section">
   <h3>{{ 'checkout.addresses.shipping_address.heading' | translate }}</h3>
-  <formly-form [form]="form" [fields]="shipOptionFields"></formly-form>
+  <formly-form [form]="shipOptionForm" [fields]="shipOptionFields"></formly-form>
 </div>
 
 <!-- Shipping Address -->

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.html
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.html
@@ -11,7 +11,10 @@
 </ish-formly-address-form>
 
 <!-- Taxation ID and Email address input field-->
-<formly-form [form]="attributesForm" [fields]="attributesFields"></formly-form>
+<ish-formly-address-extension-form
+  [form]="attributesForm"
+  [businessCustomer]="isBusinessCustomer"
+></ish-formly-address-extension-form>
 
 <!-- Shipping Address Selection Radio boxes-->
 <div class="section">

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.spec.ts
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.spec.ts
@@ -51,7 +51,7 @@ describe('Checkout Address Anonymous Form Component', () => {
   it('should add shipping address form to parent form, when shipOption is set to shipToDifferentAddress', () => {
     fixture.detectChanges();
 
-    component.form.get('shipOption').setValue('shipToDifferentAddress');
+    component.shipOptionForm.get('shipOption').setValue('shipToDifferentAddress');
 
     fixture.detectChanges();
 

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.spec.ts
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.spec.ts
@@ -5,6 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { FormlyAddressExtensionFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component';
 import { FormlyAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-form/formly-address-form.component';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
@@ -18,7 +19,11 @@ describe('Checkout Address Anonymous Form Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [CheckoutAddressAnonymousFormComponent, MockComponent(FormlyAddressFormComponent)],
+      declarations: [
+        CheckoutAddressAnonymousFormComponent,
+        MockComponent(FormlyAddressExtensionFormComponent),
+        MockComponent(FormlyAddressFormComponent),
+      ],
       imports: [
         FeatureToggleModule.forTesting('businessCustomerRegistration'),
         FormlyTestingModule.withPresetMocks(['taxationID']),
@@ -41,11 +46,6 @@ describe('Checkout Address Anonymous Form Component', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
-  });
-
-  it('should set input field for taxation-id, when businessCustomerRegistration feature is enabled', () => {
-    fixture.detectChanges();
-    expect(component.parentForm.get('additionalAddressAttributes').value).toContainKey('taxationID');
   });
 
   it('should add shipping address form to parent form, when shipOption is set to shipToDifferentAddress', () => {

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.ts
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.ts
@@ -19,7 +19,6 @@ export class CheckoutAddressAnonymousFormComponent implements OnInit, OnDestroy 
   attributesForm: FormGroup = new FormGroup({});
   shipOptionForm: FormGroup = new FormGroup({});
 
-  attributesFields: FormlyFieldConfig[];
   shipOptionFields: FormlyFieldConfig[];
 
   isBusinessCustomer = false;
@@ -33,28 +32,7 @@ export class CheckoutAddressAnonymousFormComponent implements OnInit, OnDestroy 
   constructor(private featureToggleService: FeatureToggleService) {}
 
   ngOnInit() {
-    this.attributesFields = [
-      {
-        type: 'ish-fieldset-field',
-        fieldGroup: [
-          {
-            key: 'email',
-            type: 'ish-email-field',
-            templateOptions: {
-              required: true,
-              label: 'checkout.addresses.email.label',
-              customDescription: {
-                key: 'account.address.email.hint',
-              },
-              postWrappers: [{ wrapper: 'description', index: -1 }],
-            },
-          },
-        ],
-      },
-    ];
-
     if (this.featureToggleService.enabled('businessCustomerRegistration')) {
-      this.attributesFields = [this.createTaxationIDField(), ...this.attributesFields];
       this.isBusinessCustomer = true;
     }
 
@@ -91,17 +69,6 @@ export class CheckoutAddressAnonymousFormComponent implements OnInit, OnDestroy 
           ? this.parentForm.removeControl('shippingAddress')
           : this.parentForm.setControl('shippingAddress', this.shippingAddressForm);
       });
-  }
-
-  private createTaxationIDField(): FormlyFieldConfig {
-    return {
-      type: 'ish-fieldset-field',
-      fieldGroup: [
-        {
-          type: '#taxationID',
-        },
-      ],
-    };
   }
 
   ngOnDestroy() {

--- a/src/app/pages/checkout-receipt/checkout-receipt/checkout-receipt.component.html
+++ b/src/app/pages/checkout-receipt/checkout-receipt/checkout-receipt.component.html
@@ -13,7 +13,7 @@
     <div class="row d-flex">
       <!-- Invoice Address -->
       <ish-info-box heading="checkout.widget.billing-address.heading" class="infobox-wrapper col-md-6">
-        <ish-address [address]="order.invoiceToAddress"></ish-address>
+        <ish-address [address]="order.invoiceToAddress" [displayEmail]="true"></ish-address>
       </ish-info-box>
 
       <!-- Shipping Address -->

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
@@ -48,7 +48,7 @@
         editRouterLink="/checkout/address"
         class="infobox-wrapper col-md-6"
       >
-        <ish-address [address]="basket.invoiceToAddress"></ish-address>
+        <ish-address [address]="basket.invoiceToAddress" [displayEmail]="true"></ish-address>
       </ish-info-box>
 
       <!-- Shipping Address -->

--- a/src/app/shared/components/basket/basket-address-summary/basket-address-summary.component.html
+++ b/src/app/shared/components/basket/basket-address-summary/basket-address-summary.component.html
@@ -7,7 +7,7 @@
     <h5 class="float-left">{{ 'checkout.address.billing.label' | translate }}</h5>
   </div>
   <div data-testing-id="address-summary-invoice-to-address">
-    <ish-address [address]="basket.invoiceToAddress"></ish-address>
+    <ish-address [address]="basket.invoiceToAddress" [displayEmail]="true"></ish-address>
   </div>
 
   <!-- Shipping Address -->

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.html
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.html
@@ -13,7 +13,7 @@
     </a>
 
     <!-- display invoice address -->
-    <ish-address [address]="address"></ish-address>
+    <ish-address [address]="address" [displayEmail]="true"></ish-address>
   </div>
   <p *ngIf="!address && showErrors" class="text-danger">
     {{ 'checkout.addresses.no_Selection.invoice.error' | translate }}
@@ -28,7 +28,7 @@
 </ng-container>
 
 <!-- Add a new Invoice to address -->
-<div class="row" *ngIf="collapseChange | async">
+<div class="row" *ngIf="(collapseChange | async) && (isLoggedIn$ | async)">
   <button
     data-testing-id="create-invoice-address-link"
     class="btn btn-link"
@@ -45,6 +45,7 @@
   <ish-formly-customer-address-form
     [address]="editAddress"
     [resetForm]="collapseChange | async"
+    [extension]="(isLoggedIn$ | async) === false"
     (save)="saveAddress($event)"
     (cancel)="cancelEditAddress()"
   >

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
@@ -31,6 +31,7 @@ describe('Basket Invoice Address Widget Component', () => {
 
     accountFacade = mock(AccountFacade);
     when(accountFacade.addresses$()).thenReturn(EMPTY);
+    when(accountFacade.isLoggedIn$).thenReturn(of(true));
 
     await TestBed.configureTestingModule({
       imports: [FormlyTestingModule, TranslateModule.forRoot()],
@@ -160,11 +161,11 @@ describe('Basket Invoice Address Widget Component', () => {
 
       component.addresses$.subscribe(addrs => {
         expect(addrs.map(add => add.id)).toMatchInlineSnapshot(`
-      Array [
-        "3",
-        "4",
-      ]
-    `);
+                Array [
+                  "3",
+                  "4",
+                ]
+            `);
         done();
       });
     });

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
@@ -33,6 +33,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
   invoiceAddress$: Observable<Address>;
   addresses$: Observable<Address[]>;
   customerAddresses$: Observable<Address[]>;
+  isLoggedIn$: Observable<boolean>;
 
   form = new UntypedFormGroup({});
   fields: FormlyFieldConfig[];
@@ -64,6 +65,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
         addresses?.filter(address => address.invoiceToAddress).filter(address => address.id !== invoiceAddress?.id)
       )
     );
+    this.isLoggedIn$ = this.accountFacade.isLoggedIn$;
 
     this.fields = [
       {

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.html
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.html
@@ -62,7 +62,7 @@
 </ng-container>
 
 <!-- Add a new Shipping to address -->
-<div *ngIf="collapseChange | async" class="row">
+<div *ngIf="displayAddAddressLink$ | async" class="row">
   <button
     data-testing-id="create-shipping-address-link"
     class="btn btn-link"

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
@@ -27,11 +27,13 @@ describe('Basket Shipping Address Widget Component', () => {
 
   beforeEach(async () => {
     checkoutFacade = mock(CheckoutFacade);
+    accountFacade = mock(AccountFacade);
+
     when(checkoutFacade.basket$).thenReturn(EMPTY);
     when(checkoutFacade.basketShippingAddress$).thenReturn(EMPTY);
     when(checkoutFacade.basketInvoiceAndShippingAddressEqual$).thenReturn(of(false));
 
-    accountFacade = mock(AccountFacade);
+    when(accountFacade.isLoggedIn$).thenReturn(of(true));
     when(accountFacade.addresses$()).thenReturn(EMPTY);
 
     await TestBed.configureTestingModule({
@@ -69,6 +71,18 @@ describe('Basket Shipping Address Widget Component', () => {
     expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
       Array [
         "create-shipping-address-link",
+        "shipping-address-form",
+      ]
+    `);
+  });
+
+  it('should not render create link if an anonymous user has different sinvoice and shipping address', () => {
+    when(accountFacade.isLoggedIn$).thenReturn(of(false));
+
+    fixture.detectChanges();
+
+    expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+      Array [
         "shipping-address-form",
       ]
     `);

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
@@ -34,6 +34,7 @@ export class BasketShippingAddressWidgetComponent implements OnInit, OnDestroy {
   shippingAddress$: Observable<Address>;
   addresses$: Observable<Address[]>;
   customerAddresses$: Observable<Address[]>;
+  displayAddAddressLink$: Observable<boolean>;
 
   basketInvoiceAndShippingAddressEqual$: Observable<boolean>;
   basketShippingAddressDeletable$: Observable<boolean>;
@@ -74,6 +75,12 @@ export class BasketShippingAddressWidgetComponent implements OnInit, OnDestroy {
         addresses?.filter(address => address.shipToAddress).filter(address => address.id !== shippingAddress?.id)
       )
     );
+
+    this.displayAddAddressLink$ = combineLatest([
+      this.collapseChange,
+      this.accountFacade.isLoggedIn$,
+      this.basketInvoiceAndShippingAddressEqual$,
+    ]).pipe(map(([collapseChange, loggedIn, addressesEqual]) => collapseChange && (loggedIn || addressesEqual)));
 
     this.fields = [
       {

--- a/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.html
+++ b/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.html
@@ -1,0 +1,1 @@
+<formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>

--- a/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.spec.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
+
+import { FormlyAddressExtensionFormComponent } from './formly-address-extension-form.component';
+
+describe('Formly Address Extension Form Component', () => {
+  let component: FormlyAddressExtensionFormComponent;
+  let fixture: ComponentFixture<FormlyAddressExtensionFormComponent>;
+  let element: HTMLElement;
+  let fb: FormBuilder;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FormlyAddressExtensionFormComponent],
+      imports: [FormlyTestingModule.withPresetMocks(['taxationID'])],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormlyAddressExtensionFormComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    fb = TestBed.inject(FormBuilder);
+
+    component.form = fb.group({});
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should always set input field for email', () => {
+    fixture.detectChanges();
+    expect(component.form.value).toContainKey('email');
+  });
+
+  it('should set input field for taxation-id, when businessCustomerRegistration feature is enabled', () => {
+    component.businessCustomer = true;
+    fixture.detectChanges();
+    expect(component.form.value).toContainKey('taxationID');
+  });
+
+  it('should not set input field for taxation-id, when businessCustomerRegistration feature is disabled', () => {
+    component.businessCustomer = false;
+    fixture.detectChanges();
+    expect(component.form.value).not.toContainKey('taxationID');
+  });
+});

--- a/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+
+/**
+ * Sub form with additional fields like email address and taxation id to extend the anonymous invoice address form.
+ */
+@Component({
+  selector: 'ish-formly-address-extension-form',
+  templateUrl: './formly-address-extension-form.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormlyAddressExtensionFormComponent implements OnInit {
+  @Input() form: FormGroup;
+  @Input() businessCustomer: boolean;
+  @Input() model: Partial<{ email: string; taxationId: string }> = {}; // model with data for the update mode.
+
+  fields: FormlyFieldConfig[];
+
+  ngOnInit() {
+    this.fields = [
+      {
+        type: 'ish-fieldset-field',
+        fieldGroup: [
+          {
+            key: 'email',
+            type: 'ish-email-field',
+            templateOptions: {
+              required: true,
+              label: 'checkout.addresses.email.label',
+              customDescription: {
+                key: 'account.address.email.hint',
+              },
+              postWrappers: [{ wrapper: 'description', index: -1 }],
+            },
+          },
+        ],
+      },
+    ];
+    if (this.businessCustomer) {
+      this.fields = [this.createTaxationIDField(), ...this.fields];
+    }
+  }
+
+  private createTaxationIDField(): FormlyFieldConfig {
+    return {
+      type: 'ish-fieldset-field',
+      fieldGroup: [
+        {
+          type: '#taxationID',
+        },
+      ],
+    };
+  }
+}

--- a/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
@@ -83,7 +83,9 @@ export class FormlyAddressFormComponent implements OnInit, OnChanges {
 
       this.addressModel.countryCode = model.countryCode;
       this.addressForm.updateValueAndValidity();
-      this.addressForm.get('countryCode').markAsDirty();
+      if (model.countryCode) {
+        this.addressForm.get('countryCode').markAsDirty();
+      }
 
       this.parentForm?.setControl('address', this.addressForm);
     }

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.html
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.html
@@ -12,6 +12,12 @@
     [prefilledAddress]="address"
   ></ish-formly-address-form>
 
+  <ish-formly-address-extension-form
+    *ngIf="extension"
+    [form]="extensionForm"
+    [model]="extensionModel"
+  ></ish-formly-address-extension-form>
+
   <div class="row">
     <div class="offset-md-4 col-md-8 offset-lg-0 col-lg-12 offset-lg-4 col-xl-8">
       <button [disabled]="formDisabled" type="submit" class="btn btn-primary">

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.spec.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.spec.ts
@@ -7,6 +7,7 @@ import { of } from 'rxjs';
 import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { FormlyAddressExtensionFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component';
 import { FormlyAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-form/formly-address-form.component';
 
 import { FormlyCustomerAddressFormComponent } from './formly-customer-address-form.component';
@@ -20,7 +21,11 @@ describe('Formly Customer Address Form Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [FormlyCustomerAddressFormComponent, MockComponent(FormlyAddressFormComponent)],
+      declarations: [
+        FormlyCustomerAddressFormComponent,
+        MockComponent(FormlyAddressExtensionFormComponent),
+        MockComponent(FormlyAddressFormComponent),
+      ],
       imports: [ReactiveFormsModule, TranslateModule.forRoot()],
       providers: [{ provide: AccountFacade, useFactory: () => instance(accountFacade) }],
     }).compileComponents();
@@ -51,6 +56,7 @@ describe('Formly Customer Address Form Component', () => {
   it('should render an address form component on creation', () => {
     fixture.detectChanges();
     expect(element.querySelector('ish-formly-address-form')).toBeTruthy();
+    expect(element.querySelector('ish-formly-address-extension-form')).toBeFalsy();
   });
 
   it('should throw cancel event when cancel is clicked', () => {
@@ -122,5 +128,11 @@ describe('Formly Customer Address Form Component', () => {
     component.ngOnChanges(changes);
 
     expect(component.form.value.address.countryCode).toEqual('foo');
+  });
+
+  it('should render the extension form if extension is true', () => {
+    component.extension = true;
+    fixture.detectChanges();
+    expect(element.querySelector('ish-formly-address-extension-form')).toBeTruthy();
   });
 });

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.spec.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.spec.ts
@@ -7,6 +7,7 @@ import { of } from 'rxjs';
 import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { FormlyAddressExtensionFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component';
 import { FormlyAddressFormComponent } from 'ish-shared/formly-address-forms/components/formly-address-form/formly-address-form.component';
 
@@ -26,7 +27,11 @@ describe('Formly Customer Address Form Component', () => {
         MockComponent(FormlyAddressExtensionFormComponent),
         MockComponent(FormlyAddressFormComponent),
       ],
-      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      imports: [
+        FeatureToggleModule.forTesting('businessCustomerRegistration'),
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+      ],
       providers: [{ provide: AccountFacade, useFactory: () => instance(accountFacade) }],
     }).compileComponents();
   });

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
@@ -38,11 +38,17 @@ import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges, OnDestroy {
   @Input() address: Partial<Address>;
   @Input() resetForm = false;
+  // display address extension form fields
+  @Input() extension = false;
 
   @Output() save = new EventEmitter<Address>();
   @Output() cancel = new EventEmitter();
 
   form: FormGroup;
+  extensionForm: FormGroup = new FormGroup({});
+
+  extensionModel: { email: string };
+
   submitted = false;
   businessCustomer$: Observable<boolean>;
 
@@ -64,6 +70,7 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges, On
     // create form for creating a new address
     this.form = new FormGroup({
       address: new FormGroup({}),
+      additionalAddressAttributes: this.extensionForm,
     });
   }
 
@@ -72,6 +79,8 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges, On
    */
   ngOnChanges(c: SimpleChanges) {
     this.doResetForm(c.resetForm?.currentValue);
+
+    this.extensionModel = this.address ? { email: this.address.email } : undefined;
   }
 
   doResetForm(resetForm: boolean) {
@@ -99,6 +108,9 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges, On
     if (this.address) {
       // update form values in the original address
       formAddress = { ...this.address, ...formAddress };
+    }
+    if (this.extension) {
+      formAddress = { ...formAddress, email: this.extensionForm.get('email')?.value };
     }
     this.save.emit(formAddress);
   }

--- a/src/app/shared/formly-address-forms/formly-address-forms.module.ts
+++ b/src/app/shared/formly-address-forms/formly-address-forms.module.ts
@@ -6,6 +6,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { FormsSharedModule } from 'ish-shared/forms/forms.module';
 
+import { FormlyAddressExtensionFormComponent } from './components/formly-address-extension-form/formly-address-extension-form.component';
 import { FormlyAddressFormComponent } from './components/formly-address-form/formly-address-form.component';
 import { FormlyCustomerAddressFormComponent } from './components/formly-customer-address-form/formly-customer-address-form.component';
 import {
@@ -20,8 +21,8 @@ import { AddressFormUSConfiguration } from './configurations/us/address-form-us.
 
 @NgModule({
   imports: [CommonModule, FormlyModule, FormsSharedModule, ReactiveFormsModule, TranslateModule],
-  declarations: [FormlyAddressFormComponent, FormlyCustomerAddressFormComponent],
-  exports: [FormlyAddressFormComponent, FormlyCustomerAddressFormComponent],
+  declarations: [FormlyAddressExtensionFormComponent, FormlyAddressFormComponent, FormlyCustomerAddressFormComponent],
+  exports: [FormlyAddressExtensionFormComponent, FormlyAddressFormComponent, FormlyCustomerAddressFormComponent],
   providers: [
     AddressFormConfigurationProvider,
     { provide: ADDRESS_FORM_CONFIGURATION, useClass: AddressFormDEConfiguration, multi: true },


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If an anonymous user starts the checkout he can enter an email address.

    1. The email address is not shown on any checkout page
    2. If the user navigates back to the checkout address page and enters another invoice address address the email address gets lost and the user is able to place the order without email address.
    3. The email address cannot be changed by the user during checkout.
    4. The email address is not validated in the checkout as guest form.
    5. Company address fields are not shown in the checkout address form for anonymous users.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1303 

## What Is the New Behavior?

    1. The email address of an anonymous user should always be displayed as part of the invoice address, i.e. in the invoice address widget of the checkout address page, the checkout right panel and the invoice address on review/receipt/order detail page
    2. The anonymous user should not be able to enter a new invoice address, he can only change his invoice address. He can enter a new shipping address if his invoice and shipping addresses are equal.
    3. For anonymous users the email address should be added to the invoice address form on the checkout address page.
    4. The email address is validated in the checkout as guest form.
    5. Company address fields are shown in the checkout address form for anonymous users.

Besides this the company input fields are shown on the edit address form for an anonymous b2b user on checkout address page.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#80664](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80664)