### PR TITLE
fix: 'npm install' not working with PWA release zip file

### DIFF
--- a/schematics/src/helpers/lazy-components/factory.ts
+++ b/schematics/src/helpers/lazy-components/factory.ts
@@ -48,10 +48,10 @@ async function deleteOldComponents() {
   if (process.env.CI !== 'true') {
     let gitAvailable = false;
     try {
-      cp.execSync('git --version');
+      cp.execSync('git status');
       gitAvailable = true;
     } catch (error) {
-      console.warn('Git is not installed. Skipping deletion.');
+      console.warn('Git is not installed or it is not a Git repository. Skipping deletion.');
     }
 
     if (gitAvailable) {


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

If the PWA 3.1.0 release assets (zip or tar.gz - https://github.com/intershop/intershop-pwa/releases/tag/3.1.0)  files are used to start a PWA it fails at the `npm install`.

This is due to the lazy components schematic needing git and a git repository but it checked only for the git command not for being in a git repository.

```
$ npm install

> intershop-pwa@3.1.0 postinstall
> npm-run-all --silent build:eslint-rules build:schematics synchronize-lazy-components init-development-environment ngcc

fatal: not a git repository (or any of the parent directories): .git
Command failed: git clean -dnx
fatal: not a git repository (or any of the parent directories): .git

npm ERR! code 1
npm ERR! path D:\intershop-pwa-3.1.0
npm ERR! command failed
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c npm-run-all --silent build:eslint-rules build:schematics synchronize-lazy-components init-development-environment ngcc

npm ERR! A complete log of this run can be found in:

```

## What Is the New Behavior?

Changed the check from `git --version` to `git status` to check for both relevant requirements.


## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#80842](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80842)