### PR TITLE
feat: route to product detail page if only one search result was found

### DIFF
--- a/e2e/cypress/e2e/specs/shopping/search-products.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/shopping/search-products.b2c.e2e-spec.ts
@@ -5,9 +5,12 @@ import { SearchResultPage } from '../../pages/shopping/search-result.page';
 
 const _ = {
   suggestTerm: 'ko',
-  searchTerm: 'kodak M552',
   suggestItemText: 'Kodak',
+  searchTerm: 'kodak M552',
   product: '7912057',
+  searchTermWithMoreResults: 'acer',
+  searchTermWithOneResult: 'acer c110',
+  oneResultProduct: '9438012',
 };
 
 describe('Searching User', () => {
@@ -34,6 +37,18 @@ describe('Searching User', () => {
     at(ProductDetailPage, page => {
       page.sku.should('have.text', _.product);
       page.breadcrumb.items.should('have.length', 4);
+    });
+  });
+
+  it(`should perform another search and land on search result page`, () => {
+    at(ProductDetailPage, page => page.header.searchBox.search(_.searchTermWithMoreResults));
+    at(SearchResultPage, page => page.productList.visibleProducts.should('have.length.gte', 1));
+  });
+
+  it(`should perform search with only one search result and land on product detail page`, () => {
+    at(SearchResultPage, page => page.header.searchBox.search(_.searchTermWithOneResult));
+    at(ProductDetailPage, page => {
+      page.sku.should('have.text', _.oneResultProduct);
     });
   });
 });

--- a/e2e/cypress/e2e/specs/system/change-language-search-result.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/system/change-language-search-result.b2c.e2e-spec.ts
@@ -12,7 +12,7 @@ const _ = {
     dollarPrice: '33.75',
     euroPrice: '25,00',
   },
-  searchTerm: 'conversion lens',
+  searchTerm: 'lens',
 };
 
 describe('Language Changing User', () => {

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -125,7 +125,7 @@ describe('Shopping Store', () => {
       })
     );
     when(productsServiceMock.searchProducts('something', anyNumber(), anything(), anyNumber())).thenReturn(
-      of({ products: [{ sku: 'P2' } as Product], sortableAttributes: [], total: 1 })
+      of({ products: [{ sku: 'P1' }, { sku: 'P2' }] as Product[], sortableAttributes: [], total: 2 })
     );
 
     promotionsServiceMock = mock(PromotionsService);
@@ -281,8 +281,8 @@ describe('Shopping Store', () => {
         tick(5000);
       }));
 
-      it('should load the product for the search results', fakeAsync(() => {
-        expect(getProductIds(store.state)).toEqual(['P2']);
+      it('should load the products for the search results', fakeAsync(() => {
+        expect(getProductIds(store.state)).toEqual(['P1', 'P2']);
       }));
 
       it('should trigger required actions when searching', fakeAsync(() => {
@@ -308,11 +308,13 @@ describe('Shopping Store', () => {
           [Filter Internal] Load Filter for Search:
             searchTerm: "something"
           [Products API] Load Product Success:
+            product: {"sku":"P1"}
+          [Products API] Load Product Success:
             product: {"sku":"P2"}
           [Product Listing Internal] Set Product Listing Pages:
-            1: ["P2"]
+            1: ["P1","P2"]
             id: {"type":"search","value":"something"}
-            itemCount: 1
+            itemCount: 2
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
@@ -536,11 +538,13 @@ describe('Shopping Store', () => {
           [Filter Internal] Load Filter for Search:
             searchTerm: "something"
           [Products API] Load Product Success:
+            product: {"sku":"P1"}
+          [Products API] Load Product Success:
             product: {"sku":"P2"}
           [Product Listing Internal] Set Product Listing Pages:
-            1: ["P2"]
+            1: ["P1","P2"]
             id: {"type":"search","value":"something"}
-            itemCount: 1
+            itemCount: 2
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
@@ -885,8 +889,8 @@ describe('Shopping Store', () => {
       tick(5000);
     }));
 
-    it('should load the product for the search results', fakeAsync(() => {
-      expect(getProductIds(store.state)).toEqual(['P2']);
+    it('should load the products for the search results', fakeAsync(() => {
+      expect(getProductIds(store.state)).toEqual(['P1', 'P2']);
     }));
 
     it('should trigger required actions when searching', fakeAsync(() => {
@@ -911,11 +915,13 @@ describe('Shopping Store', () => {
         [Filter Internal] Load Filter for Search:
           searchTerm: "something"
         [Products API] Load Product Success:
+          product: {"sku":"P1"}
+        [Products API] Load Product Success:
           product: {"sku":"P2"}
         [Product Listing Internal] Set Product Listing Pages:
-          1: ["P2"]
+          1: ["P1","P2"]
           id: {"type":"search","value":"something"}
-          itemCount: 1
+          itemCount: 2
           sortableAttributes: []
         [Filter API] Load Filter Success:
           filterNavigation: {}


### PR DESCRIPTION


## PR Type

[x] Feature

## What Is the Current Behavior?

When searching for products and only one product is returned as the search result (either through searching explicitly for an SKU or by name) this product is displayed in the product list and a user would need to click it to switch to the product detail page.

## What Is the New Behavior?

When searching for products and only one product is returned as the search result a redirect to the product detail page is automatically done.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#80856](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80856)