### PR TITLE
feat: enhanced variation selection with color code and swatch image

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -26,6 +26,9 @@ You can keep the existing behavior by modifying the updateBasketItemsDesiredDeli
 
 The `ProductsService` was changed to use `extended=true` REST calls for product details and variations to fetch variation attributes with additional `attributeType` and `metaData` information that can be used to control the rendering of different variation select types.
 The added `VariationAttributeMapper` maps the additional information in a backwards compatible way.
+To handle the different variation select rendering types the existing `ProductVariationSelectComponent` now contains the logic to select the fitting variation select rendering component.
+The rendering and behavior of the existing `ProductVariationSelectComponent` as a standard select box was moved to the new `ProductVariationSelectDefaultComponent`.
+A `ProductVariationSelectSwatchComponent` for colorCode and swatchImage variation select rendering and a `ProductVariationSelectEnhancedComponent` for a select box rendering with color codes or swatch images and a mobile optimization were added.
 
 ## 3.0 to 3.1
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -24,6 +24,9 @@ After entering a desired delivery date on the checkout shipping page and after s
 In case of large basket (> 20 items) this might cause (unacceptable) long response times.
 You can keep the existing behavior by modifying the updateBasketItemsDesiredDeliveryDate() method of the basket service to always return an empty array without doing anything.
 
+The `ProductsService` was changed to use `extended=true` REST calls for product details and variations to fetch variation attributes with additional `attributeType` and `metaData` information that can be used to control the rendering of different variation select types.
+The added `VariationAttributeMapper` maps the additional information in a backwards compatible way.
+
 ## 3.0 to 3.1
 
 The SSR environment variable 'ICM_IDENTITY_PROVIDER' will be removed in a future release ( PWA 5.0 ).

--- a/src/app/core/models/image/image.mapper.ts
+++ b/src/app/core/models/image/image.mapper.ts
@@ -53,7 +53,7 @@ export class ImageMapper {
    * @param url The relative or absolute image URL.
    * @returns The URL.
    */
-  private fromEffectiveUrl(url: string): string {
+  fromEffectiveUrl(url: string): string {
     if (!url) {
       return;
     }

--- a/src/app/core/models/product-variation/product-variation.helper.spec.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.spec.ts
@@ -9,8 +9,8 @@ const productVariations = [
     sku: '222',
     productMasterSKU: 'M111',
     variableVariationAttributes: [
-      { name: 'Attr 1', type: 'String', value: 'A', variationAttributeId: 'a1' },
-      { name: 'Attr 2', type: 'String', value: 'A', variationAttributeId: 'a2' },
+      { name: 'Attr 1', value: 'A', variationAttributeId: 'a1' },
+      { name: 'Attr 2', value: 'A', variationAttributeId: 'a2' },
     ],
   },
   {
@@ -18,32 +18,32 @@ const productVariations = [
     productMasterSKU: 'M111',
     attributes: [{ name: 'defaultVariation', type: 'Boolean', value: true }],
     variableVariationAttributes: [
-      { name: 'Attr 1', type: 'String', value: 'A', variationAttributeId: 'a1' },
-      { name: 'Attr 2', type: 'String', value: 'B', variationAttributeId: 'a2' },
+      { name: 'Attr 1', value: 'A', variationAttributeId: 'a1' },
+      { name: 'Attr 2', value: 'B', variationAttributeId: 'a2' },
     ],
   },
   {
     sku: '444',
     productMasterSKU: 'M111',
     variableVariationAttributes: [
-      { name: 'Attr 1', type: 'String', value: 'B', variationAttributeId: 'a1' },
-      { name: 'Attr 2', type: 'String', value: 'A', variationAttributeId: 'a2' },
+      { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
+      { name: 'Attr 2', value: 'A', variationAttributeId: 'a2' },
     ],
   },
   {
     sku: '555',
     productMasterSKU: 'M111',
     variableVariationAttributes: [
-      { name: 'Attr 1', type: 'String', value: 'B', variationAttributeId: 'a1' },
-      { name: 'Attr 2', type: 'String', value: 'B', variationAttributeId: 'a2' },
+      { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
+      { name: 'Attr 2', value: 'B', variationAttributeId: 'a2' },
     ],
   },
   {
     sku: '666',
     productMasterSKU: 'M111',
     variableVariationAttributes: [
-      { name: 'Attr 1', type: 'String', value: 'B', variationAttributeId: 'a1' },
-      { name: 'Attr 2', type: 'String', value: 'C', variationAttributeId: 'a2' },
+      { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
+      { name: 'Attr 2', value: 'C', variationAttributeId: 'a2' },
     ],
   },
 ] as VariationProduct[];
@@ -51,11 +51,11 @@ const productVariations = [
 const productMaster = {
   sku: 'M111',
   variationAttributeValues: [
-    { name: 'Attr 1', type: 'String', value: 'A', variationAttributeId: 'a1' },
-    { name: 'Attr 1', type: 'String', value: 'B', variationAttributeId: 'a1' },
-    { name: 'Attr 2', type: 'String', value: 'A', variationAttributeId: 'a2' },
-    { name: 'Attr 2', type: 'String', value: 'B', variationAttributeId: 'a2' },
-    { name: 'Attr 2', type: 'String', value: 'C', variationAttributeId: 'a2' },
+    { name: 'Attr 1', value: 'A', variationAttributeId: 'a1' },
+    { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
+    { name: 'Attr 2', value: 'A', variationAttributeId: 'a2' },
+    { name: 'Attr 2', value: 'B', variationAttributeId: 'a2' },
+    { name: 'Attr 2', value: 'C', variationAttributeId: 'a2' },
   ],
 } as VariationProductMaster;
 

--- a/src/app/core/models/product-variation/product-variation.helper.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.ts
@@ -33,6 +33,7 @@ export class ProductVariationHelper {
         label: attr.value,
         value: attr.value,
         type: attr.variationAttributeId,
+        metaData: attr.metaData,
         active: currentSettings?.[attr.variationAttributeId]?.value === attr.value,
       }))
       .map(option => ({
@@ -50,6 +51,7 @@ export class ProductVariationHelper {
       return {
         id: attribute.variationAttributeId,
         label: attribute.name,
+        attributeType: attribute.attributeType,
         options: groupedOptions[attrId],
       };
     });

--- a/src/app/core/models/product-variation/variation-attribute.interface.ts
+++ b/src/app/core/models/product-variation/variation-attribute.interface.ts
@@ -1,0 +1,23 @@
+import { VariationAttributeType } from './variation-attribute.model';
+
+export interface VariationAttributeData {
+  variationAttributeId: string;
+  name: string;
+  value?: VariationAttributeValue;
+  values?: {
+    value: VariationAttributeValue;
+    metadata?: VariationAttributeMetaData;
+  }[];
+  attributeType?: VariationAttributeType;
+  metadata?: VariationAttributeMetaData;
+}
+
+interface VariationAttributeValue {
+  name: string;
+  value: string;
+}
+
+export interface VariationAttributeMetaData {
+  colorCode?: string;
+  imagePath?: string;
+}

--- a/src/app/core/models/product-variation/variation-attribute.mapper.ts
+++ b/src/app/core/models/product-variation/variation-attribute.mapper.ts
@@ -1,0 +1,52 @@
+/* eslint-disable ish-custom-rules/project-structure */
+import { Injectable } from '@angular/core';
+
+import { ImageMapper } from 'ish-core/models/image/image.mapper';
+
+import { VariationAttributeData, VariationAttributeMetaData } from './variation-attribute.interface';
+import { VariationAttribute, VariationAttributeType } from './variation-attribute.model';
+
+/**
+ * Maps variation attributes data of HTTP requests to client side model instance.
+ */
+@Injectable({ providedIn: 'root' })
+export class VariationAttributeMapper {
+  constructor(private imageMapper: ImageMapper) {}
+
+  fromData(data: VariationAttributeData[]): VariationAttribute[] {
+    return data?.map(varAttr => ({
+      variationAttributeId: varAttr.variationAttributeId,
+      name: varAttr.name,
+      value: varAttr.value.value,
+      attributeType: varAttr.attributeType,
+      metaData: this.mapMetaData(varAttr.attributeType, varAttr.metadata),
+    }));
+  }
+
+  fromMasterData(variationAttributes: VariationAttributeData[]): VariationAttribute[] {
+    return variationAttributes
+      ?.map(varAttr =>
+        varAttr.values.map(value => ({
+          variationAttributeId: varAttr.variationAttributeId,
+          name: varAttr.name,
+          value: value.value.value,
+          attributeType: varAttr.attributeType,
+          metaData: this.mapMetaData(varAttr.attributeType, value.metadata),
+        }))
+      )
+      .flat();
+  }
+
+  private mapMetaData(attributeType: VariationAttributeType, metaData: VariationAttributeMetaData): string {
+    switch (attributeType) {
+      case 'colorCode':
+      case 'defaultAndColorCode':
+        return metaData?.colorCode;
+      case 'swatchImage':
+      case 'defaultAndSwatchImage':
+        return this.imageMapper.fromEffectiveUrl(metaData?.imagePath);
+      default:
+        return;
+    }
+  }
+}

--- a/src/app/core/models/product-variation/variation-attribute.model.ts
+++ b/src/app/core/models/product-variation/variation-attribute.model.ts
@@ -1,5 +1,14 @@
-import { Attribute } from 'ish-core/models/attribute/attribute.model';
-
-export interface VariationAttribute extends Attribute<string> {
+export interface VariationAttribute {
   variationAttributeId: string;
+  name: string;
+  value: string;
+  attributeType: VariationAttributeType;
+  metaData?: string;
 }
+
+export type VariationAttributeType =
+  | 'default'
+  | 'colorCode'
+  | 'defaultAndColorCode'
+  | 'swatchImage'
+  | 'defaultAndSwatchImage';

--- a/src/app/core/models/product-variation/variation-option-group.model.ts
+++ b/src/app/core/models/product-variation/variation-option-group.model.ts
@@ -4,4 +4,5 @@ export interface VariationOptionGroup {
   options: VariationSelectOption[];
   label: string;
   id: string;
+  attributeType?: string;
 }

--- a/src/app/core/models/product-variation/variation-select-option.model.ts
+++ b/src/app/core/models/product-variation/variation-select-option.model.ts
@@ -4,4 +4,5 @@ export interface VariationSelectOption {
   type: string;
   alternativeCombination?: boolean;
   active?: boolean;
+  metaData?: string;
 }

--- a/src/app/core/models/product/product.interface.ts
+++ b/src/app/core/models/product/product.interface.ts
@@ -5,7 +5,7 @@ import { CategoryData } from 'ish-core/models/category/category.interface';
 import { Image } from 'ish-core/models/image/image.model';
 import { Link } from 'ish-core/models/link/link.model';
 import { PriceData } from 'ish-core/models/price/price.interface';
-import { VariationAttribute } from 'ish-core/models/product-variation/variation-attribute.model';
+import { VariationAttributeData } from 'ish-core/models/product-variation/variation-attribute.interface';
 import { SeoAttributesData } from 'ish-core/models/seo-attributes/seo-attributes.interface';
 import { Warranty } from 'ish-core/models/warranty/warranty.model';
 
@@ -41,8 +41,7 @@ export interface ProductData {
   stepOrderQuantity?: number;
   packingUnit: string;
 
-  variationAttributeValues?: VariationAttribute[];
-  variableVariationAttributes?: VariationAttribute[];
+  variationAttributeValuesExtended?: VariationAttributeData[];
   partOfRetailSet: boolean;
 
   attachments?: AttachmentData[];
@@ -74,5 +73,5 @@ export interface ProductDataStub {
 }
 
 export interface ProductVariationLink extends Link {
-  variableVariationAttributeValues: VariationAttribute[];
+  variableVariationAttributeValuesExtended: VariationAttributeData[];
 }

--- a/src/app/core/models/product/product.mapper.spec.ts
+++ b/src/app/core/models/product/product.mapper.spec.ts
@@ -66,7 +66,7 @@ describe('Product Mapper', () => {
       const product: Product = productMapper.fromData({
         sku: '1',
         productMaster: true,
-        variationAttributeValues: [],
+        variationAttributeValuesExtended: [],
       } as ProductData);
       expect(product).toBeTruthy();
       expect(product.type).toEqual('VariationProductMaster');
@@ -78,7 +78,7 @@ describe('Product Mapper', () => {
       const product: Product = productMapper.fromData({
         sku: '1',
         productMaster: false,
-        variableVariationAttributes: [],
+        variationAttributeValuesExtended: [],
       } as ProductData);
       expect(product).toBeTruthy();
       expect(product.type).toEqual('Product');

--- a/src/app/core/models/product/product.mapper.ts
+++ b/src/app/core/models/product/product.mapper.ts
@@ -8,6 +8,7 @@ import { CategoryData } from 'ish-core/models/category/category.interface';
 import { CategoryMapper } from 'ish-core/models/category/category.mapper';
 import { ImageMapper } from 'ish-core/models/image/image.mapper';
 import { Link } from 'ish-core/models/link/link.model';
+import { VariationAttributeMapper } from 'ish-core/models/product-variation/variation-attribute.mapper';
 import { SeoAttributesMapper } from 'ish-core/models/seo-attributes/seo-attributes.mapper';
 
 import { SkuQuantityType } from './product.helper';
@@ -43,7 +44,8 @@ export class ProductMapper {
   constructor(
     private imageMapper: ImageMapper,
     private attachmentMapper: AttachmentMapper,
-    private categoryMapper: CategoryMapper
+    private categoryMapper: CategoryMapper,
+    private variationAttributeMapper: VariationAttributeMapper
   ) {}
 
   static parseSkuFromURI(uri: string): string {
@@ -91,7 +93,9 @@ export class ProductMapper {
   fromVariationLink(link: ProductVariationLink, productMasterSKU: string): Partial<VariationProduct> {
     return {
       ...this.fromLink(link),
-      variableVariationAttributes: link.variableVariationAttributeValues,
+      variableVariationAttributes: this.variationAttributeMapper.fromData(
+        link.variableVariationAttributeValuesExtended
+      ),
       productMasterSKU,
       type: 'VariationProduct',
       failed: false,
@@ -227,14 +231,14 @@ export class ProductMapper {
     if (data.productMaster) {
       return {
         ...product,
-        variationAttributeValues: data.variationAttributeValues,
+        variationAttributeValues: this.variationAttributeMapper.fromMasterData(data.variationAttributeValuesExtended),
         type: 'VariationProductMaster',
       };
     } else if (data.mastered) {
       return {
         ...product,
         productMasterSKU: data.productMasterSKU,
-        variableVariationAttributes: data.variableVariationAttributes,
+        variableVariationAttributes: this.variationAttributeMapper.fromData(data.variationAttributeValuesExtended),
         type: 'VariationProduct',
       };
     } else if (data.productTypes?.includes('BUNDLE') || data.productBundle) {

--- a/src/app/core/services/products/products.service.spec.ts
+++ b/src/app/core/services/products/products.service.spec.ts
@@ -129,21 +129,23 @@ describe('Products Service', () => {
   it("should get all product variations data when 'getProductVariations' is called and more than 50 variations exist", done => {
     const total = 156;
     when(apiServiceMock.get(`products/${productSku}/variations`, anything())).thenCall((_, opts) =>
-      !opts.params ? of({ elements: [], amount: 40, total }) : of({ elements: [], total })
+      !opts?.params.has('amount') ? of({ elements: [], amount: 40, total }) : of({ elements: [], total })
     );
 
     productsService.getProductVariations(productSku).subscribe(() => {
       verify(apiServiceMock.get(`products/${productSku}/variations`, anything())).times(4);
-      expect(capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(0)?.[1]?.params).toBeUndefined();
+      expect(
+        capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(0)?.[1]?.params?.toString()
+      ).toMatchInlineSnapshot(`"extended=true"`);
       expect(
         capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(1)?.[1]?.params?.toString()
-      ).toMatchInlineSnapshot(`"amount=40&offset=40"`);
+      ).toMatchInlineSnapshot(`"extended=true&amount=40&offset=40"`);
       expect(
         capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(2)?.[1]?.params?.toString()
-      ).toMatchInlineSnapshot(`"amount=40&offset=80"`);
+      ).toMatchInlineSnapshot(`"extended=true&amount=40&offset=80"`);
       expect(
         capture<string, AvailableOptions>(apiServiceMock.get).byCallIndex(3)?.[1]?.params?.toString()
-      ).toMatchInlineSnapshot(`"amount=36&offset=120"`);
+      ).toMatchInlineSnapshot(`"extended=true&amount=36&offset=120"`);
       done();
     });
   });

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -44,7 +44,7 @@ export class ProductsService {
       return throwError(() => new Error('getProduct() called without a sku'));
     }
 
-    const params = new HttpParams().set('allImages', 'true');
+    const params = new HttpParams().set('allImages', true).set('extended', true);
 
     return this.apiService
       .get<ProductData>(`products/${sku}`, { sendSPGID: true, params })
@@ -260,8 +260,13 @@ export class ProductsService {
       return throwError(() => new Error('getProductVariations() called without a sku'));
     }
 
+    const params = new HttpParams().set('extended', true);
+
     return this.apiService
-      .get<{ elements: Link[]; total: number; amount: number }>(`products/${sku}/variations`, { sendSPGID: true })
+      .get<{ elements: Link[]; total: number; amount: number }>(`products/${sku}/variations`, {
+        sendSPGID: true,
+        params,
+      })
       .pipe(
         switchMap(resp =>
           !resp.total
@@ -277,7 +282,7 @@ export class ProductsService {
                         this.apiService
                           .get<{ elements: Link[] }>(`products/${sku}/variations`, {
                             sendSPGID: true,
-                            params: new HttpParams().set('amount', length).set('offset', offset),
+                            params: params.set('amount', length).set('offset', offset),
                           })
                           .pipe(mapToProperty('elements'))
                       )

--- a/src/app/shared/components/product/product-variation-select-default/product-variation-select-default.component.html
+++ b/src/app/shared/components/product/product-variation-select-default/product-variation-select-default.component.html
@@ -1,0 +1,20 @@
+<select
+  class="form-control"
+  [id]="uuid + group.id"
+  [attr.data-testing-id]="group.id"
+  (change)="optionChange(group.id, $event.target)"
+>
+  <ng-container *ngFor="let option of group.options">
+    <option
+      *ngIf="!option.alternativeCombination || multipleOptions"
+      [value]="option.value"
+      [selected]="option.active"
+      [attr.data-testing-id]="group.id + '-' + option.value"
+    >
+      {{ option.label }}
+      <ng-container *ngIf="option.alternativeCombination">
+        - {{ 'product.available_in_different_configuration' | translate }}
+      </ng-container>
+    </option>
+  </ng-container>
+</select>

--- a/src/app/shared/components/product/product-variation-select-default/product-variation-select-default.component.spec.ts
+++ b/src/app/shared/components/product/product-variation-select-default/product-variation-select-default.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { anything, capture, spy, verify } from 'ts-mockito';
+
+import { VariationOptionGroup } from 'ish-core/models/product-variation/variation-option-group.model';
+import { findAllDataTestingIDs } from 'ish-core/utils/dev/html-query-utils';
+
+import { ProductVariationSelectDefaultComponent } from './product-variation-select-default.component';
+
+describe('Product Variation Select Default Component', () => {
+  let component: ProductVariationSelectDefaultComponent;
+  let fixture: ComponentFixture<ProductVariationSelectDefaultComponent>;
+  let element: HTMLElement;
+
+  const group = { id: 'a', options: [{ value: 'B' }, { value: 'C' }] } as VariationOptionGroup;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProductVariationSelectDefaultComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProductVariationSelectDefaultComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    component.group = group;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should initialize form of option group', () => {
+    fixture.detectChanges();
+
+    expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+      Array [
+        "a",
+        "a-B",
+        "a-C",
+      ]
+    `);
+  });
+
+  it('should set active values for form', () => {
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('select[data-testing-id=a]')).nativeElement.value).toMatchInlineSnapshot(
+      `"B"`
+    );
+  });
+
+  it('should trigger changeOption output handler if select value changes', () => {
+    fixture.detectChanges();
+    const emitter = spy(component.changeOption);
+    const select = fixture.debugElement.query(By.css('select')).nativeElement;
+    select.value = 'C';
+    select.dispatchEvent(new Event('change'));
+
+    verify(emitter.emit(anything())).once();
+    const [arg] = capture(emitter.emit).last();
+    expect(arg).toMatchInlineSnapshot(`
+      Object {
+        "group": "a",
+        "value": "C",
+      }
+    `);
+  });
+});

--- a/src/app/shared/components/product/product-variation-select-default/product-variation-select-default.component.ts
+++ b/src/app/shared/components/product/product-variation-select-default/product-variation-select-default.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { VariationOptionGroup } from 'ish-core/models/product-variation/variation-option-group.model';
+
+@Component({
+  selector: 'ish-product-variation-select-default',
+  templateUrl: './product-variation-select-default.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductVariationSelectDefaultComponent {
+  @Input() group: VariationOptionGroup;
+  @Input() uuid: string;
+  @Input() multipleOptions: boolean;
+
+  @Output() changeOption = new EventEmitter<{ group: string; value: string }>();
+
+  optionChange(group: string, target: EventTarget) {
+    this.changeOption.emit({ group, value: (target as HTMLDataElement).value });
+  }
+}

--- a/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.html
+++ b/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.html
@@ -1,0 +1,58 @@
+<!-- desktop: display enhanced select boxes with color codes or swatch images with labels -->
+<ng-container *ngIf="(deviceType$ | async) === 'desktop'; else mobile">
+  <div ngbDropdown>
+    <button ngbDropdownToggle type="button" class="btn variation-select" [id]="uuid + group.id">
+      <ng-container *ngFor="let option of group.options">
+        <ng-container *ngIf="option.active">
+          <ng-container *ngTemplateOutlet="optionTemplate; context: { group, option }"></ng-container>
+        </ng-container>
+      </ng-container>
+    </button>
+    <div ngbDropdownMenu class="variation-options" [attr.aria-labelledby]="uuid + group.id + 'label'">
+      <ng-container *ngFor="let option of group.options">
+        <button
+          ngbDropdownItem
+          *ngIf="!option.alternativeCombination || multipleOptions"
+          [value]="option.value"
+          [attr.data-testing-id]="group.id + '-' + option.value"
+          (click)="optionChange(group.id, option.value)"
+        >
+          <ng-container *ngTemplateOutlet="optionTemplate; context: { group, option }"></ng-container>
+        </button>
+      </ng-container>
+    </div>
+  </div>
+</ng-container>
+
+<!-- mobile/tablet: display a list of color codes or swatch images with labels -->
+<ng-template #mobile>
+  <div class="mobile-variation-select">
+    <div *ngFor="let option of group.options" class="mobile-variation-option">
+      <a (click)="optionChange(group.id, option.value)">
+        <ng-container *ngTemplateOutlet="optionTemplate; context: { group, option }"></ng-container>
+      </a>
+    </div>
+  </div>
+</ng-template>
+
+<!-- reusable template to render the individual options as color code or image swatch with label -->
+<ng-template #optionTemplate let-group="group" let-option="option">
+  <span
+    *ngIf="group.attributeType === 'defaultAndColorCode'"
+    class="color-code"
+    [ngStyle]="{ 'background-color': '#' + option.metaData }"
+    [ngClass]="{ 'light-color': option.label.toLowerCase() === 'white' }"
+  ></span>
+  <img
+    *ngIf="group.attributeType === 'defaultAndSwatchImage'"
+    class="image-swatch"
+    [src]="option.metaData"
+    alt="{{ option.label }}"
+  />
+  <span class="label" [ngClass]="{ selected: option.active }"
+    >{{ option.label }}
+    <ng-container *ngIf="option.alternativeCombination">
+      - {{ 'product.available_in_different_configuration' | translate }}
+    </ng-container>
+  </span>
+</ng-template>

--- a/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.scss
+++ b/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.scss
@@ -1,0 +1,66 @@
+@import 'variables';
+
+.variation-select {
+  width: 100%;
+  padding-right: 12px;
+  padding-left: 12px;
+  overflow: hidden;
+  text-align: left;
+  border: 1px solid $gray-400;
+
+  &.dropdown-toggle::after {
+    position: absolute;
+    top: 17px;
+    right: 10px;
+  }
+
+  .label.selected {
+    font-family: $font-family-regular;
+  }
+}
+
+.variation-options {
+  width: 100%;
+
+  .dropdown-item {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+}
+
+.mobile-variation-select {
+  margin: $space-default * 0.5 0 $space-default 0;
+  font-family: $font-family-regular;
+
+  .mobile-variation-option {
+    margin-bottom: $space-default * 0.5;
+  }
+}
+
+span.color-code,
+img.image-swatch {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  margin-right: $space-default * 0.5;
+  vertical-align: middle;
+}
+
+span.color-code {
+  border: 1px solid transparent;
+  border-radius: 50%;
+
+  &.light-color {
+    border: 1px solid $border-color-light;
+  }
+}
+
+span.label {
+  font-family: $font-family-regular;
+  color: $text-color-primary;
+  text-transform: none;
+
+  &.selected {
+    font-family: $font-family-bold;
+  }
+}

--- a/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.spec.ts
+++ b/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.spec.ts
@@ -1,0 +1,134 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
+import { anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
+
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { VariationOptionGroup } from 'ish-core/models/product-variation/variation-option-group.model';
+
+import { ProductVariationSelectEnhancedComponent } from './product-variation-select-enhanced.component';
+
+describe('Product Variation Select Enhanced Component', () => {
+  let component: ProductVariationSelectEnhancedComponent;
+  let fixture: ComponentFixture<ProductVariationSelectEnhancedComponent>;
+  let element: HTMLElement;
+  let appFacade: AppFacade;
+
+  const group_colorCode = {
+    id: 'color',
+    attributeType: 'defaultAndColorCode',
+    options: [
+      { value: 'black', label: 'Black', metaData: '000000', active: true },
+      { value: 'white', label: 'White', metaData: 'FFFFFF' },
+    ],
+  } as VariationOptionGroup;
+
+  const group_swatchImage = {
+    id: 'swatch',
+    attributeType: 'defaultAndSwatchImage',
+    options: [
+      { value: 'Y', label: 'yyy', metaData: 'imageY.png' },
+      { value: 'Z', label: 'zzz', metaData: 'imageZ.png', active: true },
+    ],
+  } as VariationOptionGroup;
+
+  beforeEach(async () => {
+    appFacade = mock(AppFacade);
+    await TestBed.configureTestingModule({
+      declarations: [ProductVariationSelectEnhancedComponent],
+      providers: [{ provide: AppFacade, useFactory: () => instance(appFacade) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProductVariationSelectEnhancedComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    component.group = group_colorCode;
+    component.uuid = 'uuid';
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should render a color code select when the attribute type is "defaultAndColorCode" for mobile', () => {
+    component.group = group_colorCode;
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <div class="mobile-variation-select">
+        <div class="mobile-variation-option">
+          <a
+            ><span class="color-code" style="background-color: rgb(0, 0, 0)"></span
+            ><span class="label selected">Black </span></a
+          >
+        </div>
+        <div class="mobile-variation-option">
+          <a
+            ><span class="color-code light-color" style="background-color: rgb(255, 255, 255)"></span
+            ><span class="label">White </span></a
+          >
+        </div>
+      </div>
+    `);
+  });
+
+  it('should render a swatch image select when the attribute type is "defaultAndColorCode" for desktop', () => {
+    when(appFacade.deviceType$).thenReturn(of('desktop'));
+    component.group = group_swatchImage;
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <div ngbdropdown="">
+        <button ngbdropdowntoggle="" type="button" class="btn variation-select" id="uuidswatch">
+          <img class="image-swatch" alt="zzz" src="imageZ.png" /><span class="label selected">zzz </span>
+        </button>
+        <div ngbdropdownmenu="" class="variation-options" aria-labelledby="uuidswatchlabel">
+          <button ngbdropdownitem="" value="Y" data-testing-id="swatch-Y">
+            <img class="image-swatch" alt="yyy" src="imageY.png" /><span class="label">yyy </span></button
+          ><button ngbdropdownitem="" value="Z" data-testing-id="swatch-Z">
+            <img class="image-swatch" alt="zzz" src="imageZ.png" /><span class="label selected"
+              >zzz
+            </span>
+          </button>
+        </div>
+      </div>
+    `);
+  });
+
+  it('should trigger changeOption output handler if color code element is clicked (mobile)', () => {
+    component.group = group_colorCode;
+    fixture.detectChanges();
+    const emitter = spy(component.changeOption);
+    const link = fixture.debugElement.query(By.css('.label.selected')).parent.nativeElement;
+    link.dispatchEvent(new Event('click'));
+
+    verify(emitter.emit(anything())).once();
+    const [arg] = capture(emitter.emit).last();
+    expect(arg).toMatchInlineSnapshot(`
+      Object {
+        "group": "color",
+        "value": "black",
+      }
+    `);
+  });
+
+  it('should trigger changeOption output handler if swatch image element is clicked (desktop)', () => {
+    when(appFacade.deviceType$).thenReturn(of('desktop'));
+    component.group = group_swatchImage;
+    fixture.detectChanges();
+    const emitter = spy(component.changeOption);
+    const link = fixture.debugElement.queryAll(By.css('.label.selected')).pop().parent.nativeElement;
+    link.dispatchEvent(new Event('click'));
+
+    verify(emitter.emit(anything())).once();
+    const [arg] = capture(emitter.emit).last();
+    expect(arg).toMatchInlineSnapshot(`
+      Object {
+        "group": "swatch",
+        "value": "Z",
+      }
+    `);
+  });
+});

--- a/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.ts
+++ b/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { VariationOptionGroup } from 'ish-core/models/product-variation/variation-option-group.model';
+import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
+
+@Component({
+  selector: 'ish-product-variation-select-enhanced',
+  templateUrl: './product-variation-select-enhanced.component.html',
+  styleUrls: ['./product-variation-select-enhanced.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductVariationSelectEnhancedComponent implements OnInit {
+  @Input() group: VariationOptionGroup;
+  @Input() uuid: string;
+  @Input() multipleOptions: boolean;
+
+  @Output() changeOption = new EventEmitter<{ group: string; value: string }>();
+
+  deviceType$: Observable<DeviceType>;
+
+  constructor(private appFacade: AppFacade) {}
+
+  ngOnInit() {
+    this.deviceType$ = this.appFacade.deviceType$;
+  }
+
+  optionChange(group: string, value: string) {
+    this.changeOption.emit({ group, value });
+  }
+}

--- a/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.html
+++ b/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.html
@@ -1,0 +1,12 @@
+<ul>
+  <li *ngFor="let option of group.options" [ngClass]="{ selected: option.active }">
+    <a (click)="optionChange(group.id, option.value)" title="{{ option.label }}">
+      <span
+        *ngIf="group.attributeType === 'colorCode'"
+        [ngStyle]="{ 'background-color': '#' + option.metaData }"
+        [ngClass]="{ 'light-color': option.label.toLowerCase() === 'white' }"
+      ></span>
+      <img *ngIf="group.attributeType === 'swatchImage'" [src]="option.metaData" alt="{{ option.label }}" />
+    </a>
+  </li>
+</ul>

--- a/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.scss
+++ b/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.scss
@@ -1,0 +1,36 @@
+@import 'variables';
+
+ul {
+  padding: 0;
+  margin: 10px 0;
+
+  li {
+    display: inline-block;
+    margin-right: 5px;
+    border: 1px solid transparent;
+    border-radius: 50%;
+
+    &.selected {
+      border: 1px solid $border-color-light;
+    }
+
+    a {
+      display: block;
+      border: 1px solid transparent;
+      border-radius: 50%;
+
+      span,
+      img {
+        display: block;
+        width: 32px;
+        height: 32px;
+        border: 1px solid transparent;
+        border-radius: 50%;
+
+        &.light-color {
+          border: 1px solid $border-color-light;
+        }
+      }
+    }
+  }
+}

--- a/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.spec.ts
+++ b/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.spec.ts
@@ -1,0 +1,116 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { anything, capture, spy, verify } from 'ts-mockito';
+
+import { VariationOptionGroup } from 'ish-core/models/product-variation/variation-option-group.model';
+
+import { ProductVariationSelectSwatchComponent } from './product-variation-select-swatch.component';
+
+describe('Product Variation Select Swatch Component', () => {
+  let component: ProductVariationSelectSwatchComponent;
+  let fixture: ComponentFixture<ProductVariationSelectSwatchComponent>;
+  let element: HTMLElement;
+
+  const group_colorCode = {
+    id: 'color',
+    attributeType: 'colorCode',
+    options: [
+      { value: 'black', label: 'Black', metaData: '000000', active: true },
+      { value: 'white', label: 'White', metaData: 'FFFFFF' },
+    ],
+  } as VariationOptionGroup;
+
+  const group_swatchImage = {
+    id: 'swatch',
+    attributeType: 'swatchImage',
+    options: [
+      { value: 'Y', label: 'yyy', metaData: 'imageY.png' },
+      { value: 'Z', label: 'zzz', metaData: 'imageZ.png', active: true },
+    ],
+  } as VariationOptionGroup;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProductVariationSelectSwatchComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProductVariationSelectSwatchComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    component.group = group_colorCode;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should render a color code when the attribute type is "colorCode"', () => {
+    component.group = group_colorCode;
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <ul>
+        <li class="selected">
+          <a title="Black"><span style="background-color: rgb(0, 0, 0)"></span></a>
+        </li>
+        <li>
+          <a title="White"
+            ><span class="light-color" style="background-color: rgb(255, 255, 255)"></span
+          ></a>
+        </li>
+      </ul>
+    `);
+  });
+
+  it('should render a swatch image when the attribute type is "swatchImage"', () => {
+    component.group = group_swatchImage;
+    fixture.detectChanges();
+    expect(element).toMatchInlineSnapshot(`
+      <ul>
+        <li>
+          <a title="yyy"><img alt="yyy" src="imageY.png" /></a>
+        </li>
+        <li class="selected">
+          <a title="zzz"><img alt="zzz" src="imageZ.png" /></a>
+        </li>
+      </ul>
+    `);
+  });
+
+  it('should trigger changeOption output handler if color code element is clicked', () => {
+    component.group = group_colorCode;
+    fixture.detectChanges();
+    const emitter = spy(component.changeOption);
+    const link = fixture.debugElement.query(By.css('li.selected a')).nativeElement;
+    link.dispatchEvent(new Event('click'));
+
+    verify(emitter.emit(anything())).once();
+    const [arg] = capture(emitter.emit).last();
+    expect(arg).toMatchInlineSnapshot(`
+      Object {
+        "group": "color",
+        "value": "black",
+      }
+    `);
+  });
+
+  it('should trigger changeOption output handler if swatch image element is clicked', () => {
+    component.group = group_swatchImage;
+    fixture.detectChanges();
+    const emitter = spy(component.changeOption);
+    const link = fixture.debugElement.query(By.css('li.selected a')).nativeElement;
+    link.dispatchEvent(new Event('click'));
+
+    verify(emitter.emit(anything())).once();
+    const [arg] = capture(emitter.emit).last();
+    expect(arg).toMatchInlineSnapshot(`
+      Object {
+        "group": "swatch",
+        "value": "Z",
+      }
+    `);
+  });
+});

--- a/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.ts
+++ b/src/app/shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { VariationOptionGroup } from 'ish-core/models/product-variation/variation-option-group.model';
+
+@Component({
+  selector: 'ish-product-variation-select-swatch',
+  templateUrl: './product-variation-select-swatch.component.html',
+  styleUrls: ['./product-variation-select-swatch.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductVariationSelectSwatchComponent {
+  @Input() group: VariationOptionGroup;
+
+  @Output() changeOption = new EventEmitter<{ group: string; value: string }>();
+
+  optionChange(group: string, value: string) {
+    this.changeOption.emit({ group, value });
+  }
+}

--- a/src/app/shared/components/product/product-variation-select/product-variation-select.component.html
+++ b/src/app/shared/components/product/product-variation-select/product-variation-select.component.html
@@ -2,27 +2,37 @@
   <ng-container *ngIf="variationOptions$ | async as variationOptions">
     <div *ngFor="let group of variationOptions" class="product-variation">
       <div class="form-group">
-        <label [for]="uuid + '__' + group.id" class="col-form-label">{{ group.label }}</label>
-        <select
-          class="form-control"
-          [id]="uuid + '__' + group.id"
-          [attr.data-testing-id]="group.id"
-          (change)="optionChange(group.id, $event.target)"
-        >
-          <ng-container *ngFor="let option of group.options">
-            <option
-              *ngIf="!option.alternativeCombination || variationOptions.length > 1"
-              [value]="option.value"
-              [selected]="option.active"
-              [attr.data-testing-id]="group.id + '-' + option.value"
-            >
-              {{ option.label }}
-              <ng-container *ngIf="option.alternativeCombination">
-                - {{ 'product.available_in_different_configuration' | translate }}
-              </ng-container>
-            </option>
+        <label [for]="uuid + group.id" [id]="uuid + group.id + 'label'" class="col-form-label">{{ group.label }}</label>
+
+        <!-- multiple switch case expressions - https://stackoverflow.com/a/45950368 -->
+        <ng-container [ngSwitch]="true">
+          <ng-container *ngSwitchCase="group.attributeType === 'colorCode' || group.attributeType === 'swatchImage'">
+            <ish-product-variation-select-swatch
+              [group]="group"
+              (changeOption)="optionChange($event)"
+            ></ish-product-variation-select-swatch>
           </ng-container>
-        </select>
+          <ng-container
+            *ngSwitchCase="
+              group.attributeType === 'defaultAndColorCode' || group.attributeType === 'defaultAndSwatchImage'
+            "
+          >
+            <ish-product-variation-select-enhanced
+              [group]="group"
+              [uuid]="uuid"
+              [multipleOptions]="variationOptions.length > 1"
+              (changeOption)="optionChange($event)"
+            ></ish-product-variation-select-enhanced>
+          </ng-container>
+          <ng-container *ngSwitchDefault>
+            <ish-product-variation-select-default
+              [group]="group"
+              [uuid]="uuid"
+              [multipleOptions]="variationOptions.length > 1"
+              (changeOption)="optionChange($event)"
+            ></ish-product-variation-select-default>
+          </ng-container>
+        </ng-container>
       </div>
     </div>
   </ng-container>

--- a/src/app/shared/components/product/product-variation-select/product-variation-select.component.spec.ts
+++ b/src/app/shared/components/product/product-variation-select/product-variation-select.component.spec.ts
@@ -1,13 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { VariationProduct, VariationProductMaster } from 'ish-core/models/product/product.model';
-import { findAllDataTestingIDs } from 'ish-core/utils/dev/html-query-utils';
+import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
+import { ProductVariationSelectDefaultComponent } from 'ish-shared/components/product/product-variation-select-default/product-variation-select-default.component';
+import { ProductVariationSelectEnhancedComponent } from 'ish-shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component';
+import { ProductVariationSelectSwatchComponent } from 'ish-shared/components/product/product-variation-select-swatch/product-variation-select-swatch.component';
 
 import { ProductVariationSelectComponent } from './product-variation-select.component';
 
@@ -19,17 +21,26 @@ describe('Product Variation Select Component', () => {
 
   const productMaster = {
     variationAttributeValues: [
-      { variationAttributeId: 'a1', value: 'A' },
-      { variationAttributeId: 'a1', value: 'B' },
-      { variationAttributeId: 'a2', value: 'C' },
-      { variationAttributeId: 'a2', value: 'D' },
+      { variationAttributeId: 'a1', value: 'A', attributeType: 'colorCode' },
+      { variationAttributeId: 'a1', value: 'B', attributeType: 'colorCode' },
+      { variationAttributeId: 'a2', value: 'C', attributeType: 'defaultAndColorCode' },
+      { variationAttributeId: 'a2', value: 'D', attributeType: 'defaultAndColorCode' },
+      { variationAttributeId: 'a3', value: 'E', attributeType: 'swatchImage' },
+      { variationAttributeId: 'a3', value: 'F', attributeType: 'swatchImage' },
+      { variationAttributeId: 'a4', value: 'G', attributeType: 'defaultAndSwatchImage' },
+      { variationAttributeId: 'a4', value: 'H', attributeType: 'defaultAndSwatchImage' },
+      { variationAttributeId: 'a5', value: 'I', attributeType: 'default' },
+      { variationAttributeId: 'a5', value: 'J', attributeType: 'default' },
     ],
   } as VariationProductMaster;
 
   const variationProduct = {
     variableVariationAttributes: [
-      { variationAttributeId: 'a1', value: 'B' },
-      { variationAttributeId: 'a2', value: 'D' },
+      { variationAttributeId: 'a1', value: 'B', attributeType: 'colorCode' },
+      { variationAttributeId: 'a2', value: 'D', attributeType: 'defaultAndColorCode' },
+      { variationAttributeId: 'a3', value: 'F', attributeType: 'swatchImage' },
+      { variationAttributeId: 'a4', value: 'H', attributeType: 'defaultAndSwatchImage' },
+      { variationAttributeId: 'a5', value: 'J', attributeType: 'default' },
     ],
   } as VariationProduct;
 
@@ -42,8 +53,12 @@ describe('Product Variation Select Component', () => {
   beforeEach(async () => {
     context = mock(ProductContextFacade);
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
-      declarations: [ProductVariationSelectComponent],
+      declarations: [
+        MockComponent(ProductVariationSelectDefaultComponent),
+        MockComponent(ProductVariationSelectEnhancedComponent),
+        MockComponent(ProductVariationSelectSwatchComponent),
+        ProductVariationSelectComponent,
+      ],
       providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }],
     }).compileComponents();
   });
@@ -63,45 +78,30 @@ describe('Product Variation Select Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
-  it('should initialize form of option groups', () => {
+  it('should render the different attribute types with the fitting product variation select components', () => {
     fixture.detectChanges();
 
-    expect(findAllDataTestingIDs(fixture)).toMatchInlineSnapshot(`
+    expect(findAllCustomElements(element)).toMatchInlineSnapshot(`
       Array [
-        "a1",
-        "a1-A",
-        "a1-B",
-        "a2",
-        "a2-C",
-        "a2-D",
+        "ish-product-variation-select-swatch",
+        "ish-product-variation-select-enhanced",
+        "ish-product-variation-select-swatch",
+        "ish-product-variation-select-enhanced",
+        "ish-product-variation-select-default",
       ]
     `);
   });
 
-  it('should set active values for form', () => {
+  it('should trigger a contex value change if value changes', () => {
     fixture.detectChanges();
 
-    expect(fixture.debugElement.query(By.css('select[data-testing-id=a1]')).nativeElement.value).toMatchInlineSnapshot(
-      `"B"`
-    );
-
-    expect(fixture.debugElement.query(By.css('select[data-testing-id=a2]')).nativeElement.value).toMatchInlineSnapshot(
-      `"D"`
-    );
-  });
-
-  it('should trigger value change if value changes', () => {
-    fixture.detectChanges();
-
-    const select = fixture.debugElement.query(By.css('select')).nativeElement;
-    select.value = 'A';
-    select.dispatchEvent(new Event('change'));
+    component.optionChange({ group: 'a2', value: 'C' });
 
     verify(context.changeVariationOption(anything(), anything())).once();
     expect(capture(context.changeVariationOption).last()).toMatchInlineSnapshot(`
       Array [
-        "a1",
-        "A",
+        "a2",
+        "C",
       ]
     `);
   });

--- a/src/app/shared/components/product/product-variation-select/product-variation-select.component.ts
+++ b/src/app/shared/components/product/product-variation-select/product-variation-select.component.ts
@@ -26,7 +26,7 @@ export class ProductVariationSelectComponent implements OnInit {
     this.visible$ = this.context.select('displayProperties', 'variations');
   }
 
-  optionChange(group: string, target: EventTarget) {
-    this.context.changeVariationOption(group, (target as HTMLDataElement).value);
+  optionChange(event: { group: string; value: string }) {
+    this.context.changeVariationOption(event.group, event.value);
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -129,6 +129,9 @@ import { ProductRowComponent } from './components/product/product-row/product-ro
 import { ProductShipmentComponent } from './components/product/product-shipment/product-shipment.component';
 import { ProductTileComponent } from './components/product/product-tile/product-tile.component';
 import { ProductVariationDisplayComponent } from './components/product/product-variation-display/product-variation-display.component';
+import { ProductVariationSelectDefaultComponent } from './components/product/product-variation-select-default/product-variation-select-default.component';
+import { ProductVariationSelectEnhancedComponent } from './components/product/product-variation-select-enhanced/product-variation-select-enhanced.component';
+import { ProductVariationSelectSwatchComponent } from './components/product/product-variation-select-swatch/product-variation-select-swatch.component';
 import { ProductVariationSelectComponent } from './components/product/product-variation-select/product-variation-select.component';
 import { ProductsListComponent } from './components/product/products-list/products-list.component';
 import { PromotionDetailsComponent } from './components/promotion/promotion-details/promotion-details.component';
@@ -207,6 +210,7 @@ const declaredComponents = [
   LineItemEditDialogComponent,
   LineItemListElementComponent,
   LoginModalComponent,
+  PagingComponent,
   ProductChooseVariationComponent,
   ProductIdComponent,
   ProductItemVariationsComponent,
@@ -247,9 +251,9 @@ const exportedComponents = [
   ErrorMessageComponent,
   FilterNavigationComponent,
   IdentityProviderLoginComponent,
-  InPlaceEditComponent,
   InfoBoxComponent,
   InfoMessageComponent,
+  InPlaceEditComponent,
   LineItemListComponent,
   LoadingComponent,
   LoginFormComponent,
@@ -274,9 +278,12 @@ const exportedComponents = [
   ProductQuantityComponent,
   ProductQuantityLabelComponent,
   ProductShipmentComponent,
+  ProductsListComponent,
   ProductVariationDisplayComponent,
   ProductVariationSelectComponent,
-  ProductsListComponent,
+  ProductVariationSelectDefaultComponent,
+  ProductVariationSelectEnhancedComponent,
+  ProductVariationSelectSwatchComponent,
   PromotionDetailsComponent,
   PromotionRemoveComponent,
   SearchBoxComponent,
@@ -285,7 +292,7 @@ const exportedComponents = [
 
 @NgModule({
   imports: [...importExportModules],
-  declarations: [...declaredComponents, ...exportedComponents, PagingComponent],
+  declarations: [...declaredComponents, ...exportedComponents],
   exports: [...exportedComponents, ...importExportModules],
 })
 export class SharedModule {

--- a/src/styles/global/forms.scss
+++ b/src/styles/global/forms.scss
@@ -127,6 +127,10 @@ input.form-check-input {
   color: $text-color-quaternary;
 }
 
+select {
+  font-family: $font-family-regular;
+}
+
 // ERROR and SUCCESS
 .has-feedback {
   .form-control[type='number'] {

--- a/src/styles/pages/category/product-list.scss
+++ b/src/styles/pages/category/product-list.scss
@@ -23,6 +23,10 @@
         width: 60%;
         text-align: left;
 
+        @include media-breakpoint-down(sm) {
+          width: 100%;
+        }
+
         &.read-only {
           text-align: center;
         }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Currently the PWA renders for the variation selection only standard select boxes with standard options even though different variation selection types can be configured in the ICM back end.

![image](https://user-images.githubusercontent.com/50741106/207610723-ef72be23-222e-44b9-8be1-2f21e0431f3d.png)

![image](https://user-images.githubusercontent.com/50741106/207611086-8ce0bd93-7337-4013-bc48-02fc26bce73c.png)

## What Is the New Behavior?

This pull request introduces an extended `/variations` and `/products` REST call and a variation attribute mapper to fetch and prepare/map additional variation information required for distinct renderings.

It also introduces different rendering components for `Default`, `Swatch Image/HTML Color Code` and `Default and Swatch Image/Default and HTML Color Code` (including a mobile view adaption).

![image](https://user-images.githubusercontent.com/50741106/207612628-0b4453fa-6e8b-4899-afaa-a28c0e27cd5d.png)
![image](https://user-images.githubusercontent.com/50741106/207854268-7337adb7-e1bd-44bf-a989-a400ed9010b6.png)
![image](https://user-images.githubusercontent.com/50741106/207854395-a6c52e32-0efc-4b95-9fbd-f990c4ea5e69.png)
![image](https://user-images.githubusercontent.com/50741106/207612765-d6a41b4d-b599-499c-8c16-a2bb85b55377.png)
![image](https://user-images.githubusercontent.com/50741106/207854659-cd27edde-cbee-446e-ae0a-753ccdb54d29.png)
![image](https://user-images.githubusercontent.com/50741106/207854585-67da4c4e-cd5c-466e-96e3-2383275cc370.png)

## Does this PR Introduce a Breaking Change?

[x] Yes

* extended `/variations` and `/products` REST call
* added VariationAttributeMapper used in ProductMapper
* introduces different rendering components

## Other Information

[AB#80929](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/80929)