### PR TITLE
style: keep the footer at the bottom of the page

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,11 @@ kb_sync_latest_only
 
 # Migrations
 
+## 3.1 to 3.2
+
+A styling adaption was made to the application shell to expand it to the full page height so the footer now always stays at the bottom.
+Together with that an inline style of the `main-container` was moved to the global styling definition.
+
 ## 3.0 to 3.1
 
 The SSR environment variable 'ICM_IDENTITY_PROVIDER' will be removed in a future release ( PWA 5.0 ).

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <header data-testing-id="page-header" class="top"><ish-header></ish-header></header>
 
   <div class="wrapper">
-    <div role="main" class="container main-container" style="position: relative; min-height: 200px">
+    <div role="main" class="container main-container">
       <router-outlet></router-outlet>
     </div>
   </div>

--- a/src/app/extensions/store-locator/pages/store-locator/store-locator-page.component.html
+++ b/src/app/extensions/store-locator/pages/store-locator/store-locator-page.component.html
@@ -1,7 +1,8 @@
-<h1 class="mt-5">{{ 'store_locator.title' | translate }}</h1>
+<h1>{{ 'store_locator.title' | translate }}</h1>
 
 <p>{{ 'store_locator.description' | translate }}</p>
 <p>{{ 'store_locator.howto' | translate }}</p>
+
 <form [formGroup]="form" (ngSubmit)="submitForm()">
   <div class="row">
     <fieldset class="col-sm-8">

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -2,6 +2,8 @@
 // LAYOUT
 // contains layout and presentation classes for the global page structure (header, footer, global navigation, ...)
 .main-container {
+  position: relative;
+  min-height: 200px;
   background: $color-inverse;
 }
 


### PR DESCRIPTION
Due to the asynchronous loading of the pages, the footer sometimes goes up to the header. A pre-sizing of the main container avoids this unpleasant effect

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
