### PR TITLE
fix: api token should be shared between same host

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -91,6 +91,7 @@ export class ApiTokenService {
               expires: new Date(Date.now() + 3600000),
               secure: true,
               sameSite: 'Strict',
+              path: '/',
             });
           } else {
             cookiesService.remove('apiToken');


### PR DESCRIPTION
…guration

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Api token cookies are stored with the configured multi-channel path. It cannot be shared between different configured multi sites (eg. language switch with /en, /de or /fr).

Issue Number: Closes #

## What Is the New Behavior?

The api token is stored with '/' as path.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information

[AB#81009](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81009)