### PR TITLE
fix: add promotion scope to basket checkout step (#80931)

### DIFF
--- a/src/app/core/store/customer/basket/basket-validation.effects.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.ts
@@ -42,7 +42,7 @@ export class BasketValidationEffects {
   ) {}
 
   private validationSteps: { scopes: BasketValidationScopeType[]; route: string }[] = [
-    { scopes: ['Products', 'Value', 'CostCenter'], route: '/basket' },
+    { scopes: ['Products', 'Promotion', 'Value', 'CostCenter'], route: '/basket' },
     { scopes: ['InvoiceAddress', 'ShippingAddress', 'Addresses'], route: '/checkout/address' },
     { scopes: ['Shipping'], route: '/checkout/shipping' },
     { scopes: ['Payment'], route: '/checkout/payment' },


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If a user starts the checkout process on cart page a basket validation is executed but it doesn't consider properly whether all promotions are valid and applicable. The user might stay on cart page but doesn`t get any info or error message.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
Promotions are included into the basket validation of the first checkout step. Errors are shown to the user if needed.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
[AB#81931](https://dev.azure.com/intershop-com/Products/_workitems/edit/80931)
[AB#81015](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81015)