### PR TITLE
fix: improve mock data redirection for urls w/ matrix parameter

### DIFF
--- a/docs/guides/mocking-rest-calls.md
+++ b/docs/guides/mocking-rest-calls.md
@@ -22,6 +22,15 @@ The following configuration example will mock all CMS calls.
 apiMockPaths: ['^cms/.*'],
 ```
 
+> [!TIP]
+> With PWA version 5.2.0 a filtering for matrix parameters (e.g. `/cms;pgid=JdbSDW8rrqSRpGO4S7o0b4AK0000/includes`) was introduces.
+> This way personalized REST calls can be mocked now as well with file path without the matrix parameter.
+> The configuration would look like this.
+>
+> ```
+> apiMockPaths: ['^cms.*/.*'],
+> ```
+
 ## Supply Mocked Data
 
 Mocked data is put in the folder _assets/mock-data/<path>_.

--- a/src/app/core/interceptors/mock.interceptor.spec.ts
+++ b/src/app/core/interceptors/mock.interceptor.spec.ts
@@ -28,11 +28,15 @@ describe('Mock Interceptor', () => {
 
   describe('Request URL Modification', () => {
     it.each([
-      [`${BASE_URL}/categories/Cameras`, './assets/mock-data/categories/Cameras/get.json'],
-      [`${BASE_URL};loc=en_US;cur=USD/categories/Cameras`, './assets/mock-data/categories/Cameras/get.json'],
-      [`${BASE_URL}/categories?view=tree`, './assets/mock-data/categories/get.json'],
-      [`${BASE_URL};loc=en_US;cur=USD/categories?view=tree`, './assets/mock-data/categories/get.json'],
-      ['./assets/picture.png', './assets/picture.png'],
+      [`${BASE_URL}/categories/Cameras`, '/assets/mock-data/categories/Cameras/get.json'],
+      [`${BASE_URL};loc=en_US;cur=USD/categories/Cameras`, '/assets/mock-data/categories/Cameras/get.json'],
+      [`${BASE_URL}/categories?view=tree`, '/assets/mock-data/categories/get.json'],
+      [`${BASE_URL};loc=en_US;cur=USD/categories?view=tree`, '/assets/mock-data/categories/get.json'],
+      [
+        `${BASE_URL};loc=en_US;cur=USD/products;spgid=PU8jvEfUmFeE5k_3Hq1EE7DuxlIMC/1005182`,
+        '/assets/mock-data/products/1005182/get.json',
+      ],
+      ['/assets/picture.png', '/assets/picture.png'],
     ])('should replace request to "%s" with "%s"', (incoming, outgoing) => {
       const http = new HttpRequest('GET', incoming);
 
@@ -48,28 +52,31 @@ describe('Mock Interceptor', () => {
     });
   });
 
-  describe.each`
-    item                      | within                                    | expected
-    ${'categories'}           | ${undefined}                              | ${false}
-    ${'categories'}           | ${[]}                                     | ${false}
-    ${'categories'}           | ${['categories']}                         | ${true}
-    ${'catego'}               | ${['categories']}                         | ${false}
-    ${'categories'}           | ${['cat.*']}                              | ${true}
-    ${'product/cat'}          | ${['cat.*']}                              | ${true}
-    ${'product/38201833'}     | ${['2018']}                               | ${true}
-    ${'product/cat'}          | ${['^cat.*']}                             | ${false}
-    ${'categories/Computers'} | ${['categories$']}                        | ${false}
-    ${'categories/Computers'} | ${['categories.*']}                       | ${true}
-    ${'categories/Computers'} | ${['categories/.*']}                      | ${true}
-    ${'categories/Computers'} | ${['categories/Computers']}               | ${true}
-    ${'categories/Computers'} | ${['categories/Audio']}                   | ${false}
-    ${'categories/Computers'} | ${['categories/']}                        | ${true}
-    ${'categories/Computers'} | ${['categories/(Audio|Computers|HiFi)']}  | ${true}
-    ${'categories/Computers'} | ${['categories/(Audio|Computers|HiFi)/']} | ${false}
-    ${'categories/Computers'} | ${['Computers']}                          | ${true}
-  `(`matchPath Method`, ({ item, within, expected }) => {
-    it(`should be ${expected} for URL '${item}' and mock paths [${within}]`, () => {
-      expect(mockInterceptor.matchPath(item, within)).toBe(expected);
+  describe('matchPath Method', () => {
+    // eslint-disable-next-line jest/valid-title
+    describe.each`
+      item                      | within                                    | expected
+      ${'categories'}           | ${undefined}                              | ${false}
+      ${'categories'}           | ${[]}                                     | ${false}
+      ${'categories'}           | ${['categories']}                         | ${true}
+      ${'catego'}               | ${['categories']}                         | ${false}
+      ${'categories'}           | ${['cat.*']}                              | ${true}
+      ${'product/cat'}          | ${['cat.*']}                              | ${true}
+      ${'product/38201833'}     | ${['2018']}                               | ${true}
+      ${'product/cat'}          | ${['^cat.*']}                             | ${false}
+      ${'categories/Computers'} | ${['categories$']}                        | ${false}
+      ${'categories/Computers'} | ${['categories.*']}                       | ${true}
+      ${'categories/Computers'} | ${['categories/.*']}                      | ${true}
+      ${'categories/Computers'} | ${['categories/Computers']}               | ${true}
+      ${'categories/Computers'} | ${['categories/Audio']}                   | ${false}
+      ${'categories/Computers'} | ${['categories/']}                        | ${true}
+      ${'categories/Computers'} | ${['categories/(Audio|Computers|HiFi)']}  | ${true}
+      ${'categories/Computers'} | ${['categories/(Audio|Computers|HiFi)/']} | ${false}
+      ${'categories/Computers'} | ${['Computers']}                          | ${true}
+    `(``, ({ item, within, expected }) => {
+      it(`should be ${expected} for URL '${item}' and mock paths [${within}]`, () => {
+        expect(mockInterceptor.matchPath(item, within)).toBe(expected);
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Mocking to potentially personalized resources fails due to the fact that the full request URL is passed as the target point in the Mock Interceptor class.

Setup:

```ts
apiMockPaths: ['^products.*/1005182'],
```

Console Log:

>  redirecting 'http://localhost:4200/INTERSHOP/rest/WFS/Camfil-CamfilFI-Site/rest;loc=fi_FI;cur=EUR/products;spgid=UEyi3WOuZg2RpGp_3Xqb4c3l0000/1005182' to './assets/mock-data/products;spgid=UEyi3WOuZg2RpGp_3Xqb4c3l0000/1005182/get.json'`

Response:

```
Request URL: http://localhost:4200/assets/mock-data/products/1005182/get.json?allImages=true
Request Method: GET
Status Code: 404 Not Found
```

Issue Number: N/A

## What Is the New Behavior?

Mocking to potentially personalized resources simply skips all the matrix parameters when creating a new target URL string.

Setup:

```ts
apiMockPaths: ['^products.*/1005182'],
```

Console Log:

> redirecting 'http://localhost:4200/INTERSHOP/rest/WFS/Camfil-CamfilFI-Site/rest;loc=fi_FI;cur=EUR/products;spgid=UEyi3WOuZg2RpGp_3Xqb4c3l0000/1005182' to '/assets/mock-data/products/1005182/get.json'

Response:

```
Request URL: http://localhost:4200/assets/mock-data/products/1005182/get.json?allImages=true
Request Method: GET
Status Code: 304 OK
```

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

N/A