### PR TITLE
refactor: add enum CheckoutTargetStep to set next checkout step

### DIFF
--- a/src/app/core/facades/checkout.facade.ts
+++ b/src/app/core/facades/checkout.facade.ts
@@ -6,6 +6,7 @@ import { debounceTime, distinctUntilChanged, map, sample, switchMap, take, tap }
 
 import { Address } from 'ish-core/models/address/address.model';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
 import { selectRouteData } from 'ish-core/store/core/router';
@@ -81,7 +82,7 @@ export class CheckoutFacade {
     this.store.dispatch(submitOrder());
   }
 
-  continue(targetStep: number) {
+  continue(targetStep: CheckoutStepType) {
     this.store.dispatch(continueCheckout({ targetStep }));
   }
 

--- a/src/app/core/models/checkout/checkout-step.type.ts
+++ b/src/app/core/models/checkout/checkout-step.type.ts
@@ -2,9 +2,9 @@
  * available, ordered checkout steps
  */
 export enum CheckoutStepType {
-  addresses = 1,
-  shipping,
-  payment,
-  review,
-  receipt,
+  Addresses = 1,
+  Shipping,
+  Payment,
+  Review,
+  Receipt,
 }

--- a/src/app/core/models/checkout/checkout-step.type.ts
+++ b/src/app/core/models/checkout/checkout-step.type.ts
@@ -2,6 +2,7 @@
  * available, ordered checkout steps
  */
 export enum CheckoutStepType {
+  Checkout,
   Addresses = 1,
   Shipping,
   Payment,

--- a/src/app/core/models/checkout/checkout-step.type.ts
+++ b/src/app/core/models/checkout/checkout-step.type.ts
@@ -2,8 +2,8 @@
  * available, ordered checkout steps
  */
 export enum CheckoutStepType {
-  Checkout,
-  Addresses = 1,
+  BeforeCheckout,
+  Addresses,
   Shipping,
   Payment,
   Review,

--- a/src/app/core/models/checkout/checkout-step.type.ts
+++ b/src/app/core/models/checkout/checkout-step.type.ts
@@ -1,0 +1,10 @@
+/**
+ * available, ordered checkout steps
+ */
+export enum CheckoutStepType {
+  addresses = 1,
+  shipping,
+  payment,
+  review,
+  receipt,
+}

--- a/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
@@ -8,6 +8,7 @@ import { Observable, noop, of, throwError } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { BasketValidation } from 'ish-core/models/basket-validation/basket-validation.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { Product } from 'ish-core/models/product/product.model';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
@@ -97,7 +98,7 @@ describe('Basket Validation Effects', () => {
 
       const action = startCheckout();
       const completion = continueCheckout({
-        targetStep: 1,
+        targetStep: CheckoutStepType.addresses,
       });
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-c', { c: completion });
@@ -298,7 +299,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should call the basketService for validateBasketAndContinueCheckout', done => {
-      const action = continueCheckout({ targetStep: 1 });
+      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
       actions$ = of(action);
 
       effects.validateBasketAndContinueCheckout$.subscribe(() => {
@@ -308,7 +309,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map to action of type ContinueCheckoutSuccess if targetStep is not 5 (order creation)', () => {
-      const action = continueCheckout({ targetStep: 1 });
+      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
       const completion = continueCheckoutSuccess({
         targetRoute: '/checkout/address',
         basketValidation,
@@ -320,7 +321,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map to action of type CreateOrder if targetStep is 5 (order creation)', () => {
-      const action = continueCheckout({ targetStep: 5 });
+      const action = continueCheckout({ targetStep: CheckoutStepType.receipt });
       const completion1 = continueCheckoutSuccess({ targetRoute: undefined, basketValidation });
       const completion2 = createOrder();
       actions$ = hot('-a----a----a', { a: action });
@@ -336,7 +337,7 @@ describe('Basket Validation Effects', () => {
         })
       );
 
-      const action = continueCheckout({ targetStep: 5 });
+      const action = continueCheckout({ targetStep: CheckoutStepType.receipt });
       const completion1 = continueCheckoutSuccess({ targetRoute: undefined, basketValidation });
       const completion2 = submitBasket();
       actions$ = hot('-a----a----a', { a: action });
@@ -350,7 +351,7 @@ describe('Basket Validation Effects', () => {
         throwError(() => makeHttpError({ message: 'invalid' }))
       );
 
-      const action = continueCheckout({ targetStep: 1 });
+      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
       const completion = continueCheckoutFail({ error: makeHttpError({ message: 'invalid' }) });
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-c', { c: completion });
@@ -392,7 +393,7 @@ describe('Basket Validation Effects', () => {
     }));
 
     it('should map to action of type ContinueCheckoutWithIssues if basket is not valid', () => {
-      const action = continueCheckout({ targetStep: 1 });
+      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
       basketValidation.results.valid = false;
       const completion = continueCheckoutWithIssues({
         targetRoute: '/checkout/address',

--- a/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
@@ -98,7 +98,7 @@ describe('Basket Validation Effects', () => {
 
       const action = startCheckout();
       const completion = continueCheckout({
-        targetStep: CheckoutStepType.addresses,
+        targetStep: CheckoutStepType.Addresses,
       });
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-c', { c: completion });
@@ -299,7 +299,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should call the basketService for validateBasketAndContinueCheckout', done => {
-      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
+      const action = continueCheckout({ targetStep: CheckoutStepType.Addresses });
       actions$ = of(action);
 
       effects.validateBasketAndContinueCheckout$.subscribe(() => {
@@ -309,7 +309,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map to action of type ContinueCheckoutSuccess if targetStep is not 5 (order creation)', () => {
-      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
+      const action = continueCheckout({ targetStep: CheckoutStepType.Addresses });
       const completion = continueCheckoutSuccess({
         targetRoute: '/checkout/address',
         basketValidation,
@@ -321,7 +321,7 @@ describe('Basket Validation Effects', () => {
     });
 
     it('should map to action of type CreateOrder if targetStep is 5 (order creation)', () => {
-      const action = continueCheckout({ targetStep: CheckoutStepType.receipt });
+      const action = continueCheckout({ targetStep: CheckoutStepType.Receipt });
       const completion1 = continueCheckoutSuccess({ targetRoute: undefined, basketValidation });
       const completion2 = createOrder();
       actions$ = hot('-a----a----a', { a: action });
@@ -337,7 +337,7 @@ describe('Basket Validation Effects', () => {
         })
       );
 
-      const action = continueCheckout({ targetStep: CheckoutStepType.receipt });
+      const action = continueCheckout({ targetStep: CheckoutStepType.Receipt });
       const completion1 = continueCheckoutSuccess({ targetRoute: undefined, basketValidation });
       const completion2 = submitBasket();
       actions$ = hot('-a----a----a', { a: action });
@@ -351,7 +351,7 @@ describe('Basket Validation Effects', () => {
         throwError(() => makeHttpError({ message: 'invalid' }))
       );
 
-      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
+      const action = continueCheckout({ targetStep: CheckoutStepType.Addresses });
       const completion = continueCheckoutFail({ error: makeHttpError({ message: 'invalid' }) });
       actions$ = hot('-a', { a: action });
       const expected$ = cold('-c', { c: completion });
@@ -393,7 +393,7 @@ describe('Basket Validation Effects', () => {
     }));
 
     it('should map to action of type ContinueCheckoutWithIssues if basket is not valid', () => {
-      const action = continueCheckout({ targetStep: CheckoutStepType.addresses });
+      const action = continueCheckout({ targetStep: CheckoutStepType.Addresses });
       basketValidation.results.valid = false;
       const completion = continueCheckoutWithIssues({
         targetRoute: '/checkout/address',

--- a/src/app/core/store/customer/basket/basket-validation.effects.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.ts
@@ -11,6 +11,7 @@ import {
   BasketValidationResultType,
   BasketValidationScopeType,
 } from 'ish-core/models/basket-validation/basket-validation.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { getServerConfigParameter } from 'ish-core/store/core/server-config';
 import { createOrder } from 'ish-core/store/customer/orders';
@@ -58,7 +59,7 @@ export class BasketValidationEffects {
       ofType(startCheckout),
       withLatestFrom(this.store.pipe(select(getServerConfigParameter<boolean>('basket.acceleration')))),
       filter(([, acc]) => !acc),
-      map(() => continueCheckout({ targetStep: 1 }))
+      map(() => continueCheckout({ targetStep: CheckoutStepType.addresses }))
     )
   );
 
@@ -140,7 +141,7 @@ export class BasketValidationEffects {
           withLatestFrom(this.store.pipe(select(getCurrentBasket))),
           concatMap(([basketValidation, basket]) =>
             basketValidation.results.valid
-              ? targetStep === 5 && !basketValidation.results.adjusted
+              ? targetStep === CheckoutStepType.receipt && !basketValidation.results.adjusted
                 ? basket.approval?.approvalRequired
                   ? [continueCheckoutSuccess({ targetRoute: undefined, basketValidation }), submitBasket()]
                   : [continueCheckoutSuccess({ targetRoute: undefined, basketValidation }), createOrder()]

--- a/src/app/core/store/customer/basket/basket-validation.effects.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.ts
@@ -44,7 +44,7 @@ export class BasketValidationEffects {
 
   // validation step for each checkout step type
   private validationSteps: { [targetStep: string | number]: { scopes: BasketValidationScopeType[]; route: string } } = {
-    [CheckoutStepType.Checkout]: { scopes: ['Products', 'Promotion', 'Value', 'CostCenter'], route: '/basket' },
+    [CheckoutStepType.BeforeCheckout]: { scopes: ['Products', 'Promotion', 'Value', 'CostCenter'], route: '/basket' },
     [CheckoutStepType.Addresses]: {
       scopes: ['InvoiceAddress', 'ShippingAddress', 'Addresses'],
       route: '/checkout/address',
@@ -76,7 +76,7 @@ export class BasketValidationEffects {
       withLatestFrom(this.store.pipe(select(getServerConfigParameter<boolean>('basket.acceleration')))),
       filter(([, acc]) => acc),
       concatMap(() =>
-        this.basketService.validateBasket(this.validationSteps[CheckoutStepType.Checkout].scopes).pipe(
+        this.basketService.validateBasket(this.validationSteps[CheckoutStepType.BeforeCheckout].scopes).pipe(
           map(basketValidation => startCheckoutSuccess({ basketValidation })),
           mapErrorToAction(startCheckoutFail)
         )

--- a/src/app/core/store/customer/basket/basket-validation.effects.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.ts
@@ -59,7 +59,7 @@ export class BasketValidationEffects {
       ofType(startCheckout),
       withLatestFrom(this.store.pipe(select(getServerConfigParameter<boolean>('basket.acceleration')))),
       filter(([, acc]) => !acc),
-      map(() => continueCheckout({ targetStep: CheckoutStepType.addresses }))
+      map(() => continueCheckout({ targetStep: CheckoutStepType.Addresses }))
     )
   );
 
@@ -141,7 +141,7 @@ export class BasketValidationEffects {
           withLatestFrom(this.store.pipe(select(getCurrentBasket))),
           concatMap(([basketValidation, basket]) =>
             basketValidation.results.valid
-              ? targetStep === CheckoutStepType.receipt && !basketValidation.results.adjusted
+              ? targetStep === CheckoutStepType.Receipt && !basketValidation.results.adjusted
                 ? basket.approval?.approvalRequired
                   ? [continueCheckoutSuccess({ targetRoute: undefined, basketValidation }), submitBasket()]
                   : [continueCheckoutSuccess({ targetRoute: undefined, basketValidation }), createOrder()]

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -6,6 +6,7 @@ import { Attribute } from 'ish-core/models/attribute/attribute.model';
 import { BasketInfo } from 'ish-core/models/basket-info/basket-info.model';
 import { BasketValidation, BasketValidationScopeType } from 'ish-core/models/basket-validation/basket-validation.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { ErrorFeedback } from 'ish-core/models/http-error/http-error.model';
 import { LineItemUpdate } from 'ish-core/models/line-item-update/line-item-update.model';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
@@ -110,7 +111,7 @@ export const startCheckoutFail = createAction('[Basket API] Start the checkout p
 
 export const continueCheckout = createAction(
   '[Basket] Validate Basket and continue checkout',
-  payload<{ targetStep: number }>()
+  payload<{ targetStep: CheckoutStepType }>()
 );
 
 export const continueCheckoutFail = createAction(

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -18,6 +18,7 @@ import {
 
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { Basket } from 'ish-core/models/basket/basket.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { BasketService } from 'ish-core/services/basket/basket.service';
 import { getCurrentCurrency } from 'ish-core/store/core/configuration';
 import { mapToRouterState } from 'ish-core/store/core/router';
@@ -373,7 +374,7 @@ export class BasketEffects {
             ? this.basketService.updateBasketItemsDesiredDeliveryDate(desiredDeliveryDate, basket.lineItems)
             : of([])
         ).pipe(
-          map(() => continueCheckout({ targetStep: 5 })),
+          map(() => continueCheckout({ targetStep: CheckoutStepType.Receipt })),
           mapErrorToAction(setBasketDesiredDeliveryDateFail)
         );
       })

--- a/src/app/pages/checkout-address/checkout-address-page.component.ts
+++ b/src/app/pages/checkout-address/checkout-address-page.component.ts
@@ -6,6 +6,7 @@ import { filter, first, map, take, takeUntil } from 'rxjs/operators';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { BasketView } from 'ish-core/models/basket/basket.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
 import { whenTruthy } from 'ish-core/utils/operators';
@@ -69,7 +70,7 @@ export class CheckoutAddressPageComponent implements OnInit, OnDestroy {
    */
   nextStep() {
     this.nextStepRequested = true;
-    this.checkoutFacade.continue(2);
+    this.checkoutFacade.continue(CheckoutStepType.shipping);
   }
 
   ngOnDestroy() {

--- a/src/app/pages/checkout-address/checkout-address-page.component.ts
+++ b/src/app/pages/checkout-address/checkout-address-page.component.ts
@@ -70,7 +70,7 @@ export class CheckoutAddressPageComponent implements OnInit, OnDestroy {
    */
   nextStep() {
     this.nextStepRequested = true;
-    this.checkoutFacade.continue(CheckoutStepType.shipping);
+    this.checkoutFacade.continue(CheckoutStepType.Shipping);
   }
 
   ngOnDestroy() {

--- a/src/app/pages/checkout-payment/checkout-payment-page.component.ts
+++ b/src/app/pages/checkout-payment/checkout-payment-page.component.ts
@@ -69,7 +69,7 @@ export class CheckoutPaymentPageComponent implements OnInit, OnDestroy {
    * Validates the basket and jumps to the next checkout step (Review)
    */
   nextStep() {
-    this.checkoutFacade.continue(CheckoutStepType.review);
+    this.checkoutFacade.continue(CheckoutStepType.Review);
   }
 
   ngOnDestroy() {

--- a/src/app/pages/checkout-payment/checkout-payment-page.component.ts
+++ b/src/app/pages/checkout-payment/checkout-payment-page.component.ts
@@ -4,6 +4,7 @@ import { filter, first, map, shareReplay, takeUntil, withLatestFrom } from 'rxjs
 
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { BasketView } from 'ish-core/models/basket/basket.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
 import { PaymentMethod } from 'ish-core/models/payment-method/payment-method.model';
@@ -68,7 +69,7 @@ export class CheckoutPaymentPageComponent implements OnInit, OnDestroy {
    * Validates the basket and jumps to the next checkout step (Review)
    */
   nextStep() {
-    this.checkoutFacade.continue(4);
+    this.checkoutFacade.continue(CheckoutStepType.review);
   }
 
   ngOnDestroy() {

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.ts
@@ -51,7 +51,7 @@ export class CheckoutShippingPageComponent implements OnInit, OnDestroy {
         this.nextDisabled = !basket || !shippingMethods || !shippingMethods.length || !basket.commonShippingMethod;
         this.cd.markForCheck();
         if (!this.nextDisabled) {
-          this.checkoutFacade.continue(CheckoutStepType.payment);
+          this.checkoutFacade.continue(CheckoutStepType.Payment);
         }
       });
   }

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.ts
@@ -5,6 +5,7 @@ import { shareReplay, take, takeUntil } from 'rxjs/operators';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { BasketView } from 'ish-core/models/basket/basket.model';
+import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { ShippingMethod } from 'ish-core/models/shipping-method/shipping-method.model';
 
@@ -50,7 +51,7 @@ export class CheckoutShippingPageComponent implements OnInit, OnDestroy {
         this.nextDisabled = !basket || !shippingMethods || !shippingMethods.length || !basket.commonShippingMethod;
         this.cd.markForCheck();
         if (!this.nextDisabled) {
-          this.checkoutFacade.continue(3);
+          this.checkoutFacade.continue(CheckoutStepType.payment);
         }
       });
   }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The checkout target step is set with a number. It is not really readable and understandable.

Issue Number: Closes #

## What Is the New Behavior?

The enum 'CheckoutStepType' is implemented, which represents the available, ordered checkout steps. It should improve the understanding of the code.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#81268](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81268)