### PR TITLE
fix: prevent budget bar arrow and product label ribbons to be shown in the subcategories layer

### DIFF
--- a/projects/requisition-management/src/app/pages/requisition-detail/budget-bar/budget-bar.component.scss
+++ b/projects/requisition-management/src/app/pages/requisition-detail/budget-bar/budget-bar.component.scss
@@ -34,7 +34,7 @@
 
   .overflow-indicator {
     position: absolute;
-    z-index: 2;
+    z-index: 1;
     height: 30px;
     margin-top: -7px;
 

--- a/src/styles/pages/category/product-list.scss
+++ b/src/styles/pages/category/product-list.scss
@@ -210,7 +210,7 @@
   position: absolute;
   top: 90px;
   left: -6px;
-  z-index: 10;
+  z-index: 1;
   width: auto;
   height: auto;
   padding: 0 20px;


### PR DESCRIPTION
## PR Type

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Two absolute positioned elements are shown in the subcategories layer when a user hovers over a catalog in the header: 
* my account: budget bar indicator
* product list and product detail page: product label ribbons

Budget bar indicator:
<img width="852" alt="budget-bar" src="https://user-images.githubusercontent.com/20685071/203333741-97e176cc-e620-44d8-bd34-f300715c44e3.png">

Budget bar indicator when hovering the catalog:
<img width="871" alt="budget-bar_overlay" src="https://user-images.githubusercontent.com/20685071/203334064-2f87b603-6678-4747-8576-4d757bf7ca6c.png">

Product list product label ribbon:
<img width="861" alt="plp_ribbon" src="https://user-images.githubusercontent.com/20685071/203334132-c42355f2-86b4-4074-9e47-fd4febde5084.png">

Product list product label ribbon when hovering the catalog:
<img width="864" alt="plp_ribbon_overlay" src="https://user-images.githubusercontent.com/20685071/203334189-1642313c-9abe-4a12-9e7f-fde88ae1e3f7.png">

Product detail page product label ribbon:
<img width="864" alt="pdp_ribbon" src="https://user-images.githubusercontent.com/20685071/203334320-da27fd01-c0e1-4f4f-b2cc-f21839e50afb.png">

Product detail page product label ribbon when hovering the catalog:
<img width="863" alt="pdp_ribbon_overlay" src="https://user-images.githubusercontent.com/20685071/203334399-ef537977-d6d7-461d-af7f-43e4a846df8b.png">

Issue Number: Closes #
Related issue: #762 

## What Is the New Behavior?
The budget bar indicator and the product label ribbon should not be shown in the subcategories layer.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#81281](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81281)