### PR TITLE
fix: error when submitting consecutive search after submitting search from search suggestion

### DIFF
--- a/src/app/shared/components/search/search-box/search-box.component.ts
+++ b/src/app/shared/components/search/search-box/search-box.component.ts
@@ -87,6 +87,7 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
       // something was selected via keyboard
       this.searchResults$.pipe(take(1), takeUntil(this.destroy$)).subscribe(results => {
         this.router.navigate(['/search', results[this.activeIndex].term]);
+        this.activeIndex = -1;
       });
     } else {
       this.router.navigate(['/search', suggestedTerm]);


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When searching for products with search suggest consecutive searches that have no suggests result in errors or if ther eare suggest the result might not be as expected.

## Steps to repeat

* go to the homepage of your PWA (e.g. https://intershoppwa.azurewebsites.net/)
* enter a search term that provides search suggestions (e.g. acer)
* select an entry of the suggested list (e.g. Acer C110)
![image](https://user-images.githubusercontent.com/50741106/204749000-b5313e50-d462-4d06-b9e9-7226e4966791.png)
* after submitting remove the search term from the search box and enter a different one without selecting (e.g. asus)
![image](https://user-images.githubusercontent.com/50741106/204749137-80f3764c-d768-4e72-b021-7fb3657391a1.png)
* one can see that the suggested term with the previously selected index is already selected
* pressing enter after entering the search term would trigger a search for the "selected" suggestion and not for the entered search term (probably not the expected behavior since the selection was not intentionally done)
* remove the search term again and enter a search term that will not return any suggestions (e.g. something)
* press enter to submit the search
  * no search is triggered
  * an error is logged in the console _"TypeError: se[this.activeIndex] is undefined"_
![image](https://user-images.githubusercontent.com/50741106/204749757-d2b607d1-e80f-48f5-9ac2-fb0846e2d6b5.png)

## What Is the New Behavior?

The search suggest selection index is reset after each use so that the search behaves as expected.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#81489](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81489)