### PR TITLE
fix: reset product quantity input field when switching products

### DIFF
--- a/e2e/cypress/e2e/pages/account/order-templates-details.page.ts
+++ b/e2e/cypress/e2e/pages/account/order-templates-details.page.ts
@@ -50,11 +50,15 @@ export class OrderTemplatesDetailsPage {
     cy.get('[data-testing-id="order-template-success-link"] a').click();
   }
 
-  addOrderTemplateToBasket(productId?: string, quantity?: number) {
+  updateQuantity(productId?: string, quantity?: number) {
     if (productId && quantity) {
       this.getOrderTemplateItemById(productId).find('[data-testing-id="quantity"]').clear().type(quantity.toString());
+      cy.wait(800);
     }
+  }
 
+  addOrderTemplateToBasket() {
+    cy.wait(5000);
     return performAddToCart(() => this.getOrderTemplateCartButton().find('[data-testing-id="addToCartButton"]'));
   }
 }

--- a/e2e/cypress/e2e/pages/quickorder/quickorder.page.ts
+++ b/e2e/cypress/e2e/pages/quickorder/quickorder.page.ts
@@ -10,6 +10,7 @@ export class QuickorderPage {
 
   fillFormLine(idx: number, sku: string, quantity?: number) {
     fillFormField(`[data-testing-id="quickorder-line-${idx}"]`, 'sku', sku);
+    cy.wait(800);
     if (quantity !== undefined) {
       fillFormField(`[data-testing-id="quickorder-line-${idx}"]`, 'quantity', quantity);
       return this;

--- a/e2e/cypress/e2e/specs/extras/order-templates-shopping.b2b.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/extras/order-templates-shopping.b2b.e2e-spec.ts
@@ -67,9 +67,17 @@ describe('Order Template Shopping Experience Functionality', () => {
     at(OrderTemplatesDetailsPage, page => page.getOrderTemplateItemById(_.product2).should('exist'));
   });
 
+  it('user changes the desired quantity of an item', () => {
+    at(OrderTemplatesDetailsPage, page => {
+      page.updateQuantity(_.product1, 4);
+      waitLoadingEnd();
+      page.getOrderTemplateItemById(_.product1).find('[data-testing-id="quantity"]').should('have.value', '4');
+    });
+  });
+
   it('user adds an order template from order template detail page to cart', () => {
     at(OrderTemplatesDetailsPage, page => {
-      page.addOrderTemplateToBasket(_.product1, 4);
+      page.addOrderTemplateToBasket();
       waitLoadingEnd();
       page.header.miniCart.goToCart();
     });

--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -242,11 +242,18 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
 
     this.connect(
       'hasQuantityError',
-      this.select('children').pipe(
-        map(children => Object.values(children)),
-        skipWhile(children => !children?.length),
-        map(children => !children.length || children.some(child => child.hasQuantityError)),
-        distinctUntilChanged()
+      this.select('sku').pipe(
+        whenTruthy(),
+        distinctUntilChanged(),
+        switchMap(() =>
+          this.select('children').pipe(
+            map(children => Object.values(children)),
+            debounceTime(300),
+            skipWhile(children => !children?.length),
+            map(children => !children.length || children.some(child => child.hasQuantityError)),
+            distinctUntilChanged()
+          )
+        )
       )
     );
 
@@ -272,20 +279,27 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
 
     this.connect(
       'quantity',
-      this.select('children').pipe(
-        map(children => Object.values(children)),
-        skipWhile(children => !children?.length),
-        map(children =>
-          children.reduce(
-            (sum, child) =>
-              sum +
-              (Number.isInteger(child.quantity) && !child.hasQuantityError && !child.hasProductError
-                ? child.quantity
-                : 0),
-            0
+      this.select('sku').pipe(
+        whenTruthy(),
+        distinctUntilChanged(),
+        switchMap(() =>
+          this.select('children').pipe(
+            map(children => Object.values(children)),
+            debounceTime(300),
+            skipWhile(children => !children?.length),
+            map(children =>
+              children.reduce(
+                (sum, child) =>
+                  sum +
+                  (Number.isInteger(child.quantity) && !child.hasQuantityError && !child.hasProductError
+                    ? child.quantity
+                    : 0),
+                0
+              )
+            ),
+            distinctUntilChanged()
           )
-        ),
-        distinctUntilChanged()
+        )
       )
     );
 
@@ -299,11 +313,18 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
 
     this.connect(
       'hasProductError',
-      this.select('children').pipe(
-        map(children => Object.values(children)),
-        skipWhile(children => !children?.length),
-        map(children => !children.length || children.some(child => child.hasProductError)),
-        distinctUntilChanged()
+      this.select('sku').pipe(
+        whenTruthy(),
+        distinctUntilChanged(),
+        switchMap(() =>
+          this.select('children').pipe(
+            map(children => Object.values(children)),
+            debounceTime(300),
+            skipWhile(children => !children?.length),
+            map(children => !children.length || children.some(child => child.hasProductError)),
+            distinctUntilChanged()
+          )
+        )
       )
     );
 

--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -6,6 +6,7 @@ import { BehaviorSubject, Observable, combineLatest, race } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
+  distinctUntilKeyChanged,
   filter,
   first,
   map,
@@ -257,6 +258,16 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
         first()
       ),
       (state, minOrderQuantity) => (state.quantity ??= minOrderQuantity)
+    );
+
+    this.connect(
+      'quantity',
+      this.select('product').pipe(
+        whenTruthy(),
+        distinctUntilKeyChanged('sku'),
+        map(p => p.minOrderQuantity),
+        skip(1)
+      )
     );
 
     this.connect(

--- a/src/app/extensions/order-templates/store/order-template/order-template.actions.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.actions.ts
@@ -50,7 +50,7 @@ export const deleteOrderTemplateSuccess = createAction(
 export const deleteOrderTemplateFail = createAction('[Order Templates API] Delete Order Template Fail', httpError());
 
 export const addProductToOrderTemplate = createAction(
-  '[Order Templates] Add Item to Order Template',
+  '[Order Templates] Add Product to Order Template',
   payload<{ orderTemplateId: string; sku: string; quantity?: number }>()
 );
 

--- a/src/app/extensions/order-templates/store/order-template/order-template.reducer.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.reducer.ts
@@ -2,7 +2,7 @@ import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { setErrorOn, setLoadingOn, unsetLoadingOn } from 'ish-core/utils/ngrx-creators';
+import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
 
 import { OrderTemplate } from '../../models/order-template/order-template.model';
 
@@ -10,6 +10,8 @@ import {
   addBasketToNewOrderTemplate,
   addBasketToNewOrderTemplateFail,
   addBasketToNewOrderTemplateSuccess,
+  addProductToOrderTemplate,
+  addProductToOrderTemplateFail,
   addProductToOrderTemplateSuccess,
   createOrderTemplate,
   createOrderTemplateFail,
@@ -50,9 +52,10 @@ export const orderTemplateReducer = createReducer(
     createOrderTemplate,
     addBasketToNewOrderTemplate,
     deleteOrderTemplate,
-    updateOrderTemplate
+    updateOrderTemplate,
+    addProductToOrderTemplate
   ),
-  unsetLoadingOn(
+  unsetLoadingAndErrorOn(
     loadOrderTemplatesSuccess,
     addBasketToNewOrderTemplateSuccess,
     createOrderTemplateSuccess,
@@ -66,7 +69,8 @@ export const orderTemplateReducer = createReducer(
     deleteOrderTemplateFail,
     createOrderTemplateFail,
     addBasketToNewOrderTemplateFail,
-    updateOrderTemplateFail
+    updateOrderTemplateFail,
+    addProductToOrderTemplateFail
   ),
   on(
     loadOrderTemplatesFail,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Bug 1:  If the user enters a product quantity at product detail page but doesn't commit the changes and switches directly to a different product e.g. to a product of the recently viewed product the quantity input field is not reset to the product min order quantity.

Bug 2: If the user enters a retail set at product detail page and switches directly to a different single product, then quantity is set to 0 and product and quantity errors occur.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1330

## What Is the New Behavior?
Product informations, which are related to the product quantity (e.g. quantity error), are reset if the user switches the product on product detail page.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#81785](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81785)