### PR TITLE
feat: provide and combine metrics of theme instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cd dist && npm install
 ARG displayVersion=
 LABEL displayVersion="${displayVersion}"
 ENV DISPLAY_VERSION=${displayVersion} NODE_PATH=/dist/node_modules PATH=$PATH:/dist/node_modules/.bin
-EXPOSE 4200
+EXPOSE 4200 9113
 RUN mkdir /.pm2 && chmod 777 -Rf /.pm2 && touch /dist/ecosystem.yml && chmod 777 -f /dist/ecosystem.yml
 USER nobody
 HEALTHCHECK --interval=60s --timeout=20s --start-period=2s CMD node /dist/healthcheck.js

--- a/server.ts
+++ b/server.ts
@@ -18,7 +18,26 @@ import { ngExpressEngine } from '@nguniversal/express-engine';
 import { getDeployURLFromEnv, setDeployUrlInFile } from './src/ssr/deploy-url';
 
 const client = require('prom-client');
+
 const collectDefaultMetrics = client.collectDefaultMetrics;
+
+const defaultLabels =
+  process.env.pm_id && process.env.name ? { theme: process.env.name, pm2_id: process.env.pm_id } : undefined;
+
+client.register.setDefaultLabels(defaultLabels);
+
+const requestCounts = new client.Gauge({
+  name: 'pwa_http_request_counts',
+  help: 'counter for requests labeled with: method, status_code, theme, base_href, path',
+  labelNames: ['method', 'status_code', 'base_href', 'path'],
+});
+
+const requestDuration = new client.Histogram({
+  name: 'pwa_http_request_duration_seconds',
+  help: 'duration histogram of http responses labeled with: status_code, theme',
+  buckets: [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30],
+  labelNames: ['status_code', 'base_href', 'path'],
+});
 
 const PM2 = process.env.pm_id && process.env.name ? `${process.env.pm_id} ${process.env.name}` : undefined;
 
@@ -416,34 +435,19 @@ export function app() {
   };
 
   if (/^(on|1|true|yes)$/i.test(process.env.PROMETHEUS)) {
-    const axios = require('axios');
     const onFinished = require('on-finished');
 
     server.use((req, res, next) => {
       const start = Date.now();
       onFinished(res, () => {
         const duration = Date.now() - start;
-        axios
-          .post('http://localhost:9113/report', {
-            theme: THEME,
-            method: req.method,
-            status: res.statusCode,
-            duration,
-            url: req.originalUrl,
-          })
-          .then((reportRes: { status: number; statusText: string; data: unknown }) => {
-            if (reportRes.status !== 204) {
-              console.error(
-                'ERROR unexpected return from Prometheus:',
-                reportRes.status,
-                reportRes.statusText,
-                reportRes.data
-              );
-            }
-          })
-          .catch((error: Error) => {
-            console.error('ERROR reporting to Prometheus:', error.message);
-          });
+        const matched = /;baseHref=([^;?]*)/.exec(req.originalUrl);
+        const base_href = matched?.[1] ? `${decodeURIComponent(decodeURIComponent(matched[1]))}/` : '/';
+        const cleanUrl = req.originalUrl.replace(/[;?].*/g, '');
+        const path = cleanUrl.replace(base_href, '');
+
+        requestCounts.inc({ method: req.method, status_code: res.statusCode, base_href, path });
+        requestDuration.labels({ status_code: res.statusCode, base_href, path }).observe(duration / 1000);
       });
       next();
     });
@@ -477,11 +481,7 @@ if (/^(on|1|true|yes)$/i.test(process.env.PROMETHEUS)) {
 function run() {
   const http = require('http');
   http.createServer(app()).listen(PORT);
-  if (process.env.pm_id && process.env.name) {
-    collectDefaultMetrics({ prefix: 'pwa_', labels: { theme: process.env.name, id: process.env.pm_id } });
-  } else {
-    collectDefaultMetrics({ prefix: 'pwa_' });
-  }
+  collectDefaultMetrics({ prefix: 'pwa_' });
   console.log(`Node Express server listening on http://${require('os').hostname()}:${PORT}`);
   console.log('serving static files from', BROWSER_FOLDER);
 }

--- a/server.ts
+++ b/server.ts
@@ -16,8 +16,7 @@ import {
 } from './src/main.server';
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import { getDeployURLFromEnv, setDeployUrlInFile } from './src/ssr/deploy-url';
-
-const client = require('prom-client');
+import * as client from 'prom-client';
 
 const collectDefaultMetrics = client.collectDefaultMetrics;
 
@@ -462,10 +461,10 @@ export function app() {
 }
 
 if (/^(on|1|true|yes)$/i.test(process.env.PROMETHEUS)) {
-  type MetricsMessage = { topic: string; data: any };
+  type MetricsMessage = { topic: string };
   process.on('message', (msg: MetricsMessage) => {
     if (msg.topic === 'getMetrics') {
-      client.register.getMetricsAsJSON().then((data: any) => {
+      client.register.getMetricsAsJSON().then((data: client.metric[]) => {
         process.send({
           type: 'process:msg',
           data: {

--- a/src/ssr/server-scripts/prometheus.js
+++ b/src/ssr/server-scripts/prometheus.js
@@ -68,10 +68,7 @@ app.get('/metrics', (_, res) => {
                 {
                   id: processData.pm_id,
                   type: 'process:msg',
-                  data: {
-                    theme: processData.name,
-                    instance: processData.pm_id,
-                  },
+                  data: {},
                   topic: 'getMetrics',
                 },
                 err => {
@@ -116,7 +113,7 @@ app.listen(9113, () => {
 // Listen to messages from theme applications
 pm2.launchBus((err, pm2_bus) => {
   pm2_bus.on('process:msg', msg => {
-    if (msg?.data?.topic == 'returnMetrics' && msg.process.name && msg.process.pm_id) {
+    if (msg?.data?.topic === 'returnMetrics' && msg.process.name && msg.process.pm_id) {
       const worker = `${msg.process.name} ${msg.process.pm_id}`;
       metricsPerWorker[worker] = msg.data.body;
     }


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When switching `PROMETHEUS=on` one metrics endpoint for SSR is exposed. That endpoint merely provides insights into PM2 "orchestrator" but [default metrics](https://github.com/siimon/prom-client#default-metrics) of Node.js processes are missing.

## What Is the New Behavior?
Provide above mentioned default metrics of Node.js + the possibility to include custom metrics on aggregated metrics registries.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[ x ] No

## Other Information


[AB#81853](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81853)