### PR TITLE
fix: prevent outdated informations on /basket route

### DIFF
--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -627,6 +627,34 @@ describe('Basket Effects', () => {
     });
   });
 
+  describe('loadBasketOnBasketPage$', () => {
+    it('should fire LoadBasket when route basket is navigated', () => {
+      router.navigateByUrl('/basket');
+
+      const action = routerTestNavigatedAction({
+        routerState: { url: '/basket' },
+      });
+      actions$ = of(action);
+
+      const completion = loadBasket();
+      actions$ = hot('-a', { a: action });
+      const expected$ = cold('-c', { c: completion });
+
+      expect(effects.loadBasketOnBasketPage$).toBeObservable(expected$);
+    });
+
+    it('should not fire LoadBasket when route /something is navigated', () => {
+      router.navigateByUrl('/something');
+
+      actions$ = of(
+        routerTestNavigatedAction({
+          routerState: { url: '/something' },
+        })
+      );
+      expect(effects.loadBasketOnBasketPage$).toBeObservable(cold('|'));
+    });
+  });
+
   describe('createRequisition$', () => {
     beforeEach(() => {
       store.dispatch(loadBasketSuccess({ basket: { id: 'BID' } as Basket }));

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -340,6 +340,18 @@ export class BasketEffects {
   );
 
   /**
+   * Trigger LoadBasket action after the user navigated to a basket route
+   */
+  loadBasketOnBasketPage$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      mapToRouterState(),
+      filter(routerState => /^\/basket/.test(routerState.url)),
+      map(() => loadBasket())
+    )
+  );
+
+  /**
    * Creates a requisition based on the given basket, if approval is required
    */
   createRequisition$ = createEffect(() =>


### PR DESCRIPTION


<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The basket will not be loaded again, when the user navigates to the /basket route. There is a possibility, that the rendered basket informations on the basket page are outdated. The basket could be updated in an another tab.

Issue Number: Closes #

## What Is the New Behavior?

When the user has navigated to the /basket route, then the basket will be loaded from the server. 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#81895](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81895)