### PR TITLE
fix: avoid cypress global types pollution in jest tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,6 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "exclude": ["e2e/**"]
 }


### PR DESCRIPTION
## PR Type

[x] Other: fix for test development environment

## What Is the Current Behavior?

Since the update of cypress v10 new global types were introduced. This causes to problems for all jest tests, because the wrong `Assertion` type from cypress is used.

## What Is the New Behavior?

All files within the e2e folder will be excluded by default within the `tsconfig.json` configuration.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#81914](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81914)