### PR TITLE
fix: handle google recaptcha v3 expiration

### DIFF
--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
@@ -2,8 +2,8 @@ import { ChangeDetectionStrategy, Component, Input, NgModule, OnDestroy, OnInit 
 import { FormGroup, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { RECAPTCHA_V3_SITE_KEY, ReCaptchaV3Service, RecaptchaV3Module } from 'ng-recaptcha';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Subject, interval } from 'rxjs';
+import { startWith, switchMap, takeUntil } from 'rxjs/operators';
 
 import { DirectivesModule } from 'ish-core/directives.module';
 
@@ -32,9 +32,12 @@ export class CaptchaV3Component implements OnInit, OnDestroy {
   ngOnInit() {
     this.parentForm.get('captchaAction').setValidators([Validators.required]);
 
-    this.recaptchaV3Service
-      .execute(this.parentForm.get('captchaAction').value)
-      .pipe(takeUntil(this.destroy$))
+    interval(2 * 60 * 600 - 10)
+      .pipe(
+        startWith(-1),
+        switchMap(() => this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value)),
+        takeUntil(this.destroy$)
+      )
       .subscribe(token => {
         this.parentForm.get('captcha').setValue(token);
         this.parentForm.get('captcha').updateValueAndValidity();


### PR DESCRIPTION
reCAPTCHA tokens expire after two minutes. It is recommended in the documentation to make sure to call execute when the user takes the action rather than on page load. This being difficult to implement with the current structure, an automatic refresh has been set up.

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
