### PR TITLE
fix: make ICM sitemap files available via nginx - 0.27.0 backport

### DIFF
--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -75,6 +75,27 @@ If no environment variables for multi-channel configuration are given, the confi
 
 > :warning: Multi-Channel configuration with context paths does not work in conjunction with [service workers](../concepts/progressive-web-app.md#service-worker)
 
+### Access ICM sitemap
+
+Please refer to [this](https://support.intershop.com/kb/index.php/Display/23D962#ConceptXMLSitemaps-XMLSitemapsandIntershopPWAxml_sitemap_pwa) Intershop knowledge base article on how to configure ICM to generate PWA sitemap files.
+
+```
+http://pwa/sitemap_pwa.xml
+```
+
+To make above sitemap index file available under your deployment you need to add environment variable `ICM_BASE_URL` in your nginx container.
+Let `ICM_BASE_URL` point to your ICM backend installation, e.g. `https://pwa-ish-demo.test.intershop.com`.
+When the container is started it'll process channel template as well as sitemap proxy rules like this:
+
+```yaml
+location /sitemap_ {
+proxy_pass https://pwa-ish-demo.test.intershop.com/INTERSHOP/static/WFS/inSPIRED-inTRONICS-Site/rest/inSPIRED-inTRONICS/en_US/sitemaps/pwa/sitemap_;
+}
+```
+
+The process will utilize your Multi-Channel Configuration (described above)).
+Be sure to include `application` if you deviate from standard `rest` application.
+
 ### Other
 
 The page speed configuration can also be overridden:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
   apt-get clean && \
   rm -r /var/cache/apt /var/lib/apt/lists
 COPY --from=buildstep /usr/local/nginx /usr/local/nginx
-COPY --from=nginx/nginx-prometheus-exporter /usr/bin/exporter /nginx-prometheus-exporter
+COPY --from=nginx/nginx-prometheus-exporter:0.9.0 /usr/bin/nginx-prometheus-exporter /nginx-prometheus-exporter
 COPY --from=configstep / /
 RUN chmod 777 /gomplate
 ENV NPSC_ENABLE_FILTERS=in_place_optimize_for_browser,prioritize_critical_css,inline_preview_images,lazyload_images,rewrite_images,rewrite_css,remove_comments,move_css_to_head,move_css_above_scripts,collapse_whitespace,combine_javascript,extend_cache NPSC_JsPreserveURLs=off NPSC_ImagePreserveURLs=on NPSC_ForceCaching=off CACHE=on COMPRESSION=on PAGESPEED=on DEVICE_DETECTION=on

--- a/nginx/channel.conf.tmpl
+++ b/nginx/channel.conf.tmpl
@@ -1,5 +1,17 @@
 {{ $UPSTREAM_PWA := getenv "UPSTREAM_PWA" }}
 
+{{ define "LOCATION_TEMPLATE_FOR_SITEMAP" }}
+        {{- $icmBaseUrl := getenv "ICM_BASE_URL" }}
+        {{- $baseHref := ""}}{{ if (has . "baseHref")}}{{ $baseHref = .baseHref }}{{end}}
+        {{- $channel := .channel }}
+        {{- $application := "rest" }}{{ if (has . "application") }}{{ $application = .application }}{{ end }}
+        {{- $lang := "en_US" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
+      {{- if $icmBaseUrl }}
+      proxy_pass {{ $icmBaseUrl }}/INTERSHOP/static/WFS/{{ $channel }}/{{ $application }}/{{ $channel | strings.ReplaceAll "-Site" "" }}/{{ $lang }}/sitemaps/pwa/sitemap_;
+      {{- else }}
+      rewrite ^{{ $baseHref }}/sitemap.*$ {{ $baseHref }}/;
+      {{- end -}}
+{{- end }}
 {{ define "LOCATION_TEMPLATE" }}
         {{- $channel := .channel }}
         {{- $application := "default" }}{{ if (has . "application") }}{{ $application = .application }}{{ end }}
@@ -93,10 +105,16 @@ server {
     location / {
         {{- tmpl.Exec "LOCATION_TEMPLATE" $mapping }}
     }
+    location ^~ /sitemap_ {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $mapping }}
+    }
   {{- else -}}
     {{ range $mapping }}
     location {{ .baseHref }} {
         {{- tmpl.Exec "LOCATION_TEMPLATE" . }}
+    }
+    location ^~ {{ .baseHref }}{{if not ( .baseHref | strings.HasSuffix "/")}}/{{end}}sitemap_ {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" . }}
     }
     {{ end }}
     location / {
@@ -104,7 +122,14 @@ server {
         rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" permanent;
         rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri" permanent;
     }
-  {{- end }}
+  {{- if (has ($mapping | jsonpath "$..baseHref") "/") }}
+  {{- else }}
+    {{ $first := index $mapping 0 -}}
+    location ^~ /sitemap_ {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $first }}
+    }
+  {{- end -}}
+{{- end }}
 
     # redirect server error pages to the static page /50x.html
     #

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -5,6 +5,8 @@ set -e
 
 [ -z "$UPSTREAM_PWA" ] && echo "UPSTREAM_PWA is not set" && exit 1
 
+[ -z "$ICM_BASE_URL" ] && echo "ICM_BASE_URL is not set. Cannot use sitemap proxy feature."
+
 [ -f "/etc/nginx/conf.d/default.conf" ] && rm /etc/nginx/conf.d/default.conf
 
 find /etc/nginx/features/*.conf | xargs -I{} echo {} | sed -e "s%.*\/\(\w*\).conf%\1%" | grep -E '^\w+$' | while read feature; do echo "# $feature" ; env | grep -iqE "^$feature=(on|1|true|yes)$" && echo "include /etc/nginx/features/${feature}.conf;" || echo "include /etc/nginx/features/${feature}-off[.]conf;" ; done >/etc/nginx/conf.d/features.conf
@@ -20,6 +22,7 @@ then
 fi
 
 /gomplate -d "domains=$MULTI_CHANNEL_SOURCE" </etc/nginx/conf.d/channel.conf.tmpl >/etc/nginx/conf.d/multi-channel.conf
+
 
 # Generate Pagespeed config based on environment variables
 env | grep NPSC_ | sed -e 's/^NPSC_//g' -e "s/\([A-Z_]*\)=/\L\1=/g" -e "s/_\([a-zA-Z]\)/\u\1/g" -e "s/^\([a-zA-Z]\)/\u\1/g" -e 's/=.*$//' -e 's/\=/ /' -e 's/^/\pagespeed /' > /tmp/pagespeed-prefix.txt


### PR DESCRIPTION
backport of #918 for PWA 0.27.0
(the PR is more a marker/reference for this commit, even though PWA 0.27.0 is not really supported anymore)