### PR TITLE
fix: redirect before checkout (checkout guard) due to a cookie restore timing issue

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpParams, HttpRequest, HttpResponse } from '@angular/common/http';
 import { ApplicationRef, Injectable } from '@angular/core';
-import { Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { CookieOptions } from 'express';
 import { isEqual } from 'lodash-es';
@@ -68,12 +67,7 @@ export class ApiTokenService {
 
   private initialCookie$: Observable<ApiTokenCookie>;
 
-  constructor(
-    private cookiesService: CookiesService,
-    private router: Router,
-    private store: Store,
-    appRef: ApplicationRef
-  ) {
+  constructor(private cookiesService: CookiesService, private store: Store, appRef: ApplicationRef) {
     // setup initial values
     const initialCookie = this.parseCookie();
     this.initialCookie$ = of(!SSR ? initialCookie : undefined);
@@ -212,9 +206,8 @@ export class ApiTokenService {
     if (SSR) {
       return of(true);
     }
-    return this.router.events.pipe(
+    return this.initialCookie$.pipe(
       first(),
-      switchMap(() => this.initialCookie$),
       withLatestFrom(this.apiToken$),
       switchMap(([cookie, apiToken]) => {
         if (!apiToken && fetchAnonymousToken) {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user selects a payment method that requires a redirect before checkout the user is redirected to the cart page instead of the checkout review page after returning back from the payment provider. This problem occurs because the basket is not loaded in time and the checkout guard doesn`t allow to show the review page.
Refreshing the page (F5 in the browser) does also not work.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1355

## What Is the New Behavior?
The redirect to a checkout page is working properly again.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
This issue is related to #1156 


[AB#82632](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/82632)