### PR TITLE
fix: quoting pages should be stable once

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -34,7 +34,7 @@ import {
 import { BasketView } from 'ish-core/models/basket/basket.model';
 import { User } from 'ish-core/models/user/user.model';
 import { ApiService } from 'ish-core/services/api/api.service';
-import { getCurrentBasket, getCurrentBasketId, loadBasket, loadBasketByAPIToken } from 'ish-core/store/customer/basket';
+import { getCurrentBasket, getCurrentBasketId, loadBasketByAPIToken } from 'ish-core/store/customer/basket';
 import { getOrder, getSelectedOrderId, loadOrderByAPIToken } from 'ish-core/store/customer/orders';
 import {
   fetchAnonymousUserToken,
@@ -148,23 +148,6 @@ export class ApiTokenService {
         .subscribe(([type, apiToken]) => {
           this.apiToken$.next(apiToken);
           this.cookieVanishes$.next(type);
-        });
-
-      // session keep alive
-      appRef.isStable
-        .pipe(
-          whenTruthy(),
-          first(),
-          mergeMap(() =>
-            store.pipe(
-              select(getCurrentBasket),
-              switchMap(basket => interval(10 * 60 * 1000).pipe(map(() => !!basket)))
-            )
-          ),
-          whenTruthy()
-        )
-        .subscribe(() => {
-          store.dispatch(loadBasket());
         });
     }
   }

--- a/src/app/extensions/quoting/facades/quote-context.facade.ts
+++ b/src/app/extensions/quoting/facades/quote-context.facade.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { RxState } from '@rx-angular/state';
-import { Observable, timer } from 'rxjs';
+import { Observable } from 'rxjs';
 import { distinctUntilChanged, filter, first, map, sample, switchMap, tap } from 'rxjs/operators';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
@@ -86,13 +86,7 @@ export abstract class QuoteContextFacade
     this.connect('entityAsQuoteRequest', this.select('entity').pipe(map(QuotingHelper.asQuoteRequest)));
     this.connect('entityAsQuote', this.select('entity').pipe(map(QuotingHelper.asQuote)));
 
-    this.connect(
-      'state',
-      timer(0, 2000).pipe(
-        switchMap(() => this.select('entity').pipe(map(QuotingHelper.state))),
-        distinctUntilChanged()
-      )
-    );
+    this.connect('state', this.select('entity').pipe(map(QuotingHelper.state), distinctUntilChanged()));
 
     this.connect('editable', this.select('state').pipe(map(state => state === 'New')));
   }

--- a/src/app/extensions/quoting/facades/quoting.facade.ts
+++ b/src/app/extensions/quoting/facades/quoting.facade.ts
@@ -50,10 +50,7 @@ export class QuotingFacade {
   }
 
   state$(quoteId: string) {
-    return timer(0, 2000).pipe(
-      switchMap(() => this.store.pipe(select(getQuotingEntity(quoteId)))),
-      map(QuotingHelper.state)
-    );
+    return this.store.pipe(select(getQuotingEntity(quoteId)), map(QuotingHelper.state));
   }
 
   name$(quoteId: string) {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

If you load initially a PWA quoting detail page, than the application does not get stable. The reason for it is, that the state$ method from the quoting facade and the state property from the quote-context.facade are using a timer observable to retrieve current quoting informations. This is not necessary, because the underlying quotingEntity selector will always emit new values. Other functionality like the automaticQuoteRefresh is not used.

Issue Number: Closes #

## What Is the New Behavior?

The timer observable is removed from the quoting and the quote context facade.

Furthermore the functionality to keep the session alive by fetching the basket information regularly is removed. This is not necessary, because the current token is refreshed before it will expire.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#82866](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/82866)