### PR TITLE
fix: add basket ship-to-address to product prices call 

### DIFF
--- a/src/app/core/services/prices/prices.service.spec.ts
+++ b/src/app/core/services/prices/prices.service.spec.ts
@@ -3,9 +3,12 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
+import { Address } from 'ish-core/models/address/address.model';
+import { BasketView } from 'ish-core/models/basket/basket.model';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { ProductPriceDetailsData } from 'ish-core/models/product-prices/product-prices.interface';
 import { ApiService, AvailableOptions } from 'ish-core/services/api/api.service';
+import { getCurrentBasket } from 'ish-core/store/customer/basket';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
 import { PricesService } from './prices.service';
@@ -22,6 +25,10 @@ describe('Prices Service', () => {
         provideMockStore({
           selectors: [
             { selector: getLoggedInCustomer, value: { customerNo: 'customer', isBusinessCustomer: true } as Customer },
+            {
+              selector: getCurrentBasket,
+              value: { commonShipToAddress: { urn: 'urn:4711' } as Address } as BasketView,
+            },
           ],
         }),
       ],
@@ -46,7 +53,7 @@ describe('Prices Service', () => {
         verify(apiServiceMock.get(`productprices`, anything())).once();
         expect(
           capture<string, AvailableOptions>(apiServiceMock.get).last()?.[1]?.params?.toString()
-        ).toMatchInlineSnapshot(`"sku=abc&sku=123&customerID=customer"`);
+        ).toMatchInlineSnapshot(`"sku=abc&sku=123&customerID=customer&shipToAddress=urn:4711"`);
         done();
       });
     });

--- a/src/app/core/services/prices/prices.service.ts
+++ b/src/app/core/services/prices/prices.service.ts
@@ -2,12 +2,13 @@ import { HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable, throwError } from 'rxjs';
-import { map, switchMap, take, tap } from 'rxjs/operators';
+import { map, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
 import { ProductPriceDetailsData } from 'ish-core/models/product-prices/product-prices.interface';
 import { ProductPricesMapper } from 'ish-core/models/product-prices/product-prices.mapper';
 import { ProductPriceDetails } from 'ish-core/models/product-prices/product-prices.model';
 import { ApiService } from 'ish-core/services/api/api.service';
+import { getCurrentBasket } from 'ish-core/store/customer/basket';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
 @Injectable({ providedIn: 'root' })
@@ -20,25 +21,33 @@ export class PricesService {
 
   private currentCustomer$ = this.store.pipe(select(getLoggedInCustomer), take(1));
 
+  /**
+   * Gets the prices for an array of products. Prices might be customer specific or depend on the user location (basket ship to address).
+   *
+   * @param           Array of product skus.
+   * @returns         Product Prices.
+   */
   getProductPrices(skus: string[]): Observable<ProductPriceDetails[]> {
     if (!skus || skus.length === 0) {
       return throwError(() => new Error('getProductPrices() called without skus'));
     }
 
-    let params = new HttpParams();
-    skus.map(sku => (params = params.append('sku', sku)));
-
     return this.currentCustomer$.pipe(
-      tap(customer => {
+      withLatestFrom(this.store.pipe(select(getCurrentBasket))),
+      switchMap(([customer, basket]) => {
+        let params = new HttpParams();
+        skus.map(sku => (params = params.append('sku', sku)));
+
         if (customer?.customerNo) {
           params = params.set('customerID', customer.customerNo);
         }
-      }),
-      switchMap(() =>
-        this.apiService
+        if (basket?.commonShipToAddress) {
+          params = params.set('shipToAddress', basket.commonShipToAddress.urn);
+        }
+        return this.apiService
           .get<{ data: ProductPriceDetailsData[] }>(`productprices`, { headers: this.priceHeaders, params })
-          .pipe(map(element => element?.data?.map(prices => ProductPricesMapper.fromData(prices))))
-      )
+          .pipe(map(element => element?.data?.map(prices => ProductPricesMapper.fromData(prices))));
+      })
     );
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The product price call respects the customer's default shipping address for the (gross) price display, but if the user changes his basket ship-to-address to a country that has different taxes the prices shown on the cart page might differ from the prices on the product pages.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The customer's basket ship-to-address is added as a query parameter to the product price REST call to make the result more precise and avoid differences between prices on product pages and cart prices.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#81275](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/81275)

[AB#82962](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/82962)