### PR TITLE
fix: disable add-to-cart button during page loading

### DIFF
--- a/src/app/core/store/customer/user/user.reducer.ts
+++ b/src/app/core/store/customer/user/user.reducer.ts
@@ -28,6 +28,7 @@ import {
   loadUserPaymentMethodsSuccess,
   loginUserFail,
   loginUserSuccess,
+  loginUserWithToken,
   logoutUser,
   logoutUserFail,
   logoutUserSuccess,
@@ -99,6 +100,7 @@ export const userReducer = createReducer(
     deleteUserPaymentInstrument,
     updateUserPasswordByPasswordReminder,
     requestPasswordReminder,
+    loginUserWithToken,
     logoutUser
   ),
   unsetLoadingOn(

--- a/src/app/shared/components/product/product-add-to-basket/product-add-to-basket.component.spec.ts
+++ b/src/app/shared/components/product/product-add-to-basket/product-add-to-basket.component.spec.ts
@@ -5,6 +5,7 @@ import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
+import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
@@ -21,6 +22,9 @@ describe('Product Add To Basket Component', () => {
     const checkoutFacade = mock(CheckoutFacade);
     when(checkoutFacade.basketLoading$).thenReturn(of(false));
 
+    const accountFacade = mock(AccountFacade);
+    when(accountFacade.userLoading$).thenReturn(of(false));
+
     context = mock(ProductContextFacade);
     when(context.select('displayProperties', 'addToBasket')).thenReturn(of(true));
     when(context.select('product')).thenReturn(of({} as ProductView));
@@ -32,6 +36,7 @@ describe('Product Add To Basket Component', () => {
       imports: [TranslateModule.forRoot()],
       declarations: [MockComponent(FaIconComponent), ProductAddToBasketComponent],
       providers: [
+        { provide: AccountFacade, useFactory: () => instance(accountFacade) },
         { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
         { provide: ProductContextFacade, useFactory: () => instance(context) },
       ],


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Precondition: PWA with SSR and nginx

If a logged in user clicks add-to-cart during page loading his current basket might get lost or the add-to-cart might not work properly.


Issue Number: Closes #1360 

## What Is the New Behavior?
The add-to-cart button is disabled during page (application) loading so the user can press it only after he is logged in and his current basket is already loaded.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
