### PR TITLE
fix: oAuth configuration is sometime invalid on SSR mode

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -131,7 +131,7 @@ export class ApiService {
       return of(path);
     }
     return combineLatest([
-      this.store.pipe(select(getRestEndpoint)),
+      this.store.pipe(select(getRestEndpoint), whenTruthy()),
       this.getLocale$(options),
       this.getCurrency$(options),
       of('/'),


### PR DESCRIPTION
When the browser does not have the apiToken cookie and the angular application is in SSR mode, the ApiService#constructUrlForPath function is called before the getRestEndpoint selector is properly initialized.
This leads to an incorrect ICM token retrieval URL

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
![Error](https://user-images.githubusercontent.com/108473857/216943508-3894f35d-bcb0-4c30-aded-4df37ab0d111.png)
