### PR TITLE
feat/schematic to migrate from formly v5 to v6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -182,14 +182,7 @@
         "dot-notation": "off", // disabled in favor of @typescript-eslint/dot-notation
         "eqeqeq": ["error", "always"],
         "etc/no-commented-out-code": "warn",
-        "etc/no-deprecated": [
-          "warn",
-          {
-            "ignored": {
-              "templateOptions|to|FormlyTemplateOptions|expressionProperties": "name" // deprecated formly methods are temporarily ignored
-            }
-          }
-        ],
+        "etc/no-deprecated": ["warn"],
         "id-blacklist": [
           "error",
           "any",

--- a/docs/guides/field-library.md
+++ b/docs/guides/field-library.md
@@ -14,7 +14,7 @@ kb_sync_latest_only
   - [The Field Library](#the-field-library)
     - [Retrieving Configurations](#retrieving-configurations)
     - [Retrieving Configuration Groups](#retrieving-configuration-groups)
-    - [Defining your own Configurations & Configuration Groups](#defining-your-own-configurations--configuration-groups)
+    - [Defining your own Configurations \& Configuration Groups](#defining-your-own-configurations--configuration-groups)
       - [Defining a FieldLibraryConfiguration](#defining-a-fieldlibraryconfiguration)
       - [Defining a FieldLibraryConfigurationGroup](#defining-a-fieldlibraryconfigurationgroup)
   - [Automatic Field Replacement using the '#' Pseudo-type](#automatic-field-replacement-using-the--pseudo-type)
@@ -63,7 +63,7 @@ For example, you can use the standard `firstName` field but change the label lik
 
 ```typescript
 this.fieldLibrary.getConfiguration('firstName', {
-  templateOptions: {
+  props: {
     label: 'New Label',
   },
 });
@@ -90,12 +90,12 @@ For example, the following code snippet will return the `personalInfo` configura
 ```typescript
 this.fieldLibrary.getConfigurationGroup('personalInfo', {
   firstName: {
-    templateOptions: {
+    props: {
       required: false,
     },
   },
   lastName: {
-    templateOptions: {
+    props: {
       label: 'new and improved label',
     },
   },
@@ -160,7 +160,7 @@ For example, defining a new label text works like this:
 ```typescript
 {
   type: '#firstName',
-  templateOptions: {
+  props: {
     label: 'New Label',
   }
 }

--- a/docs/guides/formly.md
+++ b/docs/guides/formly.md
@@ -63,7 +63,7 @@ const fields: FormlyFieldConfig[] = [
   {
     type: 'ish-input-field',
     key: 'example-input',
-    templateOptions: {
+    props: {
       required: true,
       label: 'Input Field Label',
     },
@@ -85,7 +85,6 @@ If you need to - for some reason - completely override the Formly configuration 
 ### Custom Field Types
 
 To define a custom field type, create a component that extends `FieldType`.
-This component will have full access to all information related to the field and form - access the fields `templateOptions` via the `to` attribute.
 Hook up the form element with the `formControl` and `formlyAttributes` inputs.
 An example field type could look like this:
 
@@ -103,7 +102,7 @@ export class ExampleInputFieldComponent extends FieldType {
 
 ```html
 <!--  example-input-field.component.html -->
-<input [type]="to.type" [formControl]="formControl" [formlyAttributes]="field" />
+<input [type]="props.type" [formControl]="formControl" [formlyAttributes]="field" />
 ```
 
 Register the custom type in the `formly.module.ts` `forChild()` function:
@@ -126,7 +125,7 @@ A simple example wrapper that adds a label to the field could look like this:
   selector: 'example-label-wrapper',
   template: `
     <label [attr.for]="id">
-      {{ to.label | translate }}
+      {{ props.label | translate }}
     </label>
     <ng-template #fieldComponent></ng-template>
   `,
@@ -162,9 +161,9 @@ A simple extension that ensures a `label` attribute is always set could look lik
 ```typescript
 export const labelDefaultValueExtension: FormlyExtension = {
   prePopulate(field: FormlyFieldConfig): void {
-    field.templateOptions = {
-      ...field.templateOptions,
-      label: field.templateOptions.label ?? 'Default Label',
+    field.props = {
+      ...field.props,
+      label: field.props.label ?? 'Default Label',
     };
   },
 };
@@ -254,7 +253,7 @@ Refer to the tables below for an overview of these parts.
 
 Template option `inputClass`: These css class(es) will be added to all input/select/textarea/text tags.
 
-| Name                 | Description                                                                                  | Relevant templateOptions                                                                                                                                                                                                                                                          |
+| Name                 | Description                                                                                  | Relevant props                                                                                                                                                                                                                                                                    |
 | -------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ish-text-input-field | Basic input field, supports all text types                                                   | type: 'text' (default),'email','tel','password'                                                                                                                                                                                                                                   |
 | ish-select-field     | Basic select field                                                                           | `options`: `{ value: any; label: string}[]` or Observable. `placeholder`: Translation key or string for the default selection                                                                                                                                                     |
@@ -271,7 +270,7 @@ Template option `inputClass`: These css class(es) will be added to all input/sel
 
 ### Wrappers
 
-| Name                           | Functionality                                                                                                                                                                                                                    | Relevant templateOptions                                                                                                                                                     |
+| Name                           | Functionality                                                                                                                                                                                                                    | Relevant props                                                                                                                                                               |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | form-field-horizontal          | Adds a label next to the field and adds red styling for invalid fields.                                                                                                                                                          | `labelClass`& `fieldClass`: Classes that will be added to the label or field `<div>`                                                                                         |
 | form-field-checkbox-horizontal | Adds a label for a checkbox or radio field, adds red styling and error messages for invalid fields. Uses `validators.validation` and `validation.messages` properties. Adds a tooltip behind the label, see also tooltip-wrapper | `labelClass`& `fieldClass`: Classes that will be added to the label or the outer field `<div>`                                                                               |
@@ -283,7 +282,7 @@ Template option `inputClass`: These css class(es) will be added to all input/sel
 
 ### Extensions
 
-| Name                     | Functionality                                                                   | Relevant templateOptions                                                                                                                                                                       |
+| Name                     | Functionality                                                                   | Relevant props                                                                                                                                                                                 |
 | ------------------------ | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | hide-if-empty            | Hides fields of type `ish-select-field` that have an empty `options` attribute. | `options`: used to determine emptiness.                                                                                                                                                        |
 | translate-select-options | Automatically translates option labels and adds a placeholder option.           | `options`: options whose labels will be translated. `placeholder`: used to determine whether to set placeholder and its text.                                                                  |

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -19,6 +19,19 @@ The deprecated SSR environment variable `ICM_IDENTITY_PROVIDER` was completely r
 Use the variable `IDENTITY_PROVIDER` instead to select the identity provider to be used if it is not the default `ICM`.
 Removed default `identityProvider` configuration from `environment.model.ts` so only hardcoded fallback from `configuration.effects.ts` works as fallback.
 
+The deprecated properties `templateOptions` and `expressionProperties` from the `FormlyFieldConfiguration` object are removed.
+Current project **must** use the new properties for all formly field configurations.
+You **must** adapt html templates too, when using the deprecated properties in there.
+
+To replace deprecated formly field properties, you can execute the new `formly-migrate` schematic.
+Please run for each configured Angular project (e.g. 'intershop-pwa') the following command:
+
+```console
+  ng g formly-migrate --project=${ANGULAR_PROJECT}
+```
+
+> **NOTE:** Not all scenarios are taken into consideration for the `formly-migrate` schematic, where a deprecated property could be found. Please check and adapt manually your code for additional changes. For further information look into the [formly migration guide](https://formly.dev/docs/guide/migration/).
+
 ## 3.2 to 3.3
 
 To improve the accessibility of the PWA in regards to more elements being tab focusable a lot of `[routerLink]="[]"` where added to links that previously did not have a link reference.

--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.ts
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.ts
@@ -49,7 +49,7 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
             key: 'buyerName',
             type: 'ish-plain-text-field',
             className: 'col-8',
-            templateOptions: {
+            props: {
               labelClass: 'col-4',
               fieldClass: 'col-8',
               label: 'account.costcenter.details.buyers.list.header.name',
@@ -59,7 +59,7 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
             key: 'budgetValue',
             type: 'ish-text-input-field',
             className: ' col-6 col-md-8',
-            templateOptions: {
+            props: {
               postWrappers: [{ wrapper: 'input-addon', index: -1 }],
               labelClass: 'col-md-4',
               fieldClass: 'col-md-8  pr-0',
@@ -81,7 +81,7 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
             key: 'budgetPeriod',
             type: 'ish-select-field',
             className: 'col-6 col-md-4',
-            templateOptions: {
+            props: {
               fieldClass: 'col-12 label-empty',
               options: FormsService.getCostCenterBudgetPeriodOptions(),
             },

--- a/projects/organization-management/src/app/components/cost-center-form/cost-center-form.component.ts
+++ b/projects/organization-management/src/app/components/cost-center-form/cost-center-form.component.ts
@@ -73,7 +73,7 @@ export class CostCenterFormComponent implements OnInit {
           {
             key: 'currency',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               fieldClass: 'd-none',
               required: true,
             },
@@ -81,7 +81,7 @@ export class CostCenterFormComponent implements OnInit {
           {
             key: 'costCenterId',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               label: 'account.costcenter.id.label',
               required: true,
               hideRequiredMarker: true,
@@ -100,7 +100,7 @@ export class CostCenterFormComponent implements OnInit {
           {
             key: 'name',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               label: 'account.costcenter.name.label',
               required: true,
               hideRequiredMarker: true,
@@ -118,7 +118,7 @@ export class CostCenterFormComponent implements OnInit {
                 className: 'col-6 col-md-8',
                 key: 'budgetValue',
                 type: 'ish-text-input-field',
-                templateOptions: {
+                props: {
                   postWrappers: [{ wrapper: 'input-addon', index: -1 }],
                   labelClass: 'col-md-6',
                   fieldClass: 'col-md-6 pr-0',
@@ -143,7 +143,7 @@ export class CostCenterFormComponent implements OnInit {
                 className: 'col-6 col-md-4',
                 type: 'ish-select-field',
                 key: 'budgetPeriod',
-                templateOptions: {
+                props: {
                   fieldClass: 'col-12 label-empty',
                   options: FormsService.getCostCenterBudgetPeriodOptions(),
                 },
@@ -153,7 +153,7 @@ export class CostCenterFormComponent implements OnInit {
           {
             key: 'costCenterManager',
             type: 'ish-select-field',
-            templateOptions: {
+            props: {
               label: 'account.costcenter.manager.label',
               required: true,
               hideRequiredMarker: true,
@@ -169,7 +169,7 @@ export class CostCenterFormComponent implements OnInit {
       },
       {
         type: 'ish-fieldset-field',
-        templateOptions: {
+        props: {
           // hide active flag for new cost centers
           fieldsetClass: !this.costCenter ? 'd-none' : undefined,
         },
@@ -177,7 +177,7 @@ export class CostCenterFormComponent implements OnInit {
           {
             key: 'active',
             type: 'ish-checkbox-field',
-            templateOptions: {
+            props: {
               label: 'account.costCenter.active.label',
             },
           },

--- a/projects/organization-management/src/app/components/user-budget-form/user-budget-form.component.ts
+++ b/projects/organization-management/src/app/components/user-budget-form/user-budget-form.component.ts
@@ -74,7 +74,7 @@ export class UserBudgetFormComponent implements OnInit, OnDestroy {
           {
             key: 'currency',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               fieldClass: 'd-none',
               required: true,
             },
@@ -82,7 +82,7 @@ export class UserBudgetFormComponent implements OnInit, OnDestroy {
           {
             key: 'orderSpentLimitValue',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               postWrappers: [{ wrapper: 'input-addon', index: -1 }],
               label: 'account.user.new.order_spend_limit.label',
               placeholder: 'account.budget.unlimited',
@@ -106,7 +106,7 @@ export class UserBudgetFormComponent implements OnInit, OnDestroy {
                 className: 'col-8',
                 key: 'budgetValue',
                 type: 'ish-text-input-field',
-                templateOptions: {
+                props: {
                   postWrappers: [{ wrapper: 'input-addon', index: -1 }],
                   labelClass: 'col-md-6',
                   fieldClass: 'col-md-6 pr-0',
@@ -129,7 +129,7 @@ export class UserBudgetFormComponent implements OnInit, OnDestroy {
                 className: 'col-4',
                 type: 'ish-select-field',
                 key: 'budgetPeriod',
-                templateOptions: {
+                props: {
                   fieldClass: 'col-12 label-empty',
                   options: this.periods.map(period => ({
                     value: period,

--- a/projects/organization-management/src/app/components/user-profile-form/user-profile-form.component.ts
+++ b/projects/organization-management/src/app/components/user-profile-form/user-profile-form.component.ts
@@ -52,7 +52,7 @@ export class UserProfileFormComponent implements OnInit {
             ? {
                 key: 'email',
                 type: 'ish-email-field',
-                templateOptions: {
+                props: {
                   label: 'account.user.email.label',
                   required: true,
                 },
@@ -61,7 +61,7 @@ export class UserProfileFormComponent implements OnInit {
           {
             key: 'active',
             type: 'ish-checkbox-field',
-            templateOptions: {
+            props: {
               label: 'account.user.active.label',
             },
           },

--- a/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.ts
+++ b/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.ts
@@ -94,7 +94,7 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
       {
         key: 'addBuyers',
         type: 'repeatCostCenterBuyers',
-        templateOptions: {},
+        props: {},
         fieldArray: {
           fieldGroupClassName: 'row list-item-row',
           fieldGroup: [
@@ -103,7 +103,7 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
               key: 'selected',
               defaultValue: false,
               className: 'col-1 col-md-2 list-item pb-0',
-              templateOptions: {
+              props: {
                 fieldClass: 'offset-md-2 col-2 mt-1',
               },
             },
@@ -111,7 +111,7 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
               key: 'name',
               type: 'ish-html-text-field',
               className: 'col-11 col-sm-10 col-md-3 list-item pb-0',
-              templateOptions: {
+              props: {
                 inputClass: 'col-form-label pb-0',
               },
             },
@@ -119,7 +119,7 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
               key: 'budgetValue',
               type: 'ish-text-input-field',
               className: 'col-6 col-md-4 list-item',
-              templateOptions: {
+              props: {
                 fieldClass: 'col-12',
                 postWrappers: [{ wrapper: 'input-addon', index: -1 }],
                 addonLeft: {
@@ -139,7 +139,7 @@ export class CostCenterBuyersPageComponent implements OnDestroy, OnInit {
               key: 'budgetPeriod',
               type: 'ish-select-field',
               className: 'col-6 col-md-3 list-item',
-              templateOptions: {
+              props: {
                 fieldClass: 'col-12',
                 options: FormsService.getCostCenterBudgetPeriodOptions(),
               },

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.ts
@@ -54,7 +54,7 @@ export class RequisitionRejectDialogComponent implements OnInit {
       {
         key: 'comment',
         type: 'ish-textarea-field',
-        templateOptions: {
+        props: {
           label: 'approval.rejectform.add_a_comment.label',
           required: true,
           maxLength: 1000,

--- a/schematics/src/collection.json
+++ b/schematics/src/collection.json
@@ -119,6 +119,11 @@
       "description": "A blank schematic.",
       "factory": "./eslint-rule/factory#eslintRule",
       "schema": "./eslint-rule/schema.json"
+    },
+    "formly-migrate": {
+      "description": "Helper to migrate formly 5 to version 6.",
+      "factory": "./migration/formly-5-to-6/factory#migrateFormly",
+      "schema": "./migration/formly-5-to-6/schema.json"
     }
   }
 }

--- a/schematics/src/migration/formly-5-to-6/factory.ts
+++ b/schematics/src/migration/formly-5-to-6/factory.ts
@@ -1,0 +1,458 @@
+import { Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { Formly6Migration as Options } from 'schemas/migration/formly-5-to-6/schema';
+import { Expression, PropertyAccessExpression, SourceFile, SyntaxKind, ts } from 'ts-morph';
+
+import { createTsMorphProject } from '../../utils/ts-morph';
+
+const PROPERTY_REPLACEMENTS: { search: string[]; replace: string }[] = [
+  { search: ['templateOptions'], replace: 'props' },
+  { search: ['validation', 'messages', 'minlength'], replace: 'minLength' },
+  { search: ['validation', 'messages', 'maxlength'], replace: 'maxLength' },
+];
+
+const FIELD_TYPE_REPLACEMENTS: { search: string[]; replace: string }[] = [{ search: ['to'], replace: 'props' }];
+
+const foundLastAccessProperty = (
+  access: PropertyAccessExpression<ts.PropertyAccessExpression>
+): PropertyAccessExpression<ts.PropertyAccessExpression> => {
+  const parent = access.getParentIfKind(SyntaxKind.PropertyAccessExpression);
+  return parent ? foundLastAccessProperty(parent) : access;
+};
+
+/* eslint-disable complexity */
+/**
+ * find property in binary and access expressions and replace it's value
+ *
+ * @param propertyName name of a FormlyFieldConfig property
+ *
+ * (1) if a method is given, which set the value of the property by a method
+ * (2) if a method is given, which set the value of the property directly
+ * (3) if a access expression is given
+ */
+function findPropertyAndReplace(source: SourceFile, expression: Expression<ts.Expression>, propertyName: string) {
+  if (expression.isKind(SyntaxKind.BinaryExpression)) {
+    const access = expression.getLeft().asKind(SyntaxKind.PropertyAccessExpression);
+    const operator = expression.getOperatorToken().asKind(SyntaxKind.EqualsToken);
+    const value = expression.getRight();
+    if (operator) {
+      if (value.isKind(SyntaxKind.CallExpression)) {
+        const methodAccess = value.getExpressionIfKind(SyntaxKind.PropertyAccessExpression);
+        if (methodAccess?.getExpressionIfKind(SyntaxKind.ThisKeyword)) {
+          const method = source
+            .getDescendantsOfKind(SyntaxKind.MethodDeclaration)
+            .find(methods => methods.getName() === methodAccess.getName());
+          const returnStatement = method
+            ?.getBody()
+            .asKind(SyntaxKind.Block)
+            .getStatementByKind(SyntaxKind.ReturnStatement);
+          if (
+            returnStatement
+              ?.getExpression()
+              .isKind(SyntaxKind.ArrayLiteralExpression || SyntaxKind.ObjectLiteralExpression)
+          ) {
+            overwriteProperty(returnStatement.getExpression());
+          }
+        }
+      } else {
+        if (access?.getName() === propertyName) {
+          overwriteProperty(value);
+        } else {
+          const identifier = access
+            ?.getDescendantsOfKind(SyntaxKind.Identifier)
+            .find(identifier => identifier.getText() === propertyName);
+          if (identifier) {
+            overwriteProperty(access);
+          }
+        }
+      }
+    }
+  } else if (
+    expression.isKind(SyntaxKind.PropertyAccessExpression) &&
+    expression?.getDescendantsOfKind(SyntaxKind.Identifier).find(identifier => identifier.getText() === propertyName)
+  ) {
+    overwriteProperty(expression);
+  }
+}
+
+/**
+ * will find property of a FormlyFieldConfig expression, which will be replaced with a new value
+ *
+ */
+function overwriteProperty(expression: Expression<ts.Expression>) {
+  if (!expression) {
+    return;
+  }
+
+  if (expression.isKind(SyntaxKind.ArrayLiteralExpression)) {
+    expression.getElements().map(overwriteProperty);
+  }
+
+  // fieldGroup, fieldArray and defaultOptions have FormlyFieldConfig as return type
+  if (expression.isKind(SyntaxKind.ObjectLiteralExpression)) {
+    const initializer = expression
+      .getProperties()
+      .find(p =>
+        p
+          .asKind(SyntaxKind.PropertyAssignment)
+          ?.getName()
+          .match(new RegExp('(fieldGroup|fieldArray|defaultOptions)$', 'g'))
+      )
+      ?.asKind(SyntaxKind.PropertyAssignment)
+      .getInitializer();
+
+    if (initializer) {
+      overwriteProperty(initializer);
+    }
+  }
+
+  PROPERTY_REPLACEMENTS.map(prop => {
+    // find correct expression which presents a property, which should be replaced
+    // property must be found along the given search path
+    const expr = prop.search.reduce((prev, curr, idx) => {
+      if (prev?.isKind(SyntaxKind.ObjectLiteralExpression)) {
+        const property = prev
+          .getProperties()
+          ?.find(p => p.isKind(SyntaxKind.PropertyAssignment) && p.getName() === curr)
+          ?.asKind(SyntaxKind.PropertyAssignment);
+
+        if (property) {
+          if (idx === prop.search.length - 1) {
+            return prev;
+          } else if (property.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression)) {
+            return property.getInitializer();
+          } else {
+            return;
+          }
+        }
+      } else if (prev?.isKind(SyntaxKind.PropertyAccessExpression)) {
+        if (idx === 0) {
+          return prev.getName() === curr
+            ? prev
+            : prev.getDescendantsOfKind(SyntaxKind.PropertyAccessExpression)?.find(p => p.getName() === curr);
+        } else {
+          const next = prev.getFirstAncestorByKind(SyntaxKind.PropertyAccessExpression);
+          return next?.getName() === curr ? next : undefined;
+        }
+      }
+    }, expression);
+
+    // replace property name
+    if (expr?.isKind(SyntaxKind.ObjectLiteralExpression)) {
+      expr
+        .getProperty(prop.search[prop.search.length - 1])
+        .asKind(SyntaxKind.PropertyAssignment)
+        .getNameNode()
+        .replaceWithText(prop.replace);
+    } else if (expr?.isKind(SyntaxKind.PropertyAccessExpression)) {
+      expr.getNameNode().replaceWithText(prop.replace);
+    }
+  });
+}
+
+/**
+ * Replace properties within a component template
+ *
+ * @param tsFile path name of ts file
+ * @param searchTerm Regex to find correct properties, which should be replaced - PLACEHOLDER key must be included to replace it with different search keys
+ * @param replacement replacement key
+ */
+function overwriteInTemplate(host: Tree, tsFile: string, searchTerm: string) {
+  const htmlFile = tsFile.replace(new RegExp(/.ts$/g), '.html');
+  const content = host.read(htmlFile)?.toString();
+
+  if (!content || !searchTerm) {
+    return;
+  }
+
+  // eslint-disable-next-line prettier/prettier
+  const overwrite = [...PROPERTY_REPLACEMENTS, ...FIELD_TYPE_REPLACEMENTS].reduce(
+    (prev, curr) =>
+      prev.replace(new RegExp(searchTerm.replace('PLACEHOLDER', curr.search.join('\\.')), 'g'), curr.replace),
+    content
+  );
+  // overwrite template in case the template has changed
+  if (content !== overwrite) {
+    host.overwrite(htmlFile, overwrite);
+  }
+}
+
+/**
+ * Returns the used import name of a specific import
+ *
+ * @returns the import name or the specified alias
+ */
+function getUsedImportName(source: SourceFile, importName: string, libraryName: string): string {
+  return source
+    .getDescendantsOfKind(SyntaxKind.ImportDeclaration)
+    .map(node => {
+      if (node.getModuleSpecifierValue() === libraryName) {
+        return node
+          .getNamedImports()
+          ?.map(i => (i.getName() === importName ? i.getAliasNode()?.getText() ?? importName : undefined))
+          .find(i => !!i);
+      }
+    })
+    .find(i => !!i);
+}
+
+/* eslint-disable complexity */
+export function migrateFormly(options: Options): Rule {
+  return async host => {
+    if (!options.project) {
+      throw new SchematicsException('Option (project) is required.');
+    }
+
+    const tsProject = createTsMorphProject(host);
+
+    const fileVisitor = (filePath: string) => {
+      if (filePath.endsWith('.ts') && !filePath.endsWith('spec.ts')) {
+        const source = tsProject.addSourceFileAtPath(filePath);
+
+        // find used import names for FormlyFieldConfig and FormlyModule imports
+
+        const formlyConfigName =
+          getUsedImportName(source, 'FormlyFieldConfig', '@ngx-formly/core') ??
+          getUsedImportName(source, 'FormlyFieldConfig', '@ngx-formly/core/lib/core');
+
+        const formlyModuleName =
+          getUsedImportName(source, 'FormlyModule', '@ngx-formly/core') ??
+          getUsedImportName(source, 'FormlyModule', '@ngx-formly/core/lib/core');
+
+        const fieldTypeName =
+          getUsedImportName(source, 'FieldType', '@ngx-formly/core') ??
+          getUsedImportName(source, 'FieldType', '@ngx-formly/core/lib/core');
+
+        const fieldWrapperName =
+          getUsedImportName(source, 'FieldWrapper', '@ngx-formly/core') ??
+          getUsedImportName(source, 'FieldWrapper', '@ngx-formly/core/lib/core');
+
+        const fieldArrayTypeName =
+          getUsedImportName(source, 'FieldArrayType', '@ngx-formly/core') ??
+          getUsedImportName(source, 'FieldArrayType', '@ngx-formly/core/lib/core');
+
+        const formlyExtensionName =
+          getUsedImportName(source, 'FormlyExtension', '@ngx-formly/core') ??
+          getUsedImportName(source, 'FormlyExtension', '@ngx-formly/core/lib/core');
+
+        // CUSTOM INTERSHOP FORMLY IMPLEMENTATION - find used import names for addressesFieldConfiguration imports
+        const addressConfImport = getUsedImportName(
+          source,
+          'addressesFieldConfiguration',
+          'ish-shared/formly-address-forms/configurations/address-form.configuration'
+        );
+
+        // Regex which checks if a property/ method is type of FormlyFieldConfig or FormlyFieldConfig[]
+        const testFormlyConfigMatcher = (testString: string) =>
+          formlyConfigName && testString ? new RegExp(`^${formlyConfigName}(?=$|\\[]$)`, 'gm').test(testString) : false;
+
+        source.forEachDescendant(node => {
+          // variable with formly type
+          if (node.isKind(SyntaxKind.VariableDeclaration) && testFormlyConfigMatcher(node.getTypeNode()?.getText())) {
+            if (node.getInitializer()) {
+              overwriteProperty(node.getInitializer());
+            }
+
+            node
+              .getFirstAncestorByKind(SyntaxKind.Block)
+              .getDescendantsOfKind(SyntaxKind.BinaryExpression)
+              .map(expression => {
+                findPropertyAndReplace(source, expression, node.getName());
+              });
+          }
+
+          // method with formly return type
+          if (
+            node.isKind(SyntaxKind.MethodDeclaration) &&
+            testFormlyConfigMatcher(node.getReturnTypeNode()?.getText())
+          ) {
+            const statement = node.getStatementByKind(SyntaxKind.ReturnStatement);
+            if (
+              statement?.getExpressionIfKind(SyntaxKind.ObjectLiteralExpression) ||
+              statement?.getExpressionIfKind(SyntaxKind.ArrayLiteralExpression)
+            ) {
+              overwriteProperty(statement.getExpression());
+            }
+          }
+
+          // classes which extends from FieldWrapper or FieldType
+          if (
+            node.isKind(SyntaxKind.HeritageClause) &&
+            node.getToken() === SyntaxKind.ExtendsKeyword &&
+            node
+              .getTypeNodes()
+              .find(type =>
+                type.getText().match(new RegExp(`(^${fieldWrapperName}|^${fieldTypeName}|^${fieldArrayTypeName})`))
+              )
+          ) {
+            // class access field, defaultOptions or to property
+            source.getDescendantsOfKind(SyntaxKind.ThisKeyword).map(expression => {
+              const accessProperty = expression.getFirstAncestorByKind(SyntaxKind.PropertyAccessExpression);
+              if (accessProperty?.getName() === 'field' || accessProperty?.getName() === 'defaultOptions') {
+                overwriteProperty(foundLastAccessProperty(accessProperty));
+                overwriteInTemplate(
+                  host,
+                  filePath,
+                  '(?:(?<=["(\\s]defaultOptions\\?\\.)|(?<=["(\\s]defaultOptions\\.))PLACEHOLDER(?=\\.|"|\\s|\\?)'
+                );
+              } else if (accessProperty?.getName() === 'to') {
+                accessProperty.getFirstChildByKind(SyntaxKind.Identifier).replaceWithText('props');
+              }
+            });
+
+            // defines a defaultOptions property
+            source.getDescendantsOfKind(SyntaxKind.PropertyDeclaration).map(prop => {
+              if (
+                prop.getName() === 'defaultOptions' &&
+                prop.getInitializer()?.isKind(SyntaxKind.ObjectLiteralExpression)
+              ) {
+                overwriteProperty(prop.getInitializer());
+                overwriteInTemplate(
+                  host,
+                  filePath,
+                  '(?:(?<=["(\\s]defaultOptions\\?\\.)|(?<=["(\\s]defaultOptions\\.))PLACEHOLDER(?=\\.|"|\\s|\\?)'
+                );
+              }
+            });
+
+            overwriteInTemplate(host, filePath, '(?<=["(\\s])PLACEHOLDER(?=\\.|"|\\s|\\?)');
+          }
+
+          // defined methods from FormlyExtension interface
+          const matchedMethods = new Set(['prePopulate', 'onPopulate', 'postPopulate']);
+
+          // classes which implements from FormlyExtension
+          if (
+            node.isKind(SyntaxKind.HeritageClause) &&
+            node.getToken() === SyntaxKind.ImplementsKeyword &&
+            node.getTypeNodes().find(type => type.getText() === formlyExtensionName)
+          ) {
+            // configured populate method and access parameter property within
+            source.getDescendantsOfKind(SyntaxKind.MethodDeclaration).map(method => {
+              if (matchedMethods.has(method.getName())) {
+                const parameter = method.getParameters()[0]?.getName();
+                method
+                  .getDescendantsOfKind(SyntaxKind.Identifier)
+                  .filter(identifier => identifier.getText() === parameter)
+                  .map(identifier => {
+                    const parent = identifier.getFirstAncestorByKind(SyntaxKind.PropertyAccessExpression);
+                    if (parent) {
+                      overwriteProperty(foundLastAccessProperty(parent));
+                    }
+                  });
+              }
+            });
+          }
+
+          // FormlyExtension is used as variable type
+          if (
+            node.isKind(SyntaxKind.VariableDeclaration) &&
+            node.getTypeNode()?.getText() === formlyExtensionName &&
+            node.getInitializer()?.isKind(SyntaxKind.ObjectLiteralExpression)
+          ) {
+            const properties = node.getInitializer().asKind(SyntaxKind.ObjectLiteralExpression).getProperties();
+            properties.map(property => {
+              // populate method is initialized with a arrow function or a method
+              if (property.isKind(SyntaxKind.PropertyAssignment) && matchedMethods.has(property.getName())) {
+                const initializer = property.getInitializer().asKind(SyntaxKind.ArrowFunction);
+                const parameter = initializer.getParameters()[0].getName();
+                property
+                  .getDescendantsOfKind(SyntaxKind.Identifier)
+                  .filter(identifier => identifier.getText() === parameter)
+                  .map(identifier => {
+                    const parent = identifier.getParentIfKind(SyntaxKind.PropertyAccessExpression);
+                    if (parent) {
+                      overwriteProperty(foundLastAccessProperty(parent));
+                    }
+                  });
+              } else if (property.isKind(SyntaxKind.MethodDeclaration) && matchedMethods.has(property.getName())) {
+                const parameter = property.getParameters()[0].getName();
+                property
+                  .getDescendantsOfKind(SyntaxKind.Identifier)
+                  .filter(identifier => identifier.getText() === parameter)
+                  .map(identifier => {
+                    const parent = identifier.getParentIfKind(SyntaxKind.PropertyAccessExpression);
+                    if (parent) {
+                      overwriteProperty(foundLastAccessProperty(parent));
+                    }
+                  });
+              }
+            });
+          }
+
+          // a method is declared, which uses a FormlyFieldConfig parameter
+          if (node.isKind(SyntaxKind.MethodDeclaration)) {
+            const parameter = node.getParameters().find(p => testFormlyConfigMatcher(p.getTypeNode()?.getText()));
+
+            // find all expressions, which could access parameter information
+            if (parameter) {
+              node.getDescendants().map(expression => {
+                if (
+                  expression.isKind(SyntaxKind.BinaryExpression) ||
+                  expression.isKind(SyntaxKind.PropertyAccessExpression)
+                ) {
+                  findPropertyAndReplace(source, expression, parameter.getName());
+                }
+              });
+            }
+          }
+
+          // FormlyModule.forChild configuration
+          if (
+            formlyModuleName &&
+            node.isKind(SyntaxKind.CallExpression) &&
+            node.getExpression()?.getText() === `${formlyModuleName}.forChild` &&
+            node.getArguments()[0].isKind(SyntaxKind.ObjectLiteralExpression)
+          ) {
+            const arg = node.getArguments()[0].asKind(SyntaxKind.ObjectLiteralExpression);
+            const typesInitializer = arg
+              .getProperties()
+              .find(prop => prop.asKind(SyntaxKind.PropertyAssignment).getName() === 'types')
+              ?.asKind(SyntaxKind.PropertyAssignment)
+              .getInitializer();
+            overwriteProperty(typesInitializer);
+          }
+
+          // FormlyFieldConfig class property is declared
+          if (node.isKind(SyntaxKind.PropertyDeclaration) && testFormlyConfigMatcher(node.getTypeNode()?.getText())) {
+            // find where property is initialized
+            source.getDescendantsOfKind(SyntaxKind.BinaryExpression).map(expression => {
+              findPropertyAndReplace(source, expression, node.getName());
+            });
+
+            overwriteInTemplate(
+              host,
+              filePath,
+              `(?:(?<=["(\\s]${node.getName()}\\?\\.)|(?<=["(\\s]${node.getName()}\\.))PLACEHOLDER(?=\\.|"|\\s|\\?)`
+            );
+          }
+
+          // CUSTOM INTERSHOP FORMLY IMPLEMENTATION
+          // method addressesFieldConfiguration is called
+          if (
+            addressConfImport &&
+            node.isKind(SyntaxKind.CallExpression) &&
+            node.getExpressionIfKind(SyntaxKind.Identifier)?.getText() === addressConfImport
+          ) {
+            const argument = node.getArguments()[0].asKind(SyntaxKind.ArrayLiteralExpression);
+
+            // find parameter elements which could potentially by FormlyFieldConfig properties
+            argument
+              .getElements()
+              .filter(el => el.isKind(SyntaxKind.ArrayLiteralExpression || SyntaxKind.ObjectLiteralExpression))
+              .map(overwriteProperty);
+          }
+        });
+
+        if (host.read(filePath)?.toString() !== source.getFullText()) {
+          host.overwrite(filePath, source.getFullText());
+        }
+      }
+    };
+
+    const workspace = await getWorkspace(host);
+    const project = workspace.projects.get(options.project);
+
+    host.getDir(`/${project.sourceRoot}`).visit(fileVisitor);
+  };
+}

--- a/schematics/src/migration/formly-5-to-6/schema.json
+++ b/schematics/src/migration/formly-5-to-6/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "SchematicsPWAComponent",
+  "title": "Formly 6 Migration",
+  "description": "Tool to do the migration from formly 5 to version 6.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "type": "string",
+      "$default": {
+        "$source": "projectName"
+      }
+    }
+  }
+}

--- a/src/app/core/models/payment-method/payment-method.mapper.spec.ts
+++ b/src/app/core/models/payment-method/payment-method.mapper.spec.ts
@@ -129,13 +129,13 @@ describe('Payment Method Mapper', () => {
       expect(paymentMethod.parameters[0].type).toEqual('ish-text-input-field');
       expect(paymentMethod.parameters[0].key).toEqual('holder');
       expect(paymentMethod.parameters[0].hide).toBeFalse();
-      expect(paymentMethod.parameters[0].templateOptions.type).toEqual('text');
-      expect(paymentMethod.parameters[0].templateOptions.required).toBeTrue();
+      expect(paymentMethod.parameters[0].props.type).toEqual('text');
+      expect(paymentMethod.parameters[0].props.required).toBeTrue();
 
-      expect(paymentMethod.parameters[1].templateOptions.pattern).toBe(regexp);
-      expect(paymentMethod.parameters[1].templateOptions.minLength).toBe(15);
-      expect(paymentMethod.parameters[1].templateOptions.maxLength).toBe(34);
-      expect(paymentMethod.parameters[1].templateOptions.attributes).toBeObject();
+      expect(paymentMethod.parameters[1].props.pattern).toBe(regexp);
+      expect(paymentMethod.parameters[1].props.minLength).toBe(15);
+      expect(paymentMethod.parameters[1].props.maxLength).toBe(34);
+      expect(paymentMethod.parameters[1].props.attributes).toBeObject();
 
       expect(paymentMethod.parameters[3].hide).toBeTrue();
     });

--- a/src/app/core/models/payment-method/payment-method.mapper.ts
+++ b/src/app/core/models/payment-method/payment-method.mapper.ts
@@ -171,7 +171,7 @@ export class PaymentMethodMapper {
       const param: FormlyFieldConfig = {
         key: p.name,
         type: p.options ? 'ish-select-field' : 'ish-text-input-field',
-        templateOptions: {
+        props: {
           labelClass: 'col-md-4',
           fieldClass: 'col-sm-6',
           type: p.type === 'string' ? 'text' : (p.type as string).toLowerCase(),
@@ -192,12 +192,12 @@ export class PaymentMethodMapper {
 
       if (p.constraints) {
         if (p.constraints.required) {
-          param.templateOptions.required = true;
+          param.props.required = true;
           param.validation.messages = { ...param.validation.messages, required: p.constraints.required.message };
         }
         if (p.constraints.size) {
-          param.templateOptions.minLength = p.constraints.size.min;
-          param.templateOptions.maxLength = p.constraints.size.max;
+          param.props.minLength = p.constraints.size.min;
+          param.props.maxLength = p.constraints.size.max;
           param.validation.messages = {
             ...param.validation.messages,
             minLength: p.constraints.size.message,
@@ -205,7 +205,7 @@ export class PaymentMethodMapper {
           };
         }
         if (p.constraints.pattern) {
-          param.templateOptions.pattern = p.constraints.pattern.regexp;
+          param.props.pattern = p.constraints.pattern.regexp;
           param.validation.messages = {
             ...param.validation.messages,
             pattern: p.constraints.pattern.message,

--- a/src/app/core/utils/dev/basket-mock-data.ts
+++ b/src/app/core/utils/dev/basket-mock-data.ts
@@ -95,7 +95,7 @@ export class BasketMockData {
         {
           key: 'IBAN',
           type: 'input',
-          templateOptions: {
+          props: {
             type: 'text',
             required: true,
           },

--- a/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.ts
@@ -46,7 +46,7 @@ export class ContactFormComponent implements OnInit {
       {
         key: 'name',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           label: 'helpdesk.contactus.name.label',
           required: true,
         },
@@ -59,7 +59,7 @@ export class ContactFormComponent implements OnInit {
       {
         key: 'email',
         type: 'ish-email-field',
-        templateOptions: {
+        props: {
           label: 'helpdesk.contactus.email.label',
           required: true,
         },
@@ -67,7 +67,7 @@ export class ContactFormComponent implements OnInit {
       {
         key: 'phone',
         type: 'ish-phone-field',
-        templateOptions: {
+        props: {
           label: 'helpdesk.contactus.phone.label',
           required: true,
         },
@@ -75,14 +75,14 @@ export class ContactFormComponent implements OnInit {
       {
         key: 'order',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           label: 'helpdesk.contactus.order.label',
         },
       },
       {
         key: 'subject',
         type: 'ish-select-field',
-        templateOptions: {
+        props: {
           label: 'helpdesk.contactus.subject.label',
           required: true,
           options: this.contactUsFacade.contactSubjects$().pipe(
@@ -101,7 +101,7 @@ export class ContactFormComponent implements OnInit {
       {
         key: 'comment',
         type: 'ish-textarea-field',
-        templateOptions: {
+        props: {
           label: 'helpdesk.contactus.comments.label',
           required: true,
           maxLength: 30000,
@@ -115,7 +115,7 @@ export class ContactFormComponent implements OnInit {
       },
       {
         type: 'ish-captcha-field',
-        templateOptions: {
+        props: {
           topic: 'contactUs',
         },
       },

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.ts
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.ts
@@ -66,7 +66,7 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
       {
         key: 'title',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           required: true,
           label: 'account.order_template.form.name.label',
           hideRequiredMarker: true,

--- a/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-form/select-order-template-form.component.ts
@@ -40,7 +40,7 @@ export class SelectOrderTemplateFormComponent implements OnInit {
         type: 'ish-text-input-field',
         key: 'newOrderTemplate',
         defaultValue: this.translate.instant('account.order_template.new_order_template.text'),
-        templateOptions: {
+        props: {
           required: true,
         },
         validation: {
@@ -56,7 +56,7 @@ export class SelectOrderTemplateFormComponent implements OnInit {
           type: 'ish-radio-field',
           key: 'orderTemplate',
           defaultValue: orderTemplateOptions[0].value,
-          templateOptions: {
+          props: {
             fieldClass: ' ',
             value: option.value,
             label: option.label,
@@ -71,7 +71,7 @@ export class SelectOrderTemplateFormComponent implements OnInit {
             {
               type: 'ish-radio-field',
               key: 'orderTemplate',
-              templateOptions: {
+              props: {
                 inputClass: 'position-static',
                 fieldClass: ' ',
                 value: 'new',
@@ -83,14 +83,14 @@ export class SelectOrderTemplateFormComponent implements OnInit {
               className: 'w-75 position-relative validation-offset-0',
               wrappers: ['validation'],
               defaultValue: this.translate.instant('account.order_template.new_order_template.text'),
-              templateOptions: {
+              props: {
                 required: true,
               },
               validation: {
                 messages: { required: 'account.order_template.name.error.required' },
               },
-              expressionProperties: {
-                'templateOptions.disabled': model => model.orderTemplate !== 'new',
+              expressions: {
+                'props.disabled': conf => conf.model.orderTemplate !== 'new',
               },
             },
           ],

--- a/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
+++ b/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
@@ -51,7 +51,7 @@ export class PunchoutUserFormComponent implements OnInit {
           {
             key: 'login',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               label: 'account.punchout.username.label',
               required: true,
               hideRequiredMarker: true,
@@ -70,7 +70,7 @@ export class PunchoutUserFormComponent implements OnInit {
           {
             key: 'active',
             type: 'ish-checkbox-field',
-            templateOptions: {
+            props: {
               label: 'account.user.active.label',
             },
           },
@@ -85,7 +85,7 @@ export class PunchoutUserFormComponent implements OnInit {
           {
             key: 'password',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               postWrappers: [{ wrapper: 'description', index: -1 }],
               label: this.punchoutUser ? 'account.punchout.password.new.label' : 'account.punchout.password.label',
               required: this.punchoutUser ? false : true,
@@ -100,7 +100,7 @@ export class PunchoutUserFormComponent implements OnInit {
           {
             key: 'passwordConfirmation',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               required: this.punchoutUser ? false : true,
               label: this.punchoutUser
                 ? 'account.punchout.password.new.confirmation.label'

--- a/src/app/extensions/quickorder/shared/direct-order/direct-order.component.ts
+++ b/src/app/extensions/quickorder/shared/direct-order/direct-order.component.ts
@@ -73,7 +73,7 @@ export class DirectOrderComponent implements OnInit, AfterViewInit {
       {
         key: 'sku',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           fieldClass: 'col-12',
           placeholder: 'shopping_cart.direct_order.item_placeholder',
           attributes: { autocomplete: 'on' },

--- a/src/app/extensions/quickorder/shared/formly/quickorder-repeat-field/quickorder-repeat-field.component.html
+++ b/src/app/extensions/quickorder/shared/formly/quickorder-repeat-field/quickorder-repeat-field.component.html
@@ -21,10 +21,10 @@
 </div>
 <div class="section d-flex flex-nowrap">
   <a [routerLink]="[]" (click)="addMultipleRows(1)" data-testing-id="add-quickorder-line">{{
-    to?.addText | translate
+    props?.addText | translate
   }}</a>
   <span class="link-separator"></span>
-  <a [routerLink]="[]" (click)="addMultipleRows(to?.numberMoreRows)">{{
-    to?.addMoreText | translate: { '0': to?.numberMoreRows }
+  <a [routerLink]="[]" (click)="addMultipleRows(props?.numberMoreRows)">{{
+    props?.addMoreText | translate: { '0': props?.numberMoreRows }
   }}</a>
 </div>

--- a/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.ts
+++ b/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.ts
@@ -61,7 +61,7 @@ export class QuickorderAddProductsFormComponent implements OnInit {
       {
         key: 'addProducts',
         type: 'repeat',
-        templateOptions: {
+        props: {
           addText: 'quickorder.page.add.row',
           addMoreText: 'quickorder.page.add.row.multiple',
           numberMoreRows: this.numberOfRows,
@@ -73,12 +73,12 @@ export class QuickorderAddProductsFormComponent implements OnInit {
               key: 'sku',
               type: 'ish-text-input-field',
               className: 'col-12 list-item search-container',
-              templateOptions: {
+              props: {
                 fieldClass: 'col-12',
                 placeholder: 'shopping_cart.direct_order.item_placeholder',
               },
-              expressionProperties: {
-                'templateOptions.required': (control: SkuQuantityType) => !!control.quantity,
+              expressions: {
+                'props.required': conf => !!conf.model.quantity,
               },
               validation: {
                 messages: {

--- a/src/app/extensions/rating/formly/rating-stars-field/rating-stars-field.component.spec.ts
+++ b/src/app/extensions/rating/formly/rating-stars-field/rating-stars-field.component.spec.ts
@@ -42,7 +42,7 @@ describe('Rating Stars Field Component', () => {
         {
           key: 'input',
           type: 'ish-rating-stars-field',
-          templateOptions: {
+          props: {
             label: 'test label',
             required: true,
           },

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
@@ -48,7 +48,7 @@ export class ProductReviewCreateDialogComponent implements OnInit {
       {
         key: 'authorFirstName',
         type: 'ish-plain-text-field',
-        templateOptions: {
+        props: {
           label: 'product.review.name.label',
           labelClass: 'col-md-3',
           fieldClass: 'col-md-9',
@@ -57,7 +57,7 @@ export class ProductReviewCreateDialogComponent implements OnInit {
       {
         key: 'rating',
         type: 'ish-rating-stars-field',
-        templateOptions: {
+        props: {
           label: 'product.review.rating.label',
           labelClass: 'col-md-3',
           fieldClass: 'col-md-9',
@@ -72,7 +72,7 @@ export class ProductReviewCreateDialogComponent implements OnInit {
       {
         key: 'title',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           label: 'product.review.title.label',
           labelClass: 'col-md-3',
           fieldClass: 'col-md-9',
@@ -87,7 +87,7 @@ export class ProductReviewCreateDialogComponent implements OnInit {
       {
         key: 'content',
         type: 'ish-textarea-field',
-        templateOptions: {
+        props: {
           label: 'product.review.content.label',
           labelClass: 'col-md-3',
           fieldClass: 'col-md-9',

--- a/src/app/extensions/store-locator/pages/store-locator/store-locator-page.component.ts
+++ b/src/app/extensions/store-locator/pages/store-locator/store-locator-page.component.ts
@@ -48,7 +48,7 @@ export class StoreLocatorPageComponent implements OnInit {
         key: 'countryCode',
         type: 'ish-select-field',
         wrappers: ['form-field-horizontal'],
-        templateOptions: {
+        props: {
           required: false,
           label: 'store_locator.form.country.label',
           placeholder: 'store_locator.form.country.default',
@@ -64,7 +64,7 @@ export class StoreLocatorPageComponent implements OnInit {
       {
         key: 'postalCode',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           type: 'text',
           label: 'store_locator.form.postalCode.label',
         },
@@ -72,7 +72,7 @@ export class StoreLocatorPageComponent implements OnInit {
       {
         key: 'city',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           type: 'text',
           label: 'store_locator.form.city.label',
         },

--- a/src/app/extensions/wishlists/shared/select-wishlist-form/select-wishlist-form.component.ts
+++ b/src/app/extensions/wishlists/shared/select-wishlist-form/select-wishlist-form.component.ts
@@ -36,7 +36,7 @@ export class SelectWishlistFormComponent implements OnInit {
         type: 'ish-text-input-field',
         key: 'newList',
         defaultValue: this.translate.instant('account.wishlists.choose_wishlist.new_wishlist_name.initial_value'),
-        templateOptions: {
+        props: {
           required: true,
         },
         validation: {
@@ -54,7 +54,7 @@ export class SelectWishlistFormComponent implements OnInit {
           type: 'ish-radio-field',
           key: 'wishlist',
           defaultValue: this.formGroup.get('wishlist')?.value || wishlistOptions[0].value,
-          templateOptions: {
+          props: {
             fieldClass: ' ',
             value: option.value,
             label: option.label,
@@ -69,7 +69,7 @@ export class SelectWishlistFormComponent implements OnInit {
             {
               type: 'ish-radio-field',
               key: 'wishlist',
-              templateOptions: {
+              props: {
                 inputClass: 'position-static',
                 fieldClass: ' ',
                 value: 'new',
@@ -81,7 +81,7 @@ export class SelectWishlistFormComponent implements OnInit {
               className: 'w-75 position-relative validation-offset-0',
               wrappers: ['validation'],
               defaultValue: this.translate.instant('account.wishlists.choose_wishlist.new_wishlist_name.initial_value'),
-              templateOptions: {
+              props: {
                 required: true,
               },
               validation: {
@@ -89,8 +89,8 @@ export class SelectWishlistFormComponent implements OnInit {
                   required: 'account.wishlist.name.error.required',
                 },
               },
-              expressionProperties: {
-                'templateOptions.disabled': model => model.wishlist !== 'new',
+              expressions: {
+                'props.disabled': conf => conf.model.wishlist !== 'new',
               },
             },
           ],

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.ts
@@ -67,7 +67,7 @@ export class WishlistPreferencesDialogComponent implements OnInit {
       {
         key: 'title',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           required: true,
           label: 'account.wishlists.wishlist_form.name.label',
           hideRequiredMarker: true,
@@ -80,7 +80,7 @@ export class WishlistPreferencesDialogComponent implements OnInit {
       {
         key: 'preferred',
         type: 'ish-checkbox-field',
-        templateOptions: {
+        props: {
           label: 'account.wishlists.wishlist_form.preferred.label',
           fieldClass: 'offset-md-4 col-md-8 d-flex align-items-center',
           tooltip: {

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
@@ -93,7 +93,7 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
     this.selectInvoiceConfig = {
       key: 'preferredInvoiceAddressUrn',
       type: 'ish-select-field',
-      templateOptions: {
+      props: {
         fieldClass: 'w-100',
         options: addressesAndUser$.pipe(
           map(([addresses, user]) =>
@@ -113,7 +113,7 @@ export class AccountAddressesComponent implements OnInit, OnDestroy {
     this.selectShippingConfig = {
       key: 'preferredShippingAddressUrn',
       type: 'ish-select-field',
-      templateOptions: {
+      props: {
         fieldClass: 'w-100',
         options: addressesAndUser$.pipe(
           map(([addresses, user]) =>

--- a/src/app/pages/account-profile-company/account-profile-company/account-profile-company.component.spec.ts
+++ b/src/app/pages/account-profile-company/account-profile-company/account-profile-company.component.spec.ts
@@ -21,7 +21,7 @@ describe('Account Profile Company Component', () => {
     when(fieldLibrary.getConfigurationGroup(anything(), anything())).thenReturn([
       {
         key: 'companyName',
-        templateOptions: {
+        props: {
           required: true,
         },
       },

--- a/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
+++ b/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
@@ -44,7 +44,7 @@ export class AccountProfileEmailComponent implements OnInit {
           {
             key: 'email',
             type: 'ish-email-field',
-            templateOptions: {
+            props: {
               label: 'account.update_email.newemail.label',
               hideRequiredMarker: true,
               required: true,
@@ -55,7 +55,7 @@ export class AccountProfileEmailComponent implements OnInit {
             key: 'emailConfirmation',
             type: 'ish-email-field',
 
-            templateOptions: {
+            props: {
               hideRequiredMarker: true,
               required: true,
               label: 'account.update_email.email_confirmation.label',
@@ -70,7 +70,7 @@ export class AccountProfileEmailComponent implements OnInit {
           {
             key: 'currentPassword',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               hideRequiredMarker: true,
               required: true,
               label: 'account.update_email.password.label',

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
@@ -43,7 +43,7 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
           {
             key: 'currentPassword',
             type: 'ish-text-input-field',
-            templateOptions: {
+            props: {
               type: 'password',
               required: true,
               hideRequiredMarker: true,
@@ -58,7 +58,7 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
           {
             key: 'password',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               postWrappers: [{ wrapper: 'description', index: -1 }],
               required: true,
               hideRequiredMarker: true,
@@ -74,7 +74,7 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
           {
             key: 'passwordConfirmation',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               required: true,
               hideRequiredMarker: true,
               label: 'account.update_password.newpassword_confirmation.label',

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
@@ -26,7 +26,7 @@ describe('Account Profile User Component', () => {
       {
         key: 'firstName',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           required: true,
         },
       },

--- a/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.ts
+++ b/src/app/pages/checkout-address/formly/components/checkout-address-anonymous-form/checkout-address-anonymous-form.component.ts
@@ -41,7 +41,7 @@ export class CheckoutAddressAnonymousFormComponent implements OnInit, OnDestroy 
         type: 'ish-radio-field',
         key: 'shipOption',
         defaultValue: 'shipToInvoiceAddress',
-        templateOptions: {
+        props: {
           label: 'checkout.addresses.shipping_address.option1.text',
           value: 'shipToInvoiceAddress',
         },
@@ -50,7 +50,7 @@ export class CheckoutAddressAnonymousFormComponent implements OnInit, OnDestroy 
         type: 'ish-radio-field',
         key: 'shipOption',
         defaultValue: 'shipToInvoiceAddress',
-        templateOptions: {
+        props: {
           label: 'checkout.addresses.shipping_address.option2.text',
           value: 'shipToDifferentAddress',
         },

--- a/src/app/pages/checkout-payment/formly/payment-save-checkbox/payment-save-checkbox.component.ts
+++ b/src/app/pages/checkout-payment/formly/payment-save-checkbox/payment-save-checkbox.component.ts
@@ -33,7 +33,7 @@ export class PaymentSaveCheckboxComponent implements OnInit {
       {
         key: 'saveForLater',
         type: 'ish-checkbox-field',
-        templateOptions: {
+        props: {
           label: 'checkout.save_edit.checkbox.label',
         },
       },

--- a/src/app/pages/checkout-payment/formly/server-validation.extension.ts
+++ b/src/app/pages/checkout-payment/formly/server-validation.extension.ts
@@ -12,8 +12,8 @@ export const serverValidationExtension: FormlyExtension = {
     if (field.hide) {
       return;
     }
-    field.templateOptions = {
-      ...field.templateOptions,
+    field.props = {
+      ...field.props,
       showValidation: (fld: FormlyFieldConfig) =>
         field.formControl?.valid &&
         field.formControl?.dirty &&
@@ -37,9 +37,9 @@ export const serverValidationExtension: FormlyExtension = {
       },
     };
 
-    field.expressionProperties = {
-      ...field.expressionProperties,
-      'validation.messages.serverError': (_, formState) => formState.errors?.[field.key as string],
+    field.expressions = {
+      ...field.expressions,
+      'validation.messages.serverError': 'formState.errors?.[field.key as string]',
     };
   },
 };

--- a/src/app/pages/checkout-payment/payment-concardis-creditcard-cvc-detail/payment-concardis-creditcard-cvc-detail.component.ts
+++ b/src/app/pages/checkout-payment/payment-concardis-creditcard-cvc-detail/payment-concardis-creditcard-cvc-detail.component.ts
@@ -39,7 +39,7 @@ export class PaymentConcardisCreditcardCvcDetailComponent extends PaymentConcard
       {
         key: 'cvcDetail',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           required: true,
           label: 'checkout.credit_card.cvc.label',
           labelClass: 'col-5 col-md-7 pl-4',

--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.spec.ts
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.spec.ts
@@ -39,7 +39,7 @@ describe('Payment Concardis Directdebit Component', () => {
           key: 'IBAN',
           name: 'IBAN',
           type: 'input',
-          templateOptions: { label: 'input', type: 'text', disabled: false },
+          props: { label: 'input', type: 'text', disabled: false },
         },
       ],
     } as PaymentMethod;

--- a/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
+++ b/src/app/pages/checkout-payment/payment-concardis-directdebit/payment-concardis-directdebit.component.ts
@@ -118,9 +118,9 @@ export class PaymentConcardisDirectdebitComponent extends PaymentConcardisCompon
 
     if (param.key === 'mandateText') {
       param.type = 'ish-checkbox-field';
-      param.templateOptions.fieldClass = 'offset-md-4 col-md-6';
-      param.templateOptions.labelClass = '';
-      param.templateOptions.label = this.getParamValue('mandateText', '');
+      param.props.fieldClass = 'offset-md-4 col-md-6';
+      param.props.labelClass = '';
+      param.props.label = this.getParamValue('mandateText', '');
       param.defaultValue = false;
       param.hide = false;
       param.validators = [Validators.pattern('false')];

--- a/src/app/pages/checkout-payment/payment-parameter-form/payment-parameter-form.component.ts
+++ b/src/app/pages/checkout-payment/payment-parameter-form/payment-parameter-form.component.ts
@@ -28,7 +28,7 @@ export class PaymentParameterFormComponent implements OnInit, OnChanges {
   ngOnInit() {
     this.fields = [];
     this.paymentMethod.parameters.forEach(param => this.fields.push({ ...param }));
-    this.fields.forEach(field => (this.model[field.key as string] = field.templateOptions?.options ? undefined : ''));
+    this.fields.forEach(field => (this.model[field.key as string] = field.props?.options ? undefined : ''));
   }
 
   /**

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
@@ -62,7 +62,7 @@ export class CheckoutReviewComponent implements OnInit, OnChanges {
       {
         type: 'ish-checkout-review-tac-field',
         key: 'termsAndConditions',
-        templateOptions: {
+        props: {
           validation: {
             show: true,
           },

--- a/src/app/pages/checkout-shipping/checkout-shipping/checkout-shipping.component.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping/checkout-shipping.component.ts
@@ -45,7 +45,7 @@ export class CheckoutShippingComponent implements OnInit, OnDestroy {
           type: 'ish-radio-field',
           key: 'shippingMethod',
           wrappers: ['shipping-radio-wrapper'],
-          templateOptions: {
+          props: {
             description: method.description,
             id: `shipping_method${method.id}`,
             value: method.id,

--- a/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.html
+++ b/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.html
@@ -1,8 +1,8 @@
 <div class="form-check" [class.has-error]="showError">
   <ng-template #fieldComponent></ng-template>
-  <label class="form-check-label" [for]="to.id" [ngClass]="to.labelClass">
-    <ish-shipping-info [shippingMethodId]="to.value"></ish-shipping-info>
-    <a *ngIf="to.description" class="details-tooltip" [ngbPopover]="ShippingMethodDescription" placement="top">
+  <label class="form-check-label" [for]="props.id" [ngClass]="props.labelClass">
+    <ish-shipping-info [shippingMethodId]="props.value"></ish-shipping-info>
+    <a *ngIf="props.description" class="details-tooltip" [ngbPopover]="ShippingMethodDescription" placement="top">
       {{ 'checkout.detail.text' | translate }}
       <fa-icon [icon]="['fas', 'info-circle']"></fa-icon>
     </a>
@@ -10,5 +10,5 @@
 </div>
 
 <ng-template #ShippingMethodDescription>
-  <span [innerHTML]="to.description"></span>
+  <span [innerHTML]="props.description"></span>
 </ng-template>

--- a/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.ts
+++ b/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.ts
@@ -4,9 +4,9 @@ import { FieldWrapper } from '@ngx-formly/core';
 /**
  * Wrapper that handles checkout specific formatting and display of radio buttons.
  *
- * @templateOptions **shippingMethod** that will have its description displayed.
- * @templateOptions **id** that will be used in the label.
- * @tempalteOptions **labelClass* that will be applied to the label.
+ * @props **shippingMethod** that will have its description displayed.
+ * @props **id** that will be used in the label.
+ * @props **labelClass* that will be applied to the label.
  *
  */
 @Component({

--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
@@ -34,7 +34,7 @@ export class RequestReminderFormComponent implements OnInit {
       {
         key: 'email',
         type: 'ish-email-field',
-        templateOptions: {
+        props: {
           label: 'account.forgotdata.email.label',
           hideRequiredMarker: true,
           required: true,
@@ -42,7 +42,7 @@ export class RequestReminderFormComponent implements OnInit {
       },
       {
         type: 'ish-captcha-field',
-        templateOptions: {
+        props: {
           topic: 'forgotPassword',
         },
       },

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
@@ -38,7 +38,7 @@ export class UpdatePasswordFormComponent implements OnInit {
           {
             key: 'password',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               postWrappers: [{ wrapper: 'description', index: -1 }],
               required: true,
               hideRequiredMarker: true,
@@ -57,7 +57,7 @@ export class UpdatePasswordFormComponent implements OnInit {
           {
             key: 'passwordConfirmation',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               required: true,
               hideRequiredMarker: true,
               label: 'account.register.password_confirmation.label',

--- a/src/app/pages/registration/formly/disable-prefilled.extension.ts
+++ b/src/app/pages/registration/formly/disable-prefilled.extension.ts
@@ -9,8 +9,8 @@ type FieldConfigWithDisabled = Omit<FormlyFieldConfig, 'options'> & { options: {
 export const disablePrefilledExtension: FormlyExtension = {
   onPopulate(field) {
     if (hasDisabled(field) && field.key) {
-      field.templateOptions = { ...field.templateOptions };
-      field.templateOptions.disabled = field.options.formState.disabled.includes(field.key as string);
+      field.props = { ...field.props };
+      field.props.disabled = field.options.formState.disabled.includes(field.key as string);
     }
   },
 };

--- a/src/app/pages/registration/formly/registration-address-field/registration-address-field.component.html
+++ b/src/app/pages/registration/formly/registration-address-field/registration-address-field.component.html
@@ -1,5 +1,5 @@
 <ish-formly-address-form
-  [businessCustomer]="to.businessCustomer"
+  [businessCustomer]="props.businessCustomer"
   [shortForm]="true"
   [parentForm]="parent"
 ></ish-formly-address-form>

--- a/src/app/pages/registration/formly/registration-address-field/registration-address-field.component.ts
+++ b/src/app/pages/registration/formly/registration-address-field/registration-address-field.component.ts
@@ -6,7 +6,7 @@ import { FieldType } from '@ngx-formly/core';
  * Type that will render an <ish-formly-address-form> component
  * and configure it to use the current form as its parent.
  *
- * @templateOption **businessCustomer** will be passed on to the component (see component documentation for infos).
+ * @props **businessCustomer** will be passed on to the component (see component documentation for infos).
  */
 @Component({
   selector: 'ish-registration-address-field',

--- a/src/app/pages/registration/formly/registration-heading-field/registration-heading-field.component.html
+++ b/src/app/pages/registration/formly/registration-heading-field/registration-heading-field.component.html
@@ -1,13 +1,13 @@
 <ng-container *ngIf="size === 'h1'; else h2">
-  <h1>{{ to.heading | translate }}</h1>
-  <p>{{ to.subheading | translate }}</p>
+  <h1>{{ props.heading | translate }}</h1>
+  <p>{{ props.subheading | translate }}</p>
   <p *ngIf="showRequiredInfo" class="indicates-required">
     <span class="required">*</span>{{ 'account.required_field.message' | translate }}
   </p>
 </ng-container>
 <ng-template #h2>
-  <h2>{{ to.heading | translate }}</h2>
-  <p>{{ to.subheading | translate }}</p>
+  <h2>{{ props.heading | translate }}</h2>
+  <p>{{ props.subheading | translate }}</p>
   <p *ngIf="showRequiredInfo" class="indicates-required">
     <span class="required">*</span>{{ 'account.required_field.message' | translate }}
   </p>

--- a/src/app/pages/registration/formly/registration-heading-field/registration-heading-field.component.spec.ts
+++ b/src/app/pages/registration/formly/registration-heading-field/registration-heading-field.component.spec.ts
@@ -33,7 +33,7 @@ describe('Registration Heading Field Component', () => {
       fields: [
         {
           type: 'heading',
-          templateOptions: {
+          props: {
             headingSize: 'h1',
             heading: 'heading',
             subHeading: 'subHeading',

--- a/src/app/pages/registration/formly/registration-heading-field/registration-heading-field.component.ts
+++ b/src/app/pages/registration/formly/registration-heading-field/registration-heading-field.component.ts
@@ -6,10 +6,10 @@ const sizes = ['h1', 'h2'];
 /**
  * Type that displays a section heading.
  *
- * @templateOption **heading** the primary heading text. Will be translated.
- * @templateOption **subheading** the secondary heading text. Wil be translated.
- * @templateOption **headingSize** determines whether the heading should be rendered with an <h1> or <h2> tag.
- * @templateOption **showRequiredInfo** determines whether a message explaining the required star should be shown.
+ * @props **heading** the primary heading text. Will be translated.
+ * @props **subheading** the secondary heading text. Wil be translated.
+ * @props **headingSize** determines whether the heading should be rendered with an <h1> or <h2> tag.
+ * @props **showRequiredInfo** determines whether a message explaining the required star should be shown.
  */
 @Component({
   selector: 'ish-registration-heading-field',
@@ -23,10 +23,10 @@ export class RegistrationHeadingFieldComponent extends FieldType {
   };
 
   get size() {
-    return sizes.includes(this.to.headingSize) ? this.to.headingSize : this.dto.headingSize;
+    return sizes.includes(this.props.headingSize) ? this.props.headingSize : this.dto.headingSize;
   }
 
   get showRequiredInfo() {
-    return this.to.showRequiredInfo ?? this.dto.showRequiredInfo;
+    return this.props.showRequiredInfo ?? this.dto.showRequiredInfo;
   }
 }

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.spec.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.spec.ts
@@ -23,7 +23,7 @@ describe('Registration Form Configuration Service', () => {
     when(fieldLibrary.getConfigurationGroup('companyInfo')).thenReturn([
       {
         key: 'companyName1',
-        templateOptions: {
+        props: {
           required: true,
         },
       },

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -55,7 +55,7 @@ export class RegistrationFormConfigurationService {
     return [
       {
         type: 'ish-registration-heading-field',
-        templateOptions: {
+        props: {
           headingSize: 'h1',
           heading: registrationConfig.sso ? 'account.register.complete_heading' : 'account.register.heading',
           subheading: 'account.register.message',
@@ -66,7 +66,7 @@ export class RegistrationFormConfigurationService {
       ...this.getPersonalInfoConfig(),
       {
         type: 'ish-registration-heading-field',
-        templateOptions: {
+        props: {
           headingSize: 'h2',
           heading: 'account.register.address.headding',
           subheading: 'account.register.address.message',
@@ -75,21 +75,21 @@ export class RegistrationFormConfigurationService {
       },
       {
         type: 'ish-fieldset-field',
-        templateOptions: {
+        props: {
           fieldsetClass: 'row',
           childClass: 'col-md-10 col-lg-8 col-xl-6',
         },
         fieldGroup: [
           {
             type: 'ish-registration-address-field',
-            templateOptions: {
+            props: {
               businessCustomer: registrationConfig.businessCustomer,
             },
           },
           {
             type: 'ish-registration-tac-field',
             key: 'termsAndConditions',
-            templateOptions: {
+            props: {
               required: true,
             },
             validators: {
@@ -98,7 +98,7 @@ export class RegistrationFormConfigurationService {
           },
           {
             type: 'ish-captcha-field',
-            templateOptions: {
+            props: {
               topic: 'register',
             },
           },
@@ -211,7 +211,7 @@ export class RegistrationFormConfigurationService {
       {
         type: 'ish-registration-heading-field',
 
-        templateOptions: {
+        props: {
           headingSize: 'h2',
           heading: 'account.register.email_password.heading',
           subheading: 'account.register.email_password.message',
@@ -220,7 +220,7 @@ export class RegistrationFormConfigurationService {
       },
       {
         type: 'ish-fieldset-field',
-        templateOptions: {
+        props: {
           fieldsetClass: 'row',
           childClass: 'col-md-10 col-lg-8 col-xl-6',
         },
@@ -234,7 +234,7 @@ export class RegistrationFormConfigurationService {
           {
             key: 'login',
             type: 'ish-email-field',
-            templateOptions: {
+            props: {
               label: 'account.register.email.label',
               required: true,
             },
@@ -242,7 +242,7 @@ export class RegistrationFormConfigurationService {
           {
             key: 'loginConfirmation',
             type: 'ish-email-field',
-            templateOptions: {
+            props: {
               label: 'account.register.email_confirmation.label',
               required: true,
             },
@@ -256,7 +256,7 @@ export class RegistrationFormConfigurationService {
           {
             key: 'password',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               postWrappers: [{ wrapper: 'description', index: -1 }],
               required: true,
               label: 'account.register.password.label',
@@ -270,7 +270,7 @@ export class RegistrationFormConfigurationService {
           {
             key: 'passwordConfirmation',
             type: 'ish-password-field',
-            templateOptions: {
+            props: {
               required: true,
               label: 'account.register.password_confirmation.label',
 
@@ -291,7 +291,7 @@ export class RegistrationFormConfigurationService {
     return [
       {
         type: 'ish-registration-heading-field',
-        templateOptions: {
+        props: {
           headingSize: 'h2',
           heading: 'account.register.personal_information.heading',
           showRequiredInfo: true,
@@ -299,7 +299,7 @@ export class RegistrationFormConfigurationService {
       },
       {
         type: 'ish-fieldset-field',
-        templateOptions: {
+        props: {
           fieldsetClass: 'row',
           childClass: 'col-md-10 col-lg-8 col-xl-6',
         },
@@ -312,7 +312,7 @@ export class RegistrationFormConfigurationService {
     return [
       {
         type: 'ish-registration-heading-field',
-        templateOptions: {
+        props: {
           headingSize: 'h2',
           heading: 'account.register.company_information.heading',
           showRequiredInfo: true,
@@ -320,7 +320,7 @@ export class RegistrationFormConfigurationService {
       },
       {
         type: 'ish-fieldset-field',
-        templateOptions: {
+        props: {
           fieldsetClass: 'row',
           childClass: 'col-md-10 col-lg-8 col-xl-6',
         },

--- a/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.ts
+++ b/src/app/shared/components/basket/basket-cost-center-selection/basket-cost-center-selection.component.ts
@@ -97,7 +97,7 @@ export class BasketCostCenterSelectionComponent implements OnInit, OnDestroy {
       {
         key: 'costCenter',
         type: 'ish-select-field',
-        templateOptions: {
+        props: {
           label: 'checkout.cost_center.select.label',
           required: true,
           hideRequiredMarker: true,

--- a/src/app/shared/components/basket/basket-desired-delivery-date/basket-desired-delivery-date.component.ts
+++ b/src/app/shared/components/basket/basket-desired-delivery-date/basket-desired-delivery-date.component.ts
@@ -38,7 +38,7 @@ export class BasketDesiredDeliveryDateComponent implements OnInit, OnChanges {
       {
         key: 'desiredDeliveryDate',
         type: 'ish-date-picker-field',
-        templateOptions: {
+        props: {
           postWrappers: [{ wrapper: 'description', index: -1 }],
           label: 'checkout.desired_delivery_date.label',
           customDescription: {
@@ -54,12 +54,12 @@ export class BasketDesiredDeliveryDateComponent implements OnInit, OnChanges {
         validators: {
           noSaturday: {
             expression: (control: FormControl, field: FormlyFieldConfig) =>
-              field.templateOptions.isSatExcluded ? SpecialValidators.noSaturday(control) : () => true,
+              field.props.isSatExcluded ? SpecialValidators.noSaturday(control) : () => true,
             message: 'checkout.desired_delivery_date.error.no_saturday',
           },
           noSunday: {
             expression: (control: FormControl, field: FormlyFieldConfig) =>
-              field.templateOptions.isSunExcluded ? SpecialValidators.noSunday(control) : () => true,
+              field.props.isSunExcluded ? SpecialValidators.noSunday(control) : () => true,
             message: 'checkout.desired_delivery_date.error.no_sunday',
           },
         },

--- a/src/app/shared/components/basket/basket-merchant-message/basket-merchant-message.component.ts
+++ b/src/app/shared/components/basket/basket-merchant-message/basket-merchant-message.component.ts
@@ -39,7 +39,7 @@ export class BasketMerchantMessageComponent implements OnInit, OnChanges {
       {
         key: 'messageToMerchant',
         type: 'ish-textarea-field',
-        templateOptions: {
+        props: {
           postWrappers: [{ wrapper: 'description', index: -1 }],
           label: 'checkout.basket_merchant_message.label',
           maxLength: 1000,

--- a/src/app/shared/components/basket/basket-order-reference/basket-order-reference.component.ts
+++ b/src/app/shared/components/basket/basket-order-reference/basket-order-reference.component.ts
@@ -36,7 +36,7 @@ export class BasketOrderReferenceComponent implements OnInit, OnChanges {
       {
         key: 'orderReferenceId',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           postWrappers: [{ wrapper: 'description', index: -1 }],
           label: 'checkout.orderReferenceId.label',
           maxLength: 35,

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
@@ -71,7 +71,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit, OnDestroy {
       {
         key: 'id',
         type: 'ish-select-field',
-        templateOptions: {
+        props: {
           fieldClass: 'col-12',
           options: FormsService.getAddressOptions(this.addresses$),
           placeholder: this.emptyOptionLabel,

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
@@ -86,7 +86,7 @@ export class BasketShippingAddressWidgetComponent implements OnInit, OnDestroy {
       {
         key: 'id',
         type: 'ish-select-field',
-        templateOptions: {
+        props: {
           fieldClass: 'col-12',
           options: FormsService.getAddressOptions(this.addresses$),
           placeholder: this.emptyOptionLabel,

--- a/src/app/shared/components/login/login-form/login-form.component.ts
+++ b/src/app/shared/components/login/login-form/login-form.component.ts
@@ -52,7 +52,7 @@ export class LoginFormComponent implements OnInit {
       {
         key: 'login',
         type: this.loginType === 'email' ? 'ish-email-field' : 'ish-text-input-field',
-        templateOptions: {
+        props: {
           label: this.loginType === 'email' ? 'account.login.email.label' : 'account.login.username.label',
           labelClass: this.labelClass || 'col-md-3',
           fieldClass: this.inputClass || 'col-md-6',
@@ -69,7 +69,7 @@ export class LoginFormComponent implements OnInit {
       {
         key: 'password',
         type: 'ish-text-input-field',
-        templateOptions: {
+        props: {
           type: 'password',
           label: 'account.login.password.label',
           labelClass: this.labelClass || 'col-md-3',

--- a/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-extension-form/formly-address-extension-form.component.ts
@@ -25,7 +25,7 @@ export class FormlyAddressExtensionFormComponent implements OnInit {
           {
             key: 'email',
             type: 'ish-email-field',
-            templateOptions: {
+            props: {
               required: true,
               label: 'checkout.addresses.email.label',
               customDescription: {

--- a/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.spec.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.spec.ts
@@ -21,7 +21,7 @@ const configurations: { [key: string]: FormlyFieldConfig[] } = {
     {
       key: 'firstName',
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'default input',
         required: true,
       },
@@ -31,7 +31,7 @@ const configurations: { [key: string]: FormlyFieldConfig[] } = {
     {
       key: 'firstName',
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'example input',
         required: true,
       },
@@ -39,7 +39,7 @@ const configurations: { [key: string]: FormlyFieldConfig[] } = {
     {
       key: 'lastName',
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'last name',
       },
     },
@@ -48,7 +48,7 @@ const configurations: { [key: string]: FormlyFieldConfig[] } = {
     {
       key: 'companyName1',
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'example input',
         required: true,
       },

--- a/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
@@ -98,7 +98,7 @@ export class FormlyAddressFormComponent implements OnInit, OnChanges {
         {
           key: 'countryCode',
           type: 'ish-select-field',
-          templateOptions: {
+          props: {
             required: true,
             label: 'account.address.country.label',
             forceRequiredStar: true,

--- a/src/app/shared/formly-address-forms/configurations/de/address-form-de.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/de/address-form-de.configuration.ts
@@ -40,7 +40,7 @@ export class AddressFormDEConfiguration extends AddressFormConfiguration {
         {
           key: 'addressLine3',
           type: 'ish-text-input-field',
-          templateOptions: {
+          props: {
             label: 'account.address.street3.label',
             required: false,
           },
@@ -50,7 +50,7 @@ export class AddressFormDEConfiguration extends AddressFormConfiguration {
         {
           key: 'postalCode',
           type: '#postalCode',
-          templateOptions: {
+          props: {
             maxLength: 5,
           },
           validators: {

--- a/src/app/shared/formly-address-forms/configurations/default/address-form-default.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/default/address-form-default.configuration.ts
@@ -45,7 +45,7 @@ export class AddressFormDefaultConfiguration extends AddressFormConfiguration {
         {
           key: 'mainDivisionCode',
           type: 'ish-select-field',
-          templateOptions: {
+          props: {
             required: true,
             label: 'account.default_address.state.label',
             placeholder: 'account.option.select.text',

--- a/src/app/shared/formly-address-forms/configurations/fr/address-form-fr.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/fr/address-form-fr.configuration.ts
@@ -38,7 +38,7 @@ export class AddressFormFRConfiguration extends AddressFormConfiguration {
         {
           key: 'postalCode',
           type: '#postalCode',
-          templateOptions: {
+          props: {
             maxLength: 5,
           },
           validators: {

--- a/src/app/shared/formly-address-forms/configurations/gb/address-form-gb.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/gb/address-form-gb.configuration.ts
@@ -39,7 +39,7 @@ export class AddressFormGBConfiguration extends AddressFormConfiguration {
         'addressLine2',
         {
           key: 'addressLine3',
-          templateOptions: {
+          props: {
             label: 'account.address.uk.locality.label',
             required: false,
           },

--- a/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
@@ -43,7 +43,7 @@ export class AddressFormUSConfiguration extends AddressFormConfiguration {
         {
           key: 'city',
           type: '#city',
-          templateOptions: {
+          props: {
             postWrappers: [{ wrapper: 'tooltip', index: -1 }],
             tooltip: {
               link: 'account.address.apo_fpo.link',
@@ -55,7 +55,7 @@ export class AddressFormUSConfiguration extends AddressFormConfiguration {
         {
           key: 'mainDivisionCode',
           type: 'ish-select-field',
-          templateOptions: {
+          props: {
             label: 'account.address.state.label',
             required: true,
             placeholder: 'account.option.select.text',

--- a/src/app/shared/formly/components/validation-icons/validation-icons.component.html
+++ b/src/app/shared/formly/components/validation-icons/validation-icons.component.html
@@ -8,9 +8,7 @@
   <ng-template #noError>
     <span class="has-success">
       <fa-icon
-        *ngIf="
-          field?.templateOptions?.showValidation ? field.templateOptions.showValidation(field) : defaultShowValidation()
-        "
+        *ngIf="field?.props?.showValidation ? field.props.showValidation(field) : defaultShowValidation()"
         class="form-control-feedback"
         [icon]="['fas', 'check']"
         data-testing-id="check-icon"

--- a/src/app/shared/formly/components/validation-icons/validation-icons.component.ts
+++ b/src/app/shared/formly/components/validation-icons/validation-icons.component.ts
@@ -4,7 +4,7 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 /**
  * Component that displays either a cross or a check mark to indicate validity.
  *
- * @templateOption **showValidation** - a function of type ``(field: FormlyFieldConfig) => boolean``
+ * @props **showValidation** - a function of type ``(field: FormlyFieldConfig) => boolean``
  * that can be used to override the check mark display condition.
  *
  */

--- a/src/app/shared/formly/dev/testing/formly-testing.module.ts
+++ b/src/app/shared/formly/dev/testing/formly-testing.module.ts
@@ -17,7 +17,7 @@ class CheckboxFieldComponent extends FieldType {}
   template: `FieldsetFieldComponent:
     <div *ngFor="let f of field.fieldGroup">
       {{ getFieldSummary(f) }}
-      {{ f.templateOptions | json }}
+      {{ f.props | json }}
     </div>`,
 })
 class FieldsetFieldComponent extends FieldType {

--- a/src/app/shared/formly/extensions/hide-if-empty-options.extension.ts
+++ b/src/app/shared/formly/extensions/hide-if-empty-options.extension.ts
@@ -5,19 +5,18 @@ import { map } from 'rxjs/operators';
 /**
  * Extension that automatically hides select fields when their options are empty.
  *
- * @templateOption **options** - array or observable of arrays that will be checked for emptiness
+ * @props **options** - array or observable of arrays that will be checked for emptiness
  */
 export const hideIfEmptyOptionsExtension: FormlyExtension = {
   prePopulate(field: FormlyFieldConfig): void {
     if (field.type !== 'ish-select-field') {
       return;
     }
-    field.expressionProperties = {
-      ...field.expressionProperties,
-      hide: (isObservable(field.templateOptions.options)
-        ? field.templateOptions.options
-        : of(field.templateOptions.options)
-      ).pipe(map(options => options?.length === 0)),
+    field.expressions = {
+      ...field.expressions,
+      hide: (isObservable(field.props.options) ? field.props.options : of(field.props.options)).pipe(
+        map(options => options?.length === 0)
+      ),
     };
   },
 };

--- a/src/app/shared/formly/extensions/post-wrappers-extension.ts
+++ b/src/app/shared/formly/extensions/post-wrappers-extension.ts
@@ -1,11 +1,11 @@
-import { FormlyConfig, FormlyExtension, FormlyFieldConfig, FormlyTemplateOptions } from '@ngx-formly/core';
+import { FormlyConfig, FormlyExtension, FormlyFieldConfig, FormlyFieldProps } from '@ngx-formly/core';
 
 type PostWrapper = string | { index: number; wrapper: string };
 
 /**
  * Extension that enables appending wrappers to the default configuration.
  *
- * @templateOption **postWrappers** - property that will be used to extend a field's wrappers without overriding the default ones.
+ * @props **postWrappers** - property that will be used to extend a field's wrappers without overriding the default ones.
  *
  * @usageNotes
  * The array is of type ``<string | {index: number; wrapper: string}>[]``.
@@ -15,13 +15,13 @@ class PostWrappersExtension implements FormlyExtension {
   constructor(private formlyConfig: FormlyConfig) {}
 
   prePopulate(field: FormlyFieldConfig): void {
-    const to: FormlyTemplateOptions & { postWrappers?: PostWrapper[] } = field.templateOptions;
-    if (!to?.postWrappers || to.postWrappers.length === 0) {
+    const props: FormlyFieldProps & { postWrappers?: PostWrapper[] } = field.props;
+    if (!props?.postWrappers || props.postWrappers.length === 0) {
       return;
     }
     const wrappers = this.formlyConfig.getType(field.type).wrappers;
-    field.wrappers = [...wrappers, ...(to.postWrappers.filter(w => typeof w === 'string') as string[])];
-    to.postWrappers
+    field.wrappers = [...wrappers, ...(props.postWrappers.filter(w => typeof w === 'string') as string[])];
+    props.postWrappers
       .filter(w => typeof w !== 'string')
       .forEach((wrapper: { index: number; wrapper: string }) => {
         field.wrappers.splice(wrapper.index, 0, wrapper.wrapper);

--- a/src/app/shared/formly/extensions/translate-placeholder.extension.ts
+++ b/src/app/shared/formly/extensions/translate-placeholder.extension.ts
@@ -4,25 +4,25 @@ import { of, race } from 'rxjs';
 import { delay, filter } from 'rxjs/operators';
 
 /**
- * Extension to translate the templateOptions.placeholder.
+ * Extension to translate the props.placeholder.
  * Uses the TranslateService and replaces the placeholder with the translated version.
  */
 class TranslatePlaceholderExtension implements FormlyExtension {
   constructor(private translate: TranslateService) {}
 
   prePopulate(field: FormlyFieldConfig): void {
-    const to = field.templateOptions;
-    if (!to?.placeholder) {
+    const props = field.props;
+    if (!props?.placeholder) {
       return;
     }
 
     race(
       // wait till service has loaded translations
-      this.translate.get(to.placeholder).pipe(filter(value => value !== to.placeholder)),
+      this.translate.get(props.placeholder).pipe(filter(value => value !== props.placeholder)),
       // abort if translation was not found
-      of(to.placeholder).pipe(delay(1000))
+      of(props.placeholder).pipe(delay(1000))
     ).subscribe(translation => {
-      field.templateOptions.placeholder = translation;
+      field.props.placeholder = translation;
     });
   }
 }

--- a/src/app/shared/formly/extensions/translate-select-options.extension.ts
+++ b/src/app/shared/formly/extensions/translate-select-options.extension.ts
@@ -4,30 +4,30 @@ import { isObservable, of } from 'rxjs';
 import { map, startWith, tap } from 'rxjs/operators';
 
 /**
- * Extension to translate the templateOptions.options and add a placeholder element.
+ * Extension to translate the props.options and add a placeholder element.
  *
- * @templateOption  **options**  defines options to be shown as key value pairs. Accepts two types:
+ * @props  **options**  defines options to be shown as key value pairs. Accepts two types:
  * * `` { value: any; label: string}[]``
  * * `` Observable<{ value: any; label: string}[]>``
- * @templateOption **placeholder** - is used to add a placeholder element. This will also be translated.
+ * @props **placeholder** - is used to add a placeholder element. This will also be translated.
  *
  * @usageNotes
  * It will use the TranslateService to translate option labels.
- * These modified options are written to ``templateOptions.processedOptions``.
+ * These modified options are written to ``props.processedOptions``.
  */
 class TranslateSelectOptionsExtension implements FormlyExtension {
   constructor(private translate: TranslateService) {}
 
   prePopulate(field: FormlyFieldConfig): void {
-    const to = field.templateOptions;
-    if (!to?.options) {
+    const props = field.props;
+    if (!props?.options) {
       return;
     }
-    field.templateOptions.processedOptions = (isObservable(to.options) ? to.options : of(to.options)).pipe(
+    field.props.processedOptions = (isObservable(props.options) ? props.options : of(props.options)).pipe(
       startWith([]),
-      map(options => (to.placeholder ? [{ value: '', label: to.placeholder }] : []).concat(options ?? [])),
+      map(options => (props.placeholder ? [{ value: '', label: props.placeholder }] : []).concat(options ?? [])),
       tap(() => {
-        if (to.placeholder && !field.formControl.value && !field.model[field.key as string]) {
+        if (props.placeholder && !field.formControl.value && !field.model[field.key as string]) {
           field.formControl.setValue('');
         }
       }),

--- a/src/app/shared/formly/field-library/configurations/address-line-1.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/address-line-1.configuration.ts
@@ -13,7 +13,7 @@ export class AddressLine1Configuration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.street.label',
         required: true,
       },

--- a/src/app/shared/formly/field-library/configurations/address-line-2.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/address-line-2.configuration.ts
@@ -13,7 +13,7 @@ export class AddressLine2Configuration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.street2.label',
         required: false,
       },

--- a/src/app/shared/formly/field-library/configurations/city.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/city.configuration.ts
@@ -13,7 +13,7 @@ export class CityConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.city.label',
         required: true,
       },

--- a/src/app/shared/formly/field-library/configurations/company-name-1.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/company-name-1.configuration.ts
@@ -13,7 +13,7 @@ export class CompanyName1Configuration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.company_name.label',
         required: true,
       },

--- a/src/app/shared/formly/field-library/configurations/company-name-2.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/company-name-2.configuration.ts
@@ -14,7 +14,7 @@ export class CompanyName2Configuration extends FieldLibraryConfiguration {
     return {
       key: 'companyName2',
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.company_name_2.label',
         required: false,
       },

--- a/src/app/shared/formly/field-library/configurations/first-name.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/first-name.configuration.ts
@@ -15,7 +15,7 @@ export class FirstNameConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.firstname.label',
         required: true,
       },

--- a/src/app/shared/formly/field-library/configurations/last-name.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/last-name.configuration.ts
@@ -15,7 +15,7 @@ export class LastNameConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.lastname.label',
         required: true,
       },

--- a/src/app/shared/formly/field-library/configurations/phone-home.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/phone-home.configuration.ts
@@ -13,7 +13,7 @@ export class PhoneHomeConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-phone-field',
-      templateOptions: {
+      props: {
         label: 'account.profile.phone.label',
         required: false,
       },

--- a/src/app/shared/formly/field-library/configurations/postal-code.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/postal-code.configuration.ts
@@ -13,7 +13,7 @@ export class PostalCodeConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.postalcode.label',
         required: true,
       },

--- a/src/app/shared/formly/field-library/configurations/taxation-id.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/taxation-id.configuration.ts
@@ -13,7 +13,7 @@ export class TaxationIDConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-text-input-field',
-      templateOptions: {
+      props: {
         label: 'account.address.taxation.label',
       },
     };

--- a/src/app/shared/formly/field-library/configurations/title.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/title.configuration.ts
@@ -18,7 +18,7 @@ export class TitleConfiguration extends FieldLibraryConfiguration {
   getFieldConfig(): FormlyFieldConfig {
     return {
       type: 'ish-select-field',
-      templateOptions: {
+      props: {
         label: 'account.address.title.label',
         placeholder: 'account.option.select.text',
         options: this.formsService.getSalutationOptions(),

--- a/src/app/shared/formly/field-library/field-library.spec.ts
+++ b/src/app/shared/formly/field-library/field-library.spec.ts
@@ -21,7 +21,7 @@ describe('Field Library', () => {
           provide: FIELD_LIBRARY_CONFIGURATION,
           useValue: {
             id: 'a',
-            getFieldConfig: () => ({ type: 'a', templateOptions: { label: 'a' } }),
+            getFieldConfig: () => ({ type: 'a', props: { label: 'a' } }),
           },
           multi: true,
         },
@@ -29,7 +29,7 @@ describe('Field Library', () => {
           provide: FIELD_LIBRARY_CONFIGURATION,
           useValue: {
             id: 'b',
-            getFieldConfig: () => ({ type: 'b', templateOptions: { label: 'b' } }),
+            getFieldConfig: () => ({ type: 'b', props: { label: 'b' } }),
           },
           multi: true,
         },
@@ -37,7 +37,7 @@ describe('Field Library', () => {
           provide: FIELD_LIBRARY_CONFIGURATION,
           useValue: {
             id: 'c',
-            getFieldConfig: () => ({ type: 'c', wrappers: ['w1', 'w2'], templateOptions: { label: 'c' } }),
+            getFieldConfig: () => ({ type: 'c', wrappers: ['w1', 'w2'], props: { label: 'c' } }),
           },
           multi: true,
         },
@@ -52,7 +52,7 @@ describe('Field Library', () => {
       expect(fieldLibrary.getConfiguration('a')).toMatchInlineSnapshot(`
         Object {
           "key": "a",
-          "templateOptions": Object {
+          "props": Object {
             "label": "a",
           },
           "type": "a",
@@ -63,14 +63,14 @@ describe('Field Library', () => {
     it('should get configuration and override correctly', () => {
       expect(
         fieldLibrary.getConfiguration('a', {
-          templateOptions: {
+          props: {
             label: 'new label',
           },
         })
       ).toMatchInlineSnapshot(`
         Object {
           "key": "a",
-          "templateOptions": Object {
+          "props": Object {
             "label": "new label",
           },
           "type": "a",
@@ -86,7 +86,7 @@ describe('Field Library', () => {
       ).toMatchInlineSnapshot(`
         Object {
           "key": "c",
-          "templateOptions": Object {
+          "props": Object {
             "label": "c",
           },
           "type": "c",
@@ -104,14 +104,14 @@ describe('Field Library', () => {
         Array [
           Object {
             "key": "a",
-            "templateOptions": Object {
+            "props": Object {
               "label": "a",
             },
             "type": "a",
           },
           Object {
             "key": "b",
-            "templateOptions": Object {
+            "props": Object {
               "label": "b",
             },
             "type": "b",
@@ -124,13 +124,13 @@ describe('Field Library', () => {
       expect(
         fieldLibrary.getConfigurationGroup('ab', {
           a: {
-            templateOptions: {
+            props: {
               label: 'new a label',
             },
           },
 
           b: {
-            templateOptions: {
+            props: {
               label: 'new b label',
             },
           },
@@ -139,14 +139,14 @@ describe('Field Library', () => {
         Array [
           Object {
             "key": "a",
-            "templateOptions": Object {
+            "props": Object {
               "label": "new a label",
             },
             "type": "a",
           },
           Object {
             "key": "b",
-            "templateOptions": Object {
+            "props": Object {
               "label": "new b label",
             },
             "type": "b",

--- a/src/app/shared/formly/field-library/library-config-replacement.extension.ts
+++ b/src/app/shared/formly/field-library/library-config-replacement.extension.ts
@@ -23,7 +23,7 @@ class LibraryConfigReplacementExtension implements FormlyExtension {
         const config = this.fieldLibrary.getConfiguration(configId, override);
         // eslint-disable-next-line ban/ban
         Object.assign(field, config);
-        field.templateOptions = config.templateOptions;
+        field.props = config.props;
       }
     }
   }

--- a/src/app/shared/formly/types/captcha-field/captcha-field.component.html
+++ b/src/app/shared/formly/types/captcha-field/captcha-field.component.html
@@ -1,1 +1,1 @@
-<ish-lazy-captcha [topic]="to.topic" [form]="form" [attr.data-testing-id]="field.key"></ish-lazy-captcha>
+<ish-lazy-captcha [topic]="props.topic" [form]="form" [attr.data-testing-id]="field.key"></ish-lazy-captcha>

--- a/src/app/shared/formly/types/captcha-field/captcha-field.component.spec.ts
+++ b/src/app/shared/formly/types/captcha-field/captcha-field.component.spec.ts
@@ -33,7 +33,7 @@ describe('Captcha Field Component', () => {
       fields: [
         {
           type: 'ish-captcha-field',
-          templateOptions: {
+          props: {
             topic: 'test',
           },
         } as FormlyFieldConfig,

--- a/src/app/shared/formly/types/captcha-field/captcha-field.component.ts
+++ b/src/app/shared/formly/types/captcha-field/captcha-field.component.ts
@@ -5,7 +5,7 @@ import { FieldType } from '@ngx-formly/core';
 /**
  * Type to include the ``ish-lazy-captcha`` component in your fields.
  *
- * @templateOption **topic** - defines the captcha topic that is passed to the component.
+ * @props **topic** - defines the captcha topic that is passed to the component.
  *
  * @usageNotes
  * Automatically adds the required ``captcha`` and ``captchaAction`` FormControls to the form.
@@ -28,7 +28,7 @@ export class CaptchaFieldComponent extends FieldType implements OnInit {
     }
 
     if (!form.get('captchaAction')) {
-      form.addControl('captchaAction', new FormControl(this.to.topic));
+      form.addControl('captchaAction', new FormControl(this.props.topic));
     }
   }
 }

--- a/src/app/shared/formly/types/checkbox-field/checkbox-field.component.html
+++ b/src/app/shared/formly/types/checkbox-field/checkbox-field.component.html
@@ -3,6 +3,6 @@
   [formControl]="formControl"
   [formlyAttributes]="field"
   class="form-check-input"
-  [ngClass]="to.inputClass"
+  [ngClass]="props.inputClass"
   [attr.data-testing-id]="field.key"
 />

--- a/src/app/shared/formly/types/checkbox-field/checkbox-field.component.ts
+++ b/src/app/shared/formly/types/checkbox-field/checkbox-field.component.ts
@@ -7,7 +7,7 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
  * @defaultWrappers form-field-checkbox-horizontal
  *
  * @usageNotes
- * Refer to the form-field-checkbox-horizontal wrapper for more info on relevant templateOptions.
+ * Refer to the form-field-checkbox-horizontal wrapper for more info on relevant props.
  */
 @Component({
   selector: 'ish-checkbox-field',

--- a/src/app/shared/formly/types/date-picker-field/date-picker-field.component.html
+++ b/src/app/shared/formly/types/date-picker-field/date-picker-field.component.html
@@ -8,7 +8,7 @@
     outsideDays="collapsed"
     navigation="arrows"
     class="form-control"
-    [ngClass]="to.inputClass"
+    [ngClass]="props.inputClass"
     name="dp"
     ngbDatepicker
     #d="ngbDatepicker"

--- a/src/app/shared/formly/types/date-picker-field/date-picker-field.component.spec.ts
+++ b/src/app/shared/formly/types/date-picker-field/date-picker-field.component.spec.ts
@@ -52,7 +52,7 @@ describe('Date Picker Field Component', () => {
         {
           key: 'desiredDeliveryDate',
           type: 'ish-date-picker-field',
-          templateOptions: templateOptionsLoc,
+          props: templateOptionsLoc,
         } as FormlyFieldConfig,
       ],
       form: new FormGroup({}),

--- a/src/app/shared/formly/types/date-picker-field/date-picker-field.component.ts
+++ b/src/app/shared/formly/types/date-picker-field/date-picker-field.component.ts
@@ -8,11 +8,11 @@ import { Observable, combineLatest, isObservable, map, of } from 'rxjs';
  * Uses NgbDatepicker with custom formatting and parsing.
  * Refer to `fixed-format-adapter.ts` and `localized-parser-formatter.ts` for more information on date formatting.
  *
- * @templateOption **minDays** - computes the minDate by adding the minimum allowed days to today.
- * @templateOption **maxDays** - computes the maxDate by adding the maximum allowed days to today.
- * @templateOption **isSatExcluded** - specifies if saturdays can be disabled.
- * @templateOption **isSunExcluded** - specifies if sundays can be disabled.
- * @templateOption **inputClass** - class to apply to the input field
+ * @props **minDays** - computes the minDate by adding the minimum allowed days to today.
+ * @props **maxDays** - computes the maxDate by adding the maximum allowed days to today.
+ * @props **isSatExcluded** - specifies if saturdays can be disabled.
+ * @props **isSunExcluded** - specifies if sundays can be disabled.
+ * @props **inputClass** - class to apply to the input field
  *
  * @defaultWrappers 'form-field-horizontal', 'validation'
  *
@@ -47,8 +47,12 @@ export class DatePickerFieldComponent extends FieldType<FieldTypeConfig> {
   }
 
   get markDateDisable$() {
-    const isSatExcluded$ = isObservable(this.to.isSatExcluded) ? this.to.isSatExcluded : of(this.to.isSatExcluded);
-    const isSunExcluded$ = isObservable(this.to.isSunExcluded) ? this.to.isSunExcluded : of(this.to.isSunExcluded);
+    const isSatExcluded$ = isObservable(this.props.isSatExcluded)
+      ? this.props.isSatExcluded
+      : of(this.props.isSatExcluded);
+    const isSunExcluded$ = isObservable(this.props.isSunExcluded)
+      ? this.props.isSunExcluded
+      : of(this.props.isSunExcluded);
 
     return combineLatest([isSatExcluded$, isSunExcluded$]).pipe(
       map(([isSatExcluded, isSunExcluded]) => (date: NgbDate) => {
@@ -60,7 +64,7 @@ export class DatePickerFieldComponent extends FieldType<FieldTypeConfig> {
   }
 
   private toObservableNumber(daysType: 'minDays' | 'maxDays') {
-    const days = daysType === 'minDays' ? this.to.minDays : this.to.maxDays;
+    const days = daysType === 'minDays' ? this.props.minDays : this.props.maxDays;
     const days$ = isObservable(days) ? days : of(days);
     return days$.pipe(map(daysLoc => (typeof daysLoc === 'number' ? daysLoc : undefined)));
   }

--- a/src/app/shared/formly/types/fieldset-field/fieldset-field.component.html
+++ b/src/app/shared/formly/types/fieldset-field/fieldset-field.component.html
@@ -1,6 +1,6 @@
-<fieldset [ngClass]="to.fieldsetClass">
-  <div [ngClass]="to.childClass">
-    <legend *ngIf="to.legend" [ngClass]="to.legendClass">{{ to.legend | translate }}</legend>
+<fieldset [ngClass]="props.fieldsetClass">
+  <div [ngClass]="props.childClass">
+    <legend *ngIf="props.legend" [ngClass]="props.legendClass">{{ props.legend | translate }}</legend>
     <formly-field *ngFor="let f of field.fieldGroup" [field]="f"></formly-field>
   </div>
 </fieldset>

--- a/src/app/shared/formly/types/fieldset-field/fieldset-field.component.spec.ts
+++ b/src/app/shared/formly/types/fieldset-field/fieldset-field.component.spec.ts
@@ -39,7 +39,7 @@ describe('Fieldset Field Component', () => {
       fields: [
         {
           type: 'ish-fieldset-field',
-          templateOptions: {
+          props: {
             legend: 'Legend text',
             legendClass: 'text-muted',
           },

--- a/src/app/shared/formly/types/fieldset-field/fieldset-field.component.ts
+++ b/src/app/shared/formly/types/fieldset-field/fieldset-field.component.ts
@@ -4,10 +4,10 @@ import { FieldType } from '@ngx-formly/core';
 /**
  * Type to render a group of fields within ``<fieldset>`` tags.
  *
- * @templateOption **fieldsetClass** - used to add styles to the ``<fieldset>`` tag.
- * @templateOption **childClass** - used to add styles to a child ``<div>``.
- * @templateOption **legend** - used to add a legend to the ``<fieldset>`` tag, the value is displayed as the legend text and will also be translated.
- * @templateOption **legendClass** - used to add styles to the ``<legend>`` tag.
+ * @props **fieldsetClass** - used to add styles to the ``<fieldset>`` tag.
+ * @props **childClass** - used to add styles to a child ``<div>``.
+ * @props **legend** - used to add a legend to the ``<fieldset>`` tag, the value is displayed as the legend text and will also be translated.
+ * @props **legendClass** - used to add styles to the ``<legend>`` tag.
  *
  * @usageNotes
  * Control the rendered children via the ``fieldGroup`` attribute.

--- a/src/app/shared/formly/types/html-text-field/html-text-field.component.html
+++ b/src/app/shared/formly/types/html-text-field/html-text-field.component.html
@@ -1,1 +1,1 @@
-<div [ngClass]="to.inputClass ? to.inputClass : 'col-form-label'" [innerHtml]="textValue"></div>
+<div [ngClass]="props.inputClass ? props.inputClass : 'col-form-label'" [innerHtml]="textValue"></div>

--- a/src/app/shared/formly/types/html-text-field/html-text-field.component.spec.ts
+++ b/src/app/shared/formly/types/html-text-field/html-text-field.component.spec.ts
@@ -35,7 +35,7 @@ describe('Html Text Field Component', () => {
         {
           key: 'displayValue',
           type: 'ish-html-text-field',
-          templateOptions: {
+          props: {
             label: 'test label',
           },
         } as FormlyFieldConfig,

--- a/src/app/shared/formly/types/html-text-field/html-text-field.component.ts
+++ b/src/app/shared/formly/types/html-text-field/html-text-field.component.ts
@@ -4,7 +4,7 @@ import { FieldType } from '@ngx-formly/core';
 /**
  * Type to display a html text value with optional styling
  *
- * @templateOption **inputClass** a class that will be used to style the div around the text
+ * @props **inputClass** a class that will be used to style the div around the text
  */
 @Component({
   selector: 'ish-html-text-field',

--- a/src/app/shared/formly/types/plain-text-field/plain-text-field.component.html
+++ b/src/app/shared/formly/types/plain-text-field/plain-text-field.component.html
@@ -1,3 +1,3 @@
-<div [ngClass]="to.inputClass ? to.inputClass : 'col-form-label'">
+<div [ngClass]="props.inputClass ? props.inputClass : 'col-form-label'">
   {{ textValue }}
 </div>

--- a/src/app/shared/formly/types/plain-text-field/plain-text-field.component.spec.ts
+++ b/src/app/shared/formly/types/plain-text-field/plain-text-field.component.spec.ts
@@ -35,7 +35,7 @@ describe('Plain Text Field Component', () => {
         {
           key: 'displayValue',
           type: 'ish-plain-text-field',
-          templateOptions: {
+          props: {
             label: 'test label',
           },
         } as FormlyFieldConfig,

--- a/src/app/shared/formly/types/plain-text-field/plain-text-field.component.ts
+++ b/src/app/shared/formly/types/plain-text-field/plain-text-field.component.ts
@@ -4,7 +4,7 @@ import { FieldType } from '@ngx-formly/core';
 /**
  * Type to simply display a text value with optional styling
  *
- * @templateOption **inputClass** a class that will be used to style the div around the text
+ * @props **inputClass** a class that will be used to style the div around the text
  */
 @Component({
   selector: 'ish-plain-text-field',

--- a/src/app/shared/formly/types/radio-field/radio-field.component.html
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.html
@@ -1,9 +1,9 @@
 <input
   type="radio"
   [formControl]="formControl"
-  [value]="to.value"
+  [value]="props.value"
   [id]="id"
   class="form-check-input"
-  [ngClass]="to.inputClass"
-  [attr.data-testing-id]="'radio-' + to.label"
+  [ngClass]="props.inputClass"
+  [attr.data-testing-id]="'radio-' + props.label"
 />

--- a/src/app/shared/formly/types/radio-field/radio-field.component.ts
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.ts
@@ -4,14 +4,14 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 /**
  * Basic type for radio buttons
  *
- * @templateOption **label** - the text that should be shown next to the radio button
- * @templateOptions **value** - the value that should be associated with this radio button
+ * @props **label** - the text that should be shown next to the radio button
+ * @props **value** - the value that should be associated with this radio button
  *
  * @defaultWrappers form-field-checkbox-horizontal
  *
  * @usageNotes
  * Link multiple radio buttons together by using the same key for each.
- * Refer to the form-field-checkbox-horizontal wrapper for more info on relevant templateOptions.
+ * Refer to the form-field-checkbox-horizontal wrapper for more info on relevant props.
  *
  */
 @Component({

--- a/src/app/shared/formly/types/select-field/select-field.component.html
+++ b/src/app/shared/formly/types/select-field/select-field.component.html
@@ -1,9 +1,9 @@
 <select
   [formControl]="formControl"
-  [compareWith]="to.compareWith ? to.compareWith : defaultOptions.templateOptions.compareWith"
+  [compareWith]="props.compareWith ? props.compareWith : defaultOptions.props.compareWith"
   [formlyAttributes]="field"
   class="form-control"
-  [ngClass]="to.inputClass"
+  [ngClass]="props.inputClass"
   [attr.data-testing-id]="field.key"
 >
   <ng-container *ngIf="selectOptions && selectOptions | formlySelectOptions: field | async as opts">

--- a/src/app/shared/formly/types/select-field/select-field.component.spec.ts
+++ b/src/app/shared/formly/types/select-field/select-field.component.spec.ts
@@ -42,7 +42,7 @@ describe('Select Field Component', () => {
         {
           key: 'select',
           type: 'ish-select-field',
-          templateOptions: {
+          props: {
             label: 'test label',
             required: true,
             options: [{ value: 1, label: 'test' }],

--- a/src/app/shared/formly/types/select-field/select-field.component.ts
+++ b/src/app/shared/formly/types/select-field/select-field.component.ts
@@ -6,17 +6,17 @@ import { SelectOption } from 'ish-core/models/select-option/select-option.model'
 /**
  * Type for a basic select field
  *
- * @templateOption **options**  defines options to be shown as key value pairs. Accepts two types:
+ * @props **options**  defines options to be shown as key value pairs. Accepts two types:
  * * `` { value: any; label: string}[]``
  * * `` Observable<{ value: any; label: string}[]>``
- * @templateOption **placeholder** defines the placeholder string that will be used as the first / default option
+ * @props **placeholder** defines the placeholder string that will be used as the first / default option
  *
  * @defaultWrappers form-field-horizontal & validation
  *
  * @usageNotes
  * The select field functionality is coupled with the translate-select-options extension. It reads the ``options`` and ``placeholder``
- * from the configuration and writes them to ``templateOptions.processedOptions``.
- * Please don't use ``templateOptions.processedOptions`` manually.
+ * from the configuration and writes them to ``props.processedOptions``.
+ * Please don't use ``props.processedOptions`` manually.
  *
  */
 @Component({
@@ -26,7 +26,7 @@ import { SelectOption } from 'ish-core/models/select-option/select-option.model'
 })
 export class SelectFieldComponent extends FieldType<FieldTypeConfig> {
   defaultOptions = {
-    templateOptions: {
+    props: {
       options: [] as SelectOption[],
       compareWith(o1: unknown, o2: unknown) {
         return o1 === o2;
@@ -35,6 +35,6 @@ export class SelectFieldComponent extends FieldType<FieldTypeConfig> {
   };
 
   get selectOptions() {
-    return this.to.processedOptions ?? this.to.options;
+    return this.props.processedOptions ?? this.props.options;
   }
 }

--- a/src/app/shared/formly/types/text-input-field/text-input-field.component.html
+++ b/src/app/shared/formly/types/text-input-field/text-input-field.component.html
@@ -1,8 +1,8 @@
 <input
-  [type]="to.type"
+  [type]="props.type"
   [formControl]="formControl"
   [formlyAttributes]="field"
   class="form-control"
-  [ngClass]="to.inputClass"
+  [ngClass]="props.inputClass"
   [attr.data-testing-id]="field.key"
 />

--- a/src/app/shared/formly/types/text-input-field/text-input-field.component.spec.ts
+++ b/src/app/shared/formly/types/text-input-field/text-input-field.component.spec.ts
@@ -34,7 +34,7 @@ describe('Text Input Field Component', () => {
         {
           key: 'input',
           type: 'ish-text-input-field',
-          templateOptions: {
+          props: {
             label: 'test label',
             required: true,
           },

--- a/src/app/shared/formly/types/text-input-field/text-input-field.component.ts
+++ b/src/app/shared/formly/types/text-input-field/text-input-field.component.ts
@@ -4,7 +4,7 @@ import { FieldType, FieldTypeConfig, FormlyFieldConfig } from '@ngx-formly/core'
 /**
  * Type for a basic input field
  *
- * @templateOption **type** supports all text types; 'text' (default), 'email', 'password', 'tel'
+ * @props **type** supports all text types; 'text' (default), 'email', 'password', 'tel'
  *
  * @defaultWrappers form-field-horizontal & validation
  */
@@ -17,14 +17,14 @@ export class TextInputFieldComponent extends FieldType<FieldTypeConfig> {
   textInputFieldTypes = ['text', 'email', 'password', 'tel'];
 
   onPopulate(field: FormlyFieldConfig) {
-    if (!field.templateOptions?.type) {
-      field.templateOptions.type = 'text';
+    if (!field.props?.type) {
+      field.props.type = 'text';
       return;
     }
 
-    if (!this.textInputFieldTypes.includes(field.templateOptions.type)) {
+    if (!this.textInputFieldTypes.includes(field.props.type)) {
       throw new Error(
-        'parameter <templateOptions.type> is not valid for TextInputFieldComponent, only text, email, password and tel are possible values'
+        'parameter <props.type> is not valid for TextInputFieldComponent, only text, email, password and tel are possible values'
       );
     }
   }

--- a/src/app/shared/formly/types/textarea-field/textarea-field.component.html
+++ b/src/app/shared/formly/types/textarea-field/textarea-field.component.html
@@ -1,9 +1,9 @@
 <textarea
   [formControl]="formControl"
-  [cols]="to.cols"
-  [rows]="to.rows"
+  [cols]="props.cols"
+  [rows]="props.rows"
   [formlyAttributes]="field"
   class="form-control"
-  [ngClass]="to.inputClass"
+  [ngClass]="props.inputClass"
   [attr.data-testing-id]="field.key"
 ></textarea>

--- a/src/app/shared/formly/types/textarea-field/textarea-field.component.spec.ts
+++ b/src/app/shared/formly/types/textarea-field/textarea-field.component.spec.ts
@@ -34,7 +34,7 @@ describe('Textarea Field Component', () => {
         {
           key: 'textarea',
           type: 'ish-textarea-field',
-          templateOptions: {
+          props: {
             label: 'test label',
             required: true,
           },

--- a/src/app/shared/formly/types/textarea-field/textarea-field.component.ts
+++ b/src/app/shared/formly/types/textarea-field/textarea-field.component.ts
@@ -4,13 +4,13 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 /**
  * Type for a basic textarea field
  *
- * @templateOptions **cols** - the amount of columns the textarea should have
- * @templateOptions **rows** - the amount of rows the textarea should have
+ * @props **cols** - the amount of columns the textarea should have
+ * @props **rows** - the amount of rows the textarea should have
  *
  * @defaultWrappers form-field-horizontal & textarea-description & validation
  *
  * @usageNotes
- * See the textarea-description wrapper for more info on the relevant templateOptions.
+ * See the textarea-description wrapper for more info on the relevant props.
  */
 @Component({
   selector: 'ish-textarea-field',
@@ -19,7 +19,7 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 })
 export class TextareaFieldComponent extends FieldType<FieldTypeConfig> {
   defaultOptions = {
-    templateOptions: {
+    props: {
       cols: 1,
       rows: 1,
     },

--- a/src/app/shared/formly/types/types.module.ts
+++ b/src/app/shared/formly/types/types.module.ts
@@ -75,7 +75,7 @@ const fieldComponents = [
           name: 'ish-email-field',
           extends: 'ish-text-input-field',
           defaultOptions: {
-            templateOptions: {
+            props: {
               type: 'email',
             },
             validators: {
@@ -93,7 +93,7 @@ const fieldComponents = [
           name: 'ish-phone-field',
           extends: 'ish-text-input-field',
           defaultOptions: {
-            templateOptions: {
+            props: {
               attributes: { maxlength: 20 },
               type: 'tel',
             },
@@ -112,7 +112,7 @@ const fieldComponents = [
           name: 'ish-password-field',
           extends: 'ish-text-input-field',
           defaultOptions: {
-            templateOptions: {
+            props: {
               type: 'password',
             },
             validators: {

--- a/src/app/shared/formly/wrappers/description-wrapper/description-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/description-wrapper/description-wrapper.component.html
@@ -1,2 +1,2 @@
 <ng-template #fieldComponent> </ng-template>
-<small class="form-text" [ngClass]="to.customDescription?.class"> {{ description | translate: args }} </small>
+<small class="form-text" [ngClass]="props.customDescription?.class"> {{ description | translate: args }} </small>

--- a/src/app/shared/formly/wrappers/description-wrapper/description-wrapper.component.spec.ts
+++ b/src/app/shared/formly/wrappers/description-wrapper/description-wrapper.component.spec.ts
@@ -47,7 +47,7 @@ describe('Description Wrapper Component', () => {
     component.fields = [
       {
         ...fieldBase,
-        templateOptions: {
+        props: {
           customDescription: 'desc',
         },
       },
@@ -73,7 +73,7 @@ describe('Description Wrapper Component', () => {
     component.fields = [
       {
         ...fieldBase,
-        templateOptions: {
+        props: {
           customDescription: {
             key: 'description',
             args: {

--- a/src/app/shared/formly/wrappers/description-wrapper/description-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/description-wrapper/description-wrapper.component.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 /**
  * Wrapper that adds a small description underneath the field.
  *
- * @templateOption **customDescription** - used to define the description text. Can be one of two types:
+ * @props **customDescription** - used to define the description text. Can be one of two types:
  * * ``string`` : a simple string that will be translated and displayed
  * * ``{ key: string, args: any, class: string}`` : a more complex object containing a translation key
  *    and arguments to be translated as well as a class that will be applied to the description.
@@ -17,10 +17,12 @@ import { FieldWrapper } from '@ngx-formly/core';
 })
 export class DescriptionWrapperComponent extends FieldWrapper {
   get description() {
-    return typeof this.to.customDescription === 'string' ? this.to.customDescription : this.to.customDescription?.key;
+    return typeof this.props.customDescription === 'string'
+      ? this.props.customDescription
+      : this.props.customDescription?.key;
   }
 
   get args() {
-    return typeof this.to.customDescription === 'string' ? {} : this.to.customDescription?.args;
+    return typeof this.props.customDescription === 'string' ? {} : this.props.customDescription?.args;
   }
 }

--- a/src/app/shared/formly/wrappers/horizontal-checkbox-wrapper/horizontal-checkbox-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/horizontal-checkbox-wrapper/horizontal-checkbox-wrapper.component.html
@@ -1,10 +1,10 @@
 <div class="row" [ngClass]="field.type === 'ish-checkbox-field' ? 'form-group' : 'mb-2'">
-  <div [class.has-error]="showError" [ngClass]="to.fieldClass ? to.fieldClass : dto.fieldClass">
+  <div [class.has-error]="showError" [ngClass]="props.fieldClass ? props.fieldClass : dto.fieldClass">
     <div class="form-check" [attr.data-testing-id]="keyString + '-wrapper'">
       <ng-template #fieldComponent></ng-template>
-      <label [attr.for]="id" class="form-check-label" [ngClass]="to.labelClass ? to.labelClass : dto.labelClass">
-        <span *ngIf="to.label">{{ to.label | translate }}</span>
-        <ish-field-tooltip *ngIf="to.tooltip" [tooltipInfo]="to.tooltip"> </ish-field-tooltip>
+      <label [attr.for]="id" class="form-check-label" [ngClass]="props.labelClass ? props.labelClass : dto.labelClass">
+        <span *ngIf="props.label">{{ props.label | translate }}</span>
+        <ish-field-tooltip *ngIf="props.tooltip" [tooltipInfo]="props.tooltip"> </ish-field-tooltip>
       </label>
     </div>
     <ng-container *ngIf="showError" class="invalid-feedback d-block">

--- a/src/app/shared/formly/wrappers/horizontal-checkbox-wrapper/horizontal-checkbox-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/horizontal-checkbox-wrapper/horizontal-checkbox-wrapper.component.ts
@@ -4,10 +4,10 @@ import { FieldWrapper } from '@ngx-formly/core';
 /**
  * Wrapper that works with checkboxes and radio buttons.
  *
- * @templateOption **label** - the label to be displayed
- * @templateOption **labelClass** - the css class to be applied to the ``<label>`` tag. Will use default value if not provided.
- * @templateOption **fieldClass** - the css class to be applied to a div around the ``#fieldComponent`` template. Will use default value if not provided.
- * @templateOption **tooltip** - tooltip information that will be passed to the ``<ish-tooltip>`` component.
+ * @props **label** - the label to be displayed
+ * @props **labelClass** - the css class to be applied to the ``<label>`` tag. Will use default value if not provided.
+ * @props **fieldClass** - the css class to be applied to a div around the ``#fieldComponent`` template. Will use default value if not provided.
+ * @props **tooltip** - tooltip information that will be passed to the ``<ish-tooltip>`` component.
  *  Refer to the component documentation for more info.
  *
  * @usageNotes

--- a/src/app/shared/formly/wrappers/horizontal-wrapper/horizontal-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/horizontal-wrapper/horizontal-wrapper.component.html
@@ -2,11 +2,11 @@
   <label
     [attr.for]="id"
     class="col-form-label"
-    [ngClass]="to.labelClass ? to.labelClass : dto.labelClass"
-    *ngIf="to.label"
-    >{{ to.label | translate }}<span class="required" *ngIf="to.required && !to.hideRequiredMarker">*</span>
+    [ngClass]="props.labelClass ? props.labelClass : dto.labelClass"
+    *ngIf="props.label"
+    >{{ props.label | translate }}<span class="required" *ngIf="props.required && !to.hideRequiredMarker">*</span>
   </label>
-  <div [ngClass]="to.fieldClass ? to.fieldClass : dto.fieldClass">
+  <div [ngClass]="props.fieldClass ? props.fieldClass : dto.fieldClass">
     <ng-template #fieldComponent></ng-template>
   </div>
 </div>

--- a/src/app/shared/formly/wrappers/horizontal-wrapper/horizontal-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/horizontal-wrapper/horizontal-wrapper.component.ts
@@ -4,11 +4,11 @@ import { FieldWrapper } from '@ngx-formly/core';
 /**
  * The default wrapper for displaying fields with labels.
  *
- * @templateOption **label** - the label to be displayed
- * @templateOption **labelClass** - the css class to be applied to the ``<label>`` tag.
- * @templateOption **fieldClass** - the css class to be applied to a div around the ``#fieldComponent`` template.
- * @templateOption **required** - apart from formly-internal validation logic, the required option is used here to display a star marker.
- * @templateOption **hideRequiredMarker** - used to not show the required star while still marking the field as required.
+ * @props **label** - the label to be displayed
+ * @props **labelClass** - the css class to be applied to the ``<label>`` tag.
+ * @props **fieldClass** - the css class to be applied to a div around the ``#fieldComponent`` template.
+ * @props **required** - apart from formly-internal validation logic, the required option is used here to display a star marker.
+ * @props **hideRequiredMarker** - used to not show the required star while still marking the field as required.
  *
  * @usageNotes
  * While validation is mostly handled by the validation wrapper, the label still needs to be styled according to error state.

--- a/src/app/shared/formly/wrappers/input-addon-wrapper/input-addon-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/input-addon-wrapper/input-addon-wrapper.component.html
@@ -1,9 +1,9 @@
-<div class="align-items-start flex-nowrap" [ngClass]="{ 'input-group': to.addonLeft || to.addonRight }">
-  <div *ngIf="to.addonLeft" class="input-group-prepend">
+<div class="align-items-start flex-nowrap" [ngClass]="{ 'input-group': props.addonLeft || props.addonRight }">
+  <div *ngIf="props.addonLeft" class="input-group-prepend">
     <span class="input-group-text">{{ addonLeftText | async | translate }}</span>
   </div>
   <div class="flex-grow-1"><ng-container #fieldComponent></ng-container></div>
-  <div *ngIf="to.addonRight" class="input-group-append">
+  <div *ngIf="props.addonRight" class="input-group-append">
     <span class="input-group-text">{{ addonRightText | async | translate }}</span>
   </div>
 </div>

--- a/src/app/shared/formly/wrappers/input-addon-wrapper/input-addon-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/input-addon-wrapper/input-addon-wrapper.component.ts
@@ -5,8 +5,8 @@ import { of } from 'rxjs';
 /**
  * Wrapper to add input-addons to fields, using bootstrap styling.
  *
- *  @templateOption **addonRight** - object of type ``{ text: string }`` or ``{ text: Observable<string> }`` that will be used to render an input addon to the right of the field.
- *  @templateOption **addonLeft** - object of type ``{ text: string }`` or ``{ text: Observable<string> }`` that will be used to render an input addon to the left of the field.
+ *  @props **addonRight** - object of type ``{ text: string }`` or ``{ text: Observable<string> }`` that will be used to render an input addon to the right of the field.
+ *  @props **addonLeft** - object of type ``{ text: string }`` or ``{ text: Observable<string> }`` that will be used to render an input addon to the left of the field.
  *
  */
 @Component({
@@ -16,16 +16,16 @@ import { of } from 'rxjs';
 })
 export class InputAddonWrapperComponent extends FieldWrapper {
   get addonLeftText() {
-    if (!this.to.addonLeft?.text) {
+    if (!this.props.addonLeft?.text) {
       return;
     }
-    return typeof this.to.addonLeft.text === 'string' ? of(this.to.addonLeft.text) : this.to.addonLeft.text;
+    return typeof this.props.addonLeft.text === 'string' ? of(this.props.addonLeft.text) : this.props.addonLeft.text;
   }
 
   get addonRightText() {
-    if (!this.to.addonRight?.text) {
+    if (!this.props.addonRight?.text) {
       return;
     }
-    return typeof this.to.addonRight.text === 'string' ? of(this.to.addonRight.text) : this.to.addonRight.text;
+    return typeof this.props.addonRight.text === 'string' ? of(this.props.addonRight.text) : this.props.addonRight.text;
   }
 }

--- a/src/app/shared/formly/wrappers/textarea-description-wrapper/textarea-description-wrapper.component.spec.ts
+++ b/src/app/shared/formly/wrappers/textarea-description-wrapper/textarea-description-wrapper.component.spec.ts
@@ -45,7 +45,7 @@ describe('Textarea Description Wrapper Component', () => {
           key: 'textarea',
           type: 'textarea',
           wrappers: ['textarea-description-wrapper'],
-          templateOptions: {
+          props: {
             maxLength: 1000,
           },
         },

--- a/src/app/shared/formly/wrappers/textarea-description-wrapper/textarea-description-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/textarea-description-wrapper/textarea-description-wrapper.component.ts
@@ -7,7 +7,7 @@ import { takeUntil } from 'rxjs/operators';
 /**
  * Wrapper to display a description that counts the remaining characters in a field.
  *
- * @templateOption **maxLength** - will be used to determine the remaining available characters.
+ * @props **maxLength** - will be used to determine the remaining available characters.
  *
  * @usageNotes
  * This wrapper is made for the textarea type but could be used for different field types as well.
@@ -33,8 +33,8 @@ export class TextareaDescriptionWrapperComponent extends FieldWrapper implements
   }
 
   setDescription(value: string) {
-    this.description$ = this.translate.get(this.to.customDescription ?? 'textarea.max_limit', {
-      0: Math.max(0, this.to.maxLength - (value?.length ?? 0)),
+    this.description$ = this.translate.get(this.props.customDescription ?? 'textarea.max_limit', {
+      0: Math.max(0, this.props.maxLength - (value?.length ?? 0)),
     });
   }
 

--- a/src/app/shared/formly/wrappers/tooltip-wrapper/tooltip-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/tooltip-wrapper/tooltip-wrapper.component.html
@@ -1,2 +1,2 @@
 <ng-template #fieldComponent></ng-template>
-<ish-field-tooltip [tooltipInfo]="to.tooltip"> </ish-field-tooltip>
+<ish-field-tooltip [tooltipInfo]="props.tooltip"> </ish-field-tooltip>

--- a/src/app/shared/formly/wrappers/tooltip-wrapper/tooltip-wrapper.component.spec.ts
+++ b/src/app/shared/formly/wrappers/tooltip-wrapper/tooltip-wrapper.component.spec.ts
@@ -36,7 +36,7 @@ describe('Tooltip Wrapper Component', () => {
           key: 'example',
           type: 'example',
           wrappers: ['tooltip-wrapper'],
-          templateOptions: {
+          props: {
             tooltip: { text: 'tooltip' },
           },
         },

--- a/src/app/shared/formly/wrappers/tooltip-wrapper/tooltip-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/tooltip-wrapper/tooltip-wrapper.component.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 /**
  * Wrapper to display a tooltip below the form field.
  *
- * @templateOption **tooltip** - will be passed to the ´´<ish-tooltip>`` component. For more info refer to the component documentation.
+ * @props **tooltip** - will be passed to the ´´<ish-tooltip>`` component. For more info refer to the component documentation.
  */
 @Component({
   selector: 'ish-tooltip-wrapper',

--- a/src/app/shared/formly/wrappers/validation-wrapper/validation-wrapper.component.spec.ts
+++ b/src/app/shared/formly/wrappers/validation-wrapper/validation-wrapper.component.spec.ts
@@ -55,7 +55,7 @@ describe('Validation Wrapper Component', () => {
           key: 'example',
           type: 'example',
           wrappers: ['validation'],
-          templateOptions: {
+          props: {
             required: true,
           },
         },

--- a/src/app/shared/formly/wrappers/validation-wrapper/validation-wrapper.component.ts
+++ b/src/app/shared/formly/wrappers/validation-wrapper/validation-wrapper.component.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 /**
  *  Wrapper to provide validation feedback and styling to fields.
  *
- *  @templateOption **required** - special validation case that is considered.
+ *  @props **required** - special validation case that is considered.
  *
  * @usageNotes
  * This wrapper uses the ``<ish-validation-message>`` and  ``<ish-validation-icons>`` components  to display validation messages
@@ -21,7 +21,7 @@ export class ValidationWrapperComponent extends FieldWrapper {
     return (
       Object.keys(this.field.validators ?? {}).length ||
       Object.keys(this.field.asyncValidators ?? {}).length ||
-      this.field.templateOptions?.required
+      this.field.props?.required
     );
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

We extensively use formly in the PWA to generate form templates via configuration objects. With the new formly version 6 a bulk of properties are deprecated ('templateOptions', 'expressionProperties', ...) and have to be replaced in the PWA. That is the reason why a schematic (script) has been created to help migrating to the new formly version 6.

Issue Number: Closes #

## What Is the New Behavior?

A schematic is created to replace deprecated ```FormlyFieldConfiguration``` object properties and to update related html templates and component files.

The following properties have been replaced:
- ```templateOptions``` to ```props```
- ```to``` to ```props```
- ```validation.messages.minlength``` to ```validation.messages.minLength```
- ```validation.messages.maxlength``` to ```validation.messages.maxLength```

Note

- Not all specified properties will be updated with running the formly schematic. There are some limitations in specific formly test cases and within map operators of rxjs pipes. It is necessary to check the code again after executing the schematic to replace properties manually.
- Other deprecated properties like ```expressionProperties``` are not part of the replacement, because some functionality has to be adapted.

Further Changes

- adapt documentation to use the correct properties

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] Yes
[ ] No

## Other Information

For further information please read the [formly migration guide](https://formly.dev/docs/guide/migration)

[AB#83801](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/83801)