### PR TITLE
feat: add reference for jest-extended in typings.spec.d.ts

### DIFF
--- a/src/typings.spec.d.ts
+++ b/src/typings.spec.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="jest" />
+/// <reference types="jest-extended" />
 
 declare namespace jest {
   interface Describe {


### PR DESCRIPTION
Add `/// <reference types="jest-extended" />` due to the fact that some editors (ie. WebStorm) do not recognizes the custom jest-extended matchers properly.

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Code style update (formatting, local variables)

## What Is the Current Behavior?

Currently, some editors do not recognize `jest-extended` matchers. 

For example:

```shell
TS2551: Property 'toBeFalse' does not exist on type 'JestMatchers<boolean>'. Did you mean 'toBeFalsy'?
```

## What Is the New Behavior?

Editor properly recognize `jest-extended` matchers without any hassle.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No
