### PR TITLE
fix: validation for passwort and email confirmation fields

### DIFF
--- a/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
+++ b/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
@@ -92,8 +92,9 @@ export class PunchoutUserFormComponent implements OnInit {
           },
           {
             key: 'passwordConfirmation',
-            type: 'ish-password-field',
+            type: 'ish-text-input-field',
             props: {
+              type: 'password',
               required: this.punchoutUser ? false : true,
               label: this.punchoutUser
                 ? 'account.punchout.password.new.confirmation.label'
@@ -104,6 +105,7 @@ export class PunchoutUserFormComponent implements OnInit {
             validation: {
               messages: {
                 required: 'account.punchout.password.confirmation.error.required',
+                equalTo: 'form.password.error.equalTo',
               },
             },
           },

--- a/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
+++ b/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
@@ -53,9 +53,9 @@ export class AccountProfileEmailComponent implements OnInit {
 
           {
             key: 'emailConfirmation',
-            type: 'ish-email-field',
-
+            type: 'ish-text-input-field',
             props: {
+              type: 'email',
               hideRequiredMarker: true,
               required: true,
               label: 'account.update_email.email_confirmation.label',

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
@@ -67,14 +67,14 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
                 key: 'account.register.password.extrainfo.message',
                 args: { 0: '7' },
               },
-
               attributes: { autocomplete: 'new-password' },
             },
           },
           {
             key: 'passwordConfirmation',
-            type: 'ish-password-field',
+            type: 'ish-text-input-field',
             props: {
+              type: 'password',
               required: true,
               hideRequiredMarker: true,
               label: 'account.update_password.newpassword_confirmation.label',
@@ -82,6 +82,7 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
             validation: {
               messages: {
                 required: 'account.register.password_confirmation.error.default',
+                equalTo: 'form.password.error.equalTo',
               },
             },
           },

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.spec.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.spec.ts
@@ -34,7 +34,7 @@ describe('Update Password Form Component', () => {
   it('should render forgot password form step 2 for password reminder', () => {
     fixture.detectChanges();
 
-    expect(element.innerHTML.match(/ish-password-field/g)).toHaveLength(2);
+    expect(element.innerHTML.match(/ish-password-field/g)).toHaveLength(1);
     expect(element.innerHTML).toContain('password');
     expect(element.innerHTML).toContain('passwordConfirmation');
 

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
@@ -56,8 +56,9 @@ export class UpdatePasswordFormComponent implements OnInit {
           },
           {
             key: 'passwordConfirmation',
-            type: 'ish-password-field',
+            type: 'ish-text-input-field',
             props: {
+              type: 'password',
               required: true,
               hideRequiredMarker: true,
               label: 'account.register.password_confirmation.label',
@@ -65,6 +66,7 @@ export class UpdatePasswordFormComponent implements OnInit {
             validation: {
               messages: {
                 required: 'account.register.password_confirmation.error.default',
+                equalTo: 'form.password.error.equalTo',
               },
             },
           },

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -241,18 +241,19 @@ export class RegistrationFormConfigurationService {
           },
           {
             key: 'loginConfirmation',
-            type: 'ish-email-field',
+            type: 'ish-text-input-field',
             props: {
+              type: 'email',
               label: 'account.register.email_confirmation.label',
               required: true,
             },
             validation: {
               messages: {
+                required: 'form.email.error.required',
                 equalTo: 'account.registration.email.not_match.error',
               },
             },
           },
-
           {
             key: 'password',
             type: 'ish-password-field',
@@ -269,16 +270,17 @@ export class RegistrationFormConfigurationService {
           },
           {
             key: 'passwordConfirmation',
-            type: 'ish-password-field',
+            type: 'ish-text-input-field',
             props: {
+              type: 'password',
               required: true,
               label: 'account.register.password_confirmation.label',
-
               attributes: { autocomplete: 'new-password' },
             },
             validation: {
               messages: {
                 required: 'account.register.password_confirmation.error.default',
+                equalTo: 'form.password.error.equalTo',
               },
             },
           },

--- a/src/app/shared/formly/types/types.module.ts
+++ b/src/app/shared/formly/types/types.module.ts
@@ -122,7 +122,6 @@ const fieldComponents = [
               messages: {
                 password: 'form.password.error.invalid',
                 required: 'form.password.error.required',
-                equalTo: 'form.password.error.equalTo',
               },
             },
           },

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -400,6 +400,7 @@
   "account.update.button.label": "Änderungen speichern",
   "account.update_email.answer.text": "Die neue E-Mail-Adresse ist sofort aktiv. Verwenden Sie sie bei der nächsten Bestellung oder aktualisieren Sie Ihre Kontoinformationen.",
   "account.update_email.breadcrumb": "E-Mail-Einstellungen bearbeiten",
+  "account.update_email.email.error.notempty": "Bitte geben Sie eine gültige E-Mail-Adresse als Bestätigung ein.",
   "account.update_email.email.label": "Aktuelle E-Mail-Adresse",
   "account.update_email.email_confirmation.error.stringcompare": "Stellen Sie sicher, dass Sie Ihre neue E-Mail-Adresse jedes Mal korrekt eingegeben haben.",
   "account.update_email.email_confirmation.label": "Neue E-Mail-Adresse wiederholen",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -400,6 +400,7 @@
   "account.update.button.label": "Save Changes",
   "account.update_email.answer.text": "Your new e-mail address takes effect immediately. Use it the next time you place an order or update your account information.",
   "account.update_email.breadcrumb": "Edit E-mail Preferences",
+  "account.update_email.email.error.notempty": "Please enter a valid email to confirm.",
   "account.update_email.email.label": "Current E-mail",
   "account.update_email.email_confirmation.error.stringcompare": "Please make sure you have typed in your new e-mail address accurately each time.",
   "account.update_email.email_confirmation.label": "Repeat New E-mail",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -400,6 +400,7 @@
   "account.update.button.label": "Enregistrer les modifications",
   "account.update_email.answer.text": "Votre nouveau courriel prend effet immédiatement. Utilisez-le la prochaine fois que vous passez une commande ou que vous modifiez les informations de votre compte.",
   "account.update_email.breadcrumb": "Modifiez vos paramètres de courriel",
+  "account.update_email.email.error.notempty": "Veuillez entrer un courriel de confirmation valide.",
   "account.update_email.email.label": "Courriel actuel",
   "account.update_email.email_confirmation.error.stringcompare": "Assurez-vous d’avoir correctement saisi le nouveau courriel à chaque fois.",
   "account.update_email.email_confirmation.label": "Répéter le nouveau courriel",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

For all confirmation fields the `ish-password-field` or `ish-email-field` is used. These fields are configured with a validator, which checks, that the form value follows some specified rules. This is not intended, because a confirmation input field should only check, if the value equals the form value of a related field.

## What Is the New Behavior?

All confirmation fields are configured with the default `ish-text-input` field type. All necessary validators are added seperatly. Furthermore the missing tranlation key `account.update_email.email.error.notempty` is added.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#83799](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/83799)