### PR TITLE
fix: remove deprecated SSR environment variable 'ICM_IDENTITY_PROVIDER'

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,12 @@ kb_sync_latest_only
 
 # Migrations
 
+## 3.3 to 4.0
+
+The deprecated SSR environment variable `ICM_IDENTITY_PROVIDER` was completely removed.
+Use the variable `IDENTITY_PROVIDER` instead to select the identity provider to be used if it is not the default `ICM`.
+Removed default `identityProvider` configuration from `environment.model.ts` so only hardcoded fallback from `configuration.effects.ts` works as fallback.
+
 ## 3.2 to 3.3
 
 To improve the accessibility of the PWA in regards to more elements being tab focusable a lot of `[routerLink]="[]"` where added to links that previously did not have a link reference.
@@ -45,11 +51,11 @@ Please use `logoutUser({ revokeToken: false })` from the account facade or dispa
 
 ## 3.0 to 3.1
 
-The SSR environment variable 'ICM_IDENTITY_PROVIDER' will be removed in a future release ( PWA 5.0 ).
-Use variable 'IDENTITY_PROVIDER' to select the provider to be used instead.
+The SSR environment variable `ICM_IDENTITY_PROVIDER` will be removed in the next major release (PWA 4.0).
+Use variable `IDENTITY_PROVIDER` to select the provider to be used instead.
 Keep this in mind before deploying or starting the Intershop PWA in server-side rendering mode.
 
-The default value of the input parameter ['queryParamsHandling'](https://angular.io/api/router/QueryParamsHandling) has been changed from 'merge' to '' for the components `product-name.component` and `product-image.component`.
+The default value of the input parameter ['queryParamsHandling'](https://angular.io/api/router/QueryParamsHandling) has been changed from `'merge'` to `''` for the components `product-name.component` and `product-image.component`.
 This has been done to prevent an unintentional application of filters for product variation master links if the product detail link does not originate from a product listing context (product list page, search result page).
 
 To prevent deprecation warnings we removed the unnecessary `~` from all 3rd party SCSS imports (see https://webpack.js.org/loaders/sass-loader/#resolving-import-at-rules - "Using ~ is deprecated and can be removed from your code (we recommend it)").

--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -44,30 +44,30 @@ If the format is _switch_, the property is switched on by supplying `on`, `1`, `
 All parameters are **case sensitive**.
 Make sure to use them as written in the table below.
 
-|                     | parameter                                   | format               | comment                                                                                          |
-| ------------------- | ------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------ |
-| **SSR Specific**    | PORT                                        | number               | Port for running the application                                                                 |
-|                     | CONCURRENCY_SSR                             | number \| max        | Concurrency for SSR instances per theme (default: 2)                                             |
-|                     | CACHE_ICM_CALLS                             | recommended \| JSON  | Enable caching for ICM calls, see [Local ICM Cache](#local-icm-cache) (default: disabled)        |
-| **General**         | ICM_BASE_URL                                | string               | Sets the base URL for the ICM                                                                    |
-|                     | ICM_CHANNEL                                 | string               | Overrides the default channel                                                                    |
-|                     | ICM_APPLICATION                             | string               | Overrides the default application                                                                |
-|                     | FEATURES                                    | comma-separated list | Overrides active features                                                                        |
-|                     | THEME                                       | string               | Overrides the default theme                                                                      |
-|                     | MULTI_SITE_LOCALE_MAP                       | JSON \| false        | Used to map locales to [url modification parameters](../guides/multi-site-configurations.md)     |
-|                     | DEPLOY_URL                                  | string               | Set a [Deploy URL][concept-deploy-url] (default `/`)                                             |
-| **Debug** :warning: | TRUST_ICM                                   | any                  | Use this if ICM is deployed with an insecure certificate                                         |
-|                     | LOGGING                                     | switch               | Enables extra log output                                                                         |
-|                     | SOURCE_MAPS                                 | switch               | Exposes source maps if activated                                                                 |
-| **Hybrid Approach** | SSR_HYBRID                                  | any                  | Enables running PWA and ICM in [Hybrid Mode][concept-hybrid]                                     |
-|                     | SSR_HYBRID_BACKEND                          | URL                  | When running in K8S, this contains the ICM WA service URL. For none K8S you can use ICM_BASE_URL |
-|                     | PROXY_ICM                                   | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)                                     |
-| **Third party**     | GTM_TOKEN                                   | string               | Token for Google Tag Manager                                                                     |
-|                     | GMA_KEY                                     | string               | API key for Google Maps                                                                          |
-|                     | SENTRY_DSN                                  | string               | Sentry DSN URL for using Sentry Error Monitor                                                    |
-|                     | PROMETHEUS                                  | switch               | Exposes Prometheus metrics                                                                       |
-|                     | IDENTITY_PROVIDER ~~ICM_IDENTITY_PROVIDER~~ | string               | ID of the default Identity Provider if other than `ICM`                                          |
-|                     | IDENTITY_PROVIDERS                          | JSON                 | Configuration of additional Identity Providers besides the default `ICM`                         |
+|                     | parameter             | format               | comment                                                                                          |
+| ------------------- | --------------------- | -------------------- | ------------------------------------------------------------------------------------------------ |
+| **SSR Specific**    | PORT                  | number               | Port for running the application                                                                 |
+|                     | CONCURRENCY_SSR       | number \| max        | Concurrency for SSR instances per theme (default: 2)                                             |
+|                     | CACHE_ICM_CALLS       | recommended \| JSON  | Enable caching for ICM calls, see [Local ICM Cache](#local-icm-cache) (default: disabled)        |
+| **General**         | ICM_BASE_URL          | string               | Sets the base URL for the ICM                                                                    |
+|                     | ICM_CHANNEL           | string               | Overrides the default channel                                                                    |
+|                     | ICM_APPLICATION       | string               | Overrides the default application                                                                |
+|                     | FEATURES              | comma-separated list | Overrides active features                                                                        |
+|                     | THEME                 | string               | Overrides the default theme                                                                      |
+|                     | MULTI_SITE_LOCALE_MAP | JSON \| false        | Used to map locales to [url modification parameters](../guides/multi-site-configurations.md)     |
+|                     | DEPLOY_URL            | string               | Set a [Deploy URL][concept-deploy-url] (default `/`)                                             |
+| **Debug** :warning: | TRUST_ICM             | any                  | Use this if ICM is deployed with an insecure certificate                                         |
+|                     | LOGGING               | switch               | Enables extra log output                                                                         |
+|                     | SOURCE_MAPS           | switch               | Exposes source maps if activated                                                                 |
+| **Hybrid Approach** | SSR_HYBRID            | any                  | Enables running PWA and ICM in [Hybrid Mode][concept-hybrid]                                     |
+|                     | SSR_HYBRID_BACKEND    | URL                  | When running in K8S, this contains the ICM WA service URL. For none K8S you can use ICM_BASE_URL |
+|                     | PROXY_ICM             | any \| URL           | Proxy ICM via `/INTERSHOP` (enabled if SSR_HYBRID is active)                                     |
+| **Third party**     | GTM_TOKEN             | string               | Token for Google Tag Manager                                                                     |
+|                     | GMA_KEY               | string               | API key for Google Maps                                                                          |
+|                     | SENTRY_DSN            | string               | Sentry DSN URL for using Sentry Error Monitor                                                    |
+|                     | PROMETHEUS            | switch               | Exposes Prometheus metrics                                                                       |
+|                     | IDENTITY_PROVIDER     | string               | ID of the default Identity Provider if other than `ICM`                                          |
+|                     | IDENTITY_PROVIDERS    | JSON                 | Configuration of additional Identity Providers besides the default `ICM`                         |
 
 ## Development
 

--- a/src/app/core/store/core/configuration/configuration.effects.ts
+++ b/src/app/core/store/core/configuration/configuration.effects.ts
@@ -4,7 +4,7 @@ import { TransferState } from '@angular/platform-browser';
 import { Actions, ROOT_EFFECTS_INIT, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { EMPTY, combineLatest, defer, fromEvent, iif, merge } from 'rxjs';
+import { EMPTY, defer, fromEvent, iif, merge } from 'rxjs';
 import { distinctUntilChanged, map, mergeMap, take, takeWhile, withLatestFrom } from 'rxjs/operators';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
@@ -71,10 +71,9 @@ export class ConfigurationEffects {
           this.stateProperties
             .getStateOrEnvOrDefault<string | string[]>('FEATURES', 'features')
             .pipe(map(x => (typeof x === 'string' ? x.split(/,/g) : x))),
-          combineLatest([
-            this.stateProperties.getStateOrEnvOrDefault<string>('IDENTITY_PROVIDER', 'identityProvider'),
-            this.stateProperties.getStateOrEnvOrDefault<string>('ICM_IDENTITY_PROVIDER', 'identityProvider'),
-          ]).pipe(map(([x, y]) => x || y || 'ICM')),
+          this.stateProperties
+            .getStateOrEnvOrDefault<string>('IDENTITY_PROVIDER', 'identityProvider')
+            .pipe(map(x => x || 'ICM')),
           this.stateProperties.getStateOrEnvOrDefault<ConfigurationType['identityProviders']>(
             'IDENTITY_PROVIDERS',
             'identityProviders'

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -19,8 +19,8 @@ export interface Environment {
   // array of REST path expressions that should always be mocked
   apiMockPaths?: string[];
 
-  // temporarily hard-coded identity provider ID, later supplied by configurations call
-  identityProvider: 'ICM' | string;
+  // global identity provider ID (fallback 'ICM')
+  identityProvider?: string;
 
   /* FEATURE TOGGLES */
   features: (
@@ -141,7 +141,6 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
   icmServerStatic: 'INTERSHOP/static/WFS',
   icmApplication: 'rest',
   hybridApplication: '-',
-  identityProvider: 'ICM',
 
   /* FEATURE TOGGLES */
   features: ['compare', 'contactUs', 'rating', 'recently', 'storeLocator'],


### PR DESCRIPTION
## PR Type

[x] Bugfix

* did not work as expected anymore anyways because of the set default `identityProvider: 'ICM' | string;` in `environment.model.ts`
* removed default from `environment.model.ts` so only hardcoded fallback from `configuration.effects.ts` works as fallback

## Does this PR Introduce a Breaking Change?

[x] No (just removed deprecated code)

## Other Information


[AB#83887](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/83887)