### PR TITLE
Correct dialog form submission with enter key

### DIFF
--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -198,3 +198,8 @@ qwertz
 appr
 
 logformat
+
+keyup
+keydown
+keypress
+mouseout

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -70,6 +70,78 @@ This rule ensures, that elements with click event handlers also handle at least 
 
 Requires any element with a `mouseout` event handler to also handle `blur` events, and any element with a `mouseover` event handler to also handle `focus` events.
 
+## Form Submission using the key "Enter"
+
+Implicit form submission using the "Enter" key is vital to assistive technologies, see also [HTML5 specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission).
+Therefore, the `form` tag has to include an `input` of `type="submit"`, for example
+
+```html
+<form>
+  <label for="foo">Name:</label>
+  <input type="text" name="foo" id="foo" />
+  <input type="submit" value="Submit" />
+</form>
+```
+
+or a button of type "submit"
+
+```html
+<form>
+  <label for="foo">Name:</label>
+  <input type="text" name="foo" id="foo" />
+  <button type="submit">Submit</button>
+</form>
+```
+
+### Form submission in dialogs
+
+Dialogs (or modals) are separated into three sections:
+
+- modal header
+- modal body
+- modal footer
+
+where the form is positioned inside the model body and the buttons are positioned inside the modal footer.
+The following simplified example shows the wrong HTML structure:
+
+:warning: **Wrong HTML structure**
+
+```html
+<div class="modal-body">
+  <form (ngSubmit)="submit()">
+    <formly-form></formly-form>
+  </form>
+</div>
+<div class="modal-footer">
+  <button type="button" (click)="submit()">Submit</button>
+  <button type="button" (click)="cancel()">Cancel</button>
+</div>
+```
+
+The button with the text "Submit" calls the same function `foo()` as the form `(ngSubmit)` but the form would not be submitted using the "Enter" key because the submit button is positioned outside the `form` tag.
+The following example shows the correct HTML structure:
+
+:heavy_check_mark: **Correct HTML structure**
+
+```html
+<form (ngSubmit)="submit()">
+  <div class="modal-body">
+    <formly-form></formly-form>
+  </div>
+  <div class="modal-footer">
+    <button type="submit">Submit</button>
+    <button type="button" (click)="cancel()">Cancel</button>
+  </div>
+</form>
+```
+
+where
+
+- the `form` tag surrounds both the formly form (including the form elements) and the submit button
+- the function `submit()` is only called at the `form` tag
+- the "Submit" button is correctly defined using `type="submit"` and does not call `submit()` using `(click)=""`
+- the "Cancel" button is only defined as `type="button"` to prevent any default behavior
+
 ## Further References
 
 - [Angular A11y ESLint Rules](https://dev.to/bitovi/angular-a11y-eslint-rules-2fjc)

--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.html
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.html
@@ -12,24 +12,23 @@
     </button>
   </div>
 
-  <div class="modal-body">
-    <form [formGroup]="costCenterBuyerForm" (ngSubmit)="submitCostCenterBuyerForm()">
+  <form [formGroup]="costCenterBuyerForm" (ngSubmit)="submitCostCenterBuyerForm()">
+    <div class="modal-body">
       <formly-form [form]="costCenterBuyerForm" [fields]="fields" [model]="model"></formly-form>
-    </form>
-  </div>
+    </div>
 
-  <div class="modal-footer">
-    <button
-      type="submit"
-      class="btn btn-primary"
-      [disabled]="formDisabled"
-      (click)="submitCostCenterBuyerForm()"
-      data-testing-id="cost-center-buyer-edit-dialog-submit"
-    >
-      {{ 'account.costcenter.details.buyers.action.save' | translate }}
-    </button>
-    <button type="button" class="btn btn-secondary" (click)="hide()">
-      {{ 'account.cancel.button.label' | translate }}
-    </button>
-  </div>
+    <div class="modal-footer">
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="formDisabled"
+        data-testing-id="cost-center-buyer-edit-dialog-submit"
+      >
+        {{ 'account.costcenter.details.buyers.action.save' | translate }}
+      </button>
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'account.cancel.button.label' | translate }}
+      </button>
+    </div>
+  </form>
 </ng-template>

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.html
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.html
@@ -13,19 +13,19 @@
       </button>
     </div>
 
-    <div class="modal-body">
-      <form [formGroup]="rejectForm" (ngSubmit)="submitForm()" class="clearfix">
+    <form [formGroup]="rejectForm" (ngSubmit)="submitForm()" class="clearfix">
+      <div class="modal-body">
         <formly-form [form]="rejectForm" [fields]="fields"></formly-form>
-      </form>
-    </div>
+      </div>
 
-    <div class="modal-footer">
-      <button class="btn btn-primary" type="submit" (click)="submitForm()" [disabled]="formDisabled">
-        {{ 'approval.rejectform.button.reject.label' | translate }}
-      </button>
-      <button class="btn btn-secondary" type="button" (click)="hide()">
-        {{ 'approval.rejectform.button.cancel.label' | translate }}
-      </button>
-    </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary" [disabled]="formDisabled">
+          {{ 'approval.rejectform.button.reject.label' | translate }}
+        </button>
+        <button type="button" class="btn btn-secondary" (click)="hide()">
+          {{ 'approval.rejectform.button.cancel.label' | translate }}
+        </button>
+      </div>
+    </form>
   </div>
 </ng-template>

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
@@ -12,25 +12,24 @@
     </button>
   </div>
 
-  <div class="modal-body">
-    <form [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm()">
+  <form [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm()">
+    <div class="modal-body">
       <!-- TODO: Show server error -->
       <formly-form [form]="orderTemplateForm" [fields]="fields" [model]="model"></formly-form>
-    </form>
-  </div>
+    </div>
 
-  <div class="modal-footer">
-    <button
-      type="submit"
-      class="btn btn-primary"
-      [disabled]="formDisabled"
-      (click)="submitOrderTemplateForm()"
-      data-testing-id="order-template-dialog-submit"
-    >
-      {{ primaryButton | translate }}
-    </button>
-    <button type="button" class="btn btn-secondary" (click)="hide()">
-      {{ 'account.cancel.button.label' | translate }}
-    </button>
-  </div>
+    <div class="modal-footer">
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="formDisabled"
+        data-testing-id="order-template-dialog-submit"
+      >
+        {{ primaryButton | translate }}
+      </button>
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'account.cancel.button.label' | translate }}
+      </button>
+    </div>
+  </form>
 </ng-template>

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -13,23 +13,23 @@
   </div>
 
   <ng-container *ngIf="showForm; else showSuccess">
-    <div class="modal-body">
-      <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+    <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+      <div class="modal-body">
         <ish-select-order-template-form
           [formGroup]="formGroup"
           [addMoveProduct]="addMoveProduct"
         ></ish-select-order-template-form>
-      </form>
-    </div>
+      </div>
 
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="submitForm()">
-        {{ submitButtonTranslationKey | translate }}
-      </button>
-      <button type="button" class="btn btn-secondary" (click)="hide()">
-        {{ 'account.cancel.button.label' | translate }}
-      </button>
-    </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary">
+          {{ submitButtonTranslationKey | translate }}
+        </button>
+        <button type="button" class="btn btn-secondary" (click)="hide()">
+          {{ 'account.cancel.button.label' | translate }}
+        </button>
+      </div>
+    </form>
   </ng-container>
 
   <ng-template #showSuccess>

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
@@ -13,20 +13,20 @@
   </div>
 
   <ng-container *ngIf="showForm; else showSuccess">
-    <div class="modal-body">
-      <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+    <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+      <div class="modal-body">
         <ish-select-wishlist-form [formGroup]="formGroup" [addMoveProduct]="addMoveProduct"></ish-select-wishlist-form>
-      </form>
-    </div>
+      </div>
 
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="submitForm()">
-        {{ submitButtonTranslationKey | translate }}
-      </button>
-      <button type="button" class="btn btn-secondary" (click)="hide()">
-        {{ 'account.wishlists.add_to_wishlist.cancel_button.text' | translate }}
-      </button>
-    </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary">
+          {{ submitButtonTranslationKey | translate }}
+        </button>
+        <button type="button" class="btn btn-secondary" (click)="hide()">
+          {{ 'account.wishlists.add_to_wishlist.cancel_button.text' | translate }}
+        </button>
+      </div>
+    </form>
   </ng-container>
 
   <ng-template #showSuccess>

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
@@ -12,25 +12,19 @@
     </button>
   </div>
 
-  <div class="modal-body">
-    <form [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
+  <form [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
+    <div class="modal-body">
       <!-- TODO: Show server error -->
       <formly-form [form]="wishListForm" [fields]="fields" [model]="model"> </formly-form>
-    </form>
-  </div>
+    </div>
 
-  <div class="modal-footer">
-    <button
-      type="button"
-      class="btn btn-primary"
-      [disabled]="formDisabled"
-      (click)="submitWishlistForm()"
-      data-testing-id="wishlist-dialog-submit"
-    >
-      {{ primaryButton | translate }}
-    </button>
-    <button type="button" class="btn btn-secondary" (click)="hide()">
-      {{ 'account.wishlists.wishlist_form.cancel_button.text' | translate }}
-    </button>
-  </div>
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="wishlist-dialog-submit">
+        {{ primaryButton | translate }}
+      </button>
+      <button type="button" class="btn btn-secondary" (click)="hide()">
+        {{ 'account.wishlists.wishlist_form.cancel_button.text' | translate }}
+      </button>
+    </div>
+  </form>
 </ng-template>


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Forms in dialogs (modals) cannot be submitted using the "Enter" key if the form includes more than one form field. 
Reason: The submit button is positioned outside the `form` tag.

## What Is the New Behavior?
Forms in dialogs (modals) can now be submitted using the "Enter" key. 

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#84027](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/84027)