### PR TITLE
fix: basket page errors on reload

### DIFF
--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -14,6 +14,7 @@ import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { loadServerConfigSuccess } from 'ish-core/store/core/server-config';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { resetOrderErrors } from 'ish-core/store/customer/orders';
+import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
@@ -655,8 +656,8 @@ describe('Basket Effects', () => {
       actions$ = of(action);
 
       const completion = loadBasket();
-      actions$ = hot('-a', { a: action });
-      const expected$ = cold('-c', { c: completion });
+      actions$ = hot('b-a', { a: action, b: personalizationStatusDetermined() });
+      const expected$ = cold('--c', { c: completion });
 
       expect(effects.loadBasketOnBasketPage$).toBeObservable(expected$);
     });

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -23,7 +23,7 @@ import { BasketService } from 'ish-core/services/basket/basket.service';
 import { getCurrentCurrency } from 'ish-core/store/core/configuration';
 import { mapToRouterState } from 'ish-core/store/core/router';
 import { resetOrderErrors } from 'ish-core/store/customer/orders';
-import { getLoggedInCustomer, loginUserSuccess } from 'ish-core/store/customer/user';
+import { getLoggedInCustomer, loginUserSuccess, personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { mapErrorToAction, mapToPayloadProperty, mapToProperty } from 'ish-core/utils/operators';
 
@@ -352,14 +352,20 @@ export class BasketEffects {
   );
 
   /**
-   * Trigger LoadBasket action after the user navigated to a basket route
+   * Reload basket information on basket route to ensure that rendered page is correct.
    */
   loadBasketOnBasketPage$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(routerNavigatedAction),
-      mapToRouterState(),
-      filter(routerState => /^\/basket/.test(routerState.url)),
-      map(() => loadBasket())
+      ofType(personalizationStatusDetermined),
+      take(1),
+      switchMap(() =>
+        this.actions$.pipe(
+          ofType(routerNavigatedAction),
+          mapToRouterState(),
+          filter(routerState => /^\/basket/.test(routerState.url)),
+          map(() => loadBasket())
+        )
+      )
     )
   );
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When the user navigates to a basket page in the browser the PWA will dispatch a `loadBasket()` action to insure that the basket is up-to-date (the user might have changed the basket in other devices or browser tabs). The PWA doesn't wait if the user is logged in or not. This may lead to problems, so the merge basket might fail or the basket page freezes in a loading animation after browser refresh on the basket page.

Issue Number: Closes #1375

## What Is the New Behavior?
On the basket page the basket action `loadBasket()` will only be triggered, if the PWA has determined the personalization status of the user.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#84033](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/84033)