### PR TITLE
fix: give the session a chance to be refreshed

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -88,7 +88,9 @@ export class ApiTokenService {
           const cookieContent = apiToken?.apiToken ? JSON.stringify(apiToken) : undefined;
           if (cookieContent) {
             cookiesService.put('apiToken', cookieContent, {
-              expires: this.cookieOptions?.expires ?? new Date(Date.now() + DEFAULT_EXPIRY_TIME),
+              expires: this.cookieOptions?.expires
+                ? new Date(this.cookieOptions?.expires.getTime() + 60000)
+                : new Date(Date.now() + DEFAULT_EXPIRY_TIME),
               secure: this.cookieOptions?.secure ?? true,
               sameSite: 'Strict',
               path: '/',


### PR DESCRIPTION
After the 3.2.0 refactoring, the session token is refreshed via an SSO mechanism. However, the expiration time of the OAuth token is the same as that of the session cookie. When the refresh time arrives, the cookie expires before the refresh token request can be made and the session is destroyed.
An extra minute of session time is given to the cookie to avoid this bug

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
