### PR TITLE
refactor: use action group creator in the store action schematics

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -38,6 +38,9 @@ Obsolete functionality that is no longer needed with the current state of the In
 - removed unused `azure-pipeline` schematic that could be used to create an Azure Pipeline template based on the generated Kubernetes charts for DevOps
 - removed migration scripts that where used for pre PWA 1.0 migration support
 
+We recommend to use the Action Group Creator to create store actions now.
+Therefore the corresponding store schematic for the action creation has been adapted.
+
 ## 3.2 to 3.3
 
 To improve the accessibility of the PWA in regards to more elements being tab focusable a lot of `[routerLink]="[]"` where added to links that previously did not have a link reference.

--- a/schematics/src/store/factory.ts
+++ b/schematics/src/store/factory.ts
@@ -210,6 +210,7 @@ export function createStore(options: Options): Rule {
           applyTemplates({
             ...strings,
             ...options,
+            actionTitle,
           }),
           move(options.path),
         ])
@@ -223,4 +224,8 @@ export function createStore(options: Options): Rule {
 
     return chain(operations);
   };
+}
+
+function actionTitle(name: string): string {
+  return name.replace(/[A-Z]/g, ' $&').trim();
 }

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.actions.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.actions.ts.template
@@ -1,13 +1,24 @@
-import { createAction } from '@ngrx/store';<% if(entity) { %>
+import { createActionGroup, emptyProps } from '@ngrx/store';<% if(entity) { %>
 
 import { <%= classify(entity) %> } from '<% if(!extension) { %>ish-core<% } else { %>../..<% } %>/models/<%= dasherize(entity) %>/<%= dasherize(entity) %>.model';
 import { httpError, payload } from 'ish-core/utils/ngrx-creators';
 <% } %>
 
-export const load<%= classify(name) %> = createAction('[<%= classify(name) %>] Load <%= classify(name) %>');
+export const <%= camelize(name) %>Actions = createActionGroup({
+  source: '<%= actionTitle(classify(name)) %>',
+  events: {
+    'Load <%= actionTitle(classify(name)) %>': emptyProps(),
+  },
+});
+
 
 <% if(entity) { %>
-export const load<%= classify(name) %>Fail = createAction('[<%= classify(name) %> API] Load <%= classify(name) %> Fail', httpError());
 
-export const load<%= classify(name) %>Success = createAction('[<%= classify(name) %> API] Load <%= classify(name) %> Success', payload<{ <%= camelize(name) %>: <%= classify(entity) %>[] }>())
+export const <%= camelize(name) %>ApiActions = createActionGroup({
+  source: '<%= actionTitle(classify(name)) %> API',
+  events: {
+    'Load <%= actionTitle(classify(name)) %> Success': payload<{ <%= camelize(name) %>: <%= classify(entity) %>[] }>(),
+    'Load <%= actionTitle(classify(name)) %> Fail': httpError<{}>(),
+  },
+});
 <% } %>

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.effects.spec.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.effects.spec.ts.template
@@ -4,7 +4,7 @@ import { Action } from '@ngrx/store';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable } from 'rxjs';
 
-import { load<%= classify(name) %> } from './<%= dasherize(name) %>.actions';
+import { <%= camelize(name) %>Actions } from './<%= dasherize(name) %>.actions';
 import { <%= classify(name) %>Effects } from './<%= dasherize(name) %>.effects';
 
 describe('<%= classify(name) %> Effects', () => {
@@ -24,7 +24,7 @@ describe('<%= classify(name) %> Effects', () => {
 
   describe('load<%= classify(name) %>$', () => {
     it('should not dispatch actions when encountering load<%= classify(name) %>', () => {
-      const action = load<%= classify(name) %>();
+      const action = <%= camelize(name) %>Actions.load<%= classify(name) %>();
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('------');
 

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.effects.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.effects.ts.template
@@ -4,7 +4,7 @@ import { Action } from '@ngrx/store';
 import { EMPTY, Observable } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 
-import { load<%= classify(name) %> } from './<%= dasherize(name) %>.actions';
+import { <%= camelize(name) %>Actions } from './<%= dasherize(name) %>.actions';
 
 @Injectable()
 export class <%= classify(name) %>Effects {
@@ -12,7 +12,7 @@ export class <%= classify(name) %>Effects {
 
   load<%= classify(name) %>$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(load<%= classify(name) %>),
+      ofType(<%= camelize(name) %>Actions.load<%= classify(name) %>),
       concatMap(() => EMPTY as Observable<Action>)
     )
   );

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.reducer.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.reducer.ts.template
@@ -7,7 +7,7 @@ import { <%= classify(entity) %> } from '<% if(!extension) { %>ish-core<% } else
 import { createReducer<% if(entity) { %>, on<% } %> } from '@ngrx/store';
 import { <% if(entity) { %>setErrorOn, unsetLoadingAndErrorOn, <% } %>setLoadingOn } from 'ish-core/utils/ngrx-creators';
 
-import { load<%= classify(name) %><% if(entity) { %>, load<%= classify(name) %>Fail, load<%= classify(name) %>Success<% } %> } from './<%= dasherize(name) %>.actions';
+import { <%= camelize(name) %>Actions<% if(entity) { %>, <%= camelize(name) %>ApiActions<% } %> } from './<%= dasherize(name) %>.actions';
 <% if(entity) { %>
 export const <%= camelize(name) %>Adapter = createEntityAdapter<<%= classify(entity) %>>();
 
@@ -31,8 +31,8 @@ const initialState: <%= classify(name) %>State = {
 <% } %>
 export const <%= camelize(name) %>Reducer = createReducer(
   initialState,
-  setLoadingOn(load<%= classify(name) %>)<% if(entity) { %>,
-  setErrorOn(load<%= classify(name) %>Fail),
-  unsetLoadingAndErrorOn(load<%= classify(name) %>Success),
-  on(load<%= classify(name) %>Success, (state, action) => <%= camelize(name) %>Adapter.upsertMany(action.payload.<%= camelize(name) %>, state))<% } %>
+  setLoadingOn(<%= camelize(name) %>Actions.load<%= classify(name) %>)<% if(entity) { %>,
+  setErrorOn(<%= camelize(name) %>ApiActions.load<%= classify(name) %>Fail),
+  unsetLoadingAndErrorOn(<%= camelize(name) %>ApiActions.load<%= classify(name) %>Success),
+  on(<%= camelize(name) %>ApiActions.load<%= classify(name) %>Success, (state, action) => <%= camelize(name) %>Adapter.upsertMany(action.payload.<%= camelize(name) %>, state))<% } %>
 );

--- a/schematics/src/store/files/__name@dasherize__/__name@dasherize__.selectors.spec.ts.template
+++ b/schematics/src/store/files/__name@dasherize__/__name@dasherize__.selectors.spec.ts.template
@@ -6,7 +6,7 @@ import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ng
 <% if(entity) { %>import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { <%= classify(entity) %> } from '<% if(!extension) { %>ish-core<% } else { %>../..<% } %>/models/<%= dasherize(entity) %>/<%= dasherize(entity) %>.model';<% } %>
 
-import { load<%= classify(name) %><% if (entity) { %>, load<%= classify(name) %>Fail, load<%= classify(name) %>Success<% } %> } from './<%= dasherize(name) %>.actions';
+import { <%= camelize(name) %>Actions<% if (entity) { %>, <%= camelize(name) %>ApiActions<% } %> } from './<%= dasherize(name) %>.actions';
 import { <% if (entity) { %>getNumberOf<%= classify(name) %>, get<%= classify(name) %>, get<%= classify(name) %>Entities, get<%= classify(name) %>Error, <% } %>get<%= classify(name) %>Loading } from './<%= dasherize(name) %>.selectors';
 
 describe('<%= classify(name) %> Selectors', () => {
@@ -41,7 +41,7 @@ describe('<%= classify(name) %> Selectors', () => {
 <% } %>  });
 
   describe('load<%= classify(name) %>', () =>{
-    const action = load<%= classify(name) %>();
+    const action = <%= camelize(name) %>Actions.load<%= classify(name) %>();
 
     beforeEach(() => {
       store$.dispatch(action);
@@ -53,7 +53,7 @@ describe('<%= classify(name) %> Selectors', () => {
 <% if (entity) { %>
     describe('load<%= classify(name) %>Success', () => {
       const <%= camelize(name) %> = [{ id: '1' }, { id: '2' }] as <%= classify(entity) %>[];
-      const successAction = load<%= classify(name) %>Success({ <%= camelize(name) %> });
+      const successAction = <%= camelize(name) %>ApiActions.load<%= classify(name) %>Success({ <%= camelize(name) %> });
 
       beforeEach(() => {
         store$.dispatch(successAction);
@@ -76,7 +76,7 @@ describe('<%= classify(name) %> Selectors', () => {
 
     describe('load<%= classify(name) %>Fail', () => {
       const error = makeHttpError({ message: 'ERROR' });
-      const failAction = load<%= classify(name) %>Fail({ error });
+      const failAction = <%= camelize(name) %>ApiActions.load<%= classify(name) %>Fail({ error });
 
       beforeEach(() => {
         store$.dispatch(failAction);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The store schematics uses action creator to create store actions.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The store schematics uses the Action Group Creator to create store actions now. Find more information in this [article](https://dev.to/ngrx/ngrx-action-group-creator-1deh)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#84626](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/84626)