### PR TITLE
fix: return a unique id in the line item list's trackBy function

### DIFF
--- a/src/app/shared/components/line-item/line-item-list/line-item-list.component.ts
+++ b/src/app/shared/components/line-item/line-item-list/line-item-list.component.ts
@@ -49,7 +49,7 @@ export class LineItemListComponent implements OnChanges {
   }
 
   trackByFn(_: number, item: Partial<LineItemView & OrderLineItem>) {
-    return item.productSKU;
+    return item.id;
   }
 
   /**


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
For rendering the line item list a trackBy function is used for performance reasons that returns the sku, but the sku is not always a unique identifier for the list items.
E.g. cart items might have the same sku if the ICM backoffice setting 'Add product behavior' (application shopping cart & checkout preference) is set to 'Allow repeats'. The default preference 'Merge quantities' is also not always applicable, e.g. if the product contains a warranty.

The equivocal trackBy return value might cause rendering problems on the line item list.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The trackby function returns the id as a unique value for a list item.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
