### PR TITLE
fix: change templateOptions to props using the formly-migrate schematic

### DIFF
--- a/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
+++ b/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
@@ -112,7 +112,7 @@ export class PunchoutUserFormComponent implements OnInit {
           {
             key: 'active',
             type: 'ish-checkbox-field',
-            templateOptions: {
+            props: {
               label: 'account.user.active.label',
               title: 'account.user.active.title',
             },


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The form is still using `templateOptions` but due to the formly update, it has to use `props`.

Issue Number: Closes #

## What Is the New Behavior?

To replace deprecated formly field properties, the new `formly-migrate` schematic `ng g formly-migrate --project=intershop-pwa` was used to update the properties from `templateOptions` to `props`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No