### PR TITLE
fix: server-validation-extension execution should not error

### DIFF
--- a/src/app/pages/checkout-payment/formly/server-validation.extension.ts
+++ b/src/app/pages/checkout-payment/formly/server-validation.extension.ts
@@ -39,7 +39,7 @@ export const serverValidationExtension: FormlyExtension = {
 
     field.expressions = {
       ...field.expressions,
-      'validation.messages.serverError': 'formState.errors?.[field.key as string]',
+      'validation.messages.serverError': field.options.formState.errors?.[field.key as string],
     };
   },
 };


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

On all pages, where the server-validation extension is used on formly-field elements, syntax errors are thrown.

`SyntaxError: Unexpected identifier 'as'`

Issue Number: Closes #

## What Is the New Behavior?

The error is fixed by not using a string to set the expression value for `validation.messages.serverError`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information
