### PR TITLE
fix: refresh the search page with query parameter 'view'

### DIFF
--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -94,7 +94,12 @@ export class ProductListingEffects {
           select(selectQueryParams),
           // filter router changes which have nothing to do with product lists like login
           filter(
-            params => !!params?.filters || !!params?.sorting || !!params?.page || Object.keys(params)?.length === 0
+            params =>
+              !!params?.filters ||
+              !!params?.view ||
+              !!params?.sorting ||
+              !!params?.page ||
+              Object.keys(params)?.length === 0
           ),
           map(params => {
             const filters = params.filters


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user refreshs the search page (browser refresh) with a query parameter 'view' the search page result is empty, e.g. https://intershoppwa.azurewebsites.net/search/acer?view=list

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
After opening/refreshing a search page with parameter 'view' the page the page result is shown.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
