### PR TITLE
Basket error modal window cant be closed

### DIFF
--- a/src/app/core/store/core/messages/messages.effects.ts
+++ b/src/app/core/store/core/messages/messages.effects.ts
@@ -5,7 +5,7 @@ import { routerRequestAction } from '@ngrx/router-store';
 import { Store, select } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { ActiveToast, IndividualConfig, ToastrService } from 'ngx-toastr';
-import { OperatorFunction, Subject, combineLatest } from 'rxjs';
+import { EMPTY, OperatorFunction, Subject, combineLatest, iif } from 'rxjs';
 import { filter, map, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
 
 import { getDeviceType } from 'ish-core/store/core/configuration';
@@ -34,77 +34,97 @@ export class MessagesEffects {
 
   infoToast$ = createEffect(
     () =>
-      this.actions$.pipe(
-        ofType(displayInfoMessage),
-        mapToPayload(),
-        this.composeToastServiceArguments(0),
-        map(args => this.toastr.info(...args)),
-        tap(() => {
-          this.applyStyle$.next();
-        }),
-        this.closeToastOnRouting()
+      iif(
+        () => !SSR,
+        this.actions$.pipe(
+          ofType(displayInfoMessage),
+          mapToPayload(),
+          this.composeToastServiceArguments(0),
+          map(args => this.toastr.info(...args)),
+          tap(() => {
+            this.applyStyle$.next();
+          }),
+          this.closeToastOnRouting()
+        ),
+        EMPTY
       ),
     { dispatch: false }
   );
 
   errorToast$ = createEffect(
     () =>
-      this.actions$.pipe(
-        ofType(displayErrorMessage),
-        mapToPayload(),
-        this.composeToastServiceArguments(0),
-        map(args => this.toastr.error(...args)),
-        tap(() => {
-          this.applyStyle$.next();
-        }),
-        this.closeToastOnRouting()
+      iif(
+        () => !SSR,
+        this.actions$.pipe(
+          ofType(displayErrorMessage),
+          mapToPayload(),
+          this.composeToastServiceArguments(0),
+          map(args => this.toastr.error(...args)),
+          tap(() => {
+            this.applyStyle$.next();
+          }),
+          this.closeToastOnRouting()
+        ),
+        EMPTY
       ),
     { dispatch: false }
   );
 
   warningToast$ = createEffect(
     () =>
-      this.actions$.pipe(
-        ofType(displayWarningMessage),
-        mapToPayload(),
-        this.composeToastServiceArguments(0),
-        map(args => this.toastr.warning(...args)),
-        tap(() => {
-          this.applyStyle$.next();
-        }),
-        this.closeToastOnRouting()
+      iif(
+        () => !SSR,
+        this.actions$.pipe(
+          ofType(displayWarningMessage),
+          mapToPayload(),
+          this.composeToastServiceArguments(0),
+          map(args => this.toastr.warning(...args)),
+          tap(() => {
+            this.applyStyle$.next();
+          }),
+          this.closeToastOnRouting()
+        ),
+        EMPTY
       ),
     { dispatch: false }
   );
 
   successToast$ = createEffect(
     () =>
-      this.actions$.pipe(
-        ofType(displaySuccessMessage),
-        mapToPayload(),
-        filter(payload => !!payload?.message),
-        this.composeToastServiceArguments(),
-        map(args => this.toastr.success(...args)),
-        tap(() => {
-          this.applyStyle$.next();
-        })
+      iif(
+        () => !SSR,
+        this.actions$.pipe(
+          ofType(displaySuccessMessage),
+          mapToPayload(),
+          filter(payload => !!payload?.message),
+          this.composeToastServiceArguments(),
+          map(args => this.toastr.success(...args)),
+          tap(() => {
+            this.applyStyle$.next();
+          })
+        ),
+        EMPTY
       ),
     { dispatch: false }
   );
 
   setToastStickyClass$ = createEffect(
     () =>
-      combineLatest([this.store.pipe(select(isStickyHeader)), this.applyStyle$]).pipe(
-        tap(([sticky]) => {
-          const container = this.document.getElementById('toast-container');
-          if (container) {
-            if (sticky) {
-              container.classList.add('toast-sticky');
-            } else {
-              container.classList.remove('toast-sticky');
+      iif(
+        () => !SSR,
+        combineLatest([this.store.pipe(select(isStickyHeader)), this.applyStyle$]).pipe(
+          tap(([sticky]) => {
+            const container = this.document.getElementById('toast-container');
+            if (container) {
+              if (sticky) {
+                container.classList.add('toast-sticky');
+              } else {
+                container.classList.remove('toast-sticky');
+              }
             }
-          }
-        })
+          })
+        ),
+        EMPTY
       ),
     { dispatch: false }
   );

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -355,17 +355,21 @@ export class BasketEffects {
    * Reload basket information on basket route to ensure that rendered page is correct.
    */
   loadBasketOnBasketPage$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(personalizationStatusDetermined),
-      take(1),
-      switchMap(() =>
-        this.actions$.pipe(
-          ofType(routerNavigatedAction),
-          mapToRouterState(),
-          filter(routerState => /^\/basket/.test(routerState.url)),
-          map(() => loadBasket())
+    iif(
+      () => !SSR,
+      this.actions$.pipe(
+        ofType(personalizationStatusDetermined),
+        take(1),
+        switchMap(() =>
+          this.actions$.pipe(
+            ofType(routerNavigatedAction),
+            mapToRouterState(),
+            filter(routerState => /^\/basket/.test(routerState.url)),
+            map(() => loadBasket())
+          )
         )
-      )
+      ),
+      EMPTY
     )
   );
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

All toaster messages will currently be rendered on SSR, if a toaster action will be dispatched during the runtime on the server.
(empty basket on basket page)

It is not possible to dismiss the SSR rendered toaster on browser side.

Furthermore basket informations will be fetched on all basket pages even on SSR. It is not possible to retrieve a personalized basket on server side.

Issue Number: Closes #1403

## What Is the New Behavior?

The message  and the loadBasketOnBasketPage effects will only subscribe to the action stream if the app is running on browser side.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#85043](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/85043)