### PR TITLE
fix: display offline products

### DIFF
--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -28,6 +28,7 @@ import {
 import { loadProductPrices } from 'ish-core/store/shopping/product-prices';
 import { getProductPrice } from 'ish-core/store/shopping/product-prices/product-prices.selectors';
 import {
+  getFailedProducts,
   getProduct,
   getProductLinks,
   getProductParts,
@@ -107,6 +108,8 @@ export class ShoppingFacade {
       )
     );
   }
+
+  failedProducts$ = this.store.pipe(select(getFailedProducts));
 
   productPrices$(sku: string | Observable<string>, fresh = false) {
     return toObservable(sku).pipe(

--- a/src/app/core/store/shopping/products/products.selectors.ts
+++ b/src/app/core/store/shopping/products/products.selectors.ts
@@ -120,6 +120,8 @@ export const getProductLinks = (sku: string) => createSelector(getProductsState,
 
 export const getProductParts = (sku: string) => createSelector(getProductsState, state => state.parts[sku]);
 
+export const getFailedProducts = createSelector(getProductsState, state => state.failed);
+
 export const getBreadcrumbForProductPage = createSelectorFactory<object, BreadcrumbItem[]>(projector =>
   resultMemoize(projector, isEqual)
 )(

--- a/src/app/extensions/recently/pages/recently/recently-page.component.html
+++ b/src/app/extensions/recently/pages/recently/recently-page.component.html
@@ -9,11 +9,11 @@
       <div class="col-md-9">
         <ish-breadcrumb></ish-breadcrumb>
         <h1>{{ 'application.recentlyViewed.product.heading' | translate }}</h1>
-        <div class="product-list row">
-          <div *ngFor="let productSku of products" class="col-6 col-lg-4 product-list-item grid-view">
-            <ish-product-item ishProductContext [sku]="productSku" displayType="tile"></ish-product-item>
-          </div>
-        </div>
+        <ish-products-list
+          [productSKUs]="products"
+          listItemCSSClass="col-6 col-lg-4"
+          listItemStyle="tile"
+        ></ish-products-list>
       </div>
     </ng-container>
 

--- a/src/app/extensions/recently/pages/recently/recently-page.component.spec.ts
+++ b/src/app/extensions/recently/pages/recently/recently-page.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent, MockDirective } from 'ng-mocks';
+import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, verify, when } from 'ts-mockito';
 
-import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
+import { ProductsListComponent } from 'ish-shared/components/product/products-list/products-list.component';
 
 import { RecentlyFacade } from '../../facades/recently.facade';
 
@@ -24,7 +24,7 @@ describe('Recently Page Component', () => {
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, TranslateModule.forRoot()],
-      declarations: [MockComponent(BreadcrumbComponent), MockDirective(ProductContextDirective), RecentlyPageComponent],
+      declarations: [MockComponent(BreadcrumbComponent), MockComponent(ProductsListComponent), RecentlyPageComponent],
       providers: [{ provide: RecentlyFacade, useFactory: () => instance(recentlyFacade) }],
     }).compileComponents();
   });
@@ -39,11 +39,6 @@ describe('Recently Page Component', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
-  });
-
-  it('should display product items for recently used products', () => {
-    fixture.detectChanges();
-    expect(element.querySelectorAll('ish-product-item')).toHaveLength(2);
   });
 
   it('should trigger facade when clear button is clicked', () => {

--- a/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.html
+++ b/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.html
@@ -2,11 +2,7 @@
   <div *ngIf="products.length" class="product-list-container" data-testing-id="recently-viewed">
     <h2>{{ 'recentlyViewed.component.heading' | translate }}</h2>
 
-    <div class="product-list row">
-      <div *ngFor="let productSku of products" class="col-6 col-lg-3 product-list-item">
-        <ish-product-item ishProductContext [sku]="productSku" displayType="tile"></ish-product-item>
-      </div>
-    </div>
+    <ish-products-list [productSKUs]="products" listStyle="carousel" listItemStyle="tile"></ish-products-list>
 
     <a [routerLink]="['/recently']" class="view-all" data-testing-id="view-all">{{
       'common.view_all.link' | translate

--- a/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.spec.ts
+++ b/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.spec.ts
@@ -1,14 +1,13 @@
 import { Location } from '@angular/common';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslatePipe } from '@ngx-translate/core';
-import { MockDirective, MockPipe } from 'ng-mocks';
+import { MockComponent, MockPipe } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
-import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { findAllDataTestingIDs } from 'ish-core/utils/dev/html-query-utils';
+import { ProductsListComponent } from 'ish-shared/components/product/products-list/products-list.component';
 
 import { RecentlyFacade } from '../../facades/recently.facade';
 
@@ -26,7 +25,7 @@ describe('Recently Viewed Component', () => {
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([{ path: 'recently', component: RecentlyViewedComponent }])],
-      declarations: [MockDirective(ProductContextDirective), MockPipe(TranslatePipe), RecentlyViewedComponent],
+      declarations: [MockComponent(ProductsListComponent), MockPipe(TranslatePipe), RecentlyViewedComponent],
       providers: [{ provide: RecentlyFacade, useFactory: () => instance(recentlyFacade) }],
     }).compileComponents();
   });
@@ -50,48 +49,22 @@ describe('Recently Viewed Component', () => {
     expect(element).toMatchInlineSnapshot(`N/A`);
   });
 
-  describe('with items', () => {
-    beforeEach(() => {
-      when(recentlyFacade.mostRecentlyViewedProducts$).thenReturn(of(['P1', 'P2', 'P3']));
-
-      fixture.detectChanges();
-    });
-
-    it('should display product-item components for all products', () => {
-      expect(element.querySelectorAll('ish-product-item')).toHaveLength(3);
-    });
-
-    it('should display view all link on page', () => {
-      expect(findAllDataTestingIDs(fixture)).toContain('view-all');
-    });
-
-    it('should properly propagate inputs to product-tiles', () => {
-      expect(fixture.debugElement.queryAll(By.css('[ishProductContext]')).map(de => de.attributes['ng-reflect-sku']))
-        .toMatchInlineSnapshot(`
-        [
-          "P1",
-          "P2",
-          "P3",
-        ]
-      `);
-    });
+  it('should display view all link on page', () => {
+    when(recentlyFacade.mostRecentlyViewedProducts$).thenReturn(of(['P1', 'P2', 'P3']));
+    fixture.detectChanges();
+    expect(findAllDataTestingIDs(fixture)).toContain('view-all');
   });
 
-  describe('link to recently page', () => {
-    it('should navigate to recently page when view-all link is clicked', fakeAsync(() => {
-      when(recentlyFacade.mostRecentlyViewedProducts$).thenReturn(of(['P1']));
+  it('should navigate to recently page when view-all link is clicked', fakeAsync(() => {
+    when(recentlyFacade.mostRecentlyViewedProducts$).thenReturn(of(['P1']));
+    fixture.detectChanges();
 
-      fixture.detectChanges();
+    expect(location.path()).toMatchInlineSnapshot(`""`);
 
-      expect(location.path()).toMatchInlineSnapshot(`""`);
+    const link = element.querySelector('[data-testing-id="view-all"]') as HTMLLinkElement;
+    link.click();
+    tick(0);
 
-      const link = element.querySelector('[data-testing-id="view-all"]') as HTMLLinkElement;
-
-      link.click();
-
-      tick(0);
-
-      expect(location.path()).toMatchInlineSnapshot(`"/recently"`);
-    }));
-  });
+    expect(location.path()).toMatchInlineSnapshot(`"/recently"`);
+  }));
 });

--- a/src/app/extensions/recently/store/recently/recently.integration.spec.ts
+++ b/src/app/extensions/recently/store/recently/recently.integration.spec.ts
@@ -41,7 +41,7 @@ describe('Recently Integration', () => {
 
   describe('after short shopping spree', () => {
     beforeEach(fakeAsync(() => {
-      ['A', 'B', 'C', 'D', 'E', 'F', 'G'].forEach(sku =>
+      ['A', 'B', 'C', 'D', 'E', 'F'].forEach(sku =>
         store$.dispatch(loadProductSuccess({ product: { sku } as Product }))
       );
       ['A', 'B', 'F', 'C', 'A', 'D', 'E', 'D', 'A', 'B', 'A'].forEach(sku => {
@@ -53,7 +53,7 @@ describe('Recently Integration', () => {
     it('should have collected data for display on pages', () => {
       const viewed = ['A', 'B', 'D', 'E', 'C', 'F'];
       expect(getRecentlyViewedProducts(store$.state)).toEqual(viewed);
-      const filtered = ['B', 'D', 'E', 'C'];
+      const filtered = ['B', 'D', 'E', 'C', 'F'];
       expect(getMostRecentlyViewedProducts(store$.state)).toEqual(filtered);
     });
 

--- a/src/app/extensions/recently/store/recently/recently.selectors.ts
+++ b/src/app/extensions/recently/store/recently/recently.selectors.ts
@@ -27,5 +27,5 @@ export const getMostRecentlyViewedProducts = createSelector(
   getRecentlyViewedProducts,
   getSelectedProduct,
   (skus, selected): string[] =>
-    selected ? skus.filter(productSKU => productSKU && productSKU !== selected.sku).slice(0, 4) : skus.slice(0, 4)
+    selected ? skus.filter(productSKU => productSKU && productSKU !== selected.sku).slice(0, 12) : skus.slice(0, 12)
 );

--- a/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.html
@@ -1,23 +1,21 @@
 <div class="section">
   <h3>{{ 'account.wishlists.widget.heading' | translate }}</h3>
-  <ng-container *ngIf="allWishlistsItemsSkus$ | async as itemSku">
-    <ng-container *ngIf="itemSku.length > 0; else noItems" class="section">
-      <div class="product-list">
-        <swiper [config]="swiperConfig">
-          <ng-template *ngFor="let sku of itemSku" swiperSlide>
-            <ish-product-item
-              displayType="tile"
-              ishProductContext
-              [sku]="sku"
-              [configuration]="tileConfiguration"
-            ></ish-product-item>
-          </ng-template>
-        </swiper>
+  <ng-container *ngIf="allWishlistsItemsSkus$ | async as wishlistsItemsSkus">
+    <ng-container *ngIf="wishlistsItemsSkus.length > 0; else noItems" class="section">
+      <div class="product-list" data-testing-id="wishlistProductsList">
+        <ish-products-list
+          [productSKUs]="wishlistsItemsSkus"
+          listStyle="carousel"
+          listItemStyle="tile"
+          [listItemConfiguration]="tileConfiguration"
+        ></ish-products-list>
       </div>
     </ng-container>
     <ng-template #noItems>
       <p>{{ 'account.wishlists.no_items' | translate }}</p>
     </ng-template>
   </ng-container>
-  <a routerLink="/account/wishlists">{{ 'account.overview.wishlist.view_all' | translate }}</a>
+  <a routerLink="/account/wishlists" data-testing-id="emptyWishlistProductsList">{{
+    'account.overview.wishlist.view_all' | translate
+  }}</a>
 </div>

--- a/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.spec.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.spec.ts
@@ -1,7 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { EMPTY } from 'rxjs';
+import { MockComponent } from 'ng-mocks';
+import { EMPTY, of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
+
+import { ProductsListComponent } from 'ish-shared/components/product/products-list/products-list.component';
 
 import { WishlistsFacade } from '../../facades/wishlists.facade';
 
@@ -12,12 +15,14 @@ describe('Wishlist Widget Component', () => {
   let fixture: ComponentFixture<WishlistWidgetComponent>;
   let element: HTMLElement;
 
+  let wishlistFacadeMock: WishlistsFacade;
+
   beforeEach(async () => {
-    const wishlistFacadeMock = mock(WishlistsFacade);
+    wishlistFacadeMock = mock(WishlistsFacade);
     when(wishlistFacadeMock.allWishlistsItemsSkus$).thenReturn(EMPTY);
 
     await TestBed.configureTestingModule({
-      declarations: [WishlistWidgetComponent],
+      declarations: [MockComponent(ProductsListComponent), WishlistWidgetComponent],
       imports: [TranslateModule.forRoot()],
       providers: [{ provide: WishlistsFacade, useFactory: () => instance(wishlistFacadeMock) }],
     }).compileComponents();
@@ -33,5 +38,17 @@ describe('Wishlist Widget Component', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display empty list text if there are no wishlist products', () => {
+    when(wishlistFacadeMock.allWishlistsItemsSkus$).thenReturn(of());
+    fixture.detectChanges();
+    expect(element.querySelector('[data-testing-id=emptyWishlistProductsList]')).toBeTruthy();
+  });
+
+  it('should display product list if there are wishlist products', () => {
+    when(wishlistFacadeMock.allWishlistsItemsSkus$).thenReturn(of(['sku1', 'sku2']));
+    fixture.detectChanges();
+    expect(element.querySelector('[data-testing-id=wishlistProductsList]')).toBeTruthy();
   });
 });

--- a/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-widget/wishlist-widget.component.ts
@@ -1,15 +1,10 @@
-import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
-import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
-import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
 import { ProductContextDisplayProperties } from 'ish-core/facades/product-context.facade';
-import { InjectSingle } from 'ish-core/utils/injection';
 import { GenerateLazyComponent } from 'ish-core/utils/module-loader/generate-lazy-component.decorator';
 
 import { WishlistsFacade } from '../../facades/wishlists.facade';
-
-SwiperCore.use([Navigation, Pagination]);
 
 /**
  * The Wishlist Widget Component displays all unique items from all wish lists.
@@ -22,47 +17,14 @@ SwiperCore.use([Navigation, Pagination]);
 @GenerateLazyComponent()
 export class WishlistWidgetComponent implements OnInit {
   allWishlistsItemsSkus$: Observable<string[]>;
-  itemsPerSlide = 4;
   tileConfiguration: Partial<ProductContextDisplayProperties>;
 
-  /**
-   * configuration of swiper carousel
-   * find possible parameters here: http://idangero.us/swiper/api/#parameters
-   */
-  swiperConfig: SwiperOptions;
-
-  constructor(
-    private wishlistsFacade: WishlistsFacade,
-    @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
-    @Inject(MEDIUM_BREAKPOINT_WIDTH) mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>
-  ) {
+  constructor(private wishlistsFacade: WishlistsFacade) {
     this.tileConfiguration = {
       addToWishlist: false,
       addToOrderTemplate: false,
       addToCompare: false,
       addToQuote: false,
-    };
-
-    this.swiperConfig = {
-      direction: 'horizontal',
-      navigation: true,
-      pagination: {
-        clickable: true,
-      },
-      breakpoints: {
-        0: {
-          slidesPerView: 2,
-          slidesPerGroup: 2,
-        },
-        [mediumBreakpointWidth]: {
-          slidesPerView: 3,
-          slidesPerGroup: 3,
-        },
-        [largeBreakpointWidth]: {
-          slidesPerView: 4,
-          slidesPerGroup: 4,
-        },
-      },
     };
   }
 

--- a/src/app/shared/components/product/product-item/product-item.component.html
+++ b/src/app/shared/components/product/product-item/product-item.component.html
@@ -1,6 +1,5 @@
 <ng-container *ngIf="product$ | async">
   <ish-product-tile *ngIf="isTile"></ish-product-tile>
-
   <ish-product-row *ngIf="isRow"></ish-product-row>
 </ng-container>
 

--- a/src/app/shared/components/product/product-row/product-row.component.html
+++ b/src/app/shared/components/product/product-row/product-row.component.html
@@ -1,70 +1,72 @@
-<div *ngIf="product$ | async as product" class="product-tile-list row" [attr.data-testing-sku]="product.sku">
-  <div class="col-3 col-md-2">
-    <div class="product-image-container">
-      <ish-product-image imageType="S" [link]="true"></ish-product-image>
-      <ish-product-label></ish-product-label>
-    </div>
-  </div>
-
-  <div class="col-9 col-md-10">
-    <div class="row">
-      <div class="col-md-7">
-        <ish-product-name></ish-product-name>
-
-        <ish-lazy-product-rating [hideNumberOfReviews]="true"></ish-lazy-product-rating>
-
-        <ish-product-id></ish-product-id>
-
-        <div
-          *ngIf="configuration$('description') | async"
-          class="product-description"
-          [ishServerHtml]="product.shortDescription"
-        ></div>
-
-        <ish-product-promotion displayType="simpleWithDetail"></ish-product-promotion>
-
-        <div class="product-tile-actions btn-group">
-          <ish-lazy-product-add-to-quote displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-quote>
-          <ish-lazy-product-add-to-compare displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-compare>
-          <ish-lazy-product-add-to-wishlist displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-wishlist>
-          <ish-lazy-product-add-to-order-template
-            displayType="icon"
-            cssClass="btn-link"
-          ></ish-lazy-product-add-to-order-template>
-        </div>
+<ng-container *ngIf="product$ | async as product">
+  <div *ngIf="!product.failed" class="product-tile-list row" [attr.data-testing-sku]="product.sku">
+    <div class="col-3 col-md-2">
+      <div class="product-image-container">
+        <ish-product-image imageType="S" [link]="true"></ish-product-image>
+        <ish-product-label></ish-product-label>
       </div>
+    </div>
 
-      <div class="col-12 col-md-5 text-md-right">
-        <ish-product-price [showInformationalPrice]="true"></ish-product-price>
-        <ish-product-inventory></ish-product-inventory>
-        <ish-product-shipment></ish-product-shipment>
+    <div class="col-9 col-md-10">
+      <div class="row">
+        <div class="col-md-7">
+          <ish-product-name></ish-product-name>
 
-        <ish-product-item-variations></ish-product-item-variations>
+          <ish-lazy-product-rating [hideNumberOfReviews]="true"></ish-lazy-product-rating>
 
-        <div class="product-list-actions-container">
-          <ish-lazy-tacton-configure-product displayType="list-button"></ish-lazy-tacton-configure-product>
+          <ish-product-id></ish-product-id>
 
-          <div class="product-form form-horizontal row">
-            <ng-container *ngIf="configuration$('readOnly') | async; else quantityInput">
-              <div class="action-container col-12 col-xl-7">
-                <span *ngIf="configuration$('quantity') | async"
-                  >{{ 'product.quantity.label' | translate }}: {{ quantity$ | async }}</span
-                >
+          <div
+            *ngIf="configuration$('description') | async"
+            class="product-description"
+            [ishServerHtml]="product.shortDescription"
+          ></div>
+
+          <ish-product-promotion displayType="simpleWithDetail"></ish-product-promotion>
+
+          <div class="product-tile-actions btn-group">
+            <ish-lazy-product-add-to-quote displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-quote>
+            <ish-lazy-product-add-to-compare displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-compare>
+            <ish-lazy-product-add-to-wishlist displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-wishlist>
+            <ish-lazy-product-add-to-order-template
+              displayType="icon"
+              cssClass="btn-link"
+            ></ish-lazy-product-add-to-order-template>
+          </div>
+        </div>
+
+        <div class="col-12 col-md-5 text-md-right">
+          <ish-product-price [showInformationalPrice]="true"></ish-product-price>
+          <ish-product-inventory></ish-product-inventory>
+          <ish-product-shipment></ish-product-shipment>
+
+          <ish-product-item-variations></ish-product-item-variations>
+
+          <div class="product-list-actions-container">
+            <ish-lazy-tacton-configure-product displayType="list-button"></ish-lazy-tacton-configure-product>
+
+            <div class="product-form form-horizontal row">
+              <ng-container *ngIf="configuration$('readOnly') | async; else quantityInput">
+                <div class="action-container col-12 col-xl-7">
+                  <span *ngIf="configuration$('quantity') | async"
+                    >{{ 'product.quantity.label' | translate }}: {{ quantity$ | async }}</span
+                  >
+                </div>
+              </ng-container>
+              <ng-template #quantityInput>
+                <div class="action-container col-6 offset-md-6 col-lg-5 offset-lg-0">
+                  <ish-product-quantity></ish-product-quantity>
+                </div>
+              </ng-template>
+
+              <div class="action-container addtocart-container col-12 col-lg-7">
+                <ish-product-add-to-basket></ish-product-add-to-basket>
+                <ish-product-choose-variation></ish-product-choose-variation>
               </div>
-            </ng-container>
-            <ng-template #quantityInput>
-              <div class="action-container col-6 offset-md-6 col-lg-5 offset-lg-0">
-                <ish-product-quantity></ish-product-quantity>
-              </div>
-            </ng-template>
-
-            <div class="action-container addtocart-container col-12 col-lg-7">
-              <ish-product-add-to-basket></ish-product-add-to-basket>
-              <ish-product-choose-variation></ish-product-choose-variation>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/shared/components/product/product-tile/product-tile.component.html
+++ b/src/app/shared/components/product/product-tile/product-tile.component.html
@@ -1,30 +1,32 @@
-<div *ngIf="product$ | async as product" class="product-tile" [attr.data-testing-sku]="product.sku">
-  <div class="product-image-container">
-    <ish-product-image imageType="M" [link]="true"></ish-product-image>
-    <ish-product-label></ish-product-label>
+<ng-container *ngIf="product$ | async as product">
+  <div *ngIf="!product.failed" class="product-tile" [attr.data-testing-sku]="product.sku">
+    <div class="product-image-container">
+      <ish-product-image imageType="M" [link]="true"></ish-product-image>
+      <ish-product-label></ish-product-label>
+    </div>
+
+    <ish-product-name></ish-product-name>
+
+    <ish-lazy-product-rating [hideNumberOfReviews]="true"></ish-lazy-product-rating>
+
+    <ish-product-promotion displayType="simple"></ish-product-promotion>
+
+    <div *ngIf="configuration$('price') | async" class="price-container">
+      <ish-product-price [showInformationalPrice]="true"></ish-product-price>
+    </div>
+
+    <ish-product-item-variations></ish-product-item-variations>
+
+    <div class="product-tile-actions btn-group">
+      <ish-lazy-tacton-configure-product displayType="icon"></ish-lazy-tacton-configure-product>
+      <ish-lazy-product-add-to-quote displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-quote>
+      <ish-lazy-product-add-to-compare displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-compare>
+      <ish-lazy-product-add-to-order-template
+        [cssClass]="'btn btn-link mr-0'"
+        displayType="icon"
+      ></ish-lazy-product-add-to-order-template>
+      <ish-lazy-product-add-to-wishlist cssClass="btn-link" displayType="icon"></ish-lazy-product-add-to-wishlist>
+      <ish-product-add-to-basket displayType="icon" cssClass="btn-link"></ish-product-add-to-basket>
+    </div>
   </div>
-
-  <ish-product-name></ish-product-name>
-
-  <ish-lazy-product-rating [hideNumberOfReviews]="true"></ish-lazy-product-rating>
-
-  <ish-product-promotion displayType="simple"></ish-product-promotion>
-
-  <div *ngIf="configuration$('price') | async" class="price-container">
-    <ish-product-price [showInformationalPrice]="true"></ish-product-price>
-  </div>
-
-  <ish-product-item-variations></ish-product-item-variations>
-
-  <div class="product-tile-actions btn-group">
-    <ish-lazy-tacton-configure-product displayType="icon"></ish-lazy-tacton-configure-product>
-    <ish-lazy-product-add-to-quote displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-quote>
-    <ish-lazy-product-add-to-compare displayType="icon" cssClass="btn-link"></ish-lazy-product-add-to-compare>
-    <ish-lazy-product-add-to-order-template
-      [cssClass]="'btn btn-link mr-0'"
-      displayType="icon"
-    ></ish-lazy-product-add-to-order-template>
-    <ish-lazy-product-add-to-wishlist cssClass="btn-link" displayType="icon"></ish-lazy-product-add-to-wishlist>
-    <ish-product-add-to-basket displayType="icon" cssClass="btn-link"></ish-product-add-to-basket>
-  </div>
-</div>
+</ng-container>

--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -1,19 +1,33 @@
-<ng-container *ngIf="listStyle === 'carousel'; else plainList">
-  <div class="product-list">
-    <swiper [config]="swiperConfig">
-      <ng-template *ngFor="let sku of productSKUs" swiperSlide>
-        <div [ngClass]="listItemCSSClass">
-          <ish-product-item ishProductContext [sku]="sku" [displayType]="listItemStyle"></ish-product-item>
-        </div>
-      </ng-template>
-    </swiper>
-  </div>
-</ng-container>
+<ng-container *ngIf="productSKUs$ | async as products">
+  <ng-container *ngIf="products.length">
+    <ng-container *ngIf="listStyle === 'carousel'; else plainList">
+      <div class="product-list">
+        <swiper [config]="swiperConfig">
+          <ng-template *ngFor="let sku of products" swiperSlide>
+            <div [ngClass]="listItemCSSClass">
+              <ish-product-item
+                ishProductContext
+                [sku]="sku"
+                [configuration]="listItemConfiguration"
+                [displayType]="listItemStyle"
+              ></ish-product-item>
+            </div>
+          </ng-template>
+        </swiper>
+      </div>
+    </ng-container>
 
-<ng-template #plainList>
-  <div class="product-list row">
-    <div *ngFor="let sku of productSKUs" class="product-list-item" [ngClass]="listItemCSSClass">
-      <ish-product-item ishProductContext [sku]="sku" [displayType]="listItemStyle"></ish-product-item>
-    </div>
-  </div>
-</ng-template>
+    <ng-template #plainList>
+      <div class="product-list row">
+        <div *ngFor="let sku of products" class="product-list-item" [ngClass]="listItemCSSClass">
+          <ish-product-item
+            ishProductContext
+            [sku]="sku"
+            [configuration]="listItemConfiguration"
+            [displayType]="listItemStyle"
+          ></ish-product-item>
+        </div>
+      </div>
+    </ng-template>
+  </ng-container>
+</ng-container>

--- a/src/app/shared/components/product/products-list/products-list.component.spec.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.spec.ts
@@ -1,9 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
+import { of } from 'rxjs';
 import { SwiperComponent } from 'swiper/angular';
+import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductsListComponent } from './products-list.component';
@@ -12,8 +15,11 @@ describe('Products List Component', () => {
   let component: ProductsListComponent;
   let fixture: ComponentFixture<ProductsListComponent>;
   let element: HTMLElement;
+  let shoppingFacade: ShoppingFacade;
 
   beforeEach(async () => {
+    shoppingFacade = mock(ShoppingFacade);
+
     await TestBed.configureTestingModule({
       declarations: [
         MockComponent(ProductItemComponent),
@@ -21,6 +27,7 @@ describe('Products List Component', () => {
         MockDirective(ProductContextDirective),
         ProductsListComponent,
       ],
+      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
     }).compileComponents();
   });
 
@@ -28,32 +35,30 @@ describe('Products List Component', () => {
     fixture = TestBed.createComponent(ProductsListComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
+
+    when(shoppingFacade.failedProducts$).thenReturn(of([]));
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
+    expect(() => component.ngOnChanges()).not.toThrow();
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
-  describe('carousel', () => {
-    beforeEach(() => {
-      component.productSKUs = ['1', '2'];
-    });
+  it('should display a carousel when listStyle is set to carousel', () => {
+    component.productSKUs = ['1', '2'];
+    component.listStyle = 'carousel';
+    component.ngOnChanges();
+    fixture.detectChanges();
 
-    it('should display a carousel when listStyle is set to carousel', () => {
-      component.listStyle = 'carousel';
-
-      fixture.detectChanges();
-
-      expect(element).toMatchInlineSnapshot(`<div class="product-list"><swiper></swiper></div>`);
-    });
+    expect(element).toMatchInlineSnapshot(`<div class="product-list"><swiper></swiper></div>`);
   });
 
   it('should set displayType of product item to listItemStyle value', () => {
     component.productSKUs = ['1', '2'];
     component.listItemStyle = 'tile';
-
+    component.ngOnChanges();
     fixture.detectChanges();
 
     const productItem = fixture.debugElement.query(By.css('ish-product-item'))
@@ -65,7 +70,7 @@ describe('Products List Component', () => {
   it('should display product items for all product skus', () => {
     component.productSKUs = ['1', '2', '3'];
     component.listItemStyle = 'row';
-
+    component.ngOnChanges();
     fixture.detectChanges();
 
     expect(element.querySelectorAll('ish-product-item')).toHaveLength(3);
@@ -86,6 +91,21 @@ describe('Products List Component', () => {
         ng-reflect-sku="3"
         ng-reflect-display-type="row"
       ></ish-product-item>,
+      ]
+    `);
+  });
+
+  it('should display product items only for not failed product skus', () => {
+    when(shoppingFacade.failedProducts$).thenReturn(of(['1']));
+    component.productSKUs = ['1', '2', '3'];
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(element.querySelectorAll('ish-product-item')).toHaveLength(2);
+    expect(element.querySelectorAll('ish-product-item')).toMatchInlineSnapshot(`
+      NodeList [
+        <ish-product-item ishproductcontext="" ng-reflect-sku="2"></ish-product-item>,
+        <ish-product-item ishproductcontext="" ng-reflect-sku="3"></ish-product-item>,
       ]
     `);
   });

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -1,4 +1,7 @@
 import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges } from '@angular/core';
+import { isEqual } from 'lodash-es';
+import { Observable, combineLatest, of } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
 import {
@@ -6,6 +9,8 @@ import {
   MEDIUM_BREAKPOINT_WIDTH,
   SMALL_BREAKPOINT_WIDTH,
 } from 'ish-core/configurations/injection-keys';
+import { ProductContextDisplayProperties } from 'ish-core/facades/product-context.facade';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { ProductItemDisplayType } from 'ish-shared/components/product/product-item/product-item.component';
 
@@ -22,6 +27,9 @@ export class ProductsListComponent implements OnChanges {
   @Input() slideItems: number;
   @Input() listItemStyle: ProductItemDisplayType;
   @Input() listItemCSSClass: string;
+  @Input() listItemConfiguration: Partial<ProductContextDisplayProperties>;
+
+  productSKUs$: Observable<string[]>;
 
   /**
    * configuration of swiper carousel
@@ -32,7 +40,8 @@ export class ProductsListComponent implements OnChanges {
   constructor(
     @Inject(SMALL_BREAKPOINT_WIDTH) private smallBreakpointWidth: InjectSingle<typeof SMALL_BREAKPOINT_WIDTH>,
     @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>,
-    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>
+    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
+    private shoppingFacade: ShoppingFacade
   ) {
     this.swiperConfig = {
       direction: 'horizontal',
@@ -47,6 +56,12 @@ export class ProductsListComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.configureSlides(this.slideItems);
+
+    // remove all SKUs from the productSKUs Array that are also contained in the failed products Array
+    this.productSKUs$ = combineLatest([of(this.productSKUs), this.shoppingFacade.failedProducts$]).pipe(
+      distinctUntilChanged<[string[], string[]]>(isEqual),
+      map(([skus, failed]) => skus.filter(x => !failed.includes(x)))
+    );
   }
 
   /**


### PR DESCRIPTION
## PR Type
[x] Bugfix

## What Is the Current Behavior?

When setting a product to offline in the ICM, this product will still be displayed in the Intershop PWA under the "Recently Viewed" section. The display of the product is changed as soon as the page cache is invalidated via the ICM.

## What Is the New Behavior?
The product that was set offline is no longer displayed in the "Recently Viewed" section.

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x] No

## Other Information
This is the same for featured products and the wish list widget in my account area.

[AB#85105](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/85105)