### PR TITLE
fix: SEO URL improvements

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -13,7 +13,8 @@ The Intershop PWA now uses Node.js 18.15.0 LTS with the corresponding npm versio
 To migrate to this version, it is advised to delete the locale `package-lock.json` beforehand.
 
 The project was updated to work with Angular 15.
-This includes the removal of the Browserslist configuration, an updated TypeScript compiler `target` to `ES2022`, and adaptions of the Schematics configurations and tests.
+This includes the removal of the Browserslist configuration and an updated TypeScript compiler `target` and `lib` to `ES2022` (for browser support requirements that differ from the Angular 15 standard configuration see the [configuring browser compatibility](https://angular.io/guide/build#configuring-browser-compatibility) guide and the [TypeScript configuration](https://angular.io/guide/typescript-configuration) reference).
+Adaptions of the Schematics configurations and tests were necessary as well.
 In addition, all other dependencies were updated as well and resulted in necessary Stylelint and Jest test adaptions.
 
 The placeholder for theme-specific assets and styles has been changed from `placeholder` to `theme_placeholder`.

--- a/src/app/core/utils/routing.ts
+++ b/src/app/core/utils/routing.ts
@@ -39,8 +39,8 @@ export function sanitizeSlugData(slugData: string) {
       .replace(/-+/g, '-')
       .replace(/-+$/, '')
       .toLowerCase()
-      .replace('pg', 'Pg')
-      .replace('prd', 'Prd')
-      .replace('ctg', 'Ctg') || ''
+      .replaceAll('pg', 'Pg')
+      .replaceAll('prd', 'Prd')
+      .replaceAll('ctg', 'Ctg') || ''
   );
 }

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -196,7 +196,7 @@ export class SeoEffects {
   private setCanonicalLink(url: string) {
     // the canonical URL of a production system should always be with 'https:'
     // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
-    const canonicalUrl = url.replace('http:', 'https:');
+    const canonicalUrl = encodeURI(url.replace('http:', 'https:'));
     let canonicalLink = this.doc.querySelector('link[rel="canonical"]');
     if (!canonicalLink) {
       canonicalLink = this.doc.createElement('link');

--- a/src/app/pages/app-last-routing.module.ts
+++ b/src/app/pages/app-last-routing.module.ts
@@ -8,16 +8,16 @@ import { matchProductRoute } from 'ish-core/routing/product/product.route';
 
 const routes: Routes = [
   {
-    matcher: matchContentRoute,
-    loadChildren: () => import('./content/content-page.module').then(m => m.ContentPageModule),
-  },
-  {
     matcher: matchProductRoute,
     loadChildren: () => import('./product/product-page.module').then(m => m.ProductPageModule),
   },
   {
     matcher: matchCategoryRoute,
     loadChildren: () => import('./category/category-page.module').then(m => m.CategoryPageModule),
+  },
+  {
+    matcher: matchContentRoute,
+    loadChildren: () => import('./content/content-page.module').then(m => m.ContentPageModule),
   },
   {
     path: '**',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    // leave this as CommonJS, so scripts can be run with 'npx ts-node'
+    // see https://github.com/TypeStrong/ts-node#commonjs-vs-native-ecmascript-modules
     "module": "CommonJS",
     "moduleResolution": "node",
     "importHelpers": true,
@@ -25,7 +27,7 @@
       ],
       "swiper_angular": ["node_modules/swiper/angular"]
     },
-    "lib": ["es2018", "dom"],
+    "lib": ["ES2022", "dom"],
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## PR Type

[x] Bugfix


## What Is the New Behavior?

* encode canonical link to match actual link URLs
* improve matcher routing for SEO URLs (#1387)
  * reordered check for routing matches to first check product routes then category routes and at the end content page routes (to be less eager to assume it is a content page)
  * replace all occurences of object markers (pg, prd, ctg) in slug data instead of only the first (to prevent unintended object markers with multiple occurences)
  * updated ts configuration to use the Angular 15 standard configuration of `ES2022` for `lib` that includes `replaceAll`
    - `replaceAll('pg', 'Pg')` could be replaced by `replace(/pg/g, 'Pg')`

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#85110](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/85110)