### PR TITLE
fix: handle case where all recently viewed products are failed/offline

### DIFF
--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -28,7 +28,6 @@ import {
 import { loadProductPrices } from 'ish-core/store/shopping/product-prices';
 import { getProductPrice } from 'ish-core/store/shopping/product-prices/product-prices.selectors';
 import {
-  getFailedProducts,
   getProduct,
   getProductLinks,
   getProductParts,
@@ -108,8 +107,6 @@ export class ShoppingFacade {
       )
     );
   }
-
-  failedProducts$ = this.store.pipe(select(getFailedProducts));
 
   productPrices$(sku: string | Observable<string>, fresh = false) {
     return toObservable(sku).pipe(

--- a/src/app/extensions/recently/facades/recently.facade.spec.ts
+++ b/src/app/extensions/recently/facades/recently.facade.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+
+import { getFailedProducts } from 'ish-core/store/shopping/products';
+
+import { getMostRecentlyViewedProducts, getRecentlyViewedProducts } from '../store/recently';
+
+import { RecentlyFacade } from './recently.facade';
+
+describe('Recently Facade', () => {
+  let recentlyFacade: RecentlyFacade;
+  let store$: MockStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [
+        provideMockStore({
+          selectors: [
+            {
+              selector: getFailedProducts,
+              value: [],
+            },
+            {
+              selector: getRecentlyViewedProducts,
+              value: ['Sku1', 'Sku2', 'Sku3'],
+            },
+            {
+              selector: getMostRecentlyViewedProducts,
+              value: ['Sku1', 'Sku2', 'Sku3'],
+            },
+          ],
+        }),
+      ],
+    });
+
+    store$ = TestBed.inject(MockStore);
+    recentlyFacade = TestBed.inject(RecentlyFacade);
+  });
+
+  describe('recentlyViewedProducts$', () => {
+    it('should return all recently viewed products', done => {
+      recentlyFacade.recentlyViewedProducts$.subscribe(products => {
+        expect(products).toEqual(['Sku1', 'Sku2', 'Sku3']);
+        done();
+      });
+    });
+
+    it('should only return non-failed products', done => {
+      store$.overrideSelector(getFailedProducts, ['Sku1']);
+
+      recentlyFacade.recentlyViewedProducts$.subscribe(products => {
+        expect(products).toEqual(['Sku2', 'Sku3']);
+        done();
+      });
+    });
+  });
+
+  describe('mostRecentlyViewedProducts$', () => {
+    it('should return all most recently viewed products', done => {
+      recentlyFacade.mostRecentlyViewedProducts$.subscribe(products => {
+        expect(products).toEqual(['Sku1', 'Sku2', 'Sku3']);
+        done();
+      });
+    });
+
+    it('should only return non-failed products', done => {
+      store$.overrideSelector(getFailedProducts, ['Sku1', 'Sku2']);
+
+      recentlyFacade.mostRecentlyViewedProducts$.subscribe(products => {
+        expect(products).toEqual(['Sku3']);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/extensions/recently/facades/recently.facade.ts
+++ b/src/app/extensions/recently/facades/recently.facade.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
+import { OperatorFunction, map, withLatestFrom } from 'rxjs';
+
+import { getFailedProducts } from 'ish-core/store/shopping/products';
 
 import { clearRecently, getMostRecentlyViewedProducts, getRecentlyViewedProducts } from '../store/recently';
 
@@ -7,8 +10,16 @@ import { clearRecently, getMostRecentlyViewedProducts, getRecentlyViewedProducts
 export class RecentlyFacade {
   constructor(private store: Store) {}
 
-  recentlyViewedProducts$ = this.store.pipe(select(getRecentlyViewedProducts));
-  mostRecentlyViewedProducts$ = this.store.pipe(select(getMostRecentlyViewedProducts));
+  recentlyViewedProducts$ = this.store.pipe(select(getRecentlyViewedProducts), this.excludeFailedProducts());
+  mostRecentlyViewedProducts$ = this.store.pipe(select(getMostRecentlyViewedProducts), this.excludeFailedProducts());
+
+  excludeFailedProducts(): OperatorFunction<string[], string[]> {
+    return source$ =>
+      source$.pipe(
+        withLatestFrom(this.store.pipe(select(getFailedProducts))),
+        map(([products, failedProducts]) => products.filter(product => !failedProducts.includes(product)))
+      );
+  }
 
   clearRecentlyViewedProducts() {
     this.store.dispatch(clearRecently());

--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -1,33 +1,31 @@
-<ng-container *ngIf="productSKUs$ | async as products">
-  <ng-container *ngIf="products.length">
-    <ng-container *ngIf="listStyle === 'carousel'; else plainList">
-      <div class="product-list">
-        <swiper [config]="swiperConfig">
-          <ng-template *ngFor="let sku of products" swiperSlide>
-            <div [ngClass]="listItemCSSClass">
-              <ish-product-item
-                ishProductContext
-                [sku]="sku"
-                [configuration]="listItemConfiguration"
-                [displayType]="listItemStyle"
-              ></ish-product-item>
-            </div>
-          </ng-template>
-        </swiper>
-      </div>
-    </ng-container>
-
-    <ng-template #plainList>
-      <div class="product-list row">
-        <div *ngFor="let sku of products" class="product-list-item" [ngClass]="listItemCSSClass">
-          <ish-product-item
-            ishProductContext
-            [sku]="sku"
-            [configuration]="listItemConfiguration"
-            [displayType]="listItemStyle"
-          ></ish-product-item>
-        </div>
-      </div>
-    </ng-template>
+<ng-container *ngIf="productSKUs?.length">
+  <ng-container *ngIf="listStyle === 'carousel'; else plainList">
+    <div class="product-list">
+      <swiper [config]="swiperConfig">
+        <ng-template *ngFor="let sku of productSKUs" swiperSlide>
+          <div [ngClass]="listItemCSSClass">
+            <ish-product-item
+              ishProductContext
+              [sku]="sku"
+              [configuration]="listItemConfiguration"
+              [displayType]="listItemStyle"
+            ></ish-product-item>
+          </div>
+        </ng-template>
+      </swiper>
+    </div>
   </ng-container>
+
+  <ng-template #plainList>
+    <div class="product-list row">
+      <div *ngFor="let sku of productSKUs" class="product-list-item" [ngClass]="listItemCSSClass">
+        <ish-product-item
+          ishProductContext
+          [sku]="sku"
+          [configuration]="listItemConfiguration"
+          [displayType]="listItemStyle"
+        ></ish-product-item>
+      </div>
+    </div>
+  </ng-template>
 </ng-container>

--- a/src/app/shared/components/product/products-list/products-list.component.spec.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.spec.ts
@@ -1,12 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
-import { of } from 'rxjs';
 import { SwiperComponent } from 'swiper/angular';
-import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
-import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductsListComponent } from './products-list.component';
@@ -15,11 +12,8 @@ describe('Products List Component', () => {
   let component: ProductsListComponent;
   let fixture: ComponentFixture<ProductsListComponent>;
   let element: HTMLElement;
-  let shoppingFacade: ShoppingFacade;
 
   beforeEach(async () => {
-    shoppingFacade = mock(ShoppingFacade);
-
     await TestBed.configureTestingModule({
       declarations: [
         MockComponent(ProductItemComponent),
@@ -27,7 +21,6 @@ describe('Products List Component', () => {
         MockDirective(ProductContextDirective),
         ProductsListComponent,
       ],
-      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
     }).compileComponents();
   });
 
@@ -35,8 +28,6 @@ describe('Products List Component', () => {
     fixture = TestBed.createComponent(ProductsListComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
-
-    when(shoppingFacade.failedProducts$).thenReturn(of([]));
   });
 
   it('should be created', () => {
@@ -91,21 +82,6 @@ describe('Products List Component', () => {
         ng-reflect-sku="3"
         ng-reflect-display-type="row"
       ></ish-product-item>,
-      ]
-    `);
-  });
-
-  it('should display product items only for not failed product skus', () => {
-    when(shoppingFacade.failedProducts$).thenReturn(of(['1']));
-    component.productSKUs = ['1', '2', '3'];
-    component.ngOnChanges();
-    fixture.detectChanges();
-
-    expect(element.querySelectorAll('ish-product-item')).toHaveLength(2);
-    expect(element.querySelectorAll('ish-product-item')).toMatchInlineSnapshot(`
-      NodeList [
-        <ish-product-item ishproductcontext="" ng-reflect-sku="2"></ish-product-item>,
-        <ish-product-item ishproductcontext="" ng-reflect-sku="3"></ish-product-item>,
       ]
     `);
   });

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -1,7 +1,4 @@
 import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges } from '@angular/core';
-import { isEqual } from 'lodash-es';
-import { Observable, combineLatest, of } from 'rxjs';
-import { distinctUntilChanged, map } from 'rxjs/operators';
 import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
 
 import {
@@ -10,7 +7,6 @@ import {
   SMALL_BREAKPOINT_WIDTH,
 } from 'ish-core/configurations/injection-keys';
 import { ProductContextDisplayProperties } from 'ish-core/facades/product-context.facade';
-import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { ProductItemDisplayType } from 'ish-shared/components/product/product-item/product-item.component';
 
@@ -29,8 +25,6 @@ export class ProductsListComponent implements OnChanges {
   @Input() listItemCSSClass: string;
   @Input() listItemConfiguration: Partial<ProductContextDisplayProperties>;
 
-  productSKUs$: Observable<string[]>;
-
   /**
    * configuration of swiper carousel
    * https://swiperjs.com/swiper-api
@@ -40,8 +34,7 @@ export class ProductsListComponent implements OnChanges {
   constructor(
     @Inject(SMALL_BREAKPOINT_WIDTH) private smallBreakpointWidth: InjectSingle<typeof SMALL_BREAKPOINT_WIDTH>,
     @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>,
-    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
-    private shoppingFacade: ShoppingFacade
+    @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>
   ) {
     this.swiperConfig = {
       direction: 'horizontal',
@@ -56,12 +49,6 @@ export class ProductsListComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.configureSlides(this.slideItems);
-
-    // remove all SKUs from the productSKUs Array that are also contained in the failed products Array
-    this.productSKUs$ = combineLatest([of(this.productSKUs), this.shoppingFacade.failedProducts$]).pipe(
-      distinctUntilChanged<[string[], string[]]>(isEqual),
-      map(([skus, failed]) => skus.filter(x => !failed.includes(x)))
-    );
   }
 
   /**


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

When all recently viewed products that displayed in the `Recently viewed` section go offline, the PWA still renders this heading for `Recently viewed` even though there are no products displayed. 

Issue Number: Closes #

## What Is the New Behavior?
The `recently.facade.ts` now filters both the `recentlyViewedProducts` and `mostRecentlyViewedProducts`, excluding products that are in the failed products store, instead of doing the filtering inside the `products-list.component.ts`. 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Issue described in support ticket https://support.intershop.com/cse/index.php/Display/967271
