### PR TITLE
fix: adapt 'addGlobalGuard' function to work with functional guards

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -11,6 +11,9 @@ kb_sync_latest_only
 
 The Intershop PWA now uses Node.js 18.16.0 LTS with the corresponding npm version 9.5.1 to resolve an issue with Azure docker deployments (see #1416).
 
+As a leftover adaption regarding the switch from deprecated class-based route guards in favor of functional guards the `addGlobalGuard` function was adapted to actually work with functional guards.
+If the `addGlobalGuard` function is used for customizations make sure it now works as expected.
+
 ## 3.3 to 4.0
 
 The Intershop PWA now uses Node.js 18.15.0 LTS with the corresponding npm version 9.5.0 and the `"lockfileVersion": 3,`.

--- a/src/app/core/guards/hybrid-redirect.guard.ts
+++ b/src/app/core/guards/hybrid-redirect.guard.ts
@@ -8,6 +8,9 @@ import { getICMWebURL } from 'ish-core/store/hybrid';
 
 import { HYBRID_MAPPING_TABLE } from '../../../hybrid/default-url-mapping-table';
 
+/**
+ * guard that handles the Hybrid Approach functionality on the browser side using the HYBRID_MAPPING_TABLE configuration
+ */
 export function hybridRedirectGuard(_: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   return checkRedirect(state.url);
 }

--- a/src/app/core/store/hybrid/hybrid-store.module.ts
+++ b/src/app/core/store/hybrid/hybrid-store.module.ts
@@ -13,6 +13,7 @@ import { HybridEffects, SSR_HYBRID_STATE } from './hybrid.effects';
 })
 export class HybridStoreModule {
   constructor(router: Router, transferState: TransferState) {
+    // enable the Hybrid Approach handling for the browser side if Hybrid Approach is configured
     if (!SSR && transferState.get(SSR_HYBRID_STATE, false)) {
       addGlobalGuard(router, hybridRedirectGuard);
     }

--- a/src/app/core/utils/routing.ts
+++ b/src/app/core/utils/routing.ts
@@ -1,19 +1,19 @@
-import { CanActivateFn, Router } from '@angular/router';
+import { CanActivateChildFn, CanActivateFn, Router } from '@angular/router';
 
 export function addGlobalGuard(
   router: Router,
-  guard: CanActivateFn,
+  guard: CanActivateFn | CanActivateChildFn,
   config: { canActivate: boolean; canActivateChild: boolean } = { canActivate: true, canActivateChild: true }
 ) {
   router.config.forEach(route => {
-    if (config.canActivate && guard.prototype.canActivate) {
+    if (config.canActivate) {
       if (route.canActivate) {
         route.canActivate.push(guard);
       } else {
         route.canActivate = [guard];
       }
     }
-    if (config.canActivateChild && guard.prototype.canActivateChild) {
+    if (config.canActivateChild) {
       if (route.canActivateChild) {
         route.canActivateChild.push(guard);
       } else {

--- a/src/app/core/utils/routing.ts
+++ b/src/app/core/utils/routing.ts
@@ -1,5 +1,12 @@
 import { CanActivateChildFn, CanActivateFn, Router } from '@angular/router';
 
+/**
+ * function to add a functional guard to all routes
+ *
+ * @param router  The router
+ * @param guard   The functional guard
+ * @param config  An optional configuration to control whether the guard should be added for 'canActivate' or 'canActivateChild' routes (default is for both)
+ */
 export function addGlobalGuard(
   router: Router,
   guard: CanActivateFn | CanActivateChildFn,


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The changes for "refactor(Angular 15): replace class-based route guards by functional guards" (https://github.com/intershop/intershop-pwa/commit/289e1616ce4093acb35b4e070291088693e1a192) broke the registration of the global `hybridRedirectGuard` needed for the Hybrid Approach. So the Hybrid Approach is not working with PWA 4.0.0.

## What Is the New Behavior?

The global guard registration works again and the Hybrid Approach can be used with current PWA versions again.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#85701](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/85701)