### PR TITLE
fix: lazy component input are not always propagate propertly

### DIFF
--- a/schematics/src/lazy-component/factory_spec.ts
+++ b/schematics/src/lazy-component/factory_spec.ts
@@ -241,16 +241,6 @@ export class DummyComponent {
       expect(componentContent).toContain("@Input() importComplexTyped: OriginalComponent['importComplexTyped'];");
       expect(componentContent).toContain("@Input() importGenericTyped: OriginalComponent['importGenericTyped'];");
     });
-
-    it('should transfer inputs', () => {
-      expect(componentContent).toContain('component.instance.simpleTyped = this.simpleTyped');
-      expect(componentContent).toContain('component.instance.simpleTypedInitialized = this.simpleTypedInitialized');
-      expect(componentContent).toContain('component.instance.complexTyped = this.complexTyped');
-      expect(componentContent).toContain('component.instance.complexTypedInitialized = this.complexTypedInitialized');
-      expect(componentContent).toContain('component.instance.importTyped = this.importTyped');
-      expect(componentContent).toContain('component.instance.importComplexTyped = this.importComplexTyped');
-      expect(componentContent).toContain('component.instance.importGenericTyped = this.importGenericTyped');
-    });
   });
 
   describe('overwriting', () => {
@@ -272,92 +262,6 @@ export class DummyComponent {
       expect(tree.readContent('/src/app/extensions/ext/exports/lazy-dummy/lazy-dummy.component.ts')).toContain(
         'export class LazyDummyComponent'
       );
-    });
-  });
-
-  describe('component with ngOnChanges without SimpleChanges', () => {
-    let tree: UnitTestTree;
-    let componentContent: string;
-
-    beforeEach(async () => {
-      appTree.overwrite(
-        '/src/app/extensions/ext/shared/dummy/dummy.component.ts',
-        `import { ChangeDetectionStrategy, Component, Input, OnChanges, Output } from '@angular/core';
-
-import { Product, ProductHelper } from 'ish-core/models/product/product.model';
-
-@Component({
-  selector: 'ish-dummy',
-  templateUrl: './dummy.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class DummyComponent implements OnChanges {
-  @Input() input: boolean;
-
-  ngOnChanges() {
-    // do something
-  }
-}
-`
-      );
-      tree = await schematicRunner.runSchematic(
-        'lazy-component',
-        { ...defaultOptions, path: 'extensions/ext/shared/dummy/dummy.component.ts' },
-        appTree
-      );
-
-      componentContent = tree.readContent('/src/app/extensions/ext/exports/lazy-dummy/lazy-dummy.component.ts');
-    });
-
-    it('should call ngOnChanges', () => {
-      expect(componentContent).toContain('component.instance.ngOnChanges()');
-    });
-
-    it('should not import SimpleChanges', () => {
-      expect(componentContent).not.toContain('SimpleChanges');
-    });
-  });
-
-  describe('component with ngOnChanges with SimpleChanges', () => {
-    let tree: UnitTestTree;
-    let componentContent: string;
-
-    beforeEach(async () => {
-      appTree.overwrite(
-        '/src/app/extensions/ext/shared/dummy/dummy.component.ts',
-        `import { ChangeDetectionStrategy, Component, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
-
-import { Product, ProductHelper } from 'ish-core/models/product/product.model';
-
-@Component({
-  selector: 'ish-dummy',
-  templateUrl: './dummy.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class DummyComponent implements OnChanges {
-  @Input() input: boolean;
-
-  ngOnChanges(changes: SimpleChanges) {
-    // do something
-  }
-}
-`
-      );
-      tree = await schematicRunner.runSchematic(
-        'lazy-component',
-        { ...defaultOptions, path: 'extensions/ext/shared/dummy/dummy.component.ts' },
-        appTree
-      );
-
-      componentContent = tree.readContent('/src/app/extensions/ext/exports/lazy-dummy/lazy-dummy.component.ts');
-    });
-
-    it('should call ngOnChanges with parameter', () => {
-      expect(componentContent).toMatch(/component\.instance\.ngOnChanges\(\w+\)/);
-    });
-
-    it('should import SimpleChanges', () => {
-      expect(componentContent).toContain('SimpleChanges');
     });
   });
 });

--- a/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -2,8 +2,7 @@ import {
   ChangeDetectionStrategy, Component, createNgModule, OnInit, ViewChild, ViewContainerRef,
   Injector,
   ComponentRef,
-  <% if (inputNames.length) { %>Input, OnChanges, <% } %>
-  <% if (onChanges === 'complex') { %>SimpleChange, SimpleChanges, <% } %>
+  <% if (inputNames.length) { %>Input, OnChanges, SimpleChange, SimpleChanges, <% } %>
 } from '@angular/core';
 
 <% if(guardDisplay) { %>
@@ -66,30 +65,22 @@ export class <%= classify(name) %>Component implements OnInit <% if (inputNames.
 
     this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
   <% if (inputNames.length) { %>
-    this.ngOnChanges(
-      <% if (onChanges === 'complex') { %>{
+    this.ngOnChanges({
         <% for (let name of inputNames) { %>
           <%= name %>: new SimpleChange(undefined, this.<%= name %>, true),
         <% } %>
         }
-      <% } %>
     );
   <% } %>
-    this.component.changeDetectorRef.markForCheck();
+
   }
 
 <% if (inputNames.length) { %>
-  ngOnChanges(<% if (onChanges === 'complex') { %>changes: SimpleChanges<% } %>) {
+  ngOnChanges(changes: SimpleChanges) {
     if (this.component) {
-      <% for (let name of inputNames) { %>
-        this.component.instance.<%= name %> = this.<%= name %>;
-      <% } %>
-
-      <% if (onChanges === 'simple') { %>
-        this.component.instance.ngOnChanges();
-      <% } else if (onChanges === 'complex') { %>
-        this.component.instance.ngOnChanges(changes);
-      <% } %>
+      for (const inputName in changes) {
+        this.component.setInput(inputName, changes[inputName].currentValue);
+      }
     }
   }
 <% } %>

--- a/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -68,7 +68,7 @@ export class <%= classify(name) %>Component implements OnInit <% if (inputNames.
 
     const ngModuleRef = createNgModule(module, this.injector);
 
-    <% if (inputNames.length) { %> this.component =  <% } %>this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
+    <% if (inputNames.length) { %> this.component =  <% } %>this.anchor.createComponent(originalComponent, { ngModuleRef });
   <% if (inputNames.length) { %>
     this.ngOnChanges({
         <% for (let name of inputNames) { %>

--- a/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
+++ b/schematics/src/lazy-component/files/__name@dasherize__/__name@dasherize__.component.ts.template
@@ -1,7 +1,9 @@
 import {
   ChangeDetectionStrategy, Component, createNgModule, OnInit, ViewChild, ViewContainerRef,
   Injector,
+  <% if (inputNames.length) { %>
   ComponentRef,
+  <% } %>
   <% if (inputNames.length) { %>Input, OnChanges, SimpleChange, SimpleChanges, <% } %>
 } from '@angular/core';
 
@@ -10,8 +12,9 @@ import {
   import { takeUntil } from 'rxjs/operators';
 <% } %>
 
+<% if (inputNames.length) { %>
 import type { <%= classify(originalName) %>Component as OriginalComponent } from '<%= componentImportPath %>/<%= dasherize(originalName) %>/<%= dasherize(originalName) %>.component';
-
+<% } %>
 @Component({
   selector: '<%= selector %>',
   templateUrl: './<%= dasherize(name) %>.component.html',
@@ -34,7 +37,9 @@ export class <%= classify(name) %>Component implements OnInit <% if (inputNames.
   @Input() <%= name %>: OriginalComponent['<%= name %>'];
 <% } %>
 
+   <% if (inputNames.length) { %>
   private component: ComponentRef<OriginalComponent>;
+  <% } %>
 
   constructor(
     <% if(guardDisplay) { %>private featureToggleService: FeatureToggleService,<% } %>
@@ -63,7 +68,7 @@ export class <%= classify(name) %>Component implements OnInit <% if (inputNames.
 
     const ngModuleRef = createNgModule(module, this.injector);
 
-    this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
+    <% if (inputNames.length) { %> this.component =  <% } %>this.component = this.anchor.createComponent(originalComponent, { ngModuleRef });
   <% if (inputNames.length) { %>
     this.ngOnChanges({
         <% for (let name of inputNames) { %>


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

To propagate the inputs a manual management has been implemented in the lazy-component schematics.
However, this state management is quite complex (manual management of the change detector ref) and does not work if the initial component has not declared a `ngOnChange` function.


## What Is the New Behavior?

Using the standard `setInput` method simplifies the behaviour and works in all cases.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information

`npm i` has to be retriggred
