### PR TITLE
fix: add promotion code encoding to the REST call for promotion code removal

### DIFF
--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -28,6 +28,7 @@ import { ShippingMethod } from 'ish-core/models/shipping-method/shipping-method.
 import { ApiService, AvailableOptions, unpackEnvelope } from 'ish-core/services/api/api.service';
 import { OrderService } from 'ish-core/services/order/order.service';
 import { getBasketIdOrCurrent, getCurrentBasket } from 'ish-core/store/customer/basket';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 export type BasketUpdateType =
   | { invoiceToAddress: string }
@@ -396,7 +397,7 @@ export class BasketService {
    * @param codeStr   The code string of the promotion code that should be removed from basket.
    */
   removePromotionCodeFromBasket(codeStr: string): Observable<string> {
-    return this.currentBasketEndpoint().delete<string>(`promotioncodes/${codeStr}`, {
+    return this.currentBasketEndpoint().delete<string>(`promotioncodes/${encodeResourceID(codeStr)}`, {
       headers: this.basketHeaders,
     });
   }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user applies a promotion code to the basket that contains special characters like '%' and afterwards he/she removes this promotion code an error page is shown and the promotion code has not been removed.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The removal of promotion codes that include special characters works as expected.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

ICM release 7.10.40.2 or higher is needed to use promotion codes with special characters.

[AB#84823](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/84823)

[AB#85875](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/85875)