### PR TITLE
chore: emit 'NotVisible' events when target element moves out of viewport

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -17,6 +17,9 @@ If the `addGlobalGuard` function is used for customizations make sure it now wor
 The input parameter `id` of the component `ish-product-quantity` caused issues with duplicate IDs within the page html, therefore it was renamed to `elementId`.
 If the input parameter 'id' of this component has already been used it has to be renamed accordingly.
 
+The `ishIntersectionObserver` returns all 3 `IntersectionStatus` change events `Visible`, `Pending` and now `NotVisible` as well.
+The custom project code needs to be adapted if it does not filter the events where it is used (e.g `if (event === 'Visible')`).
+
 ## 3.3 to 4.0
 
 The Intershop PWA now uses Node.js 18.15.0 LTS with the corresponding npm version 9.5.0 and the `"lockfileVersion": 3,`.

--- a/src/app/core/directives/intersection-observer.directive.ts
+++ b/src/app/core/directives/intersection-observer.directive.ts
@@ -55,9 +55,7 @@ const fromIntersectionObserver = (element: HTMLElement, config: IntersectionObse
     }>();
 
     const intersectionObserver = new IntersectionObserver((entries, observer) => {
-      entries.forEach(entry => {
-        subject$.next({ entry, observer });
-      });
+      entries.forEach(entry => subject$.next({ entry, observer }));
     }, config);
 
     subject$.subscribe(() => {

--- a/src/app/core/directives/intersection-observer.directive.ts
+++ b/src/app/core/directives/intersection-observer.directive.ts
@@ -56,9 +56,7 @@ const fromIntersectionObserver = (element: HTMLElement, config: IntersectionObse
 
     const intersectionObserver = new IntersectionObserver((entries, observer) => {
       entries.forEach(entry => {
-        if (isIntersecting(entry)) {
-          subject$.next({ entry, observer });
-        }
+        subject$.next({ entry, observer });
       });
     }, config);
 
@@ -96,8 +94,4 @@ async function isVisible(element: HTMLElement) {
 
     observer.observe(element);
   });
-}
-
-function isIntersecting(entry: IntersectionObserverEntry) {
-  return entry.isIntersecting || entry.intersectionRatio > 0;
 }


### PR DESCRIPTION
## PR Type

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently the `ishIntersectionObserver` can be used as directive on a target element to determine whether the element is visible. Whenever the element moves into view and becomes visible it will emit the `IntersectionStatus` `Visible`. Given the type definition for `IntersectionStatus` [`export type IntersectionStatus = 'Visible' | 'Pending' | 'NotVisible';`] I would expect that the directive also emits a `NotVisible` event when the target element becomes invisible. This is not the case, it only emits `Pending` and `Visible` statuses.

## What Is the New Behavior?
The `ishIntersectionObserver` also emits `NotVisible` status.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[X] No

## Other Information
