### PR TITLE
fix: force a name attribute on radio inputs

### DIFF
--- a/src/app/shared/formly/types/radio-field/radio-field.component.html
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.html
@@ -4,6 +4,8 @@
   [value]="props.value"
   [id]="id"
   class="form-check-input"
+  [name]="radioName"
+  [attr.name]="radioName"
   [ngClass]="props.inputClass"
   [attr.data-testing-id]="'radio-' + props.label"
 />

--- a/src/app/shared/formly/types/radio-field/radio-field.component.ts
+++ b/src/app/shared/formly/types/radio-field/radio-field.component.ts
@@ -19,4 +19,8 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
   templateUrl: './radio-field.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RadioFieldComponent extends FieldType<FieldTypeConfig> {}
+export class RadioFieldComponent extends FieldType<FieldTypeConfig> {
+  get radioName() {
+    return `${this.field.parent?.id || ''}_${this.field.key}`;
+  }
+}


### PR DESCRIPTION
Radio inputs now have a correctly filled name attribute.
 When this attribute is not set and we bind a `[formGroup]` on the `input`, angular considers that the radio button is global.
 It is therefore impossible to create several different groups of radio buttons on the page (changing one of the buttons will erase the status of the others).
This fix prevents this unexpected behavior

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
