### PR TITLE
fix: parameters ;loc and ;cur may overlook server configuration

### DIFF
--- a/src/app/core/services/api/api.service.spec.ts
+++ b/src/app/core/services/api/api.service.spec.ts
@@ -17,7 +17,7 @@ import {
 } from 'ish-core/store/core/configuration';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { serverError } from 'ish-core/store/core/error';
-import { loadServerConfigSuccess } from 'ish-core/store/core/server-config';
+import { isServerConfigurationLoaded, loadServerConfigSuccess } from 'ish-core/store/core/server-config';
 import { getPGID } from 'ish-core/store/customer/user';
 
 import { ApiService, unpackEnvelope } from './api.service';
@@ -39,6 +39,7 @@ describe('Api Service', () => {
         providers: [
           provideMockStore({
             selectors: [
+              { selector: isServerConfigurationLoaded, value: true },
               { selector: getRestEndpoint, value: 'http://www.example.org/WFS/site/-' },
               { selector: getICMServerURL, value: undefined },
               { selector: getCurrentCurrency, value: 'USD' },
@@ -198,6 +199,7 @@ describe('Api Service', () => {
         providers: [
           provideMockStore({
             selectors: [
+              { selector: isServerConfigurationLoaded, value: true },
               { selector: getRestEndpoint, value: 'http://www.example.org/WFS/site/-' },
               { selector: getICMServerURL, value: 'http://www.example.org/WFS' },
               { selector: getCurrentCurrency, value: 'USD' },
@@ -402,6 +404,7 @@ describe('Api Service', () => {
         providers: [
           provideMockStore({
             selectors: [
+              { selector: isServerConfigurationLoaded, value: true },
               { selector: getRestEndpoint, value: 'http://www.example.org/WFS/site/-' },
               { selector: getICMServerURL, value: undefined },
               { selector: getCurrentLocale, value: undefined },
@@ -679,6 +682,7 @@ describe('Api Service', () => {
         providers: [
           provideMockStore({
             selectors: [
+              { selector: isServerConfigurationLoaded, value: true },
               { selector: getICMServerURL, value: undefined },
               { selector: getRestEndpoint, value: 'http://www.example.org' },
               { selector: getCurrentLocale, value: 'en' },

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -14,7 +14,7 @@ import {
   of,
   throwError,
 } from 'rxjs';
-import { catchError, concatMap, filter, first, map, take, withLatestFrom } from 'rxjs/operators';
+import { catchError, concatMap, filter, first, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
 import { Captcha } from 'ish-core/models/captcha/captcha.model';
 import { Link } from 'ish-core/models/link/link.model';
@@ -25,6 +25,7 @@ import {
   getRestEndpoint,
 } from 'ish-core/store/core/configuration';
 import { communicationTimeoutError, serverError } from 'ish-core/store/core/error';
+import { isServerConfigurationLoaded } from 'ish-core/store/core/server-config';
 import { getLoggedInCustomer, getLoggedInUser, getPGID } from 'ish-core/store/customer/user';
 import { whenTruthy } from 'ish-core/utils/operators';
 import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
@@ -152,9 +153,15 @@ export class ApiService {
   private getLocale$(options: AvailableOptions): Observable<string> {
     return options?.sendLocale === undefined || options.sendLocale
       ? this.store.pipe(
-          select(getCurrentLocale),
+          select(isServerConfigurationLoaded),
           whenTruthy(),
-          map(l => `;loc=${l}`)
+          switchMap(() =>
+            this.store.pipe(
+              select(getCurrentLocale),
+              whenTruthy(),
+              map(l => `;loc=${l}`)
+            )
+          )
         )
       : of('');
   }
@@ -162,9 +169,15 @@ export class ApiService {
   private getCurrency$(options: AvailableOptions): Observable<string> {
     return options?.sendCurrency === undefined || options.sendCurrency
       ? this.store.pipe(
-          select(getCurrentCurrency),
+          select(isServerConfigurationLoaded),
           whenTruthy(),
-          map(l => `;cur=${l}`)
+          switchMap(() =>
+            this.store.pipe(
+              select(getCurrentCurrency),
+              whenTruthy(),
+              map(l => `;cur=${l}`)
+            )
+          )
         )
       : of('');
   }


### PR DESCRIPTION
When the first page of the site is displayed, requests can be sent to the icm before the redux ServerConfiguration store is initialized.
This can be problematic in the case of localized URLs such as content retrieval, as the icm channel configuration can influence the value of the `;loc` and `;cur` parameters.
The fix makes sure that this store is configured before launching other localized rest requests

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
