### PR TITLE
feat(product-image): added new zoom functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "lodash-es": "^4.17.21",
         "morgan": "^1.10.0",
         "ng-recaptcha": "^11.0.0",
+        "ngx-image-zoom": "^2.1.0",
         "ngx-infinite-scroll": "^15.0.0",
         "ngx-toastr": "^16.1.1",
         "rxjs": "~7.8.0",
@@ -20927,6 +20928,14 @@
       },
       "peerDependencies": {
         "@angular/core": "^15.0.0"
+      }
+    },
+    "node_modules/ngx-image-zoom": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-image-zoom/-/ngx-image-zoom-2.1.0.tgz",
+      "integrity": "sha512-OLaPNAt/eVzWvSUqC1ttsA90gy1gNW5gwBGOPn0T6oMkvmcIHTgr06XxP2EyKzFvMD+A6/EDUxiwclsWTsIT+Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/ngx-infinite-scroll": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "lodash-es": "^4.17.21",
     "morgan": "^1.10.0",
     "ng-recaptcha": "^11.0.0",
+    "ngx-image-zoom": "^2.1.0",
     "ngx-infinite-scroll": "^15.0.0",
     "ngx-toastr": "^16.1.1",
     "rxjs": "~7.8.0",

--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -18,13 +18,10 @@
       <swiper #carousel [navigation]="true">
         <ng-container *ngFor="let imageView of largeImages; let i = index">
           <ng-template swiperSlide>
-            <div (click)="openZoomModal(i)" (keydown.enter)="openZoomModal(i)">
-              <ish-product-image
-                [ngClass]="{ 'product-image-zoom': zoomImageIds$ | async }"
-                imageType="L"
-                [imageView]="imageView"
-              ></ish-product-image>
-            </div>
+            <ish-product-image-zoom
+              [ngClass]="{ 'product-image-zoom': zoomImageIds$ | async }"
+              [imageView]="imageView"
+            ></ish-product-image-zoom>
           </ng-template>
         </ng-container>
       </swiper>
@@ -32,19 +29,3 @@
     </div>
   </div>
 </div>
-
-<ish-modal-dialog
-  *ngIf="zoomImageIds$ | async as zoomImages"
-  #zoomDialog
-  [options]="{
-    scrollable: true,
-    modalDialogClass: 'modal-fullscreen'
-  }"
->
-  <ish-product-image
-    *ngFor="let imageView of zoomImages; let i = index"
-    [id]="getZoomImageAnchorId(i)"
-    imageType="ZOOM"
-    [imageView]="imageView"
-  ></ish-product-image>
-</ish-modal-dialog>

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -65,16 +65,4 @@ export class ProductImagesComponent implements OnInit {
   isActiveSlide(slideIndex: number): boolean {
     return this.carousel?.swiperRef?.activeIndex === slideIndex;
   }
-
-  getZoomImageAnchorId(i: number) {
-    return `zoom-image-${i}`;
-  }
-
-  openZoomModal(i: number) {
-    if (this.zoomDialog) {
-      this.zoomDialog.show();
-      this.zoomDialog.scrollToAnchor(this.getZoomImageAnchorId(i));
-    }
-    return false;
-  }
 }

--- a/src/app/pages/product/product-page.module.ts
+++ b/src/app/pages/product/product-page.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgxImageZoomModule } from 'ngx-image-zoom';
 
+import { ProductImageZoomComponent } from 'ish-shared/components/product/product-image-zoom/product-image-zoom.component';
 import { SharedModule } from 'ish-shared/shared.module';
 
 import { ProductBrandComponent } from './product-brand/product-brand.component';
@@ -34,7 +36,7 @@ const productPageRoutes: Routes = [
 ];
 
 @NgModule({
-  imports: [NgbNavModule, RouterModule.forChild(productPageRoutes), SharedModule],
+  imports: [NgbNavModule, RouterModule.forChild(productPageRoutes), NgxImageZoomModule, SharedModule],
   declarations: [
     ProductBrandComponent,
     ProductBundlePartsComponent,
@@ -43,6 +45,7 @@ const productPageRoutes: Routes = [
     ProductDetailInfoComponent,
     ProductDetailVariationsComponent,
     ProductImagesComponent,
+    ProductImageZoomComponent,
     ProductLinksCarouselComponent,
     ProductLinksComponent,
     ProductLinksListComponent,

--- a/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.html
+++ b/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.html
@@ -1,0 +1,38 @@
+<div>
+  <a
+    *ngIf="link; else image"
+    data-testing-id="product-image-link"
+    [routerLink]="linkTarget || (productURL$ | async)"
+    [queryParamsHandling]="computedQueryParamsHandling"
+  >
+    <ng-container *ngTemplateOutlet="image"></ng-container>
+  </a>
+</div>
+
+<ng-template #image>
+  <ng-container *ngIf="productImage$ | async as image">
+    <ng-container *ngIf="image[0]?.effectiveUrl && image[1]?.effectiveUrl; else noImage">
+      <lib-ngx-image-zoom
+        [ngClass]="'asdf'"
+        [thumbImage]="image[0].effectiveUrl"
+        [fullImage]="image[1].effectiveUrl"
+        [zoomMode]="'click'"
+        [enableScrollZoom]="true"
+        [magnification]="1"
+        [minZoomRatio]="0.5"
+        [maxZoomRatio]="3"
+        [titleText]="altText || image[2]"
+        [altText]="altText || image[2]"
+      ></lib-ngx-image-zoom>
+    </ng-container>
+  </ng-container>
+
+  <ng-template #noImage>
+    <img
+      loading="lazy"
+      class="product-image"
+      src="/assets/img/not-available.svg"
+      [attr.alt]="'product.image.not_available.alttext' | translate"
+    />
+  </ng-template>
+</ng-template>

--- a/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.scss
+++ b/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+  width: 100%;
+
+  // stylelint-disable-next-line selector-class-pattern
+  ::ng-deep .ngxImageZoomContainer {
+    width: 100% !important;
+  }
+}

--- a/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.spec.ts
+++ b/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { NgxImageZoomModule } from 'ngx-image-zoom';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+
+import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { Image } from 'ish-core/models/image/image.model';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
+
+import { ProductImageZoomComponent } from './product-image-zoom.component';
+
+describe('Product Image Zoom Component', () => {
+  let component: ProductImageZoomComponent;
+  let element: HTMLElement;
+  let fixture: ComponentFixture<ProductImageZoomComponent>;
+  let translate: TranslateService;
+  let context: ProductContextFacade;
+
+  beforeEach(async () => {
+    context = mock(ProductContextFacade);
+    when(context.getProductImage$(anything(), anything())).thenReturn(
+      of({ effectiveUrl: '/assets/product_img/a.jpg' } as Image)
+    );
+    when(context.select('product')).thenReturn(of({} as ProductView));
+    when(context.select('productURL')).thenReturn(of('/product/TEST'));
+
+    await TestBed.configureTestingModule({
+      imports: [NgxImageZoomModule, RouterTestingModule, TranslateModule.forRoot()],
+      declarations: [ProductImageZoomComponent],
+      providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProductImageZoomComponent);
+    element = fixture.nativeElement;
+    component = fixture.componentInstance;
+
+    translate = TestBed.inject(TranslateService);
+    translate.setDefaultLang('en');
+    translate.use('en');
+    translate.set('product.image.text.alttext', 'product photo');
+    translate.set('product.image.not_available.alttext', 'no product image available');
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should render N/A image when images are not available', () => {
+    when(context.getProductImage$(anything(), anything())).thenReturn(of(undefined));
+
+    fixture.detectChanges();
+    expect(element.querySelector('img')?.attributes).toMatchInlineSnapshot(`
+      NamedNodeMap {
+        "alt": "no product image available",
+        "class": "product-image",
+        "loading": "lazy",
+        "src": "/assets/img/not-available.svg",
+      }
+    `);
+  });
+
+  it('should render img tag when image is available', () => {
+    when(context.getProductImage$(anything(), anything())).thenReturn(
+      of({
+        name: 'front S',
+        type: 'Image',
+        imageActualHeight: 110,
+        imageActualWidth: 110,
+        viewID: 'front',
+        effectiveUrl: '/assets/product_img/a.jpg',
+        typeID: 'S',
+        primaryImage: true,
+      })
+    );
+
+    fixture.detectChanges();
+    expect(element.querySelector('img')?.attributes).toMatchInlineSnapshot(`
+      NamedNodeMap {
+        "_ngcontent-a-c2": "",
+        "alt": "product photo",
+        "class": "ngxImageZoomThumbnail",
+        "src": "/assets/product_img/a.jpg",
+        "title": "product photo",
+      }
+    `);
+  });
+
+  it('should render N/A image when image source is not available', () => {
+    when(context.getProductImage$(anything(), anything())).thenReturn(
+      of({
+        name: 'front S',
+        type: 'Image',
+        imageActualHeight: 110,
+        imageActualWidth: 110,
+        viewID: 'front',
+        effectiveUrl: '',
+        typeID: 'S',
+        primaryImage: true,
+      })
+    );
+
+    fixture.detectChanges();
+    expect(element.querySelector('img').getAttribute('src')).toMatchInlineSnapshot(`"/assets/img/not-available.svg"`);
+  });
+
+  describe('image alt attribute', () => {
+    it('should render if altText set as input parameter', () => {
+      component.altText = 'test';
+      fixture.detectChanges();
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"test"`);
+    });
+
+    it('should render default text if product information is still undefined', () => {
+      when(context.select('product')).thenReturn(of(undefined));
+      fixture.detectChanges();
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"product photo"`);
+    });
+
+    it('should show product name when product name available', () => {
+      when(context.select('product')).thenReturn(of({ name: 'Lenco', sku: '1234' } as ProductView));
+
+      fixture.detectChanges();
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"Lenco product photo"`);
+    });
+
+    it('should show product sku when product name not available', () => {
+      when(context.select('product')).thenReturn(of({ sku: '1234' } as ProductView));
+
+      fixture.detectChanges();
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"1234 product photo"`);
+    });
+
+    it('should append imageView when image view is available and altText parameter not set', () => {
+      component.imageView = 'front';
+
+      fixture.detectChanges();
+      expect(element.querySelector('img').getAttribute('alt')).toMatchInlineSnapshot(`"product photo"`);
+    });
+  });
+
+  describe('link creation', () => {
+    it('should generate a link around the component if requested', () => {
+      component.link = true;
+      fixture.detectChanges();
+
+      expect(element.querySelector('a').href).toMatchInlineSnapshot(`"http://localhost/product/TEST"`);
+    });
+  });
+});

--- a/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.ts
+++ b/src/app/shared/components/product/product-image-zoom/product-image-zoom.component.ts
@@ -1,0 +1,68 @@
+import { ChangeDetectionStrategy, Component, Inject, Input, OnInit, Optional } from '@angular/core';
+import { QueryParamsHandling } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { Image } from 'ish-core/models/image/image.model';
+
+/**
+ * The Product Image Component renders the product image with the library ngx-image-zoom
+ * for the given imageType and imageView or the according defaults.
+ *
+ * @example
+ * <ish-product-image-zoom
+ *   [ngClass]="{ 'product-image-zoom': zoomImageIds$ | async }"
+ *   [imageView]="imageView"
+ * ></ish-product-image-zoom>
+ */
+@Component({
+  selector: 'ish-product-image-zoom',
+  templateUrl: './product-image-zoom.component.html',
+  styleUrls: ['./product-image-zoom.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductImageZoomComponent implements OnInit {
+  /**
+   * If true, a product link is generated around the component or the given link target is taken
+   */
+  @Input() link = false;
+  @Input() linkTarget: string;
+
+  @Input() queryParamsHandling: QueryParamsHandling = '';
+  /**
+   * The image view, e.g. 'front', 'back'.
+   */
+  @Input() imageView: string;
+  /**
+   * A custom alt text for the img tag.
+   */
+  @Input() altText: string;
+
+  productURL$: Observable<string>;
+  productImage$: Observable<[Image, Image, string]>;
+
+  computedQueryParamsHandling: QueryParamsHandling;
+
+  constructor(
+    private translateService: TranslateService,
+    private context: ProductContextFacade,
+    @Optional() @Inject('PRODUCT_QUERY_PARAMS_HANDLING') private queryParamsHandlingInjector: QueryParamsHandling
+  ) {}
+
+  ngOnInit() {
+    this.productURL$ = this.context.select('productURL');
+
+    this.productImage$ = combineLatest([
+      this.context.getProductImage$('L', this.imageView),
+      this.context.getProductImage$('ZOOM', this.imageView),
+      combineLatest([
+        this.context.select('product').pipe(map(product => product?.name || product?.sku || '')),
+        this.translateService.get('product.image.text.alttext'),
+      ]).pipe(map(parts => parts.filter(x => !!x).join(' '))),
+    ]);
+
+    this.computedQueryParamsHandling = this.queryParamsHandlingInjector ?? this.queryParamsHandling;
+  }
+}

--- a/src/styles/pages/productdetail/productdetail.scss
+++ b/src/styles/pages/productdetail/productdetail.scss
@@ -15,6 +15,7 @@
   .product-image-container {
     // set for the correct product label ribbon positioning in the PDP only
     position: relative;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
added NgxImageZoom and modified product-images.component.html to uses it

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[x] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

In the current PWA the zoom images on product-detail are opened in an overlay.

Issue Number: Closes #

## What Is the New Behavior?

The new behavior is the usage on ngx-image-zoom on product-detail to zoom images.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
