### PR TITLE
chore: add generic intersection types for ViewType & DeviceType

### DIFF
--- a/src/app/core/models/viewtype/viewtype.types.ts
+++ b/src/app/core/models/viewtype/viewtype.types.ts
@@ -1,3 +1,3 @@
-export type ViewType = 'grid' | 'list';
+export type ViewType<T extends string = ''> = T | ('grid' | 'list');
 
-export type DeviceType = 'mobile' | 'tablet' | 'desktop';
+export type DeviceType<T extends string = ''> = T | ('mobile' | 'tablet' | 'desktop');


### PR DESCRIPTION
It might be useful when building some custom view for other devices or when you're in need to create a different product listing view that requires a bit different look compared to the OOTB solution but still, you may want 
to remain everything else to be fully backward compatible.

```ts
export type MyViewType = ViewType<'simple' | 'detailed'>;

export type MyDeviceType = DeviceType<'wearable' | 'smartTv'>;
```



<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
