### PR TITLE
fix: save company name(s) at address after b2b customer registration

### DIFF
--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -123,6 +123,8 @@ export class RegistrationFormConfigurationService {
       lastName: formValue.lastName,
       ...formValue.address,
       phoneHome: formValue.phoneHome,
+      companyName1: formValue.companyName1,
+      companyName2: formValue.companyName2,
     };
 
     if (registrationConfig.sso && registrationConfig.userId) {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Company name is not stored on address during registration of a b2b customer.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
Company name is saved at the address after registration.

## Steps To Repeat
[B2B PWA](https://intershoppwa.azurewebsites.net/home):
- Click on registration
- Select business customer
- Fill in all required fields plus company name2, tax number, VAT number
- My Account
       Profile settings > Company profile =Company name plus company name2 ✅
       Addresses > Address from registration = Company name plus company name2 is missing 
--> expected:  Company name 1+2 are stored at the address

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#86558](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/86558)