### PR TITLE
feat(formly): added checkbox-field which can take a include as label

### DIFF
--- a/src/app/shared/cms/components/content-include/content-include.module.ts
+++ b/src/app/shared/cms/components/content-include/content-include.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { Injector, NgModule } from '@angular/core';
+
+import { ModuleLoaderService } from 'ish-core/utils/module-loader/module-loader.service';
+import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
+import { ContentPageletModule } from 'ish-shared/cms/components/content-pagelet/content-pagelet.module';
+
+const importExportModules = [ContentPageletModule];
+
+const exportedComponents = [ContentIncludeComponent];
+
+@NgModule({
+  imports: [...importExportModules, CommonModule],
+  declarations: [...exportedComponents],
+  exports: [...exportedComponents],
+})
+export class ContentIncludeModule {
+  constructor(moduleLoader: ModuleLoaderService, injector: Injector) {
+    moduleLoader.init(injector);
+  }
+}

--- a/src/app/shared/cms/components/content-pagelet/content-pagelet.module.ts
+++ b/src/app/shared/cms/components/content-pagelet/content-pagelet.module.ts
@@ -1,0 +1,16 @@
+import { Injector, NgModule } from '@angular/core';
+
+import { ModuleLoaderService } from 'ish-core/utils/module-loader/module-loader.service';
+import { ContentPageletComponent } from 'ish-shared/cms/components/content-pagelet/content-pagelet.component';
+
+const exportedComponents = [ContentPageletComponent];
+
+@NgModule({
+  declarations: [...exportedComponents],
+  exports: [...exportedComponents],
+})
+export class ContentPageletModule {
+  constructor(moduleLoader: ModuleLoaderService, injector: Injector) {
+    moduleLoader.init(injector);
+  }
+}

--- a/src/app/shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component.html
+++ b/src/app/shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component.html
@@ -1,0 +1,19 @@
+<div class="row form-group">
+  <div [class.has-error]="showError" class="col-md-12">
+    <div class="form-check" [attr.data-testing-id]="'form-wrapper'">
+      <input
+        type="checkbox"
+        [formControl]="formControl"
+        [formlyAttributes]="field"
+        [attr.data-testing-id]="field.key"
+        class="form-check-input"
+      />
+      <label class="form-check-label" [attr.for]="id">
+        <ish-content-include includeId="{{ field.props.labelInclude }}"></ish-content-include>
+      </label>
+    </div>
+    <ng-container *ngIf="showError" class="invalid-feedback d-block mb-2">
+      <ish-validation-message [field]="field" class="validation-message"></ish-validation-message>
+    </ng-container>
+  </div>
+</div>

--- a/src/app/shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component.spec.ts
+++ b/src/app/shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { MockComponent } from 'ng-mocks';
+
+import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
+import { FormlyTestingComponentsModule } from 'ish-shared/formly/dev/testing/formly-testing-components.module';
+import { FormlyTestingContainerComponent } from 'ish-shared/formly/dev/testing/formly-testing-container/formly-testing-container.component';
+
+import { CheckboxFieldWithIncludeComponent } from './checkbox-field-with-include.component';
+
+describe('Checkbox Field With Include Component', () => {
+  let component: FormlyTestingContainerComponent;
+  let fixture: ComponentFixture<FormlyTestingContainerComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CheckboxFieldWithIncludeComponent],
+      imports: [
+        FormlyModule.forRoot({
+          types: [{ name: 'ish-checkbox-field-with-include', component: CheckboxFieldWithIncludeComponent }],
+        }),
+        FormlyTestingComponentsModule,
+        MockComponent(ContentIncludeComponent),
+        ReactiveFormsModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    const testComponentInputs = {
+      model: { active: true },
+      fields: [
+        {
+          key: 'name',
+          type: 'ish-checkbox-field-with-include',
+          props: {
+            hideRequiredMarker: true,
+            required: true,
+            labelInclude: 'include.general.02.pagelet2-Include',
+          },
+          validation: {
+            messages: {
+              required: 'toolineo.checkbox.legal.required',
+            },
+          },
+        },
+      ],
+      form: new FormGroup({}),
+    };
+
+    fixture = TestBed.createComponent(FormlyTestingContainerComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    component.testComponentInputs = testComponentInputs;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should be rendered after creation', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('ish-form-checkbox-with-include')).toBeTruthy();
+  });
+});

--- a/src/app/shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component.ts
+++ b/src/app/shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'ish-form-checkbox-with-include',
+  templateUrl: './checkbox-field-with-include.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CheckboxFieldWithIncludeComponent extends FieldType<FieldTypeConfig> {}

--- a/src/app/shared/formly/types/types.module.ts
+++ b/src/app/shared/formly/types/types.module.ts
@@ -15,6 +15,10 @@ import { CaptchaExportsModule } from 'src/app/extensions/captcha/exports/captcha
 
 import { DirectivesModule } from 'ish-core/directives.module';
 import { IconModule } from 'ish-core/icon.module';
+import { ContentIncludeModule } from 'ish-shared/cms/components/content-include/content-include.module';
+import { ContentPageletModule } from 'ish-shared/cms/components/content-pagelet/content-pagelet.module';
+import { ComponentsModule } from 'ish-shared/formly/components/components.module';
+import { CheckboxFieldWithIncludeComponent } from 'ish-shared/formly/types/checkbox-field-with-include/checkbox-field-with-include.component';
 import { SpecialValidators, formlyValidation } from 'ish-shared/forms/validators/special-validators';
 
 import { CaptchaFieldComponent } from './captcha-field/captcha-field.component';
@@ -33,6 +37,7 @@ import { TextareaFieldComponent } from './textarea-field/textarea-field.componen
 const fieldComponents = [
   CaptchaFieldComponent,
   CheckboxFieldComponent,
+  CheckboxFieldWithIncludeComponent,
   DatePickerFieldComponent,
   FieldsetFieldComponent,
   HtmlTextFieldComponent,
@@ -47,12 +52,15 @@ const fieldComponents = [
   imports: [
     CaptchaExportsModule,
     CommonModule,
+    ComponentsModule,
+    ContentIncludeModule,
+    ContentPageletModule,
     DirectivesModule,
     FormlySelectModule,
     IconModule,
     NgbDatepickerModule,
+    NgbDatepickerModule,
     ReactiveFormsModule,
-    TranslateModule,
 
     FormlyBaseModule.forChild({
       types: [
@@ -141,6 +149,10 @@ const fieldComponents = [
           component: CheckboxFieldComponent,
           wrappers: ['form-field-checkbox-horizontal'],
         },
+        {
+          name: 'ish-checkbox-field-with-include',
+          component: CheckboxFieldWithIncludeComponent,
+        },
         { name: 'ish-captcha-field', component: CaptchaFieldComponent },
         {
           name: 'ish-fieldset-field',
@@ -158,6 +170,9 @@ const fieldComponents = [
         },
       ],
     }),
+    ReactiveFormsModule,
+    TranslateModule,
+    TranslateModule,
   ],
   providers: [
     { provide: NgbDateParserFormatter, useClass: LocalizedParserFormatter, deps: [TranslateService] },

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -21,6 +21,8 @@ import { IconModule } from 'ish-core/icon.module';
 import { PipesModule } from 'ish-core/pipes.module';
 import { RoleToggleModule } from 'ish-core/role-toggle.module';
 import { ModuleLoaderService } from 'ish-core/utils/module-loader/module-loader.service';
+import { ContentIncludeModule } from 'ish-shared/cms/components/content-include/content-include.module';
+import { ContentPageletModule } from 'ish-shared/cms/components/content-pagelet/content-pagelet.module';
 
 import { CaptchaExportsModule } from '../extensions/captcha/exports/captcha-exports.module';
 import { CompareExportsModule } from '../extensions/compare/exports/compare-exports.module';
@@ -51,9 +53,7 @@ import { CMSStandardPageComponent } from './cms/components/cms-standard-page/cms
 import { CMSStaticPageComponent } from './cms/components/cms-static-page/cms-static-page.component';
 import { CMSTextComponent } from './cms/components/cms-text/cms-text.component';
 import { CMSVideoComponent } from './cms/components/cms-video/cms-video.component';
-import { ContentIncludeComponent } from './cms/components/content-include/content-include.component';
 import { ContentNavigationComponent } from './cms/components/content-navigation/content-navigation.component';
-import { ContentPageletComponent } from './cms/components/content-pagelet/content-pagelet.component';
 import { ContentSlotComponent } from './cms/components/content-slot/content-slot.component';
 import { ContentViewcontextComponent } from './cms/components/content-viewcontext/content-viewcontext.component';
 import { AddressComponent } from './components/address/address/address.component';
@@ -153,6 +153,8 @@ const importExportModules = [
   CdkTableModule,
   CommonModule,
   CompareExportsModule,
+  ContentIncludeModule,
+  ContentPageletModule,
   ContactUsExportsModule,
   DirectivesModule,
   FeatureToggleModule,
@@ -252,9 +254,7 @@ const exportedComponents = [
   BasketValidationResultsComponent,
   BreadcrumbComponent,
   ConfirmLeaveModalComponent,
-  ContentIncludeComponent,
   ContentNavigationComponent,
-  ContentPageletComponent,
   ContentViewcontextComponent,
   ErrorMessageComponent,
   FilterNavigationComponent,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
In the current PWA it is not possible to have a formly checkbox with is labeled with an include from the icm.



Issue Number: Closes #

## What Is the New Behavior?

This is a new formly Wrapper which provides that functionality.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Usage via formly options. Example in the spec.ts
