### PR TITLE
fix: product variation master facet selection does not work for non-string filters

### DIFF
--- a/src/app/core/models/product-variation/product-variation.helper.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.ts
@@ -109,7 +109,7 @@ export class ProductVariationHelper {
             // attribute is not selected
             !selectedFacets.find(([key]) => key === attr.variationAttributeId) ||
             // selection is variation
-            selectedFacets.find(([key, val]) => key === attr.variationAttributeId && val === attr.value)
+            selectedFacets.find(([key, val]) => key === attr.variationAttributeId && val === attr.value.toString())
         )
       ).length;
   }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The product variations of a product variation master is selected by checking their `variableVariationAttributes` with the current selected facets. `val === attr.value` is used for equality check. A problem occurs when the attribute value of one of the   `variableVariationAttributes` is not a string. The check would always return false.

Issue Number: Closes #1439

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#86822](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/86822)