### PR TITLE
fix: fix: handle token errors for local development

### DIFF
--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -271,9 +271,7 @@ export class ApiTokenService {
 
   private isAuthTokenError(err: unknown) {
     return (
-      err instanceof HttpErrorResponse &&
-      typeof err.error === 'string' &&
-      (err.error.includes('AuthenticationToken') || err.error.includes('Unable to decode token'))
+      err instanceof HttpErrorResponse && typeof err.error === 'string' && err.error?.toLowerCase().includes('token')
     );
   }
 

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -271,7 +271,9 @@ export class ApiTokenService {
 
   private isAuthTokenError(err: unknown) {
     return (
-      err instanceof HttpErrorResponse && typeof err.error === 'string' && err.error.includes('AuthenticationToken')
+      err instanceof HttpErrorResponse &&
+      typeof err.error === 'string' &&
+      (err.error.includes('AuthenticationToken') || err.error.includes('Unable to decode token'))
     );
   }
 


### PR DESCRIPTION
In the case of local development, you can change the target back-end by modifying the value of the `icmBaseURL` variable  in `environment.developement.ts`. By doing so, you will need a new api token.
However, as your local DNS is still \"localhost\", there is no token renewal and the old token is kept. 
This small modification corrects this problem.

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information
