### PR TITLE
fix: display updated customer address on the myAccount address page

### DIFF
--- a/src/app/core/store/customer/addresses/addresses.effects.spec.ts
+++ b/src/app/core/store/customer/addresses/addresses.effects.spec.ts
@@ -173,7 +173,7 @@ describe('Addresses Effects', () => {
     });
 
     it('should map to action of type updateCustomerSuccess', () => {
-      const address = { urn: '123' } as Address;
+      const address = { urn: 'test' } as Address;
       const action = updateCustomerAddress({ address });
       const completion = updateCustomerAddressSuccess({ address });
       const completion2 = displaySuccessMessage({

--- a/src/app/core/store/customer/addresses/addresses.effects.ts
+++ b/src/app/core/store/customer/addresses/addresses.effects.ts
@@ -73,7 +73,7 @@ export class AddressesEffects {
       filter(([address, customer]) => !!address || !!customer),
       mergeMap(([address]) =>
         this.addressService.updateCustomerAddress('-', address).pipe(
-          mergeMap(() => [
+          mergeMap(address => [
             updateCustomerAddressSuccess({ address }),
             displaySuccessMessage({ message: 'account.addresses.address_updated.message' }),
           ]),

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
@@ -112,7 +112,7 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges {
     let formAddress: Address = this.form.value.address;
     if (this.address) {
       // update form values in the original address
-      formAddress = { ...this.address, ...formAddress };
+      formAddress = { ...this.address, mainDivisionCode: '', ...formAddress };
     }
     if (this.extension) {
       formAddress = { ...formAddress, email: this.extensionForm.get('email')?.value };


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

After changing the country of a customer address on the myAccount address page the previous country is still shown in the address tile.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The updated country is shown as expected in the address tile.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#87418](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/87418)