### PR TITLE
perf: remove 3 sec SSR delay by enabling PreviewContextID listening only in browser

### DIFF
--- a/src/app/core/services/preview/preview.service.ts
+++ b/src/app/core/services/preview/preview.service.ts
@@ -34,19 +34,21 @@ export class PreviewService {
     private route: ActivatedRoute
   ) {
     this.init();
-    race([
-      this.route.queryParams.pipe(
-        filter(params => params.PreviewContextID),
-        map(params => params.PreviewContextID),
-        take(1)
-      ),
-      // end listening for PreviewContextID if there is no such parameter at initialization
-      timer(3000),
-    ]).subscribe(value => {
-      if (!this.previewContextId && value) {
-        this.previewContextId = value;
-      }
-    });
+    if (!SSR) {
+      race([
+        this.route.queryParams.pipe(
+          filter(params => params.PreviewContextID),
+          map(params => params.PreviewContextID),
+          take(1)
+        ),
+        // end listening for PreviewContextID if there is no such parameter at initialization
+        timer(3000),
+      ]).subscribe(value => {
+        if (!this.previewContextId && value) {
+          this.previewContextId = value;
+        }
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## PR Type

[x] Other: SSR performance improvment

## What Is the Current Behavior?

`timer(3000)` in `PreviewContextID` route listening resulted in a general 3 seconds rendering time for all SSR requests

## What Is the New Behavior?

PreviewContextID is not used in SSR so it is only enabled for the browser/client mode

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
