### PR TITLE
fix: not correct /localization call for specific MULTI_CHANNEL configuration

### DIFF
--- a/src/app/core/utils/translate/icm-translate-loader.ts
+++ b/src/app/core/utils/translate/icm-translate-loader.ts
@@ -36,6 +36,7 @@ export class ICMTranslateLoader implements TranslateLoader {
     const server$ = iif(
       () => !SSR && this.transferState.hasKey(SSR_TRANSLATIONS),
       of(this.transferState.get(SSR_TRANSLATIONS, {})),
+      // the localization call should wait until all server supplied configuration parameter are applied to the state
       this.actions$.pipe(
         ofType(routerNavigationAction),
         first(),

--- a/src/app/core/utils/translate/icm-translate-loader.ts
+++ b/src/app/core/utils/translate/icm-translate-loader.ts
@@ -1,9 +1,11 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { TransferState, makeStateKey } from '@angular/platform-browser';
+import { Actions, ofType } from '@ngrx/effects';
+import { routerNavigationAction } from '@ngrx/router-store';
 import { TranslateLoader } from '@ngx-translate/core';
 import { memoize } from 'lodash-es';
 import { combineLatest, defer, from, iif, of } from 'rxjs';
-import { catchError, map, shareReplay, tap } from 'rxjs/operators';
+import { catchError, first, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 
 import { LocalizationsService } from 'ish-core/services/localizations/localizations.service';
 import { InjectSingle } from 'ish-core/utils/injection';
@@ -20,6 +22,7 @@ export const LOCAL_TRANSLATIONS = new InjectionToken<LocalTranslations>('transla
 @Injectable()
 export class ICMTranslateLoader implements TranslateLoader {
   constructor(
+    private actions$: Actions,
     private transferState: TransferState,
     private localizations: LocalizationsService,
     @Inject(LOCAL_TRANSLATIONS) private localTranslations: InjectSingle<typeof LOCAL_TRANSLATIONS>
@@ -33,10 +36,16 @@ export class ICMTranslateLoader implements TranslateLoader {
     const server$ = iif(
       () => !SSR && this.transferState.hasKey(SSR_TRANSLATIONS),
       of(this.transferState.get(SSR_TRANSLATIONS, {})),
-      this.localizations.getServerTranslations(lang).pipe(
-        tap(data => {
-          this.transferState.set(SSR_TRANSLATIONS, data);
-        })
+      this.actions$.pipe(
+        ofType(routerNavigationAction),
+        first(),
+        switchMap(() =>
+          this.localizations.getServerTranslations(lang).pipe(
+            tap(data => {
+              this.transferState.set(SSR_TRANSLATIONS, data);
+            })
+          )
+        )
       )
     );
     return combineLatest([local$, server$]).pipe(


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The PWA have different places to configure the state. ICM configurations like the icmChannel can be set by the data from the theme or by the route params from the first initial PWA router action (/home?icmChannel=abc). First the PWA will set all local configurations (theme) after ROOT_INIT. After that this configuration state can be overwritten with the route applied parameters, when the routerNavigation action is triggered.

On SSR the localization.service.ts loads on server side localizations from the ICM and adds it to the transferState. The /localization call will be fetched right after the first configuration is applied to the state. That's the reason why the wrong ICM channel will be applied to the /localization call, when the channel information should be overwritten by the PWA url params.

example:

- theme: icmChannel: default
- pwa-url: `http://pwa-url.de/home?channel=new` (will be created e.g. by nginx MULTI_CHANNEL configuration)
- Expectation: localization call uses 'new' channel
- RESULT for localization call: https://${icmBaseUrl}/INTERSHOP/rest/WFS/default/rest;loc=en_US/localizations

Issue Number: Closes #

## What Is the New Behavior?

The localization call waits until the routerNavigation action is triggered. Now it is secured that the correct configuration is set within the state.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#87527](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/87527)