### PR TITLE
fix: NoSunday date validator does not work properly

### DIFF
--- a/src/app/shared/forms/validators/special-validators.ts
+++ b/src/app/shared/forms/validators/special-validators.ts
@@ -149,6 +149,6 @@ export class SpecialValidators {
   private static noDay(control: FormControl, day: 'saturday' | 'sunday'): boolean {
     const date = control.value as Date;
 
-    return !(day === 'saturday' ? date?.getDay() === 6 : date?.getDate() === 0);
+    return !(day === 'saturday' ? date?.getDay() === 6 : date?.getDay() === 0);
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The date validator noSunday is supposed to check a date input field to be not a Sunday, but the check is not working.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The date validator works as expected.
![image](https://github.com/intershop/intershop-pwa/assets/57660644/b4722c23-9482-4cbd-a6ce-e543ef50f1f5)


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
