### PR TITLE
fix: reload the application after the pgid changed

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -12,6 +12,7 @@ import { ICMErrorMapperInterceptor } from './interceptors/icm-error-mapper.inter
 import { IdentityProviderInterceptor } from './interceptors/identity-provider.interceptor';
 import { MockInterceptor } from './interceptors/mock.interceptor';
 import { PaymentPayoneInterceptor } from './interceptors/payment-payone.interceptor';
+import { PGIDChangeInterceptor } from './interceptors/pgid-change.interceptor';
 import { PreviewInterceptor } from './interceptors/preview.interceptor';
 import { InternationalizationModule } from './internationalization.module';
 import { StateManagementModule } from './state-management.module';
@@ -29,6 +30,7 @@ import { DefaultErrorHandler } from './utils/default-error-handler';
     StateManagementModule,
   ],
   providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: PGIDChangeInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ICMErrorMapperInterceptor, multi: true },
     {
       provide: HTTP_INTERCEPTORS,

--- a/src/app/core/interceptors/pgid-change.interceptor.ts
+++ b/src/app/core/interceptors/pgid-change.interceptor.ts
@@ -1,0 +1,25 @@
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, catchError, throwError } from 'rxjs';
+
+/* eslint-disable @typescript-eslint/ban-types */
+
+/**
+ *  reload page when the pgid of the user has changed
+ */
+@Injectable()
+export class PGIDChangeInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      catchError((error: HttpErrorResponse) => {
+        if (
+          error.name === 'HttpErrorResponse' &&
+          error.message === 'Bad Request (The provided matrix parameter "pgid" does not match the authenticated user.)'
+        ) {
+          return throwError(() => window.location.reload());
+        }
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -271,7 +271,9 @@ export class ApiTokenService {
 
   private isAuthTokenError(err: unknown) {
     return (
-      err instanceof HttpErrorResponse && typeof err.error === 'string' && err.error?.toLowerCase().includes('token')
+      err instanceof HttpErrorResponse &&
+      typeof err.error === 'string' &&
+      (err.error.includes('AuthenticationToken') || err.error.includes('Unable to decode token'))
     );
   }
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user's pgid changes due to data changes in the ICM backoffice, e.g. assigning/unassigning the user to a customer group, promotion etc. the personalized REST calls will fail with a 400 error: Bad Request (The provided matrix parameter "pgid" does not match the authenticated user.) and an error page is shown in most cases.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
There is a new error handler that checks for the error above and if this error occurs the current page is reloaded. The relaod is necessary because a lot of data in the ngrx store might be affected (invalid) and the reload forces to fetch all the data from the ICM server again.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#87744](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/87744)