### PR TITLE
fix: handle multitab browsing

### DIFF
--- a/src/app/core/facades/account.facade.ts
+++ b/src/app/core/facades/account.facade.ts
@@ -38,7 +38,6 @@ import {
 import {
   createUser,
   deleteUserPaymentInstrument,
-  fetchAnonymousUserToken,
   getCustomerApprovalEmail,
   getLoggedInCustomer,
   getLoggedInUser,
@@ -101,10 +100,6 @@ export class AccountFacade {
    */
   logoutUser(options = { revokeApiToken: true }) {
     options?.revokeApiToken ? this.store.dispatch(logoutUser()) : this.store.dispatch(logoutUserSuccess());
-  }
-
-  fetchAnonymousToken() {
-    this.store.dispatch(fetchAnonymousUserToken());
   }
 
   createUser(body: CustomerRegistrationType) {

--- a/src/app/core/identity-provider/icm.identity-provider.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.ts
@@ -33,7 +33,7 @@ export class ICMIdentityProvider implements IdentityProvider {
   init() {
     this.apiTokenService.restore$().subscribe(noop);
 
-    this.apiTokenService.cookieVanishes$.subscribe(([type]) => {
+    this.apiTokenService.cookieVanishes$.subscribe(type => {
       this.accountFacade.logoutUser({ revokeApiToken: false });
       if (type === 'user') {
         this.router.navigate(['/login'], {

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -64,7 +64,7 @@ const DEFAULT_EXPIRY_TIME = 3600000;
 @Injectable({ providedIn: 'root' })
 export class ApiTokenService {
   apiToken$: Subject<string>;
-  cookieVanishes$: Subject<ApiTokenCookieType>;
+  cookieVanishes$ = new Subject<ApiTokenCookieType>();
 
   private cookieOptions: CookieOptions = {};
 

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router, UrlTree } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { Observable, noop, of, race, throwError } from 'rxjs';
-import { catchError, concatMap, delay, filter, first, map, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
+import { catchError, concatMap, delay, filter, first, map, switchMap, take, tap } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
@@ -40,16 +40,11 @@ export class PunchoutIdentityProvider implements IdentityProvider {
   }
 
   init() {
-    this.apiTokenService.cookieVanishes$
-      .pipe(withLatestFrom(this.apiTokenService.apiToken$))
-      .subscribe(([type, apiToken]) => {
-        if (!apiToken) {
-          this.accountFacade.fetchAnonymousToken();
-        }
-        if (type === 'user') {
-          this.accountFacade.logoutUser({ revokeApiToken: false });
-        }
-      });
+    this.apiTokenService.cookieVanishes$.subscribe(type => {
+      if (type === 'user') {
+        this.accountFacade.logoutUser({ revokeApiToken: false });
+      }
+    });
 
     // OAuth Service should be configured before apiToken information are restored and the refresh token mechanism is setup
     this.apiTokenService.restore$(['user', 'order']).subscribe(noop);


### PR DESCRIPTION
When browsing the site using different tabs, the identification status is not well persisted across tabs.
This is particularly annoying when a user opens several tabs to compare products before adding them to the shopping cart.

The following fix corrects these problems

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Step to reproduce the bug 
- Open 2 product tab without being logged in
- Add those product to cart on each tab
- Only the last product will be association to the current basket

Issue Number: Closes #

## What Is the New Behavior?

When an anonymous or user token is created on one tab, the change is propagated to the other tab within a second.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
