### PR TITLE
Update build-pwa.js - use defualtProject instead of hardcoded name

### DIFF
--- a/scripts/build-pwa.js
+++ b/scripts/build-pwa.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const execSync = require('child_process').execSync;
 
+const angularJson = JSON.parse(fs.readFileSync('./angular.json', { encoding: 'utf-8' }));
+
 /**
  * remove service worker cache check for resources (especially index.html)
  * https://github.com/angular/angular/issues/23613#issuecomment-415886919
@@ -15,7 +17,6 @@ function removeServiceWorkerCacheCheck(args) {
     outputPath = outputPathArg.split('=')[1];
   } else {
     // get default outputPath from angular.json
-    const angularJson = JSON.parse(fs.readFileSync('./angular.json', { encoding: 'utf-8' }));
     outputPath = angularJson.projects[angularJson.defaultProject].architect.build.options.outputPath;
   }
 
@@ -47,7 +48,7 @@ const server = processArgs.includes('server') || !processArgs.includes('client')
 const remainingArgs = processArgs.filter(a => a !== 'client' && a !== 'server');
 
 if (client) {
-  execSync(`npm run ng -- build ${configString} ${remainingArgs.join(' ')}`, {
+  execSync(`npm run ng -- build ${angularJson.defaultProject} ${configString} ${remainingArgs.join(' ')}`, {
     stdio: 'inherit',
   });
   removeServiceWorkerCacheCheck(remainingArgs);
@@ -58,7 +59,7 @@ if (configuration) {
 }
 
 if (server) {
-  execSync(`npm run ng -- run intershop-pwa:server${configString} ${remainingArgs.join(' ')}`, {
+  execSync(`npm run ng -- run ${angularJson.defaultProject}:server${configString} ${remainingArgs.join(' ')}`, {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
It might be useful when you want to build a 100% custom build based on `intershop-pwa` which is also part of the local angular.json configuration under a different project name.



<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[x] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
