### PR TITLE
fix: properly handle system signals in pwa docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN node scripts/compile-docker-scripts
 COPY dist/* /workspace/dist/
 
 FROM node:18.16.0-alpine
+RUN apk add --no-cache tini
 COPY --from=buildstep /workspace/dist /dist
 RUN cd dist && npm install
 ARG displayVersion=
@@ -37,4 +38,4 @@ EXPOSE 4200 9113
 RUN mkdir /.pm2 && chmod 777 -Rf /.pm2 && touch /dist/ecosystem.yml && chmod 777 -f /dist/ecosystem.yml
 USER nobody
 HEALTHCHECK --interval=60s --timeout=20s --start-period=2s CMD node /dist/healthcheck.js
-ENTRYPOINT ["sh","/dist/entrypoint.sh"]
+ENTRYPOINT [ "/sbin/tini", "--", "sh", "/dist/entrypoint.sh" ]

--- a/dist/entrypoint.sh
+++ b/dist/entrypoint.sh
@@ -2,18 +2,14 @@
 
 set -e
 
-trap 'echo recieved INT; exit 1' SIGINT
-trap 'echo recieved TERM; exit 0' SIGTERM
-trap 'echo recieved KILL; exit 1' SIGKILL
-
 if [ -z "$*" ]
 then
-  # use 'node dist/<theme>/run-standalone'
+  # use 'exec node dist/<theme>/run-standalone'
   # instead of pm2 to fallback to running
   # a single theme only
 
   node dist/build-ecosystem.js
-  pm2-runtime dist/ecosystem.yml
+  exec pm2-runtime dist/ecosystem.yml
 else
   exec "$@"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
         serviceWorker: 'false'
         # activeThemes: b2b
         # activeThemes: b2c
+    # command: ['node', 'dist/b2c/run-standalone']
+    # command: ['node', 'dist/b2b/run-standalone']
     environment:
       # ICM_BASE_URL:
       LOGGING: 'true'


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When trying to stop the PWA running with docker or kubernetes, it always takes some time (~10 seconds) for the container to stop. That's because the grace period times out and the container is killed.

## What Is the New Behavior?

Signals are properly propagated to the running process:
- using `exec` in scripts
- using [`tini`](https://github.com/krallin/tini) for standalone node processes

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#88361](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88361)