### PR TITLE
feat(ICM 11): co-browsing support via CEC

### DIFF
--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -15,6 +15,7 @@ bitnami
 blocklist
 breakline
 categoryref
+cobrowse
 colorcode
 compodoc
 concardis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
       #   .+:
       #     - path: /en/punchout
       #       type: Punchout
+      #     - path: /en/cobrowse
+      #       type: CoBrowse
       MULTI_CHANNEL: |
         .+:
           - baseHref: /en

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       #     clientID: ASDF12345
       #   Punchout:
       #     type: PUNCHOUT
+      #   CoBrowse:
+      #     type: cobrowse
 
     # Logging to an External Device (see logging.md)
     # volumes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ kb_sync_latest_only
   - [Guide - Authentication by the ICM Server](./guides/authentication_icm.md)
   - [Guide - Authentication with Single Sign-On (SSO)](./guides/authentication_sso.md)
   - [Guide - Authentication with the Punchout Identity Provider](./guides/authentication_punchout.md)
+  - [Guide - Authentication with the Co-Browse Identity Provider](./guides/authentication_co_browse.md)
 
 ### Developing
 

--- a/docs/guides/authentication_co_browse.md
+++ b/docs/guides/authentication_co_browse.md
@@ -1,0 +1,136 @@
+<!--
+kb_guide
+kb_pwa
+kb_everyone
+kb_sync_latest_only
+-->
+
+# Introduction
+
+The co-browse functionality is needed for the Intershop Customer Engagement Center (CEC).
+In this application a contact center agent can start a "co-browsing" storefront session.
+That means, the agent is logged in to the PWA on behalf of the user.
+Technically a special identity provider (the co-browse identity provider) is needed to handle the authentication of the user with the help of an authentication token that is provided by the CEC as an URL parameter.
+
+# Authentication with the Co-Browse Identity Provider
+
+This document describes the authentication mechanism if the co-browse identity provider is used to enable an agent to log in on behalf of a user.
+If you need an introduction regarding authentication in the PWA, read the [Authentication Concept](../concepts/authentication.md) first.
+
+## Configuration
+
+The PWA must be configured in a specific way to use co-browse as an identity provider.
+The following configuration can be added to the Angular CLI `environment.ts` files for development purposes:
+
+```typescript
+identityProvider: 'CoBrowse',
+identityProviders: {
+  'CoBrowse': {
+    type: 'cobrowse',
+  }
+},
+```
+
+> :warning: **NOTE:** This configuration enables the `Co-Browse` identity provider as the one and only configured global identity provider, meaning the standard ICM identity provider used for the standard login is no longer configured and the standard login will no longer work. As said this configuration example is only relevant for development purposes.
+
+For production like deployments, the PWA has to be be configured to use the `Co-Browse` identity provider only when the user enters the `cobrowse` route.
+This can be configured with the `OVERRIDE_IDENTITY_PROVIDERS` environment variable (see [Override Identity Providers by Path][nginx-startup]) for the NGINX container.
+Nevertheless, the SSR process needs to be provided with the co-browse identity provider configuration as one of the available identity providers.
+This way the global `identityProvider` configuration is left to be the default ICM configuration.
+
+The following is an example co-browse identity provider configuration for `docker-compose` that enables the co-browse identity provider on the `cobrowse` route only.
+
+```yaml
+pwa:
+  environment:
+    IDENTITY_PROVIDERS: |
+      CoBrowse:
+        type: cobrowse
+
+nginx:
+  environment:
+    OVERRIDE_IDENTITY_PROVIDERS: |
+      .+:
+        - path: /cobrowse
+          type: cobrowse
+```
+
+For the current PWA Helm Chart that is also used in the PWA Flux deployments the same co-browse configuration would look like this.
+
+```yaml
+environment:
+  - name: IDENTITY_PROVIDERS
+    value: |
+      {
+        "CoBrowse": {"type": "cobrowse"}
+      }
+
+cache:
+  extraEnvVars:
+    - name: OVERRIDE_IDENTITY_PROVIDERS
+      value: |
+        .+:
+          - path: /cobrowse
+            type: cobrowse
+```
+
+> :exclamation: **NOTE:** Be aware that the `OVERRIDE_IDENTITY_PROVIDERS` configuration has to match a potentially used `multiChannel` configuration.
+
+```yaml
+environment:
+  - name: IDENTITY_PROVIDERS
+    value: |
+      {
+        "CoBrowse": {"type": "cobrowse"}
+      }
+
+cache:
+  extraEnvVars:
+    - name: OVERRIDE_IDENTITY_PROVIDERS
+      value: |
+        .+:
+          - path: /en/cobrowse
+            type: cobrowse
+          - path: /de/cobrowse
+            type: cobrowse
+          - path: /fr/cobrowse
+            type: cobrowse
+
+  multiChannel: |
+    .+:
+      - baseHref: /en
+        channel: default
+        lang: en_US
+      - baseHref: /de
+        channel: default
+        lang: de_DE
+      - baseHref: /fr
+        channel: default
+        lang: fr_FR
+      - baseHref: /b2c
+        channel: default
+        theme: b2c
+```
+
+## Login
+
+A user can login by navigating to the `/cobrowse` route.
+For this purpose the query param `access-token` needs to be added to the given route.
+When the login is successful the call center agent user is logged in on behalf of a customer.
+The catalogs and products, prices, promotions, content etc. are displayed to the agent in the same way as to the user.
+
+## Token Lifetime
+
+Each authentication token has a predefined lifetime.
+That means, the token has to be refreshed to prevent it from expiring.
+Once 75% of the token's lifetime have passed ( this time can be configured in the oAuth library), an info event is emitted.
+This event is used to call the [refresh mechanism `setupRefreshTokenMechanism$`](../../src/app/core/services/token/token.service.ts) of the oAuth configuration service and the authentication token will be renewed.
+Hence, the token will not expire as long as the user keeps the PWA open in the browser.
+
+## Logout
+
+When the user logs out by clicking the logout link or navigating to the `/logout` route, the configured [`logout()`](../../src/app/core/identity-provider/co-browse.identity-provider.ts) function will be executed, which will call the [`revokeApiToken()`](../../src/app/core/services/user/user.service.ts) user service in order to deactivate the token on server side.
+Besides this, the PWA removes the token, the apiToken cookie and basket-id on browser side.
+
+[ssr-startup]: ../guides/ssr-startup.md
+[nginx-startup]: ../guides/nginx-startup.md

--- a/docs/guides/authentication_co_browse.md
+++ b/docs/guides/authentication_co_browse.md
@@ -5,17 +5,20 @@ kb_everyone
 kb_sync_latest_only
 -->
 
-# Introduction
+# Authentication with the Co-Browse Identity Provider
+
+> [!IMPORTANT]
+> To use the Co-Browse functionality ICM version 11.8.0 or above is needed.
+
+This document describes the authentication mechanism if the co-browse identity provider is used to enable an agent to log in on behalf of a user.
+If you need an introduction regarding authentication in the PWA, read the [Authentication Concept](../concepts/authentication.md) first.
+
+## Introduction
 
 The co-browse functionality is needed for the Intershop Customer Engagement Center (CEC).
 In this application a contact center agent can start a "co-browsing" storefront session.
 That means, the agent is logged in to the PWA on behalf of the user.
 Technically a special identity provider (the co-browse identity provider) is needed to handle the authentication of the user with the help of an authentication token that is provided by the CEC as an URL parameter.
-
-# Authentication with the Co-Browse Identity Provider
-
-This document describes the authentication mechanism if the co-browse identity provider is used to enable an agent to log in on behalf of a user.
-If you need an introduction regarding authentication in the PWA, read the [Authentication Concept](../concepts/authentication.md) first.
 
 ## Configuration
 
@@ -31,14 +34,16 @@ identityProviders: {
 },
 ```
 
-> :warning: **NOTE:** This configuration enables the `Co-Browse` identity provider as the one and only configured global identity provider, meaning the standard ICM identity provider used for the standard login is no longer configured and the standard login will no longer work. As said this configuration example is only relevant for development purposes.
+> [!WARNING]
+> This configuration enables the `Co-Browse` identity provider as the one and only configured global identity provider, meaning the standard ICM identity provider used for the standard login is no longer configured and the standard login will no longer work.
+> As mentioned above, this configuration example is only relevant for development purposes.
 
-For production like deployments, the PWA has to be be configured to use the `Co-Browse` identity provider only when the user enters the `cobrowse` route.
+For production-like deployments, the PWA has to be be configured to use the `Co-Browse` identity provider only when the user enters the `cobrowse` route.
 This can be configured with the `OVERRIDE_IDENTITY_PROVIDERS` environment variable (see [Override Identity Providers by Path][nginx-startup]) for the NGINX container.
 Nevertheless, the SSR process needs to be provided with the co-browse identity provider configuration as one of the available identity providers.
-This way the global `identityProvider` configuration is left to be the default ICM configuration.
+In this way, the global `identityProvider` configuration is left to be the default ICM configuration.
 
-The following is an example co-browse identity provider configuration for `docker-compose` that enables the co-browse identity provider on the `cobrowse` route only.
+The following is a sample co-browse identity provider configuration for `docker-compose` that enables the co-browse identity provider on the `cobrowse` route only.
 
 ```yaml
 pwa:
@@ -52,10 +57,10 @@ nginx:
     OVERRIDE_IDENTITY_PROVIDERS: |
       .+:
         - path: /cobrowse
-          type: cobrowse
+          type: CoBrowse
 ```
 
-For the current PWA Helm Chart that is also used in the PWA Flux deployments the same co-browse configuration would look like this.
+For the current PWA Helm Chart that is also used in the PWA Flux deployments, the same co-browse configuration would look like this:
 
 ```yaml
 environment:
@@ -71,10 +76,11 @@ cache:
       value: |
         .+:
           - path: /cobrowse
-            type: cobrowse
+            type: CoBrowse
 ```
 
-> :exclamation: **NOTE:** Be aware that the `OVERRIDE_IDENTITY_PROVIDERS` configuration has to match a potentially used `multiChannel` configuration.
+> [!IMPORTANT]
+> Be aware that the `OVERRIDE_IDENTITY_PROVIDERS` configuration has to match a potentially used `multiChannel` configuration.
 
 ```yaml
 environment:
@@ -90,11 +96,13 @@ cache:
       value: |
         .+:
           - path: /en/cobrowse
-            type: cobrowse
+            type: CoBrowse
           - path: /de/cobrowse
-            type: cobrowse
+            type: CoBrowse
           - path: /fr/cobrowse
-            type: cobrowse
+            type: CoBrowse
+          - path: /b2c/cobrowse
+            type: CoBrowse
 
   multiChannel: |
     .+:
@@ -114,8 +122,8 @@ cache:
 
 ## Login
 
-A user can login by navigating to the `/cobrowse` route.
-For this purpose the query param `access-token` needs to be added to the given route.
+A user can log in by navigating to the `/cobrowse` route.
+For this purpose, the query param `access-token` needs to be added to the given route.
 When the login is successful the call center agent user is logged in on behalf of a customer.
 The catalogs and products, prices, promotions, content etc. are displayed to the agent in the same way as to the user.
 

--- a/docs/guides/authentication_punchout.md
+++ b/docs/guides/authentication_punchout.md
@@ -28,7 +28,8 @@ identityProviders: {
 ```
 
 > [!WARNING]
-> This configuration enables the `Punchout` identity provider as the one and only configured global identity provider, meaning the standard ICM identity provider used for the standard login is no longer configured and the standard login will no longer work. As mentioned above, this configuration example is only relevant for punchout development purposes.
+> This configuration enables the `Punchout` identity provider as the one and only configured global identity provider, meaning the standard ICM identity provider used for the standard login is no longer configured and the standard login will no longer work.
+> As mentioned above, this configuration example is only relevant for punchout development purposes.
 
 For production-like deployments, the PWA has to be configured to use the `Punchout` identity provider only when the user enters the `punchout` route.
 This can be configured with the `OVERRIDE_IDENTITY_PROVIDERS` environment variable (see [Override Identity Providers by Path][nginx-startup]) for the NGINX container.
@@ -71,7 +72,7 @@ cache:
             type: Punchout
 ```
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Be aware that the `OVERRIDE_IDENTITY_PROVIDERS` configuration has to match a potentially used `multiChannel` configuration.
 
 ```yaml

--- a/docs/guides/updating-pwa.md
+++ b/docs/guides/updating-pwa.md
@@ -75,7 +75,9 @@ bootstrap                             4.4.1     4.5.0    4.5.0  intershop-pwa  d
 
 Perform updates with `ng update` as well.
 
-> [!IMPORTANT] > `@types/node` should always remain on the LTS version.
+> [!IMPORTANT]
+>
+> `@types/node` should always remain on the LTS version.
 > You can update to specific versions with `ng update @types/node@12`.
 
 ### 3. Update Project Utilities for Testing, Reporting and Linting

--- a/src/app/core/identity-provider.module.ts
+++ b/src/app/core/identity-provider.module.ts
@@ -6,6 +6,7 @@ import { noop } from 'rxjs';
 import { PunchoutIdentityProviderModule } from '../extensions/punchout/identity-provider/punchout-identity-provider.module';
 
 import { Auth0IdentityProvider } from './identity-provider/auth0.identity-provider';
+import { CoBrowseIdentityProvider } from './identity-provider/co-browse.identity-provider';
 import { ICMIdentityProvider } from './identity-provider/icm.identity-provider';
 import { IDENTITY_PROVIDER_IMPLEMENTOR, IdentityProviderFactory } from './identity-provider/identity-provider.factory';
 import { IdentityProviderCapabilities } from './identity-provider/identity-provider.interface';
@@ -38,6 +39,14 @@ export function storageFactory(): OAuthStorage {
       useValue: {
         type: 'auth0',
         implementor: Auth0IdentityProvider,
+      },
+    },
+    {
+      provide: IDENTITY_PROVIDER_IMPLEMENTOR,
+      multi: true,
+      useValue: {
+        type: 'cobrowse',
+        implementor: CoBrowseIdentityProvider,
       },
     },
   ],

--- a/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
@@ -125,7 +125,7 @@ describe('Co Browse Identity Provider', () => {
       const accessToken = 'login-access-token';
 
       beforeEach(() => {
-        queryParams = { token: accessToken };
+        queryParams = { 'access-token': accessToken };
       });
 
       it('should trigger loginUserWithToken method on login', done => {

--- a/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
@@ -1,0 +1,141 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Params, Router, UrlTree, convertToParamMap } from '@angular/router';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { EMPTY, Observable, Subject, of, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { anything, instance, mock, resetCalls, verify, when } from 'ts-mockito';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { selectQueryParam } from 'ish-core/store/core/router';
+import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
+
+import { CoBrowseIdentityProvider } from './co-browse.identity-provider';
+
+function getSnapshot(queryParams: Params): ActivatedRouteSnapshot {
+  return {
+    queryParamMap: convertToParamMap(queryParams),
+  } as ActivatedRouteSnapshot;
+}
+
+describe('Co Browse Identity Provider', () => {
+  const apiTokenService = mock(ApiTokenService);
+  const appFacade = mock(AppFacade);
+  const accountFacade = mock(AccountFacade);
+  const checkoutFacade = mock(CheckoutFacade);
+
+  let identityProvider: CoBrowseIdentityProvider;
+  let store$: MockStore;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AccountFacade, useFactory: () => instance(accountFacade) },
+        { provide: ApiTokenService, useFactory: () => instance(apiTokenService) },
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
+        { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
+        provideMockStore(),
+      ],
+    }).compileComponents();
+
+    identityProvider = TestBed.inject(CoBrowseIdentityProvider);
+    router = TestBed.inject(Router);
+    store$ = TestBed.inject(MockStore);
+  });
+
+  beforeEach(() => {
+    when(apiTokenService.restore$(anything())).thenReturn(of(true));
+    when(apiTokenService.cookieVanishes$).thenReturn(new Subject());
+    when(checkoutFacade.basket$).thenReturn(EMPTY);
+
+    resetCalls(apiTokenService);
+    resetCalls(appFacade);
+    resetCalls(accountFacade);
+    resetCalls(checkoutFacade);
+
+    window.sessionStorage.clear();
+  });
+
+  describe('init', () => {
+    it('should restore apiToken on startup', () => {
+      identityProvider.init();
+      verify(apiTokenService.restore$(anything())).once();
+      verify(apiTokenService.removeApiToken()).never();
+    });
+
+    it('should add basket-id to session storage, when basket is available', () => {
+      when(checkoutFacade.basket$).thenReturn(of(BasketMockData.getBasket()));
+      identityProvider.init();
+      expect(window.sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
+    });
+  });
+
+  describe('triggerLogout', () => {
+    beforeEach(() => {
+      when(checkoutFacade.basket$).thenReturn(of(BasketMockData.getBasket()));
+      when(accountFacade.isLoggedIn$).thenReturn(of(false));
+      store$.overrideSelector(selectQueryParam(anything()), undefined);
+      identityProvider.init();
+    });
+
+    it('should remove api token and basket-id on logout', done => {
+      expect(window.sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
+
+      const logoutTrigger$ = identityProvider.triggerLogout() as Observable<UrlTree>;
+
+      logoutTrigger$.subscribe(() => {
+        expect(window.sessionStorage.getItem('basket-id')).toBeNull();
+        verify(accountFacade.logoutUser()).once();
+        done();
+      });
+    });
+
+    it('should return to home page per default on subscribe', done => {
+      const routerSpy = jest.spyOn(router, 'parseUrl');
+
+      const logoutTrigger$ = identityProvider.triggerLogout() as Observable<UrlTree>;
+
+      logoutTrigger$.subscribe(() => {
+        expect(routerSpy).toHaveBeenCalledWith('/home');
+        done();
+      });
+    });
+  });
+
+  describe('triggerLogin', () => {
+    let queryParams = {};
+
+    beforeEach(() => {
+      identityProvider.init();
+      when(accountFacade.userError$).thenReturn(timer(Infinity).pipe(switchMap(() => EMPTY)));
+      when(accountFacade.isLoggedIn$).thenReturn(of(true));
+    });
+
+    it('should throw an business error without query params on login', () => {
+      const result$ = identityProvider.triggerLogin(getSnapshot(queryParams));
+
+      verify(appFacade.setBusinessError('cobrowse.error.missing.parameter')).once();
+      expect(result$).toBeFalsy();
+    });
+
+    describe('with access-token', () => {
+      const accessToken = 'login-access-token';
+
+      beforeEach(() => {
+        queryParams = { 'access-token': accessToken };
+      });
+
+      it('should trigger loginUserWithToken method on login', done => {
+        const login$ = identityProvider.triggerLogin(getSnapshot(queryParams)) as Observable<boolean | UrlTree>;
+
+        login$.subscribe(() => {
+          verify(accountFacade.loginUserWithToken(accessToken)).once();
+          done();
+        });
+      });
+    });
+  });
+});

--- a/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
@@ -121,11 +121,11 @@ describe('Co Browse Identity Provider', () => {
       expect(result$).toBeFalsy();
     });
 
-    describe('with access-token', () => {
+    describe('with token', () => {
       const accessToken = 'login-access-token';
 
       beforeEach(() => {
-        queryParams = { 'access-token': accessToken };
+        queryParams = { token: accessToken };
       });
 
       it('should trigger loginUserWithToken method on login', done => {

--- a/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
@@ -48,7 +48,7 @@ describe('Co Browse Identity Provider', () => {
 
   beforeEach(() => {
     when(apiTokenService.restore$(anything())).thenReturn(of(true));
-    when(apiTokenService.cookieVanishes$).thenReturn(new Subject());
+    when(apiTokenService.getCookieVanishes$()).thenReturn(new Subject());
     when(checkoutFacade.basket$).thenReturn(EMPTY);
 
     resetCalls(apiTokenService);

--- a/src/app/core/identity-provider/co-browse.identity-provider.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.ts
@@ -1,0 +1,122 @@
+import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { Store, select } from '@ngrx/store';
+import { Observable, noop, of, race, throwError } from 'rxjs';
+import { catchError, concatMap, delay, filter, first, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { IdentityProvider, TriggerReturnType } from 'ish-core/identity-provider/identity-provider.interface';
+import { selectQueryParam } from 'ish-core/store/core/router';
+import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { whenTruthy } from 'ish-core/utils/operators';
+
+@Injectable({ providedIn: 'root' })
+export class CoBrowseIdentityProvider implements IdentityProvider {
+  constructor(
+    protected router: Router,
+    protected store: Store,
+    protected apiTokenService: ApiTokenService,
+    private appFacade: AppFacade,
+    private accountFacade: AccountFacade,
+    private checkoutFacade: CheckoutFacade
+  ) {}
+
+  getCapabilities() {
+    return {
+      editPassword: false,
+      editEmail: false,
+      editProfile: false,
+    };
+  }
+
+  init() {
+    this.apiTokenService.cookieVanishes$
+      .pipe(withLatestFrom(this.apiTokenService.apiToken$))
+      .subscribe(([type, apiToken]) => {
+        if (!apiToken) {
+          this.accountFacade.fetchAnonymousToken();
+        }
+        if (type === 'user') {
+          this.accountFacade.logoutUser({ revokeApiToken: false });
+        }
+      });
+
+    // OAuth Service should be configured before apiToken information are restored and the refresh token mechanism is setup
+    this.apiTokenService.restore$(['user', 'order']).subscribe(noop);
+
+    this.checkoutFacade.basket$.pipe(whenTruthy(), first()).subscribe(basketView => {
+      window.sessionStorage.setItem('basket-id', basketView.id);
+    });
+  }
+
+  triggerLogin(route: ActivatedRouteSnapshot): TriggerReturnType {
+    // check for required start parameters before doing anything with the co-browse route
+    // ToDo: adapt parameter name
+    if (!route.queryParamMap.has('access-token')) {
+      this.appFacade.setBusinessError('cobrowse.error.missing.parameter');
+      return false;
+    }
+
+    // ToDo: this functionality will change
+    this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
+
+    return race(
+      // throw an error if a user login error occurs
+      this.accountFacade.userError$.pipe(
+        whenTruthy(),
+        take(1),
+        concatMap(userError => throwError(() => userError))
+      ),
+
+      // handle the punchout functions once the punchout user is logged in
+      this.accountFacade.isLoggedIn$.pipe(
+        whenTruthy(),
+        take(1),
+        map(() => this.router.parseUrl('/home')),
+        // punchout error after successful authentication (needs to logout)
+        catchError(error =>
+          this.accountFacade.userLoading$.pipe(
+            first(loading => !loading),
+            delay(0),
+            switchMap(() => {
+              this.accountFacade.logoutUser();
+              this.apiTokenService.removeApiToken();
+              this.appFacade.setBusinessError(error);
+              return of(this.router.parseUrl('/error'));
+            })
+          )
+        )
+      )
+    ).pipe(
+      // general punchout error handling (parameter missing, authentication error)
+      catchError(error => {
+        this.appFacade.setBusinessError(error);
+        return of(this.router.parseUrl('/error'));
+      })
+    );
+  }
+
+  triggerLogout(): TriggerReturnType {
+    window.sessionStorage.removeItem('basket-id');
+    this.accountFacade.logoutUser(); // user will be logged out and related refresh token is revoked on server
+    return this.accountFacade.isLoggedIn$.pipe(
+      // wait until the user is logged out before you go to homepage to prevent unnecessary REST calls
+      filter(loggedIn => !loggedIn),
+      take(1),
+      switchMap(() =>
+        this.store.pipe(
+          select(selectQueryParam('returnUrl')),
+          map(returnUrl => returnUrl || '/home'),
+          map(returnUrl => this.router.parseUrl(returnUrl))
+        )
+      )
+    );
+  }
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return this.apiTokenService.intercept(req, next);
+  }
+}

--- a/src/app/core/identity-provider/co-browse.identity-provider.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.ts
@@ -55,13 +55,13 @@ export class CoBrowseIdentityProvider implements IdentityProvider {
   triggerLogin(route: ActivatedRouteSnapshot): TriggerReturnType {
     // check for required start parameters before doing anything with the co-browse route
     // ToDo: adapt parameter name
-    if (!route.queryParamMap.has('access-token')) {
+    if (!route.queryParamMap.has('token')) {
       this.appFacade.setBusinessError('cobrowse.error.missing.parameter');
       return false;
     }
 
     // ToDo: this functionality will change
-    this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
+    this.accountFacade.loginUserWithToken(route.queryParamMap.get('token'));
 
     return race(
       // throw an error if a user login error occurs

--- a/src/app/core/identity-provider/co-browse.identity-provider.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.ts
@@ -54,14 +54,12 @@ export class CoBrowseIdentityProvider implements IdentityProvider {
 
   triggerLogin(route: ActivatedRouteSnapshot): TriggerReturnType {
     // check for required start parameters before doing anything with the co-browse route
-    // ToDo: adapt parameter name
-    if (!route.queryParamMap.has('token')) {
+    if (!route.queryParamMap.has('access-token')) {
       this.appFacade.setBusinessError('cobrowse.error.missing.parameter');
       return false;
     }
 
-    // ToDo: this functionality will change
-    this.accountFacade.loginUserWithToken(route.queryParamMap.get('token'));
+    this.accountFacade.loginUserWithToken(route.queryParamMap.get('access-token'));
 
     return race(
       // throw an error if a user login error occurs

--- a/src/app/core/identity-provider/co-browse.identity-provider.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { Observable, noop, of, race, throwError } from 'rxjs';
-import { catchError, concatMap, delay, filter, first, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
+import { catchError, concatMap, delay, filter, first, map, switchMap, take } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
@@ -33,16 +33,11 @@ export class CoBrowseIdentityProvider implements IdentityProvider {
   }
 
   init() {
-    this.apiTokenService.cookieVanishes$
-      .pipe(withLatestFrom(this.apiTokenService.apiToken$))
-      .subscribe(([type, apiToken]) => {
-        if (!apiToken) {
-          this.accountFacade.fetchAnonymousToken();
-        }
-        if (type === 'user') {
-          this.accountFacade.logoutUser({ revokeApiToken: false });
-        }
-      });
+    this.apiTokenService.getCookieVanishes$().subscribe(type => {
+      if (type === 'user') {
+        this.accountFacade.logoutUser({ revokeApiToken: false });
+      }
+    });
 
     // OAuth Service should be configured before apiToken information are restored and the refresh token mechanism is setup
     this.apiTokenService.restore$(['user', 'order']).subscribe(noop);

--- a/src/app/pages/app-routing.module.ts
+++ b/src/app/pages/app-routing.module.ts
@@ -126,6 +126,7 @@ const routes: Routes = [
     },
   },
   { path: 'cookies', loadChildren: () => import('./cookies/cookies-page.module').then(m => m.CookiesPageModule) },
+  { path: 'cobrowse', loadChildren: () => import('./co-browse/co-browse-page.module').then(m => m.CoBrowsePageModule) },
 ];
 
 @NgModule({

--- a/src/app/pages/co-browse/co-browse-page.guard.ts
+++ b/src/app/pages/co-browse/co-browse-page.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+
+/**
+ * The user is logged in with the co-browse identity provider
+ */
+
+export async function coBrowsePageGuard(route: ActivatedRouteSnapshot) {
+  const router = inject(Router);
+
+  if (SSR) {
+    return router.parseUrl('/loading');
+  }
+  return router.createUrlTree(['/login'], { queryParams: route.queryParams });
+}

--- a/src/app/pages/co-browse/co-browse-page.module.ts
+++ b/src/app/pages/co-browse/co-browse-page.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { coBrowsePageGuard } from './co-browse-page.guard';
+
+const coBrowsePageRoutes: Routes = [
+  {
+    path: '',
+    children: [],
+    canActivate: [coBrowsePageGuard],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(coBrowsePageRoutes)],
+})
+export class CoBrowsePageModule {}

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -819,6 +819,7 @@
   "checkout.widget.shipping-address.heading": "Lieferadresse",
   "checkout.widget.shipping_method.desired_delivery_date": "Wunschlieferdatum",
   "checkout.widget.shipping_method.heading": "Versandart",
+  "cobrowse.error.missing.parameter": "Fehler beim Starten des Co-Browsens. Benötigter Startparameter fehlt.",
   "common.button.navbarCollapsed.text": "Navigation umschalten",
   "common.button.spinning.label": "Wird hinzugefügt...",
   "common.date_format.letters.M": "m",

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -819,7 +819,7 @@
   "checkout.widget.shipping-address.heading": "Lieferadresse",
   "checkout.widget.shipping_method.desired_delivery_date": "Wunschlieferdatum",
   "checkout.widget.shipping_method.heading": "Versandart",
-  "cobrowse.error.missing.parameter": "Fehler beim Starten des Co-Browsens. Benötigter Startparameter fehlt.",
+  "cobrowse.error.missing.parameter": "Fehler beim Starten des Co-Browsens. Der benötigte Startparameter fehlt.",
   "common.button.navbarCollapsed.text": "Navigation umschalten",
   "common.button.spinning.label": "Wird hinzugefügt...",
   "common.date_format.letters.M": "m",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -819,7 +819,7 @@
   "checkout.widget.shipping-address.heading": "Shipping Address",
   "checkout.widget.shipping_method.desired_delivery_date": "Desired Delivery Date",
   "checkout.widget.shipping_method.heading": "Shipping Method",
-  "cobrowse.error.missing.parameter": "Error starting co-browsing. Required start parameter is missing.",
+  "cobrowse.error.missing.parameter": "Error starting co-browsing. The required start parameter is missing.",
   "common.button.navbarCollapsed.text": "Toggle navigation",
   "common.button.spinning.label": "Adding...",
   "common.date_format.letters.M": "m",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -819,6 +819,7 @@
   "checkout.widget.shipping-address.heading": "Shipping Address",
   "checkout.widget.shipping_method.desired_delivery_date": "Desired Delivery Date",
   "checkout.widget.shipping_method.heading": "Shipping Method",
+  "cobrowse.error.missing.parameter": "Error starting co-browsing. Required start parameter is missing.",
   "common.button.navbarCollapsed.text": "Toggle navigation",
   "common.button.spinning.label": "Adding...",
   "common.date_format.letters.M": "m",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -819,7 +819,7 @@
   "checkout.widget.shipping-address.heading": "Adresse de livraison",
   "checkout.widget.shipping_method.desired_delivery_date": "Date de livraison souhaitée",
   "checkout.widget.shipping_method.heading": "Mode d’expédition",
-  "cobrowse.error.missing.parameter": "ToDo: Erreur",
+  "cobrowse.error.missing.parameter": "Échec de démarrer la co-navigation. Le paramètre de départ est requis.",
   "common.button.navbarCollapsed.text": "Basculer la navigation",
   "common.button.spinning.label": "En cours d’ajout...",
   "common.date_format.letters.M": "m",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -819,6 +819,7 @@
   "checkout.widget.shipping-address.heading": "Adresse de livraison",
   "checkout.widget.shipping_method.desired_delivery_date": "Date de livraison souhaitée",
   "checkout.widget.shipping_method.heading": "Mode d’expédition",
+  "cobrowse.error.missing.parameter": "ToDo: Erreur",
   "common.button.navbarCollapsed.text": "Basculer la navigation",
   "common.button.spinning.label": "En cours d’ajout...",
   "common.date_format.letters.M": "m",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the New Behavior?
Co-browsing feature enables an administrative Intershop Contact Center user to be able to login in into the pwa as a user with no need to have the credentials of that user giving him/her (the admin) the ability to see how the site looks from a real user perspective.
A new route 'cobrowse' has been introduced that has to be called together with a parameter 'token' to support this feature.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Pending Issues
- [ ] ICM release 11.8 is needed or ICM 7.10 without SSO
- [ ] the co-browse identity provider should always be active when the user enters the cobrowse route together with a valid token as query parameter. Currently, this works only properly with a multisite configuration

## Other Information


[AB#88392](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88392)