### PR TITLE
fix: repair partial build after npm upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY templates/webpack/* /workspace/templates/webpack/
 ARG testing=false
 ENV TESTING=${testing}
 ARG activeThemes=
-RUN if [ ! -z "${activeThemes}" ]; then npm config set active-themes="${activeThemes}"; fi
+RUN if [ ! -z "${activeThemes}" ]; then npm pkg set config.active-themes="${activeThemes}"; fi
 RUN npm run build:multi client -- --deploy-url=DEPLOY_URL_PLACEHOLDER
 COPY tsconfig.server.json server.ts /workspace/
 RUN npm run build:multi server


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Build-related changes

## What Is the Current Behavior?

After npm upgrade, the command `npm config set active-themes` does no longer work for a partial build in the Dockerfile.
Test by uncommenting the build args of the SSR image `activeThemes: b2c` in the `docker-compose.yml`:
https://github.com/intershop/intershop-pwa/blob/2c79d9704ab8644d5c57c7b1370cd2ea2a718b41/docker-compose.yml#L6-L12

## What Is the New Behavior?

Using `npm pkg set config.active-themes` to modify the package.json in the Dockerfile when building.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#88442](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88442)