### PR TITLE
feat: fallback to loading when encountering proxy timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,9 @@ services:
     environment:
       UPSTREAM_PWA: 'http://pwa:4200'
       NGINX_ENTRYPOINT_QUIET_LOGS: ANYVALUE
-      CACHE: 0
+      # CACHE: 0
+      CACHE_DURATION_NGINX_OK: 20s
+      CACHE_DURATION_NGINX_NF: 1d
       # SSL: 1
       # SSR: 0
       # DEBUG: 1

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -1,5 +1,36 @@
 {{ $UPSTREAM_PWA := getenv "UPSTREAM_PWA" }}
 
+{{ define "LOCATION_TEMPLATE_FOR_LOADING" }}
+        {{- $channel := .channel }}
+        {{- $application := "" }}{{ if (has . "application") }}{{ $application = join ( slice ";application" .application ) "=" }}{{ end }}
+        {{- $identityProvider := "" }}{{ if (has . "identityProvider") }}{{ $identityProvider = .identityProvider }}{{ end }}
+        {{- $lang := "default" }}{{ if (has . "lang") }}{{ $lang = .lang }}{{ end }}
+        {{- $currency := "" }}{{ if (has . "currency") }}{{ $currency = .currency }}{{ end }}
+        {{- $features := "" }}{{ if (has . "features") }}{{ $features = join ( slice ";features" .features ) "=" }}{{ end }}
+        {{- $addFeatures := "" }}{{ if (has . "addFeatures") }}{{ $addFeatures = join ( slice ";addFeatures" .addFeatures ) "=" }}{{ end }}
+        {{- $theme := "" }}{{ if (has . "theme") }}{{ $theme = join ( slice ";theme" .theme ) "=" }}{{ end }}
+        {{- $baseHref := "/" }}{{ if (has . "baseHref") }}{{ $baseHref = .baseHref }}{{ end }}
+        {{- $icmScheme := "" }}{{ if (has . "icmScheme") }}{{ $icmScheme = join ( slice "icmScheme" .icmScheme ) "=" }}{{ end }}
+        {{- $icmPort := "" }}{{ if (has . "icmPort") }}{{ $icmPort = join ( slice "icmPort" .icmPort ) "=" }}{{ end }}
+        {{- $icmHost := "default" }}{{ if (has . "icmHost") }}{{ $icmHost = .icmHost }}{{ end }}
+
+        rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang={{ $lang }}';
+        rewrite '^(?!.*;currency=.*)(.*)$' '$1;currency={{ $currency }}';
+
+      {{ if $identityProvider }}
+        rewrite '^(?!.*;identityProvider=.*)(.*)$' '$1;identityProvider={{ $identityProvider }}';
+      {{ end }}
+
+        set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $features }}{{ $addFeatures }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
+
+        rewrite '^(.*)$' '$1$default_rewrite_params' break;
+
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 200 1h;
+
+        proxy_pass {{ getenv "UPSTREAM_PWA" }};
+{{- end }}
+
 {{ define "LOCATION_TEMPLATE" }}
         {{- $channel := .channel }}
         {{- $application := "" }}{{ if (has . "application") }}{{ $application = join ( slice ";application" .application ) "=" }}{{ end }}
@@ -54,6 +85,9 @@
         set $default_rewrite_params ';icmHost={{ $icmHost }}{{ $icmScheme }}{{ $icmPort }};channel={{ $channel }}{{ $application }}{{ $features }}{{ $addFeatures }}{{ $theme }};baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }};device=$ua_device';
 
         rewrite '^(.*)$' '$1$default_rewrite_params' break;
+
+        proxy_read_timeout 3s;
+        error_page 504 =200 '{{ $baseHref }}/loading;baseHref={{ $baseHref | strings.ReplaceAll "/" "%2F" }}';
 
         proxy_pass {{ getenv "UPSTREAM_PWA" }};
         proxy_buffer_size 128k;
@@ -170,6 +204,9 @@ server {
     location / {
         {{- tmpl.Exec "LOCATION_TEMPLATE" $mapping }}
     }
+    location /loading {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_LOADING" $mapping }}
+    }
     location ^~ /sitemap_ {
         {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $mapping }}
     }
@@ -177,6 +214,9 @@ server {
     {{ range $mapping }}
     location {{ .baseHref }} {
         {{- tmpl.Exec "LOCATION_TEMPLATE" . }}
+    }
+    location {{ .baseHref }}/loading {
+        {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_LOADING" . }}
     }
     location ^~ {{ .baseHref }}{{if not ( .baseHref | strings.HasSuffix "/")}}/{{end}}sitemap_ {
         {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" . }}

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -2,7 +2,7 @@ import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { flatten, range } from 'lodash-es';
 import { Observable, from, identity, of, throwError } from 'rxjs';
-import { defaultIfEmpty, map, mergeMap, switchMap, toArray, withLatestFrom } from 'rxjs/operators';
+import { defaultIfEmpty, delay, map, mergeMap, switchMap, toArray, withLatestFrom } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
@@ -46,9 +46,10 @@ export class ProductsService {
 
     const params = new HttpParams().set('allImages', true).set('extended', true);
 
-    return this.apiService
-      .get<ProductData>(`products/${sku}`, { sendSPGID: true, params })
-      .pipe(map(element => this.productMapper.fromData(element)));
+    return this.apiService.get<ProductData>(`products/${sku}`, { sendSPGID: true, params }).pipe(
+      delay(5000),
+      map(element => this.productMapper.fromData(element))
+    );
   }
 
   /**


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

High loads on SSR (as well as improper configuration or technical debt) can exhaust all rendering processes and users get long loading times or timeouts.

## What Is the New Behavior?

If a timeout is encountered, the loading page will be sent to the user so that Angular can boot up on the client. This does not give the user a full page response, but he can use the webshop.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## TODO/Discussion

- [ ] make timeout configurable
- [ ] reduce code duplication
- [ ] assure the loading page is always available and not unavailable to high load as well
- [ ] research if it is possible to cache the timeout-ed response after it is finally rendered (with built-in methods, it is discarded), or if the SSR rendering can be cancelled

## Other Information

[AB#88480](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88480)