### PR TITLE
chore: reactivate curly rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -179,6 +179,7 @@
             "max": 10
           }
         ],
+        "curly": "warn",
         "dot-notation": "off", // disabled in favor of @typescript-eslint/dot-notation
         "eqeqeq": ["error", "always"],
         "etc/no-commented-out-code": "warn",

--- a/e2e/cypress-ci-e2e.ts
+++ b/e2e/cypress-ci-e2e.ts
@@ -71,10 +71,18 @@ const run = (
   config = { ...config, env: { ...config.env, numRuns: num } };
 
   // activate video only for last run
-  if (num >= MAX_NUM_RUNS) config.config.video = true;
-  if (num > 1) config.config.trashAssetsBeforeRuns = false;
-  if (spec) config.spec = spec;
-  if (retryGroup) config.group = retryGroup;
+  if (num >= MAX_NUM_RUNS) {
+    config.config.video = true;
+  }
+  if (num > 1) {
+    config.config.trashAssetsBeforeRuns = false;
+  }
+  if (spec) {
+    config.spec = spec;
+  }
+  if (retryGroup) {
+    config.group = retryGroup;
+  }
 
   console.log(config);
 

--- a/eslint-rules/src/rules/sort-testbed-metadata-arrays.ts
+++ b/eslint-rules/src/rules/sort-testbed-metadata-arrays.ts
@@ -33,7 +33,9 @@ const sortTestbedMetadataArraysRule: TSESLint.RuleModule<keyof typeof messages> 
           .map((current, index, list) => [current, list[index + 1]])
           .find(([current, next]) => next && getText(current).localeCompare(getText(next)) === 1);
 
-        if (!unorderedNodes) return;
+        if (!unorderedNodes) {
+          return;
+        }
 
         const [unorderedNode, nextNode] = unorderedNodes;
         context.report({

--- a/schematics/src/utils/lint-fix.ts
+++ b/schematics/src/utils/lint-fix.ts
@@ -33,7 +33,9 @@ export function applyLintFix(): Rule {
       .map(action => action.path.substring(1))
       .filter(path => path.endsWith('.ts') || path.endsWith('.html'))
       .forEach(file => {
-        if (!lintFiles.includes(file)) lintFiles.push(file);
+        if (!lintFiles.includes(file)) {
+          lintFiles.push(file);
+        }
       });
 
     registerLintAtEnd(findProjectRoot());

--- a/scripts/find-dead-code.ts
+++ b/scripts/find-dead-code.ts
@@ -146,13 +146,17 @@ function checkNode(node: Node) {
       .getLeadingCommentRanges()
       .some(c => c.getText().includes('not-dead-code'))
   ) {
-    if (process.env.DEBUG) console.warn('ignoring (1)', node.getText());
+    if (process.env.DEBUG) {
+      console.warn('ignoring (1)', node.getText());
+    }
     return;
   }
 
   const ignoreComment = node.getPreviousSiblingIfKind(SyntaxKind.SingleLineCommentTrivia);
   if (ignoreComment?.getText().includes('not-dead-code')) {
-    if (process.env.DEBUG) console.warn('ignoring (2)', node.getText());
+    if (process.env.DEBUG) {
+      console.warn('ignoring (2)', node.getText());
+    }
     return;
   }
 


### PR DESCRIPTION
## PR Type

[x] Code style update (formatting, local variables)

## What Is the Current Behavior?

I was typing an if statement as a one-liner and after hitting save, I expected that braces are added and my one-liner is broken to the new line. I remember this to be default behavior before.

## What Is the New Behavior?

Reactivated eslint rule `curly`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#88491](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88491)