### PR TITLE
fix: avoid pgid errors when an apiToken is available

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -35,6 +35,8 @@ To keep the current behavior in an existing project, either adapt the `0` defaul
 
 The [Brotli NGINX module](https://github.com/google/ngx_brotli) is used instead of gzip for compression on the NGINX server now, see [NGINX Optimizations](./optimizations.md#nginx-optimizations).
 
+The methods `hasUserApiTokenCookie()` and `parseCookie()` have been moved from the apiToken.service to the cookies.service, the `parseCookie()` method has been renamed to `getApiTokenCookie()`.
+
 ## From 4.2 to 5.0
 
 Starting with the Intershop PWA 5.0 we develop and test against an Intershop Commerce Management 11 server.

--- a/e2e/cypress/e2e/pages/shopping/family.page.ts
+++ b/e2e/cypress/e2e/pages/shopping/family.page.ts
@@ -15,6 +15,7 @@ export class FamilyPage {
   readonly filterNavigation = new FilterNavigationModule();
 
   static navigateTo(categoryUniqueId: string, page?: number) {
+    cy.clearCookie('apiToken');
     cy.visit(`/ctg${categoryUniqueId}${page ? `?page=${page}` : ''}`);
   }
 }

--- a/src/app/core/services/api/api.service.spec.ts
+++ b/src/app/core/services/api/api.service.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { Action, Store } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { noop } from 'rxjs';
-import { anything, capture, spy, verify } from 'ts-mockito';
+import { anything, capture, instance, mock, spy, verify } from 'ts-mockito';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { Link } from 'ish-core/models/link/link.model';
@@ -19,6 +19,7 @@ import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { serverError } from 'ish-core/store/core/error';
 import { isServerConfigurationLoaded, loadServerConfigSuccess } from 'ish-core/store/core/server-config';
 import { getPGID } from 'ish-core/store/customer/user';
+import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 
 import { ApiService, unpackEnvelope } from './api.service';
 
@@ -37,6 +38,7 @@ describe('Api Service', () => {
         // https://angular.io/guide/http#testing-http-requests
         imports: [HttpClientTestingModule],
         providers: [
+          { provide: CookiesService, useFactory: () => instance(mock(CookiesService)) },
           provideMockStore({
             selectors: [
               { selector: isServerConfigurationLoaded, value: true },
@@ -197,6 +199,7 @@ describe('Api Service', () => {
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
         providers: [
+          { provide: CookiesService, useFactory: () => instance(mock(CookiesService)) },
           provideMockStore({
             selectors: [
               { selector: isServerConfigurationLoaded, value: true },
@@ -402,6 +405,7 @@ describe('Api Service', () => {
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
         providers: [
+          { provide: CookiesService, useFactory: () => instance(mock(CookiesService)) },
           provideMockStore({
             selectors: [
               { selector: isServerConfigurationLoaded, value: true },
@@ -557,6 +561,7 @@ describe('Api Service', () => {
       TestBed.configureTestingModule({
         // https://angular.io/guide/http#testing-http-requests
         imports: [CoreStoreModule.forTesting(['configuration', 'serverConfig']), HttpClientTestingModule],
+        providers: [{ provide: CookiesService, useFactory: () => instance(mock(CookiesService)) }],
       });
 
       apiService = TestBed.inject(ApiService);
@@ -680,6 +685,7 @@ describe('Api Service', () => {
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
         providers: [
+          { provide: CookiesService, useFactory: () => instance(mock(CookiesService)) },
           provideMockStore({
             selectors: [
               { selector: isServerConfigurationLoaded, value: true },

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -12,7 +12,9 @@ import {
   identity,
   iif,
   of,
+  race,
   throwError,
+  timer,
 } from 'rxjs';
 import { catchError, concatMap, filter, first, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
@@ -28,6 +30,8 @@ import { communicationTimeoutError, serverError } from 'ish-core/store/core/erro
 import { isServerConfigurationLoaded } from 'ish-core/store/core/server-config';
 import { getBasketIdOrCurrent } from 'ish-core/store/customer/basket';
 import { getLoggedInCustomer, getLoggedInUser, getPGID } from 'ish-core/store/customer/user';
+import { ApiTokenCookie } from 'ish-core/utils/api-token/api-token.service';
+import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 import { whenTruthy } from 'ish-core/utils/operators';
 import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
@@ -69,7 +73,7 @@ export class ApiService {
   static TOKEN_HEADER_KEY = 'authentication-token';
   static AUTHORIZATION_HEADER_KEY = 'Authorization';
 
-  constructor(private httpClient: HttpClient, private store: Store) {}
+  constructor(private httpClient: HttpClient, private store: Store, private cookiesService: CookiesService) {}
 
   /**
 -  * sets the request header for the appropriate captcha service
@@ -132,6 +136,10 @@ export class ApiService {
     if (path.startsWith('http://') || path.startsWith('https://')) {
       return of(path);
     }
+
+    // get current apiToken cookie information
+    const apiToken = this.getApiTokenFromCookie();
+
     return combineLatest([
       this.store.pipe(select(getRestEndpoint), whenTruthy()),
       this.getLocale$(options),
@@ -139,8 +147,15 @@ export class ApiService {
       of('/'),
       of(path.includes('/') ? path.split('/')[0] : path),
       // pgid
-      this.store.pipe(
-        select(getPGID),
+      race(
+        this.store.pipe(
+          select(getPGID),
+          // when an apiToken is available, then the pgid has to be set when the options are enabled
+          apiToken && (options?.sendPGID || options?.sendSPGID) ? whenTruthy() : identity
+        ),
+        // on timeout current pgid will be selected
+        timer(3000).pipe(switchMap(() => this.store.pipe(select(getPGID))))
+      ).pipe(
         map(pgid => (options?.sendPGID && pgid ? `;pgid=${pgid}` : options?.sendSPGID && pgid ? `;spgid=${pgid}` : ''))
       ),
       // remaining path
@@ -199,6 +214,22 @@ export class ApiService {
         )
       ),
     ]);
+  }
+
+  /**
+   * retrieve an apiToken when it is assigned to an authenticated user
+   */
+  private getApiTokenFromCookie(): string {
+    const cookieContent = this.cookiesService.get('apiToken');
+    if (cookieContent) {
+      try {
+        const apiTokenCookie: ApiTokenCookie = JSON.parse(cookieContent);
+        return !apiTokenCookie?.isAnonymous ? apiTokenCookie.apiToken : undefined;
+      } catch (err) {
+        // ignore
+      }
+    }
+    return;
   }
 
   /**

--- a/src/app/core/store/customer/user/user.effects.spec.ts
+++ b/src/app/core/store/customer/user/user.effects.spec.ts
@@ -20,7 +20,7 @@ import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { loadServerConfigSuccess } from 'ish-core/store/core/server-config';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
-import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { routerTestNavigatedAction } from 'ish-core/utils/dev/routing';
 
@@ -73,7 +73,7 @@ describe('User Effects', () => {
   let store: Store;
   let userServiceMock: UserService;
   let paymentServiceMock: PaymentService;
-  let apiTokenServiceMock: ApiTokenService;
+  let cookiesServiceMock: CookiesService;
   let oAuthServiceMock: OAuthService;
   let tokenServiceMock: TokenService;
   let router: Router;
@@ -103,7 +103,7 @@ describe('User Effects', () => {
   beforeEach(() => {
     userServiceMock = mock(UserService);
     paymentServiceMock = mock(PaymentService);
-    apiTokenServiceMock = mock(ApiTokenService);
+    cookiesServiceMock = mock(CookiesService);
     oAuthServiceMock = mock(OAuthService);
     tokenServiceMock = mock(TokenService);
 
@@ -122,7 +122,7 @@ describe('User Effects', () => {
     when(paymentServiceMock.getUserPaymentMethods(anything())).thenReturn(of([]));
     when(paymentServiceMock.createUserPayment(anything(), anything())).thenReturn(of({ id: 'paymentInstrumentId' }));
     when(paymentServiceMock.deleteUserPaymentInstrument(anyString(), anyString())).thenReturn(of(undefined));
-    when(apiTokenServiceMock.hasUserApiTokenCookie()).thenReturn(false);
+    when(cookiesServiceMock.hasUserApiTokenCookie()).thenReturn(false);
     when(oAuthServiceMock.events).thenReturn(of());
 
     TestBed.configureTestingModule({
@@ -132,7 +132,7 @@ describe('User Effects', () => {
         RouterTestingModule.withRoutes([{ path: '**', children: [] }]),
       ],
       providers: [
-        { provide: ApiTokenService, useFactory: () => instance(apiTokenServiceMock) },
+        { provide: CookiesService, useFactory: () => instance(cookiesServiceMock) },
         { provide: PaymentService, useFactory: () => instance(paymentServiceMock) },
         { provide: TokenService, useFactory: () => instance(tokenServiceMock) },
         { provide: UserService, useFactory: () => instance(userServiceMock) },

--- a/src/app/core/store/customer/user/user.effects.ts
+++ b/src/app/core/store/customer/user/user.effects.ts
@@ -13,7 +13,7 @@ import { UserService } from 'ish-core/services/user/user.service';
 import { displaySuccessMessage } from 'ish-core/store/core/messages';
 import { selectQueryParam, selectUrl } from 'ish-core/store/core/router';
 import { getServerConfigParameter } from 'ish-core/store/core/server-config';
-import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
+import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
 import { getPGID, personalizationStatusDetermined } from '.';
@@ -72,8 +72,8 @@ export class UserEffects {
     private userService: UserService,
     private paymentService: PaymentService,
     private router: Router,
-    private apiTokenService: ApiTokenService,
-    private tokenService: TokenService
+    private tokenService: TokenService,
+    private cookiesService: CookiesService
   ) {}
 
   loginUser$ = createEffect(() =>
@@ -280,7 +280,7 @@ export class UserEffects {
   determinePersonalizationStatus$ = createEffect(() =>
     this.store.pipe(
       select(getPGID),
-      map(pgid => !this.apiTokenService.hasUserApiTokenCookie() || pgid),
+      map(pgid => !this.cookiesService.hasUserApiTokenCookie() || pgid),
       whenTruthy(),
       delay(100),
       map(() => personalizationStatusDetermined())

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -4,6 +4,7 @@ import { Inject, Injectable, TransferState } from '@angular/core';
 import { COOKIE_CONSENT_OPTIONS } from 'ish-core/configurations/injection-keys';
 import { COOKIE_CONSENT_VERSION } from 'ish-core/configurations/state-keys';
 import { CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
+import { ApiTokenCookie } from 'ish-core/utils/api-token/api-token.service';
 import { browserNameVersion } from 'ish-core/utils/browser-detection';
 import { InjectSingle } from 'ish-core/utils/injection';
 
@@ -78,6 +79,22 @@ export class CookiesService {
     } else {
       return false;
     }
+  }
+
+  getApiTokenCookie(): ApiTokenCookie {
+    if (!SSR) {
+      try {
+        return JSON.parse(this.get('apiToken') || 'null');
+      } catch (err) {
+        // ignore
+      }
+    }
+    return;
+  }
+
+  hasUserApiTokenCookie() {
+    const apiTokenCookie = this.getApiTokenCookie();
+    return apiTokenCookie?.type === 'user' && !apiTokenCookie?.isAnonymous;
   }
 
   /**


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Some ICM REST requests (e.g. /cms/include) will fail, when an apiToken is send without pgid information.

Issue Number: Closes #

## What Is the New Behavior?

When an apiToken is available, all REST request will wait until pgid is available in case the option to send the pgid/ spgid is enabled.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

Steps to Repeat:

(1) Run the PWA with the `https://pwa-ish-demo.test.intershop.com` as configured ICM.
(1) Login with a user
(2) Go to the /home page
(3) Refresh the page
(4) Check within Network tab, that `/cms/includes/include.homepage.content.pagelet2-Include REST` request fails with following error message: `Bad Request (Matrix parameter "pgid" is required if auth token is present)`


[AB#88541](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88541)