### PR TITLE
fix: remove query parameter "page" for product detail page routes

### DIFF
--- a/src/app/shared/components/product/product-image/product-image.component.html
+++ b/src/app/shared/components/product/product-image/product-image.component.html
@@ -4,6 +4,7 @@
     data-testing-id="product-image-link"
     [routerLink]="linkTarget || (productURL$ | async)"
     [queryParamsHandling]="computedQueryParamsHandling"
+    [queryParams]="{ page: null }"
     ><ng-container *ngTemplateOutlet="image"></ng-container>
   </a>
 </div>

--- a/src/app/shared/components/product/product-name/product-name.component.html
+++ b/src/app/shared/components/product/product-name/product-name.component.html
@@ -6,6 +6,7 @@
         data-testing-id="product-name-link"
         [routerLink]="productURL$ | async"
         [queryParamsHandling]="computedQueryParamsHandling"
+        [queryParams]="{ page: null }"
         >{{ alternate || productName }}</a
       >
     </ng-container>


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When "paging" is enabled instead of "endless-scrolling" on product list pages, the query parameter "page" is part of the URL to determine the current page. If a product detail page is opened from a paged product listing page, this query parameter "page" is part of the product detail page URL. If a master product detail page is opened, the parameter "page" is also used for the paging in the master product detail page and the paged page from the product listing page is opened in the master product detail page (e.g. product listing page "3" opens page "3" on the master product detail page).

## What Is the New Behavior?
The query parameter "page" is removed from the link to the product detail page.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#88618](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88618)
#88428
