### PR TITLE
fix: replace translate.instant

### DIFF
--- a/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.html
+++ b/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.html
@@ -58,6 +58,9 @@
       name="SortingAttribute"
       (change)="changeSortBy($event.target)"
     >
+      <option value="default" [selected]="sortBy === 'default'">
+        {{ 'product.items.sorting.default.label' | translate }}
+      </option>
       <option *ngFor="let o of sortOptions" [value]="o.value" [selected]="o.value === sortBy">{{ o.label }}</option>
     </select>
   </div>

--- a/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.spec.ts
+++ b/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
 
 import { ProductListToolbarComponent } from './product-list-toolbar.component';
@@ -14,7 +13,7 @@ describe('Product List Toolbar Component', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [MockComponent(FaIconComponent), ProductListToolbarComponent],
-      imports: [RouterTestingModule, TranslateModule.forRoot()],
+      imports: [RouterTestingModule],
     }).compileComponents();
   });
 

--- a/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.ts
+++ b/src/app/shared/components/product/product-list-toolbar/product-list-toolbar.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 
 import { SortableAttributesType } from 'ish-core/models/product-listing/product-listing.model';
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
@@ -23,7 +22,7 @@ export class ProductListToolbarComponent implements OnChanges {
 
   sortOptions: SelectOption[] = [];
 
-  constructor(private router: Router, private activatedRoute: ActivatedRoute, private translate: TranslateService) {}
+  constructor(private router: Router, private activatedRoute: ActivatedRoute) {}
 
   ngOnChanges() {
     this.sortOptions = this.mapSortableAttributesToSelectOptions(this.sortableAttributes);
@@ -41,12 +40,10 @@ export class ProductListToolbarComponent implements OnChanges {
   }
 
   private mapSortableAttributesToSelectOptions(sortableAttributes: SortableAttributesType[] = []): SelectOption[] {
-    const options = sortableAttributes
+    return sortableAttributes
       .filter(x => !!x)
       .map(sk => ({ value: sk.name, label: sk.displayName || sk.name }))
       .sort((a, b) => a.label.localeCompare(b.label));
-    options.unshift({ value: 'default', label: this.translate.instant('product.items.sorting.default.label') });
-    return options;
   }
 
   get listView() {


### PR DESCRIPTION
## PR Type

[x] Refactoring

## What Is the New Behavior?

Replaces usage of [`TranslateService.instant`](https://github.com/ngx-translate/core#methods).

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#88620](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88620)