### PR TITLE
feat: activate identity provider on specific url path

### DIFF
--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -92,8 +92,45 @@ When the cookie vanishes, the PWA emits a new value for the [`cookieVanishes$` s
 The identity provider implementation defines how the application should behave in such a case.
 With the ICM identity provider, for example, the user is then automatically logged out and routed to the `/login` page.
 
+## Activate Identity Provider on specific paths
+
+It is possible to activate the identity provider for specific pwa url paths, e.g. login automatically a punchout user when the PWA enters a `/punchout` route.
+The behavior can be configured primarily by adding `activeOnPath` property for the IDENTITY_PROVIDER_IMPLEMENTOR.
+
+```typescript
+  providers: [
+    {
+      provide: IDENTITY_PROVIDER_IMPLEMENTOR,
+      multi: true,
+      useValue: {
+        type: 'PUNCHOUT',
+        implementor: PunchoutIdentityProvider,
+        feature: 'punchout',
+        activeOnPath: 'punchout', // without slash at beginning
+      },
+    },
+  ],
+```
+
+This configuration would activate the specific identity provider, when the PWA initially routes to a specific url.
+
+Another possibility of the identity provider activation could be the usage of the `OVERRIDE_IDENTITY_PROVIDERS` environment variable within the nginx deployment.
+
+```yaml
+nginx:
+  environment:
+    OVERRIDE_IDENTITY_PROVIDERS: |
+      .+:
+        - path: /punchout
+          type: Punchout
+```
+
+Like the `MULTI_CHANNEL` configuration the feature will add the `identityProvider` parameter to the generated PWA url, when the nginx retrieves a request with a certain domain and path.
+More details can be seen in [Further References](#further-references) below.
+
 ## Further References
 
 - [Guide - ICM Identity Provider](../guides/authentication_icm.md)
 - [Guide - Punchout Identity Provider](../guides/authentication_punchout.md)
 - [Guide - Single Sign-On (SSO) Identity Provider](../guides/authentication_sso.md)
+- [Guide - NGINX Startup](../guides/nginx-startup.md)

--- a/docs/guides/authentication_punchout.md
+++ b/docs/guides/authentication_punchout.md
@@ -42,13 +42,6 @@ pwa:
     IDENTITY_PROVIDERS: |
       Punchout:
         type: PUNCHOUT
-
-nginx:
-  environment:
-    OVERRIDE_IDENTITY_PROVIDERS: |
-      .+:
-        - path: /punchout
-          type: Punchout
 ```
 
 For the current PWA Helm Chart that is also used in the PWA Flux deployments the same punchout configuration would look like this.
@@ -107,6 +100,9 @@ cache:
         channel: default
         theme: b2c
 ```
+
+With the PWA 5.0 release there is another possibility to configure the PUNCHOUT authentication that works in development and production environments: The PUNCHOUT identity provider is activated when the user enters a certain route ('/punchout').
+Find more information in the [Authentication Concept](../concepts/authentication.md).
 
 ## Login
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -17,6 +17,11 @@ We renamed the input parameter 'id' to 'productListingId' for the product listin
 The api-token.service has been refactored and the class variables `apiToken$` and `cookieVanishes$` have got the private modifier.
 Use the public getter/setter methods to access these variables outside the class.
 
+A new way to activate an identity provider on a specific route is introduced (see #1484).
+The property `activeOnPath` is added as an additional configuration for the `IDENTITY_PROVIDER_IMPLEMENTOR` [injection token](../../src/app/extensions/punchout/identity-provider/punchout-identity-provider.module.ts).
+The punchout identity provider is now configured per default, that the `PunchoutIdentityProvider` is activated, when the PWA is initially rendered with the `/punchout` path.
+Please remove the `activeOnPath` property to use the old behavior.
+
 ## From 4.1 to 4.2
 
 The basket attribute 'orderReferenceId' is now saved as native attribute 'externalOrderReference' at the basket, but it still exists at the basket and can be displayed further on if needed.

--- a/src/app/core/guards/identity-provider-invite.guard.ts
+++ b/src/app/core/guards/identity-provider-invite.guard.ts
@@ -1,9 +1,9 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { first, isObservable, of, switchMap } from 'rxjs';
+import { first, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { isPromise } from 'ish-core/utils/functions';
+import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderInviteGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
@@ -15,7 +15,7 @@ export function identityProviderInviteGuard(route: ActivatedRouteSnapshot, state
     switchMap(() => {
       if (identityProviderFactory.getInstance().triggerInvite) {
         const inviteReturn$ = identityProviderFactory.getInstance().triggerInvite(route, state);
-        return isObservable(inviteReturn$) || isPromise(inviteReturn$) ? inviteReturn$ : of(inviteReturn$);
+        return getTriggerReturnType$(inviteReturn$);
       } else {
         return of(false);
       }

--- a/src/app/core/guards/identity-provider-invite.guard.ts
+++ b/src/app/core/guards/identity-provider-invite.guard.ts
@@ -3,13 +3,13 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { first, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
+import { getTriggerReturnType$ } from 'ish-core/utils/functions';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderInviteGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.initialized$.pipe(
+  return identityProviderFactory.getInitialized$().pipe(
     whenTruthy(),
     first(),
     switchMap(() => {

--- a/src/app/core/guards/identity-provider-invite.guard.ts
+++ b/src/app/core/guards/identity-provider-invite.guard.ts
@@ -1,12 +1,24 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { first, isObservable, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+import { isPromise } from 'ish-core/utils/functions';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderInviteGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.getInstance().triggerInvite
-    ? identityProviderFactory.getInstance().triggerInvite(route, state)
-    : false;
+  return identityProviderFactory.initialized$.pipe(
+    whenTruthy(),
+    first(),
+    switchMap(() => {
+      if (identityProviderFactory.getInstance().triggerInvite) {
+        const inviteReturn$ = identityProviderFactory.getInstance().triggerInvite(route, state);
+        return isObservable(inviteReturn$) || isPromise(inviteReturn$) ? inviteReturn$ : of(inviteReturn$);
+      } else {
+        return of(false);
+      }
+    })
+  );
 }

--- a/src/app/core/guards/identity-provider-login.guard.ts
+++ b/src/app/core/guards/identity-provider-login.guard.ts
@@ -1,10 +1,20 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { first, isObservable, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+import { isPromise } from 'ish-core/utils/functions';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderLoginGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.getInstance().triggerLogin(route, state);
+  return identityProviderFactory.initialized$.pipe(
+    whenTruthy(),
+    first(),
+    switchMap(() => {
+      const loginReturn$ = identityProviderFactory.getInstance().triggerLogin(route, state);
+      return isObservable(loginReturn$) || isPromise(loginReturn$) ? loginReturn$ : of(loginReturn$);
+    })
+  );
 }

--- a/src/app/core/guards/identity-provider-login.guard.ts
+++ b/src/app/core/guards/identity-provider-login.guard.ts
@@ -3,13 +3,13 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { first, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
+import { getTriggerReturnType$ } from 'ish-core/utils/functions';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderLoginGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.initialized$.pipe(
+  return identityProviderFactory.getInitialized$().pipe(
     whenTruthy(),
     first(),
     switchMap(() => {

--- a/src/app/core/guards/identity-provider-login.guard.ts
+++ b/src/app/core/guards/identity-provider-login.guard.ts
@@ -1,9 +1,9 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { first, isObservable, of, switchMap } from 'rxjs';
+import { first, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { isPromise } from 'ish-core/utils/functions';
+import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderLoginGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
@@ -14,7 +14,7 @@ export function identityProviderLoginGuard(route: ActivatedRouteSnapshot, state:
     first(),
     switchMap(() => {
       const loginReturn$ = identityProviderFactory.getInstance().triggerLogin(route, state);
-      return isObservable(loginReturn$) || isPromise(loginReturn$) ? loginReturn$ : of(loginReturn$);
+      return getTriggerReturnType$(loginReturn$);
     })
   );
 }

--- a/src/app/core/guards/identity-provider-logout.guard.ts
+++ b/src/app/core/guards/identity-provider-logout.guard.ts
@@ -1,8 +1,8 @@
 import { inject } from '@angular/core';
-import { first, isObservable, of, switchMap } from 'rxjs';
+import { first, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { isPromise } from 'ish-core/utils/functions';
+import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderLogoutGuard() {
@@ -13,7 +13,7 @@ export function identityProviderLogoutGuard() {
     first(),
     switchMap(() => {
       const logoutReturn$ = identityProviderFactory.getInstance().triggerLogout();
-      return isObservable(logoutReturn$) || isPromise(logoutReturn$) ? logoutReturn$ : of(logoutReturn$);
+      return getTriggerReturnType$(logoutReturn$);
     })
   );
 }

--- a/src/app/core/guards/identity-provider-logout.guard.ts
+++ b/src/app/core/guards/identity-provider-logout.guard.ts
@@ -2,13 +2,13 @@ import { inject } from '@angular/core';
 import { first, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
+import { getTriggerReturnType$ } from 'ish-core/utils/functions';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderLogoutGuard() {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.initialized$.pipe(
+  return identityProviderFactory.getInitialized$().pipe(
     whenTruthy(),
     first(),
     switchMap(() => {

--- a/src/app/core/guards/identity-provider-password.guard.ts
+++ b/src/app/core/guards/identity-provider-password.guard.ts
@@ -1,9 +1,9 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { first, isObservable, of, switchMap } from 'rxjs';
+import { first, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { isPromise } from 'ish-core/utils/functions';
+import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderPasswordGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
@@ -15,7 +15,7 @@ export function identityProviderPasswordGuard(route: ActivatedRouteSnapshot, sta
     switchMap(() => {
       if (identityProviderFactory.getType() !== 'ICM' && identityProviderFactory.getInstance().triggerInvite) {
         const inviteReturn$ = identityProviderFactory.getInstance().triggerInvite(route, state);
-        return isObservable(inviteReturn$) || isPromise(inviteReturn$) ? inviteReturn$ : of(inviteReturn$);
+        return getTriggerReturnType$(inviteReturn$);
       } else {
         return of(true);
       }

--- a/src/app/core/guards/identity-provider-password.guard.ts
+++ b/src/app/core/guards/identity-provider-password.guard.ts
@@ -3,13 +3,13 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { first, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
+import { getTriggerReturnType$ } from 'ish-core/utils/functions';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderPasswordGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.initialized$.pipe(
+  return identityProviderFactory.getInitialized$().pipe(
     whenTruthy(),
     first(),
     switchMap(() => {

--- a/src/app/core/guards/identity-provider-password.guard.ts
+++ b/src/app/core/guards/identity-provider-password.guard.ts
@@ -1,12 +1,24 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { first, isObservable, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+import { isPromise } from 'ish-core/utils/functions';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderPasswordGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.getType() !== 'ICM' && identityProviderFactory.getInstance().triggerInvite
-    ? identityProviderFactory.getInstance().triggerInvite(route, state)
-    : true;
+  return identityProviderFactory.initialized$.pipe(
+    whenTruthy(),
+    first(),
+    switchMap(() => {
+      if (identityProviderFactory.getType() !== 'ICM' && identityProviderFactory.getInstance().triggerInvite) {
+        const inviteReturn$ = identityProviderFactory.getInstance().triggerInvite(route, state);
+        return isObservable(inviteReturn$) || isPromise(inviteReturn$) ? inviteReturn$ : of(inviteReturn$);
+      } else {
+        return of(true);
+      }
+    })
+  );
 }

--- a/src/app/core/guards/identity-provider-register.guard.ts
+++ b/src/app/core/guards/identity-provider-register.guard.ts
@@ -1,9 +1,9 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { first, isObservable, of, switchMap } from 'rxjs';
+import { first, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { isPromise } from 'ish-core/utils/functions';
+import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderRegisterGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
@@ -16,10 +16,10 @@ export function identityProviderRegisterGuard(route: ActivatedRouteSnapshot, sta
       const identityProvider = identityProviderFactory.getInstance();
       if (identityProvider.triggerRegister) {
         const registerReturn$ = identityProvider.triggerRegister(route, state);
-        return isObservable(registerReturn$) || isPromise(registerReturn$) ? registerReturn$ : of(registerReturn$);
+        return getTriggerReturnType$(registerReturn$);
       } else {
         const loginReturn$ = identityProvider.triggerLogin(route, state);
-        return isObservable(loginReturn$) || isPromise(loginReturn$) ? loginReturn$ : of(loginReturn$);
+        return getTriggerReturnType$(loginReturn$);
       }
     })
   );

--- a/src/app/core/guards/identity-provider-register.guard.ts
+++ b/src/app/core/guards/identity-provider-register.guard.ts
@@ -1,13 +1,26 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { first, isObservable, of, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+import { isPromise } from 'ish-core/utils/functions';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderRegisterGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  const identityProvider = identityProviderFactory.getInstance();
-  return identityProvider.triggerRegister
-    ? identityProvider.triggerRegister(route, state)
-    : identityProvider.triggerLogin(route, state);
+  return identityProviderFactory.initialized$.pipe(
+    whenTruthy(),
+    first(),
+    switchMap(() => {
+      const identityProvider = identityProviderFactory.getInstance();
+      if (identityProvider.triggerRegister) {
+        const registerReturn$ = identityProvider.triggerRegister(route, state);
+        return isObservable(registerReturn$) || isPromise(registerReturn$) ? registerReturn$ : of(registerReturn$);
+      } else {
+        const loginReturn$ = identityProvider.triggerLogin(route, state);
+        return isObservable(loginReturn$) || isPromise(loginReturn$) ? loginReturn$ : of(loginReturn$);
+      }
+    })
+  );
 }

--- a/src/app/core/guards/identity-provider-register.guard.ts
+++ b/src/app/core/guards/identity-provider-register.guard.ts
@@ -3,13 +3,13 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { first, switchMap } from 'rxjs';
 
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
-import { getTriggerReturnType$ } from 'ish-core/identity-provider/identity-provider.interface';
+import { getTriggerReturnType$ } from 'ish-core/utils/functions';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function identityProviderRegisterGuard(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
   const identityProviderFactory = inject(IdentityProviderFactory);
 
-  return identityProviderFactory.initialized$.pipe(
+  return identityProviderFactory.getInitialized$().pipe(
     whenTruthy(),
     first(),
     switchMap(() => {

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -1,7 +1,7 @@
 import { Injectable, InjectionToken, Injector, Type } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { once } from 'lodash-es';
-import { BehaviorSubject, combineLatest, noop } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, noop } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 import { FeatureToggleService } from 'ish-core/feature-toggle.module';
@@ -30,7 +30,7 @@ export class IdentityProviderFactory {
     type?: string;
   };
 
-  initialized$ = new BehaviorSubject<boolean>(false);
+  private initialized$ = new BehaviorSubject<boolean>(false);
 
   constructor(private store: Store, private injector: Injector, private featureToggleService: FeatureToggleService) {
     if (!SSR) {
@@ -99,5 +99,9 @@ export class IdentityProviderFactory {
 
   getType(): string {
     return this.config?.type;
+  }
+
+  getInitialized$(): Observable<boolean> {
+    return this.initialized$.asObservable();
   }
 }

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -101,6 +101,9 @@ export class IdentityProviderFactory {
     return this.config?.type;
   }
 
+  /**
+   * notifies when correct identity provider is selected
+   */
   getInitialized$(): Observable<boolean> {
     return this.initialized$.asObservable();
   }

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -1,16 +1,8 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { Observable, isObservable, of } from 'rxjs';
-
-import { isPromise } from 'ish-core/utils/functions';
+import { Observable } from 'rxjs';
 
 export type TriggerReturnType = Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
-
-export function getTriggerReturnType$(
-  returnType: TriggerReturnType
-): Observable<TriggerReturnType> | Promise<TriggerReturnType> {
-  return isObservable(returnType) || isPromise(returnType) ? returnType : of(returnType);
-}
 
 export interface IdentityProviderCapabilities {
   editPassword?: boolean;

--- a/src/app/core/identity-provider/identity-provider.interface.ts
+++ b/src/app/core/identity-provider/identity-provider.interface.ts
@@ -1,8 +1,16 @@
 import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, isObservable, of } from 'rxjs';
+
+import { isPromise } from 'ish-core/utils/functions';
 
 export type TriggerReturnType = Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
+
+export function getTriggerReturnType$(
+  returnType: TriggerReturnType
+): Observable<TriggerReturnType> | Promise<TriggerReturnType> {
+  return isObservable(returnType) || isPromise(returnType) ? returnType : of(returnType);
+}
 
 export interface IdentityProviderCapabilities {
   editPassword?: boolean;

--- a/src/app/core/interceptors/identity-provider.interceptor.ts
+++ b/src/app/core/interceptors/identity-provider.interceptor.ts
@@ -12,7 +12,7 @@ export class IdentityProviderInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     if (req.url.startsWith(this.appFacade.icmBaseUrl)) {
-      return this.identityProviderFactory.initialized$.pipe(
+      return this.identityProviderFactory.getInitialized$().pipe(
         whenTruthy(),
         first(),
         switchMap(() => this.identityProviderFactory.getInstance()?.intercept(req, next) ?? next.handle(req))

--- a/src/app/core/interceptors/identity-provider.interceptor.ts
+++ b/src/app/core/interceptors/identity-provider.interceptor.ts
@@ -1,9 +1,10 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, first, switchMap } from 'rxjs';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { IdentityProviderFactory } from 'ish-core/identity-provider/identity-provider.factory';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 @Injectable()
 export class IdentityProviderInterceptor implements HttpInterceptor {
@@ -11,7 +12,11 @@ export class IdentityProviderInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     if (req.url.startsWith(this.appFacade.icmBaseUrl)) {
-      return this.identityProviderFactory.getInstance()?.intercept(req, next) ?? next.handle(req);
+      return this.identityProviderFactory.initialized$.pipe(
+        whenTruthy(),
+        first(),
+        switchMap(() => this.identityProviderFactory.getInstance()?.intercept(req, next) ?? next.handle(req))
+      );
     }
     return next.handle(req);
   }

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -1,6 +1,8 @@
 import { capitalize, range, snakeCase } from 'lodash-es';
 import { Observable, isObservable, of } from 'rxjs';
 
+import { TriggerReturnType } from 'ish-core/identity-provider/identity-provider.interface';
+
 /**
  * Returns an array of array slices with requested length.
  * Truncates whenever no complete remaining slice could be constructed.
@@ -84,6 +86,15 @@ export function decamelizeString(str: string): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isPromise(obj: any): obj is Promise<any> {
+function isPromise(obj: any): obj is Promise<any> {
   return !!obj && typeof obj.then === 'function';
+}
+
+/**
+ * Returns an observable or promise with a triggerReturnType as emitted value
+ */
+export function getTriggerReturnType$(
+  returnType: TriggerReturnType
+): Observable<TriggerReturnType> | Promise<TriggerReturnType> {
+  return isObservable(returnType) || isPromise(returnType) ? returnType : of(returnType);
 }

--- a/src/app/core/utils/functions.ts
+++ b/src/app/core/utils/functions.ts
@@ -82,3 +82,8 @@ export function decamelizeString(str: string): string {
         .join(' ')
     : str;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isPromise(obj: any): obj is Promise<any> {
+  return !!obj && typeof obj.then === 'function';
+}

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.module.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.module.ts
@@ -13,6 +13,7 @@ import { PunchoutIdentityProvider } from './punchout-identity-provider';
         type: 'PUNCHOUT',
         implementor: PunchoutIdentityProvider,
         feature: 'punchout',
+        activeOnPath: 'punchout',
       },
     },
   ],


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently the PWA can only be setup with one active identity provider. The PWA should be configured for specific identity providers in such a way, that these are active, when the PWA is rendered with a specific url path. The punchout identity provider should be used, when the 'punchout' feature is active and the PWA is initially loaded with /punchout.

Issue Number: Closes #

## What Is the New Behavior?

The `activeOnPath` property is introduced for the `IdentityProviderImplementor` interface. When the current url path matches the configured value, then the new identity provider is used. If no url path has a match with the available identity providers, then the old behavior is used.

Furthermore all identity provider guards and interceptors are adapted to wait until a active identity provider is found.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information


[AB#88708](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88708)