### PR TITLE
feat: implement better handling for cookie 'SameSite' and 'secure' settings

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,17 @@ kb_sync_latest_only
 
 # Migrations
 
+## 4.1 to 4.2
+
+A better handling for cookie `SameSite` and `secure` settings was implemented with new defaults to `SameSite=Strict` and `secure`.
+This can still be overridden when calling `cookies.services` `put` method with explicitly set values.
+Now the `secure` setting is always set to `true` if in `https` mode, you can prevent this by explicitly setting it to `false`.
+If the PWA is run with `http` (should only be in development environments) `secure` is not set.
+Additionally if the PWA is run in an iframe all cookies are set with `SameSite=None` (e.g. for punchout or Design View).
+Be aware that some browsers no longer accept cookies with `SameSite=None` without `secure`.
+Before by default no `SameSite` was set so browsers treated it as `SameSite=Lax`, this needs to be set explicitly now if it is really intended.
+For migrating check the calls of the `cookies.service` `put` method whether they need to be adapted.
+
 ## 4.0 to 4.1
 
 The Intershop PWA now uses Node.js 18.16.0 LTS with the corresponding npm version 9.5.1 to resolve an issue with Azure Docker deployments (see #1416).

--- a/src/app/core/utils/api-token/api-token.service.ts
+++ b/src/app/core/utils/api-token/api-token.service.ts
@@ -88,8 +88,7 @@ export class ApiTokenService {
         if (cookieContent) {
           this.cookiesService.put('apiToken', cookieContent, {
             expires: this.cookieOptions?.expires ?? new Date(Date.now() + DEFAULT_EXPIRY_TIME),
-            secure: this.cookieOptions?.secure ?? true,
-            sameSite: 'Strict',
+            secure: this.cookieOptions?.secure,
             path: '/',
           });
         }

--- a/src/app/core/utils/browser-detection.ts
+++ b/src/app/core/utils/browser-detection.ts
@@ -1,0 +1,23 @@
+/* eslint-disable etc/no-deprecated, unicorn/no-null */
+
+// simple browser and version detection: https://stackoverflow.com/questions/5916900/how-can-you-detect-the-version-of-a-browser
+export function browserNameVersion() {
+  const ua = navigator.userAgent;
+  let tem;
+  let M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+  if (/trident/i.test(M[1])) {
+    tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+    return `IE ${tem[1] || ''}`;
+  }
+  if (M[1] === 'Chrome') {
+    tem = ua.match(/\b(OPR|Edge)\/(\d+)/);
+    if (tem !== null) {
+      return tem.slice(1).join(' ').replace('OPR', 'Opera');
+    }
+  }
+  M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
+  if ((tem = ua.match(/version\/(\d+)/i)) !== null) {
+    M.splice(1, 1, tem[1]);
+  }
+  return M.join(' ');
+}

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -148,8 +148,14 @@ export class CookiesService {
     str += `;path=${path}`;
     str += opts.domain ? `;domain=${opts.domain}` : '';
     str += expires ? `;expires=${expires.toUTCString()}` : '';
-    str += opts.sameSite ? `;SameSite=${opts.sameSite}` : '';
-    str += opts.secure && location.protocol === 'https:' ? ';secure' : '';
+
+    // if in an iframe set cookies always with SameSite=None, otherwise set the given SameSite, default to SameSite=Strict
+    str += `;SameSite=${window.parent !== window ? 'None' : opts.sameSite || 'Strict'}`;
+
+    // if in http mode (should only be in development) or if explicitly set to false do not set the cookie secure, default to secure
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+    str += window.location.protocol === 'http:' || opts.secure === false ? '' : ';secure';
+
     const cookiesLength = str.length + 1;
     if (cookiesLength > 4096) {
       // eslint-disable-next-line no-console

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -5,6 +5,7 @@ import { TransferState } from '@angular/platform-browser';
 import { COOKIE_CONSENT_OPTIONS } from 'ish-core/configurations/injection-keys';
 import { COOKIE_CONSENT_VERSION } from 'ish-core/configurations/state-keys';
 import { CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
+import { browserNameVersion } from 'ish-core/utils/browser-detection';
 import { InjectSingle } from 'ish-core/utils/injection';
 
 interface CookiesOptions {
@@ -143,6 +144,12 @@ export class CookiesService {
     if (typeof expires === 'string') {
       expires = new Date(expires);
     }
+
+    // fix for Safari 14 not keeping 'SameSite=Strict' cookies when redirecting to a payment provider etc.
+    if (browserNameVersion() === 'Safari 14' && opts.sameSite !== 'None') {
+      opts.sameSite = 'Lax';
+    }
+
     let str = `${encodeURIComponent(name)}=${encodeURIComponent(value || '')}`;
     str += `;path=${path}`;
     str += opts.domain ? `;domain=${opts.domain}` : '';

--- a/src/app/core/utils/cookies/cookies.service.ts
+++ b/src/app/core/utils/cookies/cookies.service.ts
@@ -57,7 +57,6 @@ export class CookiesService {
     this.deleteAllCookies();
     this.put('cookieConsent', JSON.stringify({ enabledOptions: options, version: cookieConsentVersion }), {
       expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
-      sameSite: 'Strict',
     });
     window.location.reload();
   }

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.spec.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.spec.ts
@@ -192,9 +192,9 @@ describe('Punchout Identity Provider', () => {
               boolean | UrlTree
             >;
             login$.subscribe(() => {
-              verify(cookiesService.put('punchout_SID', 'sid', anything())).once();
-              verify(cookiesService.put('punchout_ReturnURL', 'home', anything())).once();
-              verify(cookiesService.put('punchout_BasketID', 'basket-id', anything())).once();
+              verify(cookiesService.put('punchout_SID', 'sid')).once();
+              verify(cookiesService.put('punchout_ReturnURL', 'home')).once();
+              verify(cookiesService.put('punchout_BasketID', 'basket-id')).once();
             });
 
             tick(500);
@@ -213,7 +213,7 @@ describe('Punchout Identity Provider', () => {
               boolean | UrlTree
             >;
             login$.subscribe(() => {
-              verify(cookiesService.put('punchout_HookURL', 'url', anything())).once();
+              verify(cookiesService.put('punchout_HookURL', 'url')).once();
               verify(checkoutFacade.createBasket()).once();
               expect(routerSpy).toHaveBeenCalledWith('/home');
               done();

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
@@ -149,18 +149,9 @@ export class PunchoutIdentityProvider implements IdentityProvider {
     return this.punchoutService.getCxmlPunchoutSession(route.queryParamMap.get('sid')).pipe(
       // persist cXML session information (sid, returnURL, basketId) in cookies for later basket transfer
       tap(data => {
-        this.cookiesService.put('punchout_SID', route.queryParamMap.get('sid'), {
-          sameSite: 'None',
-          secure: true,
-        });
-        this.cookiesService.put('punchout_ReturnURL', data.returnURL, {
-          sameSite: 'None',
-          secure: true,
-        });
-        this.cookiesService.put('punchout_BasketID', data.basketId, {
-          sameSite: 'None',
-          secure: true,
-        });
+        this.cookiesService.put('punchout_SID', route.queryParamMap.get('sid'));
+        this.cookiesService.put('punchout_ReturnURL', data.returnURL);
+        this.cookiesService.put('punchout_BasketID', data.basketId);
       }),
       // use the basketId basket for the current PWA session (instead of default current basket)
       // TODO: if load basket error (currently no error page) -> logout and do not use default 'current' basket
@@ -173,10 +164,7 @@ export class PunchoutIdentityProvider implements IdentityProvider {
 
   private handleOciPunchoutLogin(route: ActivatedRouteSnapshot) {
     // save HOOK_URL to cookie for later basket transfer
-    this.cookiesService.put('punchout_HookURL', route.queryParamMap.get('HOOK_URL'), {
-      sameSite: 'None',
-      secure: true,
-    });
+    this.cookiesService.put('punchout_HookURL', route.queryParamMap.get('HOOK_URL'));
 
     const basketId = window.sessionStorage.getItem('basket-id');
     if (!basketId) {

--- a/src/app/shell/application/cookies-banner/cookies-banner.component.html
+++ b/src/app/shell/application/cookies-banner/cookies-banner.component.html
@@ -1,7 +1,7 @@
 <div
   *ngIf="showBanner"
   [@bottomOut]="transitionBanner"
-  (@bottomOut.done)="acceptAllAnimationDone($event)"
+  (@bottomOut.done)="setCookiesConsent($event)"
   class="cookies-banner"
 >
   <div [ishServerHtml]="'cookies.banner.text' | translate"></div>

--- a/src/app/shell/application/cookies-banner/cookies-banner.component.ts
+++ b/src/app/shell/application/cookies-banner/cookies-banner.component.ts
@@ -19,6 +19,7 @@ import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 export class CookiesBannerComponent implements OnInit {
   showBanner = false;
   transitionBanner: string = undefined;
+  cookiesConsentFor: string[] = undefined;
 
   constructor(private transferState: TransferState, private cookiesService: CookiesService) {}
 
@@ -47,13 +48,18 @@ export class CookiesBannerComponent implements OnInit {
     this.transitionBanner = 'bottom-out';
   }
 
-  acceptAllAnimationDone(event: AnimationEvent): void {
-    if (event.toState === 'bottom-out') {
-      this.cookiesService.setCookiesConsentForAll();
-    }
+  acceptOnlyRequired() {
+    this.transitionBanner = 'bottom-out';
+    this.cookiesConsentFor = ['required'];
   }
 
-  acceptOnlyRequired() {
-    this.cookiesService.setCookiesConsentFor(['required']);
+  setCookiesConsent(event: AnimationEvent): void {
+    if (event.toState === this.transitionBanner) {
+      if (this.cookiesConsentFor === undefined) {
+        this.cookiesService.setCookiesConsentForAll();
+      } else {
+        this.cookiesService.setCookiesConsentFor(this.cookiesConsentFor);
+      }
+    }
   }
 }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the New Behavior?

feat: implement better handling for cookie 'SameSite' and 'secure' settings

* defaults to 'SameSite=Strict' and 'secure' if not explicitly set to other values
* sets all cookies with 'SameSite=None' if run within an iframe
* if run with 'http' (should only be in development environments) 'secure' is not set
* inspired by https://medium.com/trabe/cookies-and-iframes-f7cca58b3b9e


## Does this PR Introduce a Breaking Change?

[x] Yes

The `cookies.service` has new defaults: `SameSite=Strict` and `secure` (see [Migrations / 4.1 to 4.2](https://github.com/intershop/intershop-pwa/blob/develop/docs/guides/migrations.md#41-to-42) for more details).

## Other Information


[AB#88753](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88753)