### PR TITLE
chore: ignore compiled health check script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,7 +34,6 @@
 /dist/**/*
 !/dist/.gitignore
 !/dist/entrypoint.sh
-!/dist/healthcheck.js
 !/dist/robots.txt
 
 # from docs/.gitignore

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,5 +1,4 @@
 /**/*
 !.gitignore
 !/entrypoint.sh
-!/healthcheck.js
 !/robots.txt


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

`dist/healthcheck.js` is still excluded in `dist/.gitignore` even though it is compiled output since 9946ca26a.

## What Is the New Behavior?

removed exclude

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#88757](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88757)