### PR TITLE
fix: remove token informations from local storage after succesful logout

### DIFF
--- a/e2e/cypress/e2e/specs/account/login-user.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/account/login-user.b2c.e2e-spec.ts
@@ -32,11 +32,32 @@ describe('Returning User', () => {
       });
     });
 
+    it('should have saved apiToken as cookie and within localStorage', () => {
+      cy.getCookie('apiToken').then(cookie => {
+        expect(cookie).to.not.be.empty;
+        cy.wrap(JSON.parse(decodeURIComponent(cookie.value))).should('have.property', 'type', 'user');
+      });
+
+      cy.getAllLocalStorage().then(
+        localStorage => expect(localStorage[Cypress.config('baseUrl')].access_token).to.not.be.empty
+      );
+    });
+
     it('should logout and be redirected to home page', () => {
       at(MyAccountPage, page => {
         page.header.logout();
       });
       at(HomePage);
+    });
+
+    it('should have removed apiToken cookie and infos from localStorage', () => {
+      cy.getCookie('apiToken').then(cookie => {
+        expect(cookie).to.be.null;
+      });
+
+      cy.getAllLocalStorage().then(
+        localStorage => expect(localStorage[Cypress.config('baseUrl')].access_token).to.be.undefined
+      );
     });
   });
 

--- a/src/app/core/identity-provider/icm.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.spec.ts
@@ -5,6 +5,7 @@ import { Observable, Subject, of } from 'rxjs';
 import { anything, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { TokenService } from 'ish-core/services/token/token.service';
 import { selectQueryParam } from 'ish-core/store/core/router';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 
@@ -23,6 +24,7 @@ describe('Icm Identity Provider', () => {
       providers: [
         { provide: AccountFacade, useFactory: () => instance(accountFacade) },
         { provide: ApiTokenService, useFactory: () => instance(apiTokenService) },
+        { provide: TokenService, useFactory: () => instance(mock(TokenService)) },
         provideMockStore(),
       ],
     }).compileComponents();

--- a/src/app/core/identity-provider/icm.identity-provider.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.ts
@@ -3,9 +3,10 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { Observable, noop } from 'rxjs';
-import { filter, map, switchMap, take } from 'rxjs/operators';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { TokenService } from 'ish-core/services/token/token.service';
 import { selectQueryParam } from 'ish-core/store/core/router';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 
@@ -17,7 +18,8 @@ export class ICMIdentityProvider implements IdentityProvider {
     private router: Router,
     private store: Store,
     private apiTokenService: ApiTokenService,
-    private accountFacade: AccountFacade
+    private accountFacade: AccountFacade,
+    private tokenService: TokenService
   ) {}
 
   getCapabilities() {
@@ -46,11 +48,13 @@ export class ICMIdentityProvider implements IdentityProvider {
   }
 
   triggerLogout(): TriggerReturnType {
+    // revoke current token
     this.accountFacade.logoutUser();
     return this.accountFacade.isLoggedIn$.pipe(
       // wait until the user is logged out before you go to homepage to prevent unnecessary REST calls
       filter(loggedIn => !loggedIn),
       take(1),
+      tap(() => this.tokenService.logOut()), // remove token from storage when user is logged out
       switchMap(() =>
         this.store.pipe(
           select(selectQueryParam('returnUrl')),

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -67,6 +67,10 @@ export class TokenService {
     );
   }
 
+  logOut() {
+    this.oAuthService.logOut(true);
+  }
+
   /**
    * Refresh existing tokens, when token is about to expire
    *

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.spec.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.spec.ts
@@ -8,6 +8,7 @@ import { anyString, anything, instance, mock, resetCalls, verify, when } from 't
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { TokenService } from 'ish-core/services/token/token.service';
 import { selectQueryParam } from 'ish-core/store/core/router';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
@@ -46,6 +47,7 @@ describe('Punchout Identity Provider', () => {
         { provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) },
         { provide: CookiesService, useFactory: () => instance(cookiesService) },
         { provide: PunchoutService, useFactory: () => instance(punchoutService) },
+        { provide: TokenService, useFactory: () => instance(mock(TokenService)) },
         provideMockStore(),
       ],
     }).compileComponents();

--- a/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
+++ b/src/app/extensions/punchout/identity-provider/punchout-identity-provider.ts
@@ -9,6 +9,7 @@ import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { IdentityProvider, TriggerReturnType } from 'ish-core/identity-provider/identity-provider.interface';
+import { TokenService } from 'ish-core/services/token/token.service';
 import { selectQueryParam } from 'ish-core/store/core/router';
 import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
@@ -26,7 +27,8 @@ export class PunchoutIdentityProvider implements IdentityProvider {
     private accountFacade: AccountFacade,
     private punchoutService: PunchoutService,
     private cookiesService: CookiesService,
-    private checkoutFacade: CheckoutFacade
+    private checkoutFacade: CheckoutFacade,
+    private tokenService: TokenService
   ) {}
 
   getCapabilities() {
@@ -132,6 +134,7 @@ export class PunchoutIdentityProvider implements IdentityProvider {
       // wait until the user is logged out before you go to homepage to prevent unnecessary REST calls
       filter(loggedIn => !loggedIn),
       take(1),
+      tap(() => this.tokenService.logOut()), // remove token from storage when user is logged out
       switchMap(() =>
         this.store.pipe(
           select(selectQueryParam('returnUrl')),


### PR DESCRIPTION
## PR Type

[x] Bugfix


## What Is the Current Behavior?

During the logout process for the icm and punchout identity provider only the apiToken cookie will be removed. The related access token information within the localStorage, which is handled by the OAuthService, will not be deleted. This can lead to unwanted behavior, that the OAuthService triggers an action to refresh the revoked access_token.

## What Is the New Behavior?

The pwa will remove for the icm and punchout identity provider all access_token informations, when the logout of the user is successful.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#88809](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88809)