### PR TITLE
perf: use better suited operators for REST requests

### DIFF
--- a/src/app/core/store/content/page-tree/page-tree.effects.ts
+++ b/src/app/core/store/content/page-tree/page-tree.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatMap, map } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 
 import { CMSService } from 'ish-core/services/cms/cms.service';
 import { mapErrorToAction, mapToPayload } from 'ish-core/utils/operators';
@@ -15,7 +15,7 @@ export class PageTreeEffects {
     this.actions$.pipe(
       ofType(loadContentPageTree),
       mapToPayload(),
-      concatMap(({ rootId, depth }) =>
+      mergeMap(({ rootId, depth }) =>
         this.cmsService.getContentPageTree(rootId, depth).pipe(
           map(pagetree => loadContentPageTreeSuccess({ pagetree })),
           mapErrorToAction(loadContentPageTreeFail)

--- a/src/app/core/store/content/parameters/parameters.effects.ts
+++ b/src/app/core/store/content/parameters/parameters.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatMap, mergeMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 import { Product } from 'ish-core/models/product/product.model';
 import { ProductsService } from 'ish-core/services/products/products.service';
@@ -21,7 +21,7 @@ export class ParametersEffects {
     this.actions$.pipe(
       ofType(loadParametersProductListFilter),
       mapToPayload(),
-      concatMap(({ id, searchParameter, amount }) =>
+      mergeMap(({ id, searchParameter, amount }) =>
         this.productsService.getFilteredProducts(searchParameter, amount).pipe(
           mergeMap(({ products }) => [
             ...products.map((product: Product) => loadProductSuccess({ product })),

--- a/src/app/core/store/content/viewcontexts/viewcontexts.effects.ts
+++ b/src/app/core/store/content/viewcontexts/viewcontexts.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatMap, map } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 
 import { CMSService } from 'ish-core/services/cms/cms.service';
 import { mapErrorToAction, mapToPayload } from 'ish-core/utils/operators';
@@ -19,7 +19,7 @@ export class ViewcontextsEffects {
     this.actions$.pipe(
       ofType(loadViewContextEntrypoint),
       mapToPayload(),
-      concatMap(({ viewContextId, callParameters }) =>
+      mergeMap(({ viewContextId, callParameters }) =>
         this.cmsService.getViewContextContent(viewContextId, callParameters).pipe(
           map(({ entrypoint, pagelets }) =>
             loadViewContextEntrypointSuccess({ entrypoint, pagelets, viewContextId, callParameters })

--- a/src/app/core/store/core/server-config/server-config.effects.ts
+++ b/src/app/core/store/core/server-config/server-config.effects.ts
@@ -48,7 +48,7 @@ export class ServerConfigEffects {
   loadServerConfig$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadServerConfig),
-      concatMap(() =>
+      switchMap(() =>
         this.configService.getServerConfiguration().pipe(
           map(config => loadServerConfigSuccess({ config })),
           mapErrorToAction(loadServerConfigFail)
@@ -64,7 +64,7 @@ export class ServerConfigEffects {
       switchMap(() => this.store.pipe(select(isExtraConfigurationLoaded))),
       whenFalsy(),
       delayUntil(this.actions$.pipe(ofType(personalizationStatusDetermined))),
-      concatMap(() =>
+      switchMap(() =>
         this.configService.getExtraConfiguration().pipe(
           map(extra => loadExtraConfigSuccess({ extra })),
           mapErrorToAction(loadExtraConfigFail)

--- a/src/app/core/store/customer/basket/basket-items.effects.ts
+++ b/src/app/core/store/customer/basket/basket-items.effects.ts
@@ -105,7 +105,7 @@ export class BasketItemsEffects {
     this.actions$.pipe(
       ofType(addItemsToBasket),
       mapToPayload(),
-      concatMap(payload => [...payload.items.map(item => loadProduct({ sku: item.sku }))])
+      mergeMap(payload => [...payload.items.map(item => loadProduct({ sku: item.sku }))])
     )
   );
 

--- a/src/app/core/store/customer/basket/basket-payment.effects.ts
+++ b/src/app/core/store/customer/basket/basket-payment.effects.ts
@@ -42,7 +42,7 @@ export class BasketPaymentEffects {
   loadBasketEligiblePaymentMethods$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadBasketEligiblePaymentMethods),
-      concatMap(() =>
+      switchMap(() =>
         this.paymentService.getBasketEligiblePaymentMethods().pipe(
           map(result => loadBasketEligiblePaymentMethodsSuccess({ paymentMethods: result })),
           mapErrorToAction(loadBasketEligiblePaymentMethodsFail)

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -116,7 +116,7 @@ export class BasketEffects {
     this.actions$.pipe(
       ofType(loadBasketByAPIToken),
       mapToPayloadProperty('apiToken'),
-      concatMap(apiToken =>
+      switchMap(apiToken =>
         this.basketService.getBasketByToken(apiToken).pipe(
           map(basket => loadBasketSuccess({ basket })),
           mapErrorToAction(loadBasketByAPITokenFail)

--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -122,7 +122,7 @@ export class OrdersEffects {
   loadOrders$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadOrders),
-      concatMap(() =>
+      switchMap(() =>
         this.orderService.getOrders().pipe(
           map(orders => loadOrdersSuccess({ orders })),
           mapErrorToAction(loadOrdersFail)

--- a/src/app/core/store/general/countries/countries.effects.ts
+++ b/src/app/core/store/general/countries/countries.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { concatMap, filter, map, withLatestFrom } from 'rxjs/operators';
+import { filter, map, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { CountryService } from 'ish-core/services/country/country.service';
 import { mapErrorToAction } from 'ish-core/utils/operators';
@@ -18,7 +18,7 @@ export class CountriesEffects {
       ofType(loadCountries),
       withLatestFrom(this.store.pipe(select(getAllCountries))),
       filter(([, countries]) => !countries.length),
-      concatMap(() =>
+      switchMap(() =>
         this.countryService.getCountries().pipe(
           map(countries => loadCountriesSuccess({ countries })),
           mapErrorToAction(loadCountriesFail)

--- a/src/app/core/store/general/regions/regions.effects.ts
+++ b/src/app/core/store/general/regions/regions.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
-import { concatMap, filter, map, withLatestFrom } from 'rxjs/operators';
+import { filter, map, mergeMap, withLatestFrom } from 'rxjs/operators';
 
 import { CountryService } from 'ish-core/services/country/country.service';
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
@@ -19,7 +19,7 @@ export class RegionsEffects {
       mapToPayloadProperty('countryCode'),
       withLatestFrom(this.store.pipe(select(getAllRegions))),
       filter(([countryCode, allRegions]) => !allRegions.some(r => r.countryCode === countryCode)),
-      concatMap(([countryCode]) =>
+      mergeMap(([countryCode]) =>
         this.countryService.getRegionsByCountry(countryCode).pipe(
           map(regions => loadRegionsSuccess({ regions })),
           mapErrorToAction(loadRegionsFail)

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -117,7 +117,7 @@ export class ProductsEffects {
       map(payload => ({ ...payload, page: payload.page ? payload.page : 1 })),
       withLatestFrom(this.store.pipe(select(getProductListingItemsPerPage('category')))),
       map(([payload, pageSize]) => ({ ...payload, amount: pageSize, offset: (payload.page - 1) * pageSize })),
-      concatMap(({ categoryId, amount, sorting, offset, page }) =>
+      mergeMap(({ categoryId, amount, sorting, offset, page }) =>
         this.productsService.getCategoryProducts(categoryId, amount, sorting, offset).pipe(
           concatMap(({ total, products, sortableAttributes }) => [
             ...products.map(product => loadProductSuccess({ product })),
@@ -152,8 +152,7 @@ export class ProductsEffects {
       map(payload => ({ ...payload, page: payload.page ? payload.page : 1 })),
       withLatestFrom(this.store.pipe(select(getProductListingItemsPerPage('master')))),
       map(([payload, pageSize]) => ({ ...payload, amount: pageSize, offset: (payload.page - 1) * pageSize })),
-
-      concatMap(({ masterSKU, amount, sorting, offset, page }) =>
+      mergeMap(({ masterSKU, amount, sorting, offset, page }) =>
         this.productsService.getProductsForMaster(masterSKU, amount, sorting, offset).pipe(
           concatMap(({ total, products, sortableAttributes }) => [
             ...products.map(product => loadProductSuccess({ product })),

--- a/src/app/extensions/contact-us/store/contact/contact.effects.ts
+++ b/src/app/extensions/contact-us/store/contact/contact.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatMap, map } from 'rxjs/operators';
+import { concatMap, map, switchMap } from 'rxjs/operators';
 
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
 
@@ -25,7 +25,7 @@ export class ContactEffects {
   loadSubjects$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadContact),
-      concatMap(() =>
+      switchMap(() =>
         this.contactService.getContactSubjects().pipe(
           map(subjects => loadContactSuccess({ subjects })),
           mapErrorToAction(loadContactFail)

--- a/src/app/extensions/punchout/store/punchout-types/punchout-types.effects.ts
+++ b/src/app/extensions/punchout/store/punchout-types/punchout-types.effects.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { routerNavigatedAction } from '@ngrx/router-store';
-import { concatMap, filter, map } from 'rxjs/operators';
+import { filter, map, switchMap } from 'rxjs/operators';
 
 import { mapErrorToAction, mapToPayloadProperty } from 'ish-core/utils/operators';
 
@@ -25,7 +25,7 @@ export class PunchoutTypesEffects {
   loadPunchoutTypes$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadPunchoutTypes),
-      concatMap(() =>
+      switchMap(() =>
         this.punchoutService.getPunchoutTypes().pipe(
           map(types => loadPunchoutTypesSuccess({ types })),
           mapErrorToAction(loadPunchoutTypesFail)


### PR DESCRIPTION
## PR Type

[ x ] Refactoring (no functional changes, no API changes)


## What Is the Current Behavior?

NGRX Effects are one of the core functionality of the PWA. It uses different actions, where the business logic is written with rxjs methods and operators. When the concatMap() operator is used, then each new subscriptions to a new observable has to wait until the previous is completed. This can lead to the problem, that http request are send sequentially although it could be done in parallel. Mainly loading actions  

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#88843](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88843)