### PR TITLE
fix: prevent setting values on uninitialized field

### DIFF
--- a/src/app/shared/cms/components/cms-carousel/cms-carousel.component.html
+++ b/src/app/shared/cms/components/cms-carousel/cms-carousel.component.html
@@ -4,7 +4,7 @@
       <ngb-carousel
         #ngbCarousel
         [interval]="0"
-        [showNavigationArrows]="pageletSlides.length > 1"
+        [showNavigationArrows]="pageletSlides?.length > 1"
         [showNavigationIndicators]="pagelet.booleanParam('ShowIndicators')"
       >
         <ng-template ngbSlide *ngFor="let slidePagelets of pageletSlides">

--- a/src/app/shared/cms/components/cms-carousel/cms-carousel.component.ts
+++ b/src/app/shared/cms/components/cms-carousel/cms-carousel.component.ts
@@ -43,19 +43,21 @@ export class CMSCarouselComponent implements CMSComponent, OnChanges, OnDestroy 
     const slotPagelets = this.pagelet.slot('app_sf_base_cm:slot.carousel.items.pagelet2-Slot').pageletIDs;
     this.pageletSlides = arraySlices(slotPagelets, this.slideItems);
 
-    this.appRef.isStable
-      .pipe(
-        whenTruthy(),
-        map(() => (this.pagelet.booleanParam('StartCycling') ? this.pagelet.numberParam('SlideInterval', 5000) : 0)),
-        take(1),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(val => {
-        if (val) {
-          this.carousel.interval = val;
-          this.carousel.cycle();
-        }
-      });
+    if (!SSR) {
+      this.appRef.isStable
+        .pipe(
+          whenTruthy(),
+          map(() => (this.pagelet.booleanParam('StartCycling') ? this.pagelet.numberParam('SlideInterval', 5000) : 0)),
+          take(1),
+          takeUntil(this.destroy$)
+        )
+        .subscribe(val => {
+          if (val && this.carousel) {
+            this.carousel.interval = val;
+            this.carousel.cycle();
+          }
+        });
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## What Is the Current Behavior?

While doing load tests I observed the following errors:
```
5 b2c ERROR TypeError Cannot read properties of undefined (reading 'length') at templateFn (/dist/b2c/server/webpack:/src/app/shared/cms/components/cms-carousel/cms-carousel.component.html:6:23)
5 b2c
5 b2c /dist/b2c/server/webpack:/src/app/shared/cms/components/cms-carousel/cms-carousel.component.ts:55
          this.carousel.interval = val;
                        ^
5 b2c TypeError: Cannot set properties of undefined (setting 'interval')
    at Object.next (/dist/b2c/server/webpack:/src/app/shared/cms/components/cms-carousel/cms-carousel.component.ts:55:25)
    at ConsumerObserver2.next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/Subscriber.js:113:33)
    at SafeSubscriber2._next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/Subscriber.js:80:26)
    at SafeSubscriber2.next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/Subscriber.js:51:18)
    at onNext (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/operators/take.js:15:32)
    at OperatorSubscriber2._next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js:33:21)
    at OperatorSubscriber2.next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/Subscriber.js:51:18)
    at onNext (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/operators/map.js:10:24)
    at OperatorSubscriber2._next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js:33:21)
    at OperatorSubscriber2.Subscriber2.next (/dist/b2c/server/webpack:/node_modules/rxjs/dist/cjs/internal/Subscriber.js:51:18)
```

## What Is the New Behavior?

- checks added
- cycle start disabled for SSR

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#88948](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/88948)