### PR TITLE
perf: increase pm2 ssr max memory

### DIFF
--- a/src/ssr/server-scripts/build-ecosystem.js
+++ b/src/ssr/server-scripts/build-ecosystem.js
@@ -34,7 +34,7 @@ Object.entries(ports).forEach(([theme, port]) => {
     name: ${theme}
     instances: ${process.env.CONCURRENCY_SSR || 2}
     exec_mode: cluster
-    max_memory_restart: ${process.env.SSR_MAX_MEM || '400M'}
+    max_memory_restart: ${process.env.SSR_MAX_MEM || '600M'}
     env:
       BROWSER_FOLDER: dist/${theme}/browser
       PORT: ${port}


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: Performance Improvement

## What Is the Current Behavior?

Monitoring showed that 400 MB is not enough memory for peak performance and will cause restarts by PM2.

## What Is the New Behavior?

Increased default limit.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#89006](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/89006)