### PR TITLE
chore: add docker image names to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@
 version: '3'
 services:
   pwa:
+    image: intershophub/intershop-pwa-ssr
     build:
       context: .
       args:
@@ -58,6 +59,7 @@ services:
   # </CDN-Example>
 
   nginx:
+    image: intershophub/intershop-pwa-nginx
     build: nginx
     depends_on:
       - pwa


### PR DESCRIPTION
Enables running the project after checkout fast with `docker compose up` which pulls `latest` images.


[AB#89774](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/89774)