### PR TITLE
fix: display salutions on registration page rendering

### DIFF
--- a/src/app/shared/forms/utils/forms.service.spec.ts
+++ b/src/app/shared/forms/utils/forms.service.spec.ts
@@ -15,6 +15,7 @@ describe('Forms Service', () => {
 
   beforeEach(() => {
     translateServiceMock = mock(TranslateService);
+    when(translateServiceMock.get(anyString())).thenReturn(of([]));
 
     TestBed.configureTestingModule({
       imports: [CoreStoreModule.forTesting(['configuration'])],
@@ -38,8 +39,6 @@ describe('Forms Service', () => {
     });
 
     it('should return salutations if countryCode is GB', done => {
-      when(translateServiceMock.get(anyString())).thenReturn(of([]));
-
       formsService.getSalutationOptionsForCountryCode('GB').subscribe(data => {
         expect(data).toHaveLength(3);
         done();
@@ -47,8 +46,6 @@ describe('Forms Service', () => {
     });
 
     it('should return salutations if countryCode is US', done => {
-      when(translateServiceMock.get(anyString())).thenReturn(of([]));
-
       formsService.getSalutationOptionsForCountryCode('US').subscribe(data => {
         expect(data).toHaveLength(3);
         done();
@@ -56,8 +53,6 @@ describe('Forms Service', () => {
     });
 
     it('should return salutations if countryCode is DE', done => {
-      when(translateServiceMock.get(anyString())).thenReturn(of([]));
-
       formsService.getSalutationOptionsForCountryCode('DE').subscribe(data => {
         expect(data).toHaveLength(3);
         done();
@@ -65,8 +60,6 @@ describe('Forms Service', () => {
     });
 
     it('should return salutations if countryCode is FR', done => {
-      when(translateServiceMock.get(anyString())).thenReturn(of([]));
-
       formsService.getSalutationOptionsForCountryCode('FR').subscribe(data => {
         expect(data).toHaveLength(3);
         done();

--- a/src/app/shared/forms/utils/forms.service.spec.ts
+++ b/src/app/shared/forms/utils/forms.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
-import { of } from 'rxjs';
-import { instance, mock } from 'ts-mockito';
+import { isEmpty, of } from 'rxjs';
+import { anyString, instance, mock, when } from 'ts-mockito';
 
 import { Address } from 'ish-core/models/address/address.model';
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
@@ -15,10 +15,12 @@ describe('Forms Service', () => {
 
   beforeEach(() => {
     translateServiceMock = mock(TranslateService);
+
     TestBed.configureTestingModule({
       imports: [CoreStoreModule.forTesting(['configuration'])],
       providers: [{ provide: TranslateService, useFactory: () => instance(translateServiceMock) }],
     });
+
     formsService = TestBed.inject(FormsService);
   });
 
@@ -28,27 +30,47 @@ describe('Forms Service', () => {
 
   describe('getSalutationOptionsForCountryCode', () => {
     it('should return an empty array if countryCode is empty', () => {
-      expect(formsService.getSalutationOptionsForCountryCode('')).toBeEmpty();
+      formsService.getSalutationOptionsForCountryCode('').pipe(isEmpty());
     });
 
     it('should return an empty array if countryCode is not known', () => {
-      expect(formsService.getSalutationOptionsForCountryCode('BG')).toBeEmpty();
+      formsService.getSalutationOptionsForCountryCode('BG').pipe(isEmpty());
     });
 
-    it('should return salutations if countryCode is GB', () => {
-      expect(formsService.getSalutationOptionsForCountryCode('GB')).toHaveLength(3);
+    it('should return salutations if countryCode is GB', done => {
+      when(translateServiceMock.get(anyString())).thenReturn(of([]));
+
+      formsService.getSalutationOptionsForCountryCode('GB').subscribe(data => {
+        expect(data).toHaveLength(3);
+        done();
+      });
     });
 
-    it('should return salutations if countryCode is US', () => {
-      expect(formsService.getSalutationOptionsForCountryCode('US')).toHaveLength(3);
+    it('should return salutations if countryCode is US', done => {
+      when(translateServiceMock.get(anyString())).thenReturn(of([]));
+
+      formsService.getSalutationOptionsForCountryCode('US').subscribe(data => {
+        expect(data).toHaveLength(3);
+        done();
+      });
     });
 
-    it('should return salutations if countryCode is DE', () => {
-      expect(formsService.getSalutationOptionsForCountryCode('DE')).toHaveLength(3);
+    it('should return salutations if countryCode is DE', done => {
+      when(translateServiceMock.get(anyString())).thenReturn(of([]));
+
+      formsService.getSalutationOptionsForCountryCode('DE').subscribe(data => {
+        expect(data).toHaveLength(3);
+        done();
+      });
     });
 
-    it('should return salutations if countryCode is FR', () => {
-      expect(formsService.getSalutationOptionsForCountryCode('FR')).toHaveLength(3);
+    it('should return salutations if countryCode is FR', done => {
+      when(translateServiceMock.get(anyString())).thenReturn(of([]));
+
+      formsService.getSalutationOptionsForCountryCode('FR').subscribe(data => {
+        expect(data).toHaveLength(3);
+        done();
+      });
     });
   });
 

--- a/src/app/shared/forms/utils/forms.service.ts
+++ b/src/app/shared/forms/utils/forms.service.ts
@@ -56,7 +56,6 @@ export class FormsService {
   /**
    * Gets all possible salutation options for a certain country.
    *
-   * @param translate instance of a translation service
    * @param countryCode country code of the country for which the salutations should be determined.
    * @returns salutation select options
    */
@@ -71,8 +70,6 @@ export class FormsService {
   /**
    * Gets all possible salutation options for the current locale.
    *
-   * @param  appFacade instance of the an application facade
-   * @param translate instance of a translation service
    * @returns salutation select options
    */
   getSalutationOptions(): Observable<SelectOption[]> {


### PR DESCRIPTION
## PR Type

[x] Bugfix


## What Is the Current Behavior?

The salutations on the registration form are not translated when refreshing the page.

Issue Number: Closes #


## What Is the New Behavior?

The salutations on the registration are being translated when refreshing the page.


## Does this PR Introduce a Breaking Change?

[x] No


## Other Information


[AB#89942](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/89942)