### PR TITLE
fix: deploy URL not set right for all CSS url references (e.g. fonts)

### DIFF
--- a/src/ssr/deploy-url.ts
+++ b/src/ssr/deploy-url.ts
@@ -12,7 +12,7 @@ export function setDeployUrlInFile(deployUrl: string, path: string, input: strin
 
     let newInput = input;
 
-    const cssRegex = /url\((?!http)\/?(assets.*?|[a-zA-Z].*?woff2?)\)/g;
+    const cssRegex = /url\((?!http|data)\/?(assets.*?|[a-zA-Z].*?woff2?)\)/g;
     if (cssRegex.test(newInput)) {
       newInput = newInput.replace(cssRegex, (...args) => `url(${deployUrl}${args[1]})`);
     }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

With the setting
```
DEPLOY_URL: '/extranet/'
```
and font definition in the SCSS files like this

```
/* Helvetica Neue Condensed Heavy - latin */
@font-face {
  font-family: 'HelveticaNeue-CondensedBold';
  font-style: normal;
  font-weight: 400;
  src: local('HelveticaNeue-CondensedBold '),
    //  Super Modern Browsers
    url('/assets/fonts/HelveticaNeueBold.woff2') format('woff2'),
    // Modern Browsers
    url('/assets/fonts/HelveticaNeueBold.woff') format('woff');
  font-display: swap;
}

/* Helvetica Neue Condensed - latin */
@font-face {
  font-family: 'HelveticaNeue-Condensed';
  font-style: normal;
  font-weight: 400;
  src: local('HelveticaNeue-Condensed '),
    //  Super Modern Browsers
    url('/assets/fonts/HelveticaNeueNormal.woff2') format('woff2'),
    // Modern Browsers
    url('/assets/fonts/HelveticaNeueNormal.woff') format('woff');
  font-display: swap;
}
``` 

The resulting CSS (checked inside the browser) is:
```
@font-face{font-family:HelveticaNeue-CondensedBold;font-style:normal;font-weight:400;src:local("HelveticaNeue-CondensedBold "),
url(/assets/fonts/HelveticaNeueBold.woff2) format("woff2"),url(/extranet/assets/fonts/HelveticaNeueBold.woff) format("woff");font-display:swap}
 
@font-face{font-family:HelveticaNeue-Condensed;font-style:normal;font-weight:400;src:local("HelveticaNeue-Condensed "),
url(/extranet/assets/fonts/HelveticaNeueNormal.woff2) format("woff2"),url(/extranet/assets/fonts/HelveticaNeueNormal.woff) format("woff");font-display:swap}
```
So at the very first font the `/extranet` is missing in front of `/assets`.
We have changed the order of the fonts inside the SCSS. Always the first font is affected.

## What Is the New Behavior?

* deploy URL was falsely  set for `url(data:` references - this is no longer the case
* the matcher selected `url(data` references and included the first `url(/assets/` in this match so it was not treated separately failing to add the deploy URL for the first assets URL after a data URL - this is no longer the case

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#90317](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/90317)