### PR TITLE
build: upgrade 1arp/create-a-file-action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - uses: 1arp/create-a-file-action@0.2
+      - uses: 1arp/create-a-file-action@0.3
         with:
           path: '.'
           file: 'script.bat'


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] CI-related changes

## What Is the Current Behavior?

Warning in [Windows Job](https://github.com/intershop/intershop-pwa/actions/workflows/windows.yml): `The following actions uses node12 which is deprecated and will be forced to run on node16: 1arp/create-a-file-action@0.2. For more info: `[`...`](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)

## What Is the New Behavior?

Upgrade action from 0.2 to 0.3

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#91155](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91155)