### PR TITLE
fix: include rewriting for scripts artifact in deploy-url handling

### DIFF
--- a/src/ssr/deploy-url.ts
+++ b/src/ssr/deploy-url.ts
@@ -22,7 +22,8 @@ export function setDeployUrlInFile(deployUrl: string, path: string, input: strin
       newInput = newInput.replace(assetsRegex, (...args) => `"${deployUrl}${args[1]}"`);
     }
 
-    const javascriptRegex = /"(DEPLOY_URL_PLACEHOLDER|\/)?((runtime|vendor|main|polyfills|styles)[^"]*\.(js|css))"/g;
+    const javascriptRegex =
+      /"(DEPLOY_URL_PLACEHOLDER|\/)?((runtime|vendor|main|polyfills|styles|scripts)[^"]*\.(js|css))"/g;
     if (javascriptRegex.test(newInput)) {
       newInput = newInput.replace(javascriptRegex, (...args) => `"${deployUrl}${args[2]}"`);
     }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] Bugfix

## What Is the Current Behavior?

Whenever you include external scripts in `angular.json`, angular creates a `scripts.js` file which is injected in the `index.html` file for bootstrapping the application.
This script is not yet handled properly by the deployUrl rewriting mechanism.

![image](https://github.com/intershop/intershop-pwa/assets/23452927/b0e7b856-789e-41f4-a977-0513343b4559)

## What Is the New Behavior?

Fixed

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#91192](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91192)