### PR TITLE
fix: revert irrelevant changes of "wrong ICM is used with errors on SSR"

### DIFF
--- a/src/app/core/interceptors/icm-error-mapper.interceptor.spec.ts
+++ b/src/app/core/interceptors/icm-error-mapper.interceptor.spec.ts
@@ -33,12 +33,12 @@ describe('Icm Error Mapper Interceptor', () => {
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
-            {
-              "message": "Unauthorized",
-              "name": "HttpErrorResponse",
-              "status": 401,
-            }
-          `);
+          {
+            "message": "Unauthorized",
+            "name": "HttpErrorResponse",
+            "status": 401,
+          }
+        `);
         done();
       },
     });
@@ -51,12 +51,13 @@ describe('Icm Error Mapper Interceptor', () => {
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
-        {
-          "message": "Http failure response for some: 400 Bad Request",
-          "name": "HttpErrorResponse",
-          "status": 400,
-        }
-      `);
+          {
+            "code": "Bad Request",
+            "message": "Http failure response for some: 400 Bad Request",
+            "name": "HttpErrorResponse",
+            "status": 400,
+          }
+        `);
         done();
       },
     });
@@ -73,35 +74,35 @@ describe('Icm Error Mapper Interceptor', () => {
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
-{
-  "errors": [
-    {
-      "causes": [
-        {
-          "code": "basket.promotion_code.add_code_promotion_code_not_found.error",
-          "message": "The promotion code could not be found.",
-          "paths": [
-            "$.code",
-          ],
-        },
-        {
-          "code": "some.other.error",
-          "message": "Some other error.",
-          "paths": [
-            "$.code",
-          ],
-        },
-      ],
-      "code": "basket.promotion_code.add_not_successful.error",
-      "message": "The promotion code could not be added.",
-      "status": "422",
-    },
-  ],
-  "message": "The promotion code could not be added. The promotion code could not be found. Some other error.",
-  "name": "HttpErrorResponse",
-  "status": 422,
-}
-`);
+          {
+            "errors": [
+              {
+                "causes": [
+                  {
+                    "code": "basket.promotion_code.add_code_promotion_code_not_found.error",
+                    "message": "The promotion code could not be found.",
+                    "paths": [
+                      "$.code",
+                    ],
+                  },
+                  {
+                    "code": "some.other.error",
+                    "message": "Some other error.",
+                    "paths": [
+                      "$.code",
+                    ],
+                  },
+                ],
+                "code": "basket.promotion_code.add_not_successful.error",
+                "message": "The promotion code could not be added.",
+                "status": "422",
+              },
+            ],
+            "message": "The promotion code could not be added. The promotion code could not be found. Some other error.",
+            "name": "HttpErrorResponse",
+            "status": 422,
+          }
+        `);
         done();
       },
     });
@@ -137,21 +138,21 @@ describe('Icm Error Mapper Interceptor', () => {
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
-{
-  "errors": [
-    {
-      "code": "basket.add_line_item_not_successful.error",
-      "message": "The product could not be added to your cart.",
-      "paths": [
-        "$[0]",
-      ],
-      "status": "422",
-    },
-  ],
-  "name": "HttpErrorResponse",
-  "status": 422,
-}
-`);
+          {
+            "errors": [
+              {
+                "code": "basket.add_line_item_not_successful.error",
+                "message": "The product could not be added to your cart.",
+                "paths": [
+                  "$[0]",
+                ],
+                "status": "422",
+              },
+            ],
+            "name": "HttpErrorResponse",
+            "status": 422,
+          }
+        `);
         done();
       },
     });
@@ -176,12 +177,12 @@ describe('Icm Error Mapper Interceptor', () => {
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
-        {
-          "code": "customer.credentials.login.not_unique.error",
-          "name": "HttpErrorResponse",
-          "status": 409,
-        }
-      `);
+          {
+            "code": "customer.credentials.login.not_unique.error",
+            "name": "HttpErrorResponse",
+            "status": 409,
+          }
+        `);
         done();
       },
     });
@@ -198,12 +199,12 @@ describe('Icm Error Mapper Interceptor', () => {
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
-        {
-          "message": "Bad Request (The following attributes are missing: email,preferredLanguage)",
-          "name": "HttpErrorResponse",
-          "status": 400,
-        }
-      `);
+          {
+            "message": "Bad Request (The following attributes are missing: email,preferredLanguage)",
+            "name": "HttpErrorResponse",
+            "status": 400,
+          }
+        `);
         done();
       },
     });
@@ -232,12 +233,12 @@ describe('Icm Error Mapper Interceptor', () => {
         next: fail,
         error: error => {
           expect(error).toMatchInlineSnapshot(`
-{
-  "message": "Bad Request (The following attributes are invalid: email,preferredLanguage){"email":"asdf@.","preferredLanguage":"ASDF"}",
-  "name": "HttpErrorResponse",
-  "status": 400,
-}
-`);
+            {
+              "message": "Bad Request (The following attributes are invalid: email,preferredLanguage){"email":"asdf@.","preferredLanguage":"ASDF"}",
+              "name": "HttpErrorResponse",
+              "status": 400,
+            }
+          `);
           done();
         },
       });
@@ -255,14 +256,14 @@ describe('Icm Error Mapper Interceptor', () => {
       });
   });
 
-  it('should convert other error responses directly for a fallback', done => {
+  it('should convert other error responses to simplified format', done => {
     http.get('some').subscribe({
       next: fail,
       error: error => {
         expect(error).toMatchInlineSnapshot(`
           {
-            "error": "some other format",
-            "key": "value",
+            "code": "Bad Request",
+            "message": "Http failure response for some: 400 Bad Request",
             "name": "HttpErrorResponse",
             "status": 400,
           }

--- a/src/app/core/store/core/configuration/configuration.effects.ts
+++ b/src/app/core/store/core/configuration/configuration.effects.ts
@@ -65,9 +65,7 @@ export class ConfigurationEffects {
         ofType(ROOT_EFFECTS_INIT),
         take(1),
         concatLatestFrom(() => [
-          this.stateProperties.getStateOrEnvOrDefault<string>('ICM_BASE_URL', 'icmBaseURL', {
-            disableDefault: PRODUCTION_MODE,
-          }),
+          this.stateProperties.getStateOrEnvOrDefault<string>('ICM_BASE_URL', 'icmBaseURL'),
           this.stateProperties.getStateOrEnvOrDefault<string>('ICM_SERVER', 'icmServer'),
           this.stateProperties.getStateOrEnvOrDefault<string>('ICM_SERVER_STATIC', 'icmServerStatic'),
           this.stateProperties.getStateOrEnvOrDefault<string>('ICM_CHANNEL', 'icmChannel'),

--- a/src/app/core/store/core/error/error.reducer.ts
+++ b/src/app/core/store/core/error/error.reducer.ts
@@ -1,5 +1,4 @@
 import { createReducer, on } from '@ngrx/store';
-import { pick } from 'lodash-es';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 
@@ -24,10 +23,7 @@ export const errorReducer = createReducer(
     serverConfigError,
     (state, action): ErrorState => ({
       ...state,
-      current:
-        typeof action.payload.error === 'object'
-          ? pick(action.payload.error, 'code', 'errors', 'message', 'name', 'status')
-          : action.payload.error,
+      current: action.payload.error,
       type: action.type,
     })
   )

--- a/src/app/core/utils/state-transfer/state-properties.service.ts
+++ b/src/app/core/utils/state-transfer/state-properties.service.ts
@@ -30,15 +30,9 @@ export class StatePropertiesService {
   constructor(private store: Store) {}
 
   /**
-   * Retrieve property from first set property of server state, system environment or environment.ts (default)
-   * optional the fallback to default can be disabled
-   * e.g. for production environments where there should not be a fallback for the system environment configuration
+   * Retrieve property from first set property of server state, system environment or environment.ts
    */
-  getStateOrEnvOrDefault<T>(
-    envKey: string,
-    envPropKey: keyof Environment,
-    options?: { disableDefault: boolean }
-  ): Observable<T> {
+  getStateOrEnvOrDefault<T>(envKey: string, envPropKey: keyof Environment): Observable<T> {
     return this.store.pipe(
       select(getConfigurationState),
       mapToProperty(envPropKey as keyof ConfigurationType),
@@ -47,10 +41,8 @@ export class StatePropertiesService {
           return value;
         } else if (SSR && process.env[envKey]) {
           return process.env[envKey];
-        } else if (!options?.disableDefault) {
-          return environment[envPropKey];
         } else {
-          return;
+          return environment[envPropKey];
         }
       }),
       SSR


### PR DESCRIPTION
improvent of #1519

* reverted: icmBaseURL no longer uses environment.ts fallback in production mode
* reverted: make usage of default/fallback configuration in environment.ts configurable for getting state properties
* refactored: errors should only contain properties of defined HttpError interface - this is now handled at the error interceptor
* kept: do not log an error that can't be stringified, it floods the log with irrelevant information

BREAKING CHANGES: No longer a breaking change regarding "No longer falls back to `environment.ts` configured `icmBaseURL` in production mode."

## PR Type

[x] Bugfix


## What Is the New Behavior?

The error object properties in the ~~error.reducer.ts~~ `icm-error-mapper.interceptor.ts` are reduced to the defined set of the predefined HttpError interface.

Unnecessary changes of #1519 are reverted.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#91270](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91270)