### PR TITLE
fix: navigate to anchor on master filter selection

### DIFF
--- a/src/app/pages/product/product-master-variations/product-master-variations.component.html
+++ b/src/app/pages/product/product-master-variations/product-master-variations.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="variationCount$ | async">
   <a id="variation-list-top" title="top"></a>
-  <ish-filter-navigation orientation="horizontal"></ish-filter-navigation>
+  <ish-filter-navigation orientation="horizontal" fragmentOnRouting="variation-list-top"></ish-filter-navigation>
   <ish-product-listing
     mode="paging"
     [categoryId]="categoryId$ | async"

--- a/src/app/pages/product/product-master-variations/product-master-variations.component.spec.ts
+++ b/src/app/pages/product/product-master-variations/product-master-variations.component.spec.ts
@@ -44,7 +44,9 @@ describe('Product Master Variations Component', () => {
       <a id="variation-list-top" title="top"></a
       ><ish-filter-navigation
         orientation="horizontal"
+        fragmentonrouting="variation-list-top"
         ng-reflect-orientation="horizontal"
+        ng-reflect-fragment-on-routing="variation-list-top"
       ></ish-filter-navigation
       ><ish-product-listing
         mode="paging"


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] Bugfix

## What Is the Current Behavior?

When using the filter navigation for product master pages, the page navigates to the top every time something is selected.

Steps to repeat:

- go to [public demo master product](https://intershoppwa.azurewebsites.net/computers/tablets/microsoft/microsoft-surface-book-2-prd201807231-ctgComputers.897.897_Microsoft)
- select a filter (i.e. "Display size")

expected: table stays in view

actual: page navigates to top

analysis: this functionality somehow was lost during 0435372df979810854bd496ac8193cba44c82a4b

## What Is the New Behavior?

Added `fragmentOnRouting`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#91311](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91311)