### PR TITLE
refactor: allow single value filter params

### DIFF
--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -88,7 +88,7 @@ export class CMSFacade {
       searchParameter.category = [CategoryHelper.getCategoryPath(categoryId)];
     }
 
-    searchParameter.productFilter = productFilter ? [productFilter] : ['fallback_searchquerydefinition'];
+    searchParameter.productFilter = productFilter ?? 'fallback_searchquerydefinition';
 
     return { id, searchParameter };
   }

--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.spec.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.spec.ts
@@ -41,9 +41,7 @@ describe('Filter Navigation Mapper', () => {
       expect(model.filter[0].facets).toHaveLength(1);
       expect(model.filter[0].facets[0].searchParameter).toMatchInlineSnapshot(`
         {
-          "SearchParameter": [
-            "param",
-          ],
+          "SearchParameter": "param",
           "category": undefined,
         }
       `);

--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
@@ -48,7 +48,7 @@ export class FilterNavigationMapper {
       ? filterData.filterEntries.reduce((acc, facet) => {
           const uri = this.removeSpgidFromUri(facet.link.uri);
           const category = uri.includes('/categories/')
-            ? [uri.split('/productfilters')[0].split('/categories/')[1]]
+            ? uri.split('/productfilters')[0].split('/categories/')[1]
             : undefined;
           if (facet.name !== 'Show all') {
             acc.push({

--- a/src/app/core/services/filter/filter.service.ts
+++ b/src/app/core/services/filter/filter.service.ts
@@ -44,7 +44,7 @@ export class FilterService {
     const params = appendFormParamsToHttpParams(omit(searchParameter, 'category'));
 
     const resource = searchParameter.category
-      ? `categories/${searchParameter.category[0]}/productfilters`
+      ? `categories/${searchParameter.category}/productfilters`
       : 'productfilters';
 
     return this.apiService

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -210,7 +210,7 @@ export class ProductsService {
     }
     params = appendFormParamsToHttpParams(omit(searchParameter, 'category'), params);
 
-    const resource = searchParameter.category ? `categories/${searchParameter.category[0]}/products` : 'products';
+    const resource = searchParameter.category ? `categories/${searchParameter.category}/products` : 'products';
 
     return this.apiService
       .get<{

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -128,20 +128,20 @@ describe('Product Listing Effects', () => {
         [Product Listing] Load More Products:
           id: {"type":"search","value":"term"}
         [Product Listing Internal] Load More Products For Params:
-          id: {"type":"search","value":"term","filters":{"param":[1],"sear...
-          filters: {"param":[1],"searchTerm":[1]}
+          id: {"type":"search","value":"term","filters":{"param":"foobar",...
+          filters: {"param":"foobar","searchTerm":"term"}
           sorting: undefined
           page: undefined
         [Filter Internal] Load Products For Filter:
-          id: {"type":"search","value":"term","filters":{"param":[1],"sear...
-          searchParameter: {"param":[1],"searchTerm":[1]}
+          id: {"type":"search","value":"term","filters":{"param":"foobar",...
+          searchParameter: {"param":"foobar","searchTerm":"term"}
           page: undefined
           sorting: undefined
         [Filter] Apply Filter:
-          searchParameter: {"param":[1],"searchTerm":[1]}
+          searchParameter: {"param":"foobar","searchTerm":"term"}
       `);
-      expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.param', ['foobar']);
-      expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.searchTerm', ['term']);
+      expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.param', 'foobar');
+      expect(store$.actionsArray()[1]).toHaveProperty('payload.filters.searchTerm', 'term');
     }));
 
     it('should fire all necessary actions for family page', fakeAsync(() => {
@@ -153,17 +153,17 @@ describe('Product Listing Effects', () => {
         [Product Listing] Load More Products:
           id: {"type":"category","value":"cat"}
         [Product Listing Internal] Load More Products For Params:
-          id: {"type":"category","value":"cat","filters":{"param":[1]}}
-          filters: {"param":[1]}
+          id: {"type":"category","value":"cat","filters":{"param":"foobar"}}
+          filters: {"param":"foobar"}
           sorting: undefined
           page: undefined
         [Filter Internal] Load Products For Filter:
-          id: {"type":"category","value":"cat","filters":{"param":[1]}}
-          searchParameter: {"param":[1]}
+          id: {"type":"category","value":"cat","filters":{"param":"foobar"}}
+          searchParameter: {"param":"foobar"}
           page: undefined
           sorting: undefined
         [Filter] Apply Filter:
-          searchParameter: {"param":[1]}
+          searchParameter: {"param":"foobar"}
       `);
     }));
   });

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -106,8 +106,8 @@ export class ProductListingEffects {
             const filters = params.filters
               ? {
                   ...stringToFormParams(params.filters),
-                  ...(id.type === 'search' ? { searchTerm: [id.value] } : {}),
-                  ...(id.type === 'master' ? { MasterSKU: [id.value] } : {}),
+                  ...(id.type === 'search' ? { searchTerm: id.value } : {}),
+                  ...(id.type === 'master' ? { MasterSKU: id.value } : {}),
                 }
               : undefined;
 

--- a/src/app/core/utils/url-form-params.spec.ts
+++ b/src/app/core/utils/url-form-params.spec.ts
@@ -13,9 +13,7 @@ describe('Url Form Params', () => {
     it('should handle single value transformation for single parameters', () => {
       expect(stringToFormParams('test=a')).toMatchInlineSnapshot(`
         {
-          "test": [
-            "a",
-          ],
+          "test": "a",
         }
       `);
     });
@@ -34,9 +32,7 @@ describe('Url Form Params', () => {
     it('should respect separator option when handling input', () => {
       expect(stringToFormParams('foo=a_or_b&bar=c', '_or_')).toMatchInlineSnapshot(`
         {
-          "bar": [
-            "c",
-          ],
+          "bar": "c",
           "foo": [
             "a",
             "b",
@@ -48,9 +44,7 @@ describe('Url Form Params', () => {
     it('should not fail if string starts with &', () => {
       expect(stringToFormParams('&test=a')).toMatchInlineSnapshot(`
         {
-          "test": [
-            "a",
-          ],
+          "test": "a",
         }
       `);
     });
@@ -62,9 +56,7 @@ describe('Url Form Params', () => {
             "d",
             "e",
           ],
-          "foo": [
-            "c",
-          ],
+          "foo": "c",
           "test": [
             "a",
             "b",

--- a/src/app/core/utils/url-form-params.ts
+++ b/src/app/core/utils/url-form-params.ts
@@ -1,14 +1,22 @@
 import { HttpParams } from '@angular/common/http';
 
 export interface URLFormParams {
-  [facet: string]: string[];
+  [facet: string]: string[] | string;
+}
+
+function concat(val: string[] | string, separator: string): string {
+  return Array.isArray(val) ? val.join(separator) : val;
+}
+
+function encodeAndConcat(val: string[] | string, separator: string): string {
+  return Array.isArray(val) ? val.map(encodeURIComponent).join(separator) : encodeURIComponent(val);
 }
 
 export function formParamsToString(object: URLFormParams, separator = ','): string {
   return object
     ? Object.entries(object)
-        .filter(([, value]) => Array.isArray(value) && value.length)
-        .map(([key, val]) => `${key}=${val.map(encodeURIComponent).join(separator)}`)
+        .filter(([, value]) => (Array.isArray(value) || typeof value === 'string') && value.length)
+        .map(([key, val]) => `${key}=${encodeAndConcat(val, separator)}`)
         .join('&')
     : '';
 }
@@ -20,9 +28,13 @@ export function appendFormParamsToHttpParams(
 ): HttpParams {
   return object
     ? Object.entries(object)
-        .filter(([, value]) => Array.isArray(value) && value.length)
-        .reduce((p, [key, val]) => p.set(key, val.join(separator)), params)
+        .filter(([, value]) => (Array.isArray(value) || typeof value === 'string') && value.length)
+        .reduce((p, [key, val]) => p.set(key, concat(val, separator)), params)
     : params;
+}
+
+function splitAndDecode(val: string, separator: string): string[] | string {
+  return val.includes(separator) ? val.split(separator).map(decodeURIComponent) : decodeURIComponent(val);
 }
 
 export function stringToFormParams(object: string, separator = ','): URLFormParams {
@@ -32,7 +44,7 @@ export function stringToFormParams(object: string, separator = ','): URLFormPara
         .filter(val => val?.includes('='))
         .map(val => {
           const [key, values] = val.split('=');
-          return { key: decodeURIComponent(key), value: values.split(separator).map(decodeURIComponent) };
+          return { key: decodeURIComponent(key), value: splitAndDecode(values, separator) };
         })
         .reduce((acc, val) => ({ ...acc, [val.key]: val.value }), {})
     : {};


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Filter parameters are always treated as multi-value even though most of them only make sense using a single value (`MasterSKU`, `searchTerm`)

## What Is the New Behavior?

Adapted helpers for handling params to also support single values.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[X] Yes
[ ] No

If there is an interaction with filter values in any customization, the new helpers have to be used.

## Other Information


[AB#91389](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91389)