### PR TITLE
refactor: typed environment feature toggle

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -270,7 +270,7 @@
             {
               "importNamePattern": ".*",
               "name": ".*environments/environment.*",
-              "filePattern": "^.*/app/((?!(app(.server)?.module|core/store/core/configuration/configuration\\.reducer|core/utils/state-transfer/state-properties\\.service|core/utils/injection)\\.ts).)*$",
+              "filePattern": "^.*/app/((?!(app(.server)?.module|core/store/core/configuration/configuration\\.reducer|core/utils/state-transfer/state-properties\\.service|core/utils/injection|core/utils/feature-toggle/feature-toggle\\.service)\\.ts).)*$",
               "message": "Importing environment is not allowed. Inject needed properties instead."
             },
             {

--- a/schematics/src/extension/factory.ts
+++ b/schematics/src/extension/factory.ts
@@ -15,7 +15,12 @@ import { PWAExtensionOptionsSchema as Options } from 'schemas/extension/schema';
 
 import { applyNameAndPath, detectExtension, determineArtifactName } from '../utils/common';
 import { applyLintFix } from '../utils/lint-fix';
-import { addExportToNgModule, addImportToNgModule, addImportToNgModuleBefore } from '../utils/registration';
+import {
+  addExportToNgModule,
+  addFeatureToEnvironment,
+  addImportToNgModule,
+  addImportToNgModuleBefore,
+} from '../utils/registration';
 
 export function createExtension(options: Options): Rule {
   return async host => {
@@ -66,6 +71,8 @@ export function createExtension(options: Options): Rule {
       )}-routing.module`,
     };
     operations.push(addImportToNgModuleBefore(appModuleOptions, 'AppLastRoutingModule'));
+
+    operations.push(addFeatureToEnvironment(strings.camelize(options.name)));
 
     operations.push(applyLintFix());
 

--- a/schematics/src/extension/factory_spec.ts
+++ b/schematics/src/extension/factory_spec.ts
@@ -97,6 +97,14 @@ describe('Extension Schematic', () => {
     `);
   });
 
+  it('should add extension to the environment model feature list', async () => {
+    const options = { ...defaultOptions };
+
+    const tree = await schematicRunner.runSchematic('extension', options, appTree);
+    const environmentModelContent = tree.readContent('/src/environments/environment.model.ts');
+    expect(environmentModelContent).toInclude("| 'foo'");
+  });
+
   it('should throw if app module does not contain AppLastRoutingModule', done => {
     appTree.overwrite(
       '/src/app/app.module.ts',

--- a/schematics/src/utils/registration.ts
+++ b/schematics/src/utils/registration.ts
@@ -304,3 +304,18 @@ export function setStyleUrls(componentFile: string, styleUrls: string[]): Rule {
     });
   };
 }
+
+export function addFeatureToEnvironment(feature: string): Rule {
+  return host => {
+    const source = readIntoSourceFile(host, '/src/environments/environment.model.ts');
+    const recorder = host.beginUpdate('/src/environments/environment.model.ts');
+    const existing = tsquery(
+      source,
+      `InterfaceDeclaration:has(Identifier[name=Environment]) > PropertySignature:has(Identifier[name=features]) UnionType`
+    )[0];
+    if (existing) {
+      recorder.insertLeft(existing.getEnd(), `\n    | '${feature}'`);
+    }
+    host.commitUpdate(recorder);
+  };
+}

--- a/schematics/src/utils/testHelper.ts
+++ b/schematics/src/utils/testHelper.ts
@@ -17,22 +17,24 @@ export function createApplication(schematicRunner: SchematicTestRunner) {
     })
   ).pipe(
     switchMap(workspace =>
-      schematicRunner.runExternalSchematic(
-        '@schematics/angular',
-        'application',
-        {
-          name: 'bar',
-          inlineStyle: false,
-          inlineTemplate: false,
-          routing: true,
-          style: 'scss',
-          skipTests: false,
-          skipPackageJson: false,
-          prefix: 'ish',
-          projectRoot: '',
-        },
-        workspace
-      )
+      from(
+        schematicRunner.runExternalSchematic(
+          '@schematics/angular',
+          'application',
+          {
+            name: 'bar',
+            inlineStyle: false,
+            inlineTemplate: false,
+            routing: true,
+            style: 'scss',
+            skipTests: false,
+            skipPackageJson: false,
+            prefix: 'ish',
+            projectRoot: '',
+          },
+          workspace
+        )
+      ).pipe(copyFileFromPWA('src/environments/environment.model.ts'))
     )
   );
 }

--- a/src/app/core/configurations/configuration.meta.ts
+++ b/src/app/core/configurations/configuration.meta.ts
@@ -6,6 +6,7 @@ import { applyConfiguration } from 'ish-core/store/core/configuration';
 import { ConfigurationState, configurationReducer } from 'ish-core/store/core/configuration/configuration.reducer';
 import { CoreState } from 'ish-core/store/core/core-store';
 import { RouterState } from 'ish-core/store/core/router/router.reducer';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { mergeDeep } from 'ish-core/utils/functions';
 
 class SimpleParamMap {
@@ -36,12 +37,12 @@ function extractConfigurationParameters(state: ConfigurationState, paramMap: Sim
     if (paramMap.get('features') === 'none') {
       properties.features = [];
     } else {
-      properties.features = paramMap.get<string>('features').split(/,/g);
+      properties.features = paramMap.get<string>('features').split(/,/g) as FeatureToggleType[];
     }
   }
 
   if (paramMap.has('addFeatures')) {
-    properties.addFeatures = paramMap.get<string>('addFeatures').split(/,/g);
+    properties.addFeatures = paramMap.get<string>('addFeatures').split(/,/g) as FeatureToggleType[];
   }
 
   if (paramMap.has('device')) {

--- a/src/app/core/directives/feature-toggle.directive.spec.ts
+++ b/src/app/core/directives/feature-toggle.directive.spec.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 @Component({
   template: `
@@ -24,7 +25,7 @@ describe('Feature Toggle Directive', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [FeatureToggleModule.forTesting('feature1')],
+      imports: [FeatureToggleModule.forTesting('feature1' as FeatureToggleType)],
     }).compileComponents();
   });
 
@@ -64,7 +65,7 @@ describe('Feature Toggle Directive', () => {
 
   describe('after activating the other feature', () => {
     beforeEach(() => {
-      FeatureToggleModule.switchTestingFeatures('feature2');
+      FeatureToggleModule.switchTestingFeatures('feature2' as FeatureToggleType);
       fixture.detectChanges();
     });
 

--- a/src/app/core/directives/feature-toggle.directive.ts
+++ b/src/app/core/directives/feature-toggle.directive.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Directive, Input, OnDestroy, TemplateRef, ViewContai
 import { BehaviorSubject, Subject, Subscription, combineLatest } from 'rxjs';
 import { distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
 
-import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { FeatureToggleService, FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 /**
  * Structural directive.
@@ -52,7 +52,7 @@ export class FeatureToggleDirective implements OnDestroy {
       });
   }
 
-  @Input() set ishFeature(feature: string) {
+  @Input() set ishFeature(feature: 'always' | 'never' | FeatureToggleType) {
     // end previous subscription and newly subscribe
     if (this.subscription) {
       // eslint-disable-next-line ban/ban

--- a/src/app/core/directives/not-feature-toggle.directive.spec.ts
+++ b/src/app/core/directives/not-feature-toggle.directive.spec.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 @Component({
   template: `
@@ -22,7 +23,7 @@ describe('Not Feature Toggle Directive', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [FeatureToggleModule.forTesting('feature1')],
+      imports: [FeatureToggleModule.forTesting('feature1' as FeatureToggleType)],
     }).compileComponents();
   });
 

--- a/src/app/core/directives/not-feature-toggle.directive.ts
+++ b/src/app/core/directives/not-feature-toggle.directive.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Directive, Input, OnDestroy, TemplateRef, ViewContai
 import { ReplaySubject, Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
-import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { FeatureToggleService, FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 /**
  * Structural directive.
@@ -40,7 +40,7 @@ export class NotFeatureToggleDirective implements OnDestroy {
     });
   }
 
-  @Input() set ishNotFeature(val: string) {
+  @Input() set ishNotFeature(val: 'always' | 'never' | FeatureToggleType) {
     // end previous subscription and newly subscribe
     if (this.subscription) {
       // eslint-disable-next-line ban/ban

--- a/src/app/core/feature-toggle.module.ts
+++ b/src/app/core/feature-toggle.module.ts
@@ -4,16 +4,16 @@ import { map } from 'rxjs/operators';
 
 import { FeatureToggleDirective } from './directives/feature-toggle.directive';
 import { NotFeatureToggleDirective } from './directives/not-feature-toggle.directive';
-import { FeatureToggleService, checkFeature } from './utils/feature-toggle/feature-toggle.service';
+import { FeatureToggleService, FeatureToggleType, checkFeature } from './utils/feature-toggle/feature-toggle.service';
 
 @NgModule({
   declarations: [FeatureToggleDirective, NotFeatureToggleDirective],
   exports: [FeatureToggleDirective, NotFeatureToggleDirective],
 })
 export class FeatureToggleModule {
-  private static features$ = new BehaviorSubject<string[]>(undefined);
+  private static features$ = new BehaviorSubject<FeatureToggleType[]>(undefined);
 
-  static forTesting(...features: string[]): ModuleWithProviders<FeatureToggleModule> {
+  static forTesting(...features: FeatureToggleType[]): ModuleWithProviders<FeatureToggleModule> {
     FeatureToggleModule.switchTestingFeatures(...features);
     return {
       ngModule: FeatureToggleModule,
@@ -21,17 +21,17 @@ export class FeatureToggleModule {
         {
           provide: FeatureToggleService,
           useValue: {
-            enabled$: (feature: string) =>
+            enabled$: (feature: FeatureToggleType) =>
               FeatureToggleModule.features$.pipe(map(toggles => checkFeature(toggles, feature))),
             // eslint-disable-next-line rxjs/no-subject-value
-            enabled: (feature: string) => checkFeature(FeatureToggleModule.features$.value, feature),
+            enabled: (feature: FeatureToggleType) => checkFeature(FeatureToggleModule.features$.value, feature),
           },
         },
       ],
     };
   }
 
-  static switchTestingFeatures(...features: string[]) {
+  static switchTestingFeatures(...features: FeatureToggleType[]) {
     FeatureToggleModule.features$.next(features);
   }
 }

--- a/src/app/core/guards/feature-toggle.guard.spec.ts
+++ b/src/app/core/guards/feature-toggle.guard.spec.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { FeatureToggleModule, featureToggleGuard } from 'ish-core/feature-toggle.module';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 describe('Feature Toggle Guard', () => {
   let router: Router;
@@ -10,7 +11,7 @@ describe('Feature Toggle Guard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        FeatureToggleModule.forTesting('feature1'),
+        FeatureToggleModule.forTesting('feature1' as FeatureToggleType),
         RouterTestingModule.withRoutes([
           {
             path: 'error',

--- a/src/app/core/identity-provider/identity-provider.factory.ts
+++ b/src/app/core/identity-provider/identity-provider.factory.ts
@@ -6,6 +6,7 @@ import { first } from 'rxjs/operators';
 
 import { FeatureToggleService } from 'ish-core/feature-toggle.module';
 import { getIdentityProvider } from 'ish-core/store/core/configuration';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 import { IdentityProvider } from './identity-provider.interface';
@@ -13,7 +14,7 @@ import { IdentityProvider } from './identity-provider.interface';
 interface IdentityProviderImplementor {
   type: string;
   implementor: Type<IdentityProvider<unknown>>;
-  feature?: string;
+  feature?: FeatureToggleType;
 }
 
 export const IDENTITY_PROVIDER_IMPLEMENTOR = new InjectionToken<IdentityProviderImplementor>(

--- a/src/app/core/pipes/feature-toggle.pipe.spec.ts
+++ b/src/app/core/pipes/feature-toggle.pipe.spec.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 import { FeatureTogglePipe } from './feature-toggle.pipe';
 
@@ -23,7 +24,7 @@ describe('Feature Toggle Pipe', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FeatureToggleModule.forTesting('feature1')],
+      imports: [FeatureToggleModule.forTesting('feature1' as FeatureToggleType)],
       declarations: [FeatureTogglePipe, TestComponent],
     });
   });
@@ -56,7 +57,7 @@ describe('Feature Toggle Pipe', () => {
 
   describe('after switching features', () => {
     beforeEach(() => {
-      FeatureToggleModule.switchTestingFeatures('feature2');
+      FeatureToggleModule.switchTestingFeatures('feature2' as FeatureToggleType);
       fixture.detectChanges();
     });
 

--- a/src/app/core/pipes/feature-toggle.pipe.ts
+++ b/src/app/core/pipes/feature-toggle.pipe.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, OnDestroy, Pipe, PipeTransform } from '@angular/core
 import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { FeatureToggleService, FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 /**
  * Pipe
@@ -21,7 +21,7 @@ export class FeatureTogglePipe implements PipeTransform, OnDestroy {
 
   constructor(private featureToggleService: FeatureToggleService, private cdRef: ChangeDetectorRef) {}
 
-  transform(feature: string): boolean {
+  transform(feature: 'always' | 'never' | FeatureToggleType): boolean {
     if (this.subscription) {
       // eslint-disable-next-line ban/ban
       this.subscription.unsubscribe();

--- a/src/app/core/store/core/configuration/configuration.effects.ts
+++ b/src/app/core/store/core/configuration/configuration.effects.ts
@@ -12,6 +12,7 @@ import { SSR_LOCALE } from 'ish-core/configurations/state-keys';
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 import { LocalizationsService } from 'ish-core/services/localizations/localizations.service';
 import { DomService } from 'ish-core/utils/dom/dom.service';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { distinctCompareWith, mapToPayload, whenTruthy } from 'ish-core/utils/operators';
 import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
@@ -72,7 +73,7 @@ export class ConfigurationEffects {
           this.stateProperties.getStateOrEnvOrDefault<string>('ICM_APPLICATION', 'icmApplication'),
           this.stateProperties
             .getStateOrEnvOrDefault<string | string[]>('FEATURES', 'features')
-            .pipe(map(x => (typeof x === 'string' ? x.split(/,/g) : x))),
+            .pipe(map(x => (typeof x === 'string' ? x.split(/,/g) : x) as FeatureToggleType[])),
           this.stateProperties
             .getStateOrEnvOrDefault<string>('IDENTITY_PROVIDER', 'identityProvider')
             .pipe(map(x => x || 'ICM')),

--- a/src/app/core/store/core/configuration/configuration.integration.spec.ts
+++ b/src/app/core/store/core/configuration/configuration.integration.spec.ts
@@ -102,7 +102,7 @@ describe('Configuration Integration', () => {
   }));
 
   it('should unset features if "none" was provided', fakeAsync(() => {
-    store$.dispatch(applyConfiguration({ features: ['a', 'b', 'c'] }));
+    store$.dispatch(applyConfiguration({ features: ['compare', 'wishlists'] }));
     router.navigateByUrl('/home;features=none');
     tick(500);
     expect(location.path()).toMatchInlineSnapshot(`"/home"`);
@@ -110,15 +110,14 @@ describe('Configuration Integration', () => {
   }));
 
   it('should not set features if "default" was provided', fakeAsync(() => {
-    store$.dispatch(applyConfiguration({ features: ['a', 'b', 'c'] }));
+    store$.dispatch(applyConfiguration({ features: ['compare', 'wishlists'] }));
     router.navigateByUrl('/home;features=default');
     tick(500);
     expect(location.path()).toMatchInlineSnapshot(`"/home"`);
     expect(getFeatures(store$.state)).toMatchInlineSnapshot(`
       [
-        "a",
-        "b",
-        "c",
+        "compare",
+        "wishlists",
       ]
     `);
   }));

--- a/src/app/core/store/core/configuration/configuration.reducer.ts
+++ b/src/app/core/store/core/configuration/configuration.reducer.ts
@@ -1,6 +1,7 @@
 import { createReducer, on } from '@ngrx/store';
 
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { Translations } from 'ish-core/utils/translate/translations.type';
 
 import { environment } from '../../../../../environments/environment';
@@ -16,8 +17,8 @@ export interface ConfigurationState {
   hybridApplication?: string;
   identityProvider?: string;
   identityProviders?: { [id: string]: { type?: string; [key: string]: unknown } };
-  features?: string[];
-  addFeatures?: string[];
+  features?: FeatureToggleType[];
+  addFeatures?: FeatureToggleType[];
   defaultLocale?: string;
   fallbackLocales?: string[];
   localeCurrencyOverride?: { [locale: string]: string | string[] };

--- a/src/app/core/store/core/server-config/server-config.effects.ts
+++ b/src/app/core/store/core/server-config/server-config.effects.ts
@@ -13,6 +13,7 @@ import { ConfigurationState } from 'ish-core/store/core/configuration/configurat
 import { serverConfigError } from 'ish-core/store/core/error';
 import { personalizationStatusDetermined } from 'ish-core/store/customer/user';
 import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { MultiSiteService } from 'ish-core/utils/multi-site/multi-site.service';
 import { delayUntil, mapErrorToAction, mapToPayloadProperty, whenFalsy, whenTruthy } from 'ish-core/utils/operators';
 
@@ -156,10 +157,10 @@ export class ServerConfigEffects {
   private mapFeatures(config: ServerConfig): Partial<ConfigurationState> {
     const featureConfig: Partial<ConfigurationState> = {};
     if (config.Features) {
-      featureConfig.features = (config.Features as string).split(',');
+      featureConfig.features = (config.Features as string).split(',') as FeatureToggleType[];
     }
     if (config.AddFeatures) {
-      featureConfig.addFeatures = (config.AddFeatures as string).split(',');
+      featureConfig.addFeatures = (config.AddFeatures as string).split(',') as FeatureToggleType[];
     }
     return featureConfig.features?.length || featureConfig.addFeatures?.length ? featureConfig : undefined;
   }

--- a/src/app/core/utils/feature-event/feature-event.service.ts
+++ b/src/app/core/utils/feature-event/feature-event.service.ts
@@ -3,7 +3,7 @@ import { Injectable, InjectionToken, Injector, inject } from '@angular/core';
 import { Observable, Subject, switchMap } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 
-import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { FeatureToggleService, FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { InjectMultiple } from 'ish-core/utils/injection';
 
 export interface FeatureEventResultListener {
@@ -101,7 +101,7 @@ export class FeatureEventService {
    * @param id id of generated notification event
    * @returns result listener stream, which should notify about results of notification event
    */
-  eventResultListener$(feature: string, event: string, id: string): Observable<FeatureEventResult> {
+  eventResultListener$(feature: FeatureToggleType, event: string, id: string): Observable<FeatureEventResult> {
     return this.featureToggleService
       .enabled$(feature)
       .pipe(

--- a/src/app/core/utils/feature-toggle/feature-toggle.service.spec.ts
+++ b/src/app/core/utils/feature-toggle/feature-toggle.service.spec.ts
@@ -6,6 +6,8 @@ import { FeatureToggleService } from 'ish-core/feature-toggle.module';
 import { getFeatures } from 'ish-core/store/core/configuration';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 
+import { FeatureToggleType } from './feature-toggle.service';
+
 describe('Feature Toggle Service', () => {
   describe('without features defined', () => {
     let featureToggle: FeatureToggleService;
@@ -18,8 +20,9 @@ describe('Feature Toggle Service', () => {
     });
 
     it('should report feature as deactivated, when no settings are defined', () => {
-      expect(featureToggle.enabled('something')).toBeFalse();
-      expect(featureToggle.enabled$('something')).toBeObservable(cold('a', { a: false }));
+      const feature = 'something' as FeatureToggleType;
+      expect(featureToggle.enabled(feature)).toBeFalse();
+      expect(featureToggle.enabled$(feature)).toBeObservable(cold('a', { a: false }));
     });
   });
 
@@ -38,7 +41,7 @@ describe('Feature Toggle Service', () => {
       ['never', false],
       ['feature1', true],
       ['feature2', false],
-    ])(`should have %s == %s when asked`, (feature, expected) => {
+    ])(`should have %s == %s when asked`, (feature: FeatureToggleType, expected) => {
       expect(featureToggle.enabled(feature)).toEqual(expected);
       expect(featureToggle.enabled$(feature)).toBeObservable(cold('a', { a: expected }));
     });

--- a/src/app/core/utils/feature-toggle/feature-toggle.service.ts
+++ b/src/app/core/utils/feature-toggle/feature-toggle.service.ts
@@ -2,10 +2,16 @@ import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
+import type { Environment } from 'src/environments/environment.model';
 
 import { getFeatures } from 'ish-core/store/core/configuration';
 
-export function checkFeature(features: string[] = [], feature: string): boolean {
+export type FeatureToggleType = Environment['features'][number];
+
+export function checkFeature(
+  features: FeatureToggleType[] = [],
+  feature: 'always' | 'never' | FeatureToggleType
+): boolean {
   if (feature === 'always') {
     return true;
   } else if (feature === 'never') {
@@ -17,7 +23,7 @@ export function checkFeature(features: string[] = [], feature: string): boolean 
 
 @Injectable({ providedIn: 'root' })
 export class FeatureToggleService {
-  private featureToggles$ = new BehaviorSubject<string[]>(undefined);
+  private featureToggles$ = new BehaviorSubject<FeatureToggleType[]>(undefined);
 
   constructor(store: Store) {
     store.pipe(select(getFeatures)).subscribe(this.featureToggles$);
@@ -29,7 +35,7 @@ export class FeatureToggleService {
    * This method should only be used for browser code and only for
    * logic that is not included in the initialization process.
    */
-  enabled(feature: string): boolean {
+  enabled(feature: 'always' | 'never' | FeatureToggleType): boolean {
     // eslint-disable-next-line rxjs/no-subject-value
     return checkFeature(this.featureToggles$.value, feature);
   }
@@ -37,7 +43,7 @@ export class FeatureToggleService {
   /**
    * Asynchronously check if {@param feature} is active.
    */
-  enabled$(feature: string): Observable<boolean> {
+  enabled$(feature: 'always' | 'never' | FeatureToggleType): Observable<boolean> {
     return this.featureToggles$.pipe(
       map(featureToggles => checkFeature(featureToggles, feature)),
       distinctUntilChanged()

--- a/src/app/core/utils/module-loader/module-loader.service.ts
+++ b/src/app/core/utils/module-loader/module-loader.service.ts
@@ -3,11 +3,11 @@ import { Store, select } from '@ngrx/store';
 import { Subject, takeUntil } from 'rxjs';
 
 import { getFeatures } from 'ish-core/store/core/configuration';
-import { FeatureToggleService } from 'ish-core/utils/feature-toggle/feature-toggle.service';
+import { FeatureToggleService, FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 declare interface LazyModuleType {
-  feature: string;
+  feature: FeatureToggleType;
   location(): Promise<Type<unknown>>;
 }
 

--- a/src/app/pages/account/account-navigation/account-navigation.component.ts
+++ b/src/app/pages/account/account-navigation/account-navigation.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
+import { FeatureToggleType } from 'ish-core/utils/feature-toggle/feature-toggle.service';
 
 import { navigationItems } from './account-navigation.items';
 
@@ -12,7 +13,7 @@ export interface NavigationItem {
   routerLink?: string;
   faIcon?: IconProp;
   isCollapsed?: boolean;
-  feature?: string;
+  feature?: FeatureToggleType;
   serverSetting?: string;
   permission?: string | string[];
   notRole?: string | string[];


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Feature toggles in code are handles as `string` even though typing is available.

## What Is the New Behavior?

- Typed feature toggles
- extension schematic adds feature toggle

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#91638](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91638)