### PR TITLE
fix: handle relative links in cms content

### DIFF
--- a/src/app/core/directives/server-html.directive.spec.ts
+++ b/src/app/core/directives/server-html.directive.spec.ts
@@ -14,6 +14,9 @@ describe('Server Html Directive', () => {
     let element: HTMLElement;
 
     beforeEach(() => {
+      const appFacade = mock(AppFacade);
+      when(appFacade.icmBaseUrl).thenReturn('http://example.org');
+
       @Component({
         template: ` <div [ishServerHtml]="html"></div> `,
         changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,14 +24,15 @@ describe('Server Html Directive', () => {
       class TestComponent {
         html = `<div><a href="product://8182790134362@inSPIRED-inTRONICS">Product</a></div>
         <div><a href="http://google.de">Google</a></div>
-        <div><a href="route://basket">Basket</a></div>`;
+        <div><a href="route://basket">Basket</a></div>
+        <div><a href="/INTERSHOP/static/WFS/channel/test.pdf">Relative Pdf link</a></div>`;
       }
 
       TestBed.configureTestingModule({
         declarations: [ServerHtmlDirective, TestComponent],
         providers: [
           { provide: APP_BASE_HREF, useValue: '/' },
-          { provide: AppFacade, useFactory: () => instance(mock(AppFacade)) },
+          { provide: AppFacade, useFactory: () => instance(appFacade) },
         ],
       }).compileComponents();
 
@@ -43,6 +47,9 @@ describe('Server Html Directive', () => {
           <div><a href="/product/8182790134362">Product</a></div>
           <div><a href="http://google.de">Google</a></div>
           <div><a href="/basket">Basket</a></div>
+          <div>
+            <a href="http://example.org/INTERSHOP/static/WFS/channel/test.pdf">Relative Pdf link</a>
+          </div>
         </div>
       `);
     });

--- a/src/app/core/directives/server-html.directive.ts
+++ b/src/app/core/directives/server-html.directive.ts
@@ -55,7 +55,13 @@ export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnC
   private patchElements() {
     // use setAttribute here to bypass security check
     Array.from(this.elementRef.nativeElement.querySelectorAll('[href]')).forEach((element: HTMLElement) => {
-      this.renderer.setAttribute(element, 'href', LinkParser.parseLink(element.getAttribute('href'), this.baseHref));
+      const href = element.getAttribute('href');
+
+      this.renderer.setAttribute(
+        element,
+        'href',
+        href.startsWith('/INTERSHOP/') ? this.transformMediaObjectSrc(href) : LinkParser.parseLink(href, this.baseHref)
+      );
     });
     Array.from(this.elementRef.nativeElement.querySelectorAll('[src]')).forEach((element: HTMLElement) => {
       this.renderer.setAttribute(element, 'src', this.transformMediaObjectSrc(element.getAttribute('src')));


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

When inserting a link with a relative path to a Free Style HTML Component via TinyMCE (Full Mode) in the ICM backoffice, displaying this component in the PWA lead to a wrong absolute path, as the PWA host is set instaead of the ICM base URL. 
This works without any issues when inserting images instead of links. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
Relative paths of free style HTML components are handled correctly.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
see also [AB#91284](https://dev.azure.com/intershop-com/Products/_workitems/edit/91284)




[AB#91696](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91696)