### PR TITLE
fix: remove sortkey 'default' from product list REST call

### DIFF
--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -76,7 +76,7 @@ export class ProductsService {
       .set('offset', offset.toString())
       .set('returnSortKeys', 'true')
       .set('productFilter', 'fallback_searchquerydefinition');
-    if (sortKey) {
+    if (sortKey && sortKey !== 'default') {
       params = params.set('sortKey', sortKey);
     }
 
@@ -129,7 +129,7 @@ export class ProductsService {
       .set('attrs', STUB_ATTRS)
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
-    if (sortKey) {
+    if (sortKey && sortKey !== 'default') {
       params = params.set('sortKey', sortKey);
     }
 
@@ -174,7 +174,7 @@ export class ProductsService {
       .set('attrs', STUB_ATTRS)
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
-    if (sortKey) {
+    if (sortKey && sortKey !== 'default') {
       params = params.set('sortKey', sortKey);
     }
 
@@ -205,7 +205,7 @@ export class ProductsService {
       .set('attrs', STUB_ATTRS)
       .set('attributeGroup', AttributeGroupTypes.ProductLabelAttributes)
       .set('returnSortKeys', 'true');
-    if (sortKey) {
+    if (sortKey && sortKey !== 'default') {
       params = params.set('sortKey', sortKey);
     }
     params = appendFormParamsToHttpParams(omit(searchParameter, 'category'), params);


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The REST call for fetching products for a product family page contains always a parameter 'sortKey' even if no special sort option is selected (in this case sortKey = 'default')

Issue Number: Closes #

## What Is the New Behavior?
The parameter 'sortKey' is not appended at the product REST request if the default sorting is selected.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#91958](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/91958)