### PR TITLE
fix: sanitize potentially dangerous values in order template... 

### DIFF
--- a/src/app/extensions/order-templates/models/order-template/order-template.mapper.ts
+++ b/src/app/extensions/order-templates/models/order-template/order-template.mapper.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Injectable, SecurityContext, inject } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
@@ -8,6 +9,8 @@ import { OrderTemplate, OrderTemplateItem } from './order-template.model';
 
 @Injectable({ providedIn: 'root' })
 export class OrderTemplateMapper {
+  private sanitizer = inject(DomSanitizer);
+
   private static parseIdFromURI(uri: string): string {
     const match = /wishlists[^\/]*\/([^\?]*)/.exec(uri);
     if (match) {
@@ -40,7 +43,7 @@ export class OrderTemplateMapper {
 
       return {
         id: orderTemplateId,
-        title: orderTemplateData.title,
+        title: this.sanitizer.sanitize(SecurityContext.HTML, orderTemplateData.title),
         itemsCount: orderTemplateData.itemsCount || 0,
         creationDate: orderTemplateData.creationDate,
         items,
@@ -54,7 +57,7 @@ export class OrderTemplateMapper {
     if (orderTemplate && id) {
       return {
         id,
-        title: orderTemplate.title,
+        title: this.sanitizer.sanitize(SecurityContext.HTML, orderTemplate.title),
         creationDate: orderTemplate.creationDate,
       };
     }
@@ -63,12 +66,7 @@ export class OrderTemplateMapper {
   /**
    * extract ID from URI
    */
-  fromDataToIds(orderTemplateData: OrderTemplateData): OrderTemplate {
-    if (orderTemplateData) {
-      return {
-        id: OrderTemplateMapper.parseIdFromURI(orderTemplateData.uri),
-        title: orderTemplateData.title,
-      };
-    }
+  fromDataToId(orderTemplateData: OrderTemplateData): string {
+    return orderTemplateData ? OrderTemplateMapper.parseIdFromURI(orderTemplateData.uri) : undefined;
   }
 }

--- a/src/app/extensions/order-templates/services/order-template/order-template.service.spec.ts
+++ b/src/app/extensions/order-templates/services/order-template/order-template.service.spec.ts
@@ -41,7 +41,7 @@ describe('Order Template Service', () => {
             "id": "1234",
             "items": [],
             "itemsCount": 0,
-            "title": undefined,
+            "title": null,
           },
         ]
       `);

--- a/src/app/extensions/order-templates/services/order-template/order-template.service.ts
+++ b/src/app/extensions/order-templates/services/order-template/order-template.service.ts
@@ -19,9 +19,10 @@ export class OrderTemplateService {
    */
   getOrderTemplates(): Observable<OrderTemplate[]> {
     return this.apiService.get(`customers/-/users/-/wishlists`).pipe(
-      unpackEnvelope(),
-      map(orderTemplateData => orderTemplateData.map(this.orderTemplateMapper.fromDataToIds)),
-      map(orderTemplateData => orderTemplateData.map(orderTemplate => this.getOrderTemplate(orderTemplate.id))),
+      unpackEnvelope<OrderTemplateData>(),
+      map(orderTemplateData =>
+        orderTemplateData.map(data => this.getOrderTemplate(this.orderTemplateMapper.fromDataToId(data)))
+      ),
       switchMap(obsArray => (obsArray.length ? forkJoin(obsArray) : of([])))
     );
   }

--- a/src/app/extensions/wishlists/models/wishlist/wishlist.mapper.ts
+++ b/src/app/extensions/wishlists/models/wishlist/wishlist.mapper.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Injectable, SecurityContext, inject } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
@@ -8,7 +9,9 @@ import { Wishlist, WishlistItem } from './wishlist.model';
 
 @Injectable({ providedIn: 'root' })
 export class WishlistMapper {
-  private static parseIDfromURI(uri: string): string {
+  private sanitizer = inject(DomSanitizer);
+
+  private static parseIdFromURI(uri: string): string {
     const match = /wishlists[^\/]*\/([^\?]*)/.exec(uri);
     if (match) {
       return match[1];
@@ -17,6 +20,7 @@ export class WishlistMapper {
       return;
     }
   }
+
   fromData(wishlistData: WishlistData, wishlistId: string): Wishlist {
     if (wishlistData) {
       let items: WishlistItem[];
@@ -39,7 +43,7 @@ export class WishlistMapper {
       }
       return {
         id: wishlistId,
-        title: wishlistData.title,
+        title: this.sanitizer.sanitize(SecurityContext.HTML, wishlistData.title),
         itemsCount: wishlistData.itemsCount || 0,
         preferred: wishlistData.preferred,
         public: wishlistData.public,
@@ -54,7 +58,7 @@ export class WishlistMapper {
     if (wishlist && id) {
       return {
         id,
-        title: wishlist.title,
+        title: this.sanitizer.sanitize(SecurityContext.HTML, wishlist.title),
         preferred: wishlist.preferred,
         public: wishlist.public,
       };
@@ -64,13 +68,7 @@ export class WishlistMapper {
   /**
    * extract ID from URI
    */
-  fromDataToIds(wishlistData: WishlistData): Wishlist {
-    if (wishlistData) {
-      return {
-        id: WishlistMapper.parseIDfromURI(wishlistData.uri),
-        title: wishlistData.title,
-        preferred: wishlistData.preferred,
-      };
-    }
+  fromDataToId(wishlistData: WishlistData): string {
+    return wishlistData ? WishlistMapper.parseIdFromURI(wishlistData.uri) : undefined;
   }
 }

--- a/src/app/extensions/wishlists/services/wishlist/wishlist.service.spec.ts
+++ b/src/app/extensions/wishlists/services/wishlist/wishlist.service.spec.ts
@@ -51,7 +51,7 @@ describe('Wishlist Service', () => {
             "itemsCount": 0,
             "preferred": true,
             "public": undefined,
-            "title": undefined,
+            "title": null,
           },
         ]
       `);
@@ -75,7 +75,7 @@ describe('Wishlist Service', () => {
             "itemsCount": 0,
             "preferred": true,
             "public": undefined,
-            "title": undefined,
+            "title": null,
           },
         ]
       `);

--- a/src/app/extensions/wishlists/services/wishlist/wishlist.service.ts
+++ b/src/app/extensions/wishlists/services/wishlist/wishlist.service.ts
@@ -23,9 +23,8 @@ export class WishlistService {
       first(),
       concatMap(restResource =>
         this.apiService.get(`${restResource}/-/wishlists`).pipe(
-          unpackEnvelope(),
-          map(wishlistData => wishlistData.map(this.wishlistMapper.fromDataToIds)),
-          map(wishlistData => wishlistData.map(wishlist => this.getWishlist(wishlist.id))),
+          unpackEnvelope<WishlistData>(),
+          map(wishlistData => wishlistData.map(data => this.getWishlist(this.wishlistMapper.fromDataToId(data)))),
           switchMap(obsArray => (obsArray.length ? forkJoin(obsArray) : of([])))
         )
       )


### PR DESCRIPTION
…and wishlist titles

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
It is not possible to add a malicious script (XXS) to the order template/wishlist title.
But if there is a XSS in the order template or wishlist title it is executed after the user adds a product to this order template/wishlist.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
After fetching the order templates/wishlists from the server any malicious script will be removed from the title field. This scrips is not executed any more.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#92013](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92013)