### PR TITLE
fix: trailing '/' in path results to a wrong multi channel configuration

### DIFF
--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -35,7 +35,7 @@
         include /etc/nginx/conf.d/cache-settings.conf;
 
         rewrite ^.*/index.html$ {{ $baseHref }}/loading;
-
+        rewrite ^(.*)/$ $1;
         rewrite ^{{ $baseHref }}/?$ {{ $baseHref }}/home;
 
         rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang={{ $lang }}';


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

`http://localhost:4200/b2c/home`
compared to
`http://localhost:4200/b2c/home/`
results in different storefronts even though the result should be the same

This problem is reproducible with the standard PWA with the following multi channel configuration with a docker compose deployed NGING + SSR container:
```yaml
      MULTI_CHANNEL: |
        .+:
          - baseHref: /b2c
            channel: inSPIRED-inTRONICS-Site
            theme: b2b
          - baseHref: /b2b
            channel: inSPIRED-inTRONICS_Business-Site
            theme: b2b
```

Using the wrong channel when working with a trailing `/` is the actual problem. The used themes configured channel of the `environment.b2b.ts` is used instead of the one configured in the multi channel configuration of the deployment.
The problem occurs with any path after adding a trailing `/`. 

## What Is the New Behavior?

An additional rewrite rule for NGINX - `rewrite ^(.*)/$ $1;` - removes a trailing slash before handling the route to the SSR container.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#92017](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92017)