### PR TITLE
fix: use take instead of first to prevent EmptyError on missing translation

### DIFF
--- a/src/app/core/utils/translate/fallback-missing-translation-handler.ts
+++ b/src/app/core/utils/translate/fallback-missing-translation-handler.ts
@@ -9,7 +9,7 @@ import {
 } from '@ngx-translate/core';
 import { memoize } from 'lodash-es';
 import { EMPTY, concat, defer, iif, of } from 'rxjs';
-import { filter, first, map, tap } from 'rxjs/operators';
+import { filter, map, take, tap } from 'rxjs/operators';
 
 import { getSpecificServerTranslation, loadSingleServerTranslation } from 'ish-core/store/core/configuration';
 import { InjectSingle } from 'ish-core/utils/injection';
@@ -46,7 +46,7 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
         }),
         filter(translation => translation !== undefined),
         map((translation: string) => this.translateCompiler.compile(translation, lang)),
-        first()
+        take(1)
       )
     );
   }
@@ -60,7 +60,7 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
           this.reportMissingTranslation(lang, key);
         }
       }),
-      first()
+      take(1)
     );
   }
 
@@ -93,7 +93,7 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
       ).pipe(
         // stop after first emission
         whenTruthy(),
-        first(),
+        take(1),
         map(translation => this.translateParser.interpolate(translation, params.interpolateParams)),
         map(translation => (PRODUCTION_MODE ? translation : `TRANSLATE_ME ${translation}`))
       );


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When translations are missing in both current and fallback language, the `FallbackMissingTranslationHandler` throws `EmptyError`s.

Steps to reproduce:

1. remove translation key `quickorder.page.link` in both en_US and de_DE localization files.
2. visit any page

Actual:
![image](https://github.com/intershop/intershop-pwa/assets/23452927/74490191-5058-493d-a20b-1bbbbe6d15bc)
and `EmptyError` in console.

Expected:
![image](https://github.com/intershop/intershop-pwa/assets/23452927/42c02004-ed7f-4d84-ab60-a2253d66b095)


## What Is the New Behavior?

Replaced all `first` with `take(1)` as this could happen with other sources, too.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#92108](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92108)