### PR TITLE
fix: infinite loop can occur in the mapping of the content page tree

### DIFF
--- a/src/app/core/models/content-page-tree-view/content-page-tree-view.model.spec.ts
+++ b/src/app/core/models/content-page-tree-view/content-page-tree-view.model.spec.ts
@@ -8,7 +8,7 @@ describe('Content Page Tree View Model', () => {
     const rootElement = { contentPageId: 'A', path: ['A'] } as ContentPageTreeElement;
     const child1 = { contentPageId: 'A.1', path: ['A', 'A.1'] } as ContentPageTreeElement;
     const child2 = { contentPageId: 'A.2', path: ['A', 'A.2'] } as ContentPageTreeElement;
-    const loopingChild = { contentPageId: 'A.1', path: ['A', 'A.1', 'A.1'] } as ContentPageTreeElement;
+    const loopingChild = { contentPageId: 'A.1.1', path: ['A', 'A.1', 'A.1'] } as ContentPageTreeElement;
 
     const empty = ContentPageTreeHelper.empty();
     const tree0 = ContentPageTreeHelper.add(empty, rootElement);
@@ -16,6 +16,79 @@ describe('Content Page Tree View Model', () => {
     const tree2 = ContentPageTreeHelper.add(tree1, child2);
     const loopingTree = ContentPageTreeHelper.add(tree2, loopingChild);
 
-    createContentPageTreeView(loopingTree, 'A', 'A');
+    const tree = createContentPageTreeView(loopingTree, 'A', 'A');
+
+    expect(tree).toEqual({
+      children: [
+        {
+          children: [],
+          contentPageId: 'A.1',
+          parent: 'A',
+          path: ['A', 'A.1'],
+          pathElements: [
+            { contentPageId: 'A', path: ['A'] },
+            { contentPageId: 'A.1', path: ['A', 'A.1'] },
+          ],
+        },
+        {
+          children: [],
+          contentPageId: 'A.2',
+          parent: 'A',
+          path: ['A', 'A.2'],
+          pathElements: [
+            { contentPageId: 'A', path: ['A'] },
+            { contentPageId: 'A.2', path: ['A', 'A.2'] },
+          ],
+        },
+      ],
+      contentPageId: 'A',
+      parent: undefined,
+      path: ['A'],
+      pathElements: [{ contentPageId: 'A', path: ['A'] }],
+    });
+  });
+
+  it('should not loop forever with recursive tree (subtree case)', () => {
+    const rootElement = { contentPageId: 'A', path: ['A'] } as ContentPageTreeElement;
+    const child1 = { contentPageId: 'A.1', path: ['A', 'A.1'] } as ContentPageTreeElement;
+    const child2 = { contentPageId: 'A.2', path: ['A', 'A.2'] } as ContentPageTreeElement;
+    const loopingChild = { contentPageId: 'A.1.1', path: ['A', 'A.1', 'A.1'] } as ContentPageTreeElement;
+
+    const empty = ContentPageTreeHelper.empty();
+    const tree0 = ContentPageTreeHelper.add(empty, rootElement);
+    const tree1 = ContentPageTreeHelper.add(tree0, child1);
+    const tree2 = ContentPageTreeHelper.add(tree1, child2);
+    const loopingTree = ContentPageTreeHelper.add(tree2, loopingChild);
+
+    const tree = createContentPageTreeView(loopingTree, 'A', 'A.1');
+
+    expect(tree).toEqual({
+      children: [
+        {
+          children: [],
+          contentPageId: 'A.1',
+          parent: 'A',
+          path: ['A', 'A.1'],
+          pathElements: [
+            { contentPageId: 'A', path: ['A'] },
+            { contentPageId: 'A.1', path: ['A', 'A.1'] },
+          ],
+        },
+        {
+          children: [],
+          contentPageId: 'A.2',
+          parent: 'A',
+          path: ['A', 'A.2'],
+          pathElements: [
+            { contentPageId: 'A', path: ['A'] },
+            { contentPageId: 'A.2', path: ['A', 'A.2'] },
+          ],
+        },
+      ],
+      contentPageId: 'A',
+      parent: undefined,
+      path: ['A'],
+      pathElements: [{ contentPageId: 'A', path: ['A'] }],
+    });
   });
 });

--- a/src/app/core/models/content-page-tree-view/content-page-tree-view.model.spec.ts
+++ b/src/app/core/models/content-page-tree-view/content-page-tree-view.model.spec.ts
@@ -1,0 +1,21 @@
+import { ContentPageTreeHelper } from 'ish-core/models/content-page-tree/content-page-tree.helper';
+import { ContentPageTreeElement } from 'ish-core/models/content-page-tree/content-page-tree.model';
+
+import { createContentPageTreeView } from './content-page-tree-view.model';
+
+describe('Content Page Tree View Model', () => {
+  it('should not loop forever with recursive tree', () => {
+    const rootElement = { contentPageId: 'A', path: ['A'] } as ContentPageTreeElement;
+    const child1 = { contentPageId: 'A.1', path: ['A', 'A.1'] } as ContentPageTreeElement;
+    const child2 = { contentPageId: 'A.2', path: ['A', 'A.2'] } as ContentPageTreeElement;
+    const loopingChild = { contentPageId: 'A.1', path: ['A', 'A.1', 'A.1'] } as ContentPageTreeElement;
+
+    const empty = ContentPageTreeHelper.empty();
+    const tree0 = ContentPageTreeHelper.add(empty, rootElement);
+    const tree1 = ContentPageTreeHelper.add(tree0, child1);
+    const tree2 = ContentPageTreeHelper.add(tree1, child2);
+    const loopingTree = ContentPageTreeHelper.add(tree2, loopingChild);
+
+    createContentPageTreeView(loopingTree, 'A', 'A');
+  });
+});

--- a/src/app/core/models/content-page-tree-view/content-page-tree-view.model.ts
+++ b/src/app/core/models/content-page-tree-view/content-page-tree-view.model.ts
@@ -31,7 +31,7 @@ function getContentPageTreeElements(
   // If current content page is part of element subtree or equals the element itself, then all children of elements should be analyzed
   if (tree.edges[elementId] && isContentPagePartOfPageTreeElement(tree, currentContentPageId, elementId)) {
     treeElements = tree.edges[elementId]
-      .map(child => getContentPageTreeElements(tree, child, rootId, currentContentPageId))
+      .map(child => (child === elementId ? [] : getContentPageTreeElements(tree, child, rootId, currentContentPageId)))
       .reduce((a, b) => {
         b.map(element => a.push(element));
         return a;
@@ -64,6 +64,7 @@ function isContentPagePartOfPageTreeElement(
       result = true;
     } else {
       result = tree.edges[elementId]
+        .filter(e => e !== elementId)
         .map(e => isContentPagePartOfPageTreeElement(tree, currentContentPageId, e))
         .find(res => res);
     }

--- a/src/app/core/models/content-page-tree-view/content-page-tree-view.model.ts
+++ b/src/app/core/models/content-page-tree-view/content-page-tree-view.model.ts
@@ -31,11 +31,9 @@ function getContentPageTreeElements(
   // If current content page is part of element subtree or equals the element itself, then all children of elements should be analyzed
   if (tree.edges[elementId] && isContentPagePartOfPageTreeElement(tree, currentContentPageId, elementId)) {
     treeElements = tree.edges[elementId]
-      .map(child => (child === elementId ? [] : getContentPageTreeElements(tree, child, rootId, currentContentPageId)))
-      .reduce((a, b) => {
-        b.map(element => a.push(element));
-        return a;
-      });
+      .filter(child => child !== elementId)
+      .map(child => getContentPageTreeElements(tree, child, rootId, currentContentPageId))
+      .flat();
   }
 
   const parent = tree.nodes[elementId].path[tree.nodes[elementId].path.length - 2];

--- a/src/app/core/models/content-page-tree/content-page-tree.mapper.ts
+++ b/src/app/core/models/content-page-tree/content-page-tree.mapper.ts
@@ -59,7 +59,7 @@ export class ContentPageTreeMapper {
           // yield page tree element
           return {
             name: pathElement.title,
-            path: [...newTreeElementPath],
+            path: [...newTreeElementPath].filter((v, i, a) => a.indexOf(v) === i),
             contentPageId: pathElement.itemId,
           };
         })


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
In production, we encountered a particular case, occurring only in server-side rendering, which contained the formation of a content-page-tree looping back on itself. 
It was not possible to identify the code that led to this case. 
However, the mapper was strengthened to avoid iterating indefinitely in the previous case.

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x ] No

## Other Information
