### PR TITLE
fix: issues regarding user roles selection

### DIFF
--- a/projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.html
+++ b/projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.html
@@ -25,11 +25,11 @@
             </ul>
             <p>
               <!-- Expand/Collapse user permissions -->
-              <a *ngIf="!isExpanded[i]" [routerLink]="[]" (click)="toggleExpanded(i)">
+              <a *ngIf="!isExpanded[i]" (click)="toggleExpanded(i)" (keydown.enter)="toggleExpanded(i)" tabindex="0">
                 {{ 'account.user.details.profile.role.show_permissions.link' | translate }}&nbsp;
                 <fa-icon [icon]="['fas', 'angle-down']" />
               </a>
-              <a *ngIf="isExpanded[i]" [routerLink]="[]" (click)="toggleExpanded(i)">
+              <a *ngIf="isExpanded[i]" (click)="toggleExpanded(i)" (keydown.enter)="toggleExpanded(i)" tabindex="0">
                 {{ 'account.user.details.profile.role.hide_permissions.link' | translate }}&nbsp;
                 <fa-icon [icon]="['fas', 'angle-up']" />
               </a>

--- a/projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.spec.ts
+++ b/projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
@@ -41,7 +40,7 @@ describe('User Roles Selection Component', () => {
     when(organizationManagementFacade.role$(approverRole.id)).thenReturn(of(approverRole));
 
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, RouterTestingModule, TranslateModule.forRoot()],
+      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
       declarations: [MockComponent(FaIconComponent), UserRolesSelectionComponent],
       providers: [{ provide: OrganizationManagementFacade, useFactory: () => instance(organizationManagementFacade) }],
     }).compileComponents();


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

The fixes are related to user roles selection form of the the MyAccount user management, e.g. on the user creation page or the updating user roles selection page.

## What Is the Current Behavior?
1. If the user clicks show/hide permissions link the page will be scrolled to the top and the user has to navigate to the appropriate role again.
2. After the user has saved a roles selection (creating a user, updating roles selection) there is an error in the console (NG0911: View has already been destroyed)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
1. After clicking the show/hide permissions link the page will not be scrolled.
2. There is no console error any more.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#92312](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92312)