### PR TITLE
refactor: make order list presentational

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,10 @@ kb_sync_latest_only
 
 # Migrations
 
+## From 5.0 to 5.1
+
+The OrderListComponent is strictly presentational, components using it have to supply the data.
+
 ## From 4.2 to 5.0
 
 Starting with the Intershop PWA 5.0 we develop and test against an Intershop Commerce Management 11 server.

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -10,6 +10,7 @@ kb_sync_latest_only
 ## From 5.0 to 5.1
 
 The OrderListComponent is strictly presentational, components using it have to supply the data.
+The getOrders method of the OrderService doesn't fetch all related order data by default, you can provide an additional parameter to include the data you need.
 
 ## From 4.2 to 5.0
 

--- a/projects/organization-management/src/app/pages/cost-center-detail/cost-center-detail-page.component.html
+++ b/projects/organization-management/src/app/pages/cost-center-detail/cost-center-detail-page.component.html
@@ -50,8 +50,7 @@
   <ng-container *ngIf="(user$ | async)?.login === costCenter.costCenterOwner?.login">
     <h3>{{ 'account.costcenter.details.orders.list.title' | translate }}</h3>
     <ish-order-list
-      [orders]="costCenter?.orders || []"
-      [maxListItems]="10"
+      [orders]="costCenter?.orders | slice : 0 : 10"
       [columnsToDisplay]="['creationDate', 'orderNo', 'buyer', 'lineItems', 'status', 'orderTotal']"
     />
   </ng-container>

--- a/src/app/core/facades/account.facade.ts
+++ b/src/app/core/facades/account.facade.ts
@@ -28,7 +28,13 @@ import {
   getDataRequestError,
   getDataRequestLoading,
 } from 'ish-core/store/customer/data-requests';
-import { getOrders, getOrdersLoading, getSelectedOrder, loadOrders } from 'ish-core/store/customer/orders';
+import {
+  getOrders,
+  getOrdersError,
+  getOrdersLoading,
+  getSelectedOrder,
+  loadOrders,
+} from 'ish-core/store/customer/orders';
 import {
   cancelRegistration,
   getSsoRegistrationCancelled,
@@ -171,6 +177,7 @@ export class AccountFacade {
 
   selectedOrder$ = this.store.pipe(select(getSelectedOrder));
   ordersLoading$ = this.store.pipe(select(getOrdersLoading));
+  ordersError$ = this.store.pipe(select(getOrdersError));
 
   // PAYMENT
 

--- a/src/app/core/facades/account.facade.ts
+++ b/src/app/core/facades/account.facade.ts
@@ -163,8 +163,8 @@ export class AccountFacade {
 
   // ORDERS
 
-  orders$() {
-    this.store.dispatch(loadOrders());
+  orders$(amount: number) {
+    this.store.dispatch(loadOrders({ amount }));
     return this.store.pipe(select(getOrders));
   }
 

--- a/src/app/core/facades/account.facade.ts
+++ b/src/app/core/facades/account.facade.ts
@@ -11,6 +11,7 @@ import { PasswordReminderUpdate } from 'ish-core/models/password-reminder-update
 import { PasswordReminder } from 'ish-core/models/password-reminder/password-reminder.model';
 import { PaymentInstrument } from 'ish-core/models/payment-instrument/payment-instrument.model';
 import { User } from 'ish-core/models/user/user.model';
+import { OrderListQuery } from 'ish-core/services/order/order.service';
 import { MessagesPayloadType } from 'ish-core/store/core/messages';
 import {
   createCustomerAddress,
@@ -163,8 +164,8 @@ export class AccountFacade {
 
   // ORDERS
 
-  orders$(amount: number) {
-    this.store.dispatch(loadOrders({ amount }));
+  orders$(query?: OrderListQuery) {
+    this.store.dispatch(loadOrders({ query: query || { limit: 30 } }));
     return this.store.pipe(select(getOrders));
   }
 

--- a/src/app/core/services/order/order.service.spec.ts
+++ b/src/app/core/services/order/order.service.spec.ts
@@ -72,20 +72,10 @@ describe('Order Service', () => {
   });
 
   describe('getOrders', () => {
-    it("should get orders when 'getOrders' is called without amount", done => {
-      when(apiService.get(anything(), anything())).thenReturn(of({ data: [] }));
-
-      orderService.getOrders().subscribe(() => {
-        verify(apiService.get(`orders?page[limit]=30`, anything())).once();
-        done();
-      });
-    });
-
     it("should get orders when 'getOrders' is called with amount", done => {
       when(apiService.get(anything(), anything())).thenReturn(of([]));
 
-      const amount = 10;
-      orderService.getOrders(amount).subscribe(() => {
+      orderService.getOrders(10).subscribe(() => {
         verify(apiService.get(`orders?page[limit]=10`, anything())).once();
         done();
       });

--- a/src/app/core/services/order/order.service.ts
+++ b/src/app/core/services/order/order.service.ts
@@ -120,7 +120,7 @@ export class OrderService {
    * @param amount The count of items which should be fetched.
    * @returns      A list of the user's orders
    */
-  getOrders(amount: number = 30): Observable<Order[]> {
+  getOrders(amount: number): Observable<Order[]> {
     const params = new HttpParams().set('include', this.allOrderIncludes.join());
 
     return this.apiService

--- a/src/app/core/store/customer/orders/orders.actions.ts
+++ b/src/app/core/store/customer/orders/orders.actions.ts
@@ -2,6 +2,7 @@ import { Params } from '@angular/router';
 import { createAction } from '@ngrx/store';
 
 import { Order } from 'ish-core/models/order/order.model';
+import { OrderListQuery } from 'ish-core/services/order/order.service';
 import { httpError, payload } from 'ish-core/utils/ngrx-creators';
 
 export const createOrder = createAction('[Orders] Create Order');
@@ -10,7 +11,7 @@ export const createOrderFail = createAction('[Orders API] Create Order Fail', ht
 
 export const createOrderSuccess = createAction('[Orders API] Create Order Success', payload<{ order: Order }>());
 
-export const loadOrders = createAction('[Orders Internal] Load Orders', payload<{ amount: number }>());
+export const loadOrders = createAction('[Orders Internal] Load Orders', payload<{ query: OrderListQuery }>());
 
 export const loadOrdersFail = createAction('[Orders API] Load Orders Fail', httpError());
 

--- a/src/app/core/store/customer/orders/orders.actions.ts
+++ b/src/app/core/store/customer/orders/orders.actions.ts
@@ -10,7 +10,7 @@ export const createOrderFail = createAction('[Orders API] Create Order Fail', ht
 
 export const createOrderSuccess = createAction('[Orders API] Create Order Success', payload<{ order: Order }>());
 
-export const loadOrders = createAction('[Orders Internal] Load Orders');
+export const loadOrders = createAction('[Orders Internal] Load Orders', payload<{ amount: number }>());
 
 export const loadOrdersFail = createAction('[Orders API] Load Orders Fail', httpError());
 

--- a/src/app/core/store/customer/orders/orders.effects.spec.ts
+++ b/src/app/core/store/customer/orders/orders.effects.spec.ts
@@ -8,7 +8,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, noop, of, throwError } from 'rxjs';
 import { toArray } from 'rxjs/operators';
-import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anyNumber, anyString, anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { Customer } from 'ish-core/models/customer/customer.model';
@@ -53,7 +53,7 @@ describe('Orders Effects', () => {
 
   beforeEach(() => {
     orderServiceMock = mock(OrderService);
-    when(orderServiceMock.getOrders()).thenReturn(of(orders));
+    when(orderServiceMock.getOrders(anyNumber())).thenReturn(of(orders));
     when(orderServiceMock.getOrder(anyString())).thenReturn(of(order));
     when(orderServiceMock.getOrderByToken(anyString(), anyString())).thenReturn(of(order));
 
@@ -198,17 +198,17 @@ describe('Orders Effects', () => {
 
   describe('loadOrders$', () => {
     it('should call the orderService for loadOrders', done => {
-      const action = loadOrders();
+      const action = loadOrders({ amount: 30 });
       actions$ = of(action);
 
       effects.loadOrders$.subscribe(() => {
-        verify(orderServiceMock.getOrders()).once();
+        verify(orderServiceMock.getOrders(30)).once();
         done();
       });
     });
 
     it('should load all orders of a user and dispatch a LoadOrdersSuccess action', () => {
-      const action = loadOrders();
+      const action = loadOrders({ amount: 30 });
       const completion = loadOrdersSuccess({ orders });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -217,9 +217,9 @@ describe('Orders Effects', () => {
     });
 
     it('should dispatch a LoadOrdersFail action if a load error occurs', () => {
-      when(orderServiceMock.getOrders()).thenReturn(throwError(() => makeHttpError({ message: 'error' })));
+      when(orderServiceMock.getOrders(anyNumber())).thenReturn(throwError(() => makeHttpError({ message: 'error' })));
 
-      const action = loadOrders();
+      const action = loadOrders({ amount: 30 });
       const completion = loadOrdersFail({ error: makeHttpError({ message: 'error' }) });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });

--- a/src/app/core/store/customer/orders/orders.effects.spec.ts
+++ b/src/app/core/store/customer/orders/orders.effects.spec.ts
@@ -8,7 +8,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, noop, of, throwError } from 'rxjs';
 import { toArray } from 'rxjs/operators';
-import { anyNumber, anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { Customer } from 'ish-core/models/customer/customer.model';
@@ -53,7 +53,7 @@ describe('Orders Effects', () => {
 
   beforeEach(() => {
     orderServiceMock = mock(OrderService);
-    when(orderServiceMock.getOrders(anyNumber())).thenReturn(of(orders));
+    when(orderServiceMock.getOrders(anything())).thenReturn(of(orders));
     when(orderServiceMock.getOrder(anyString())).thenReturn(of(order));
     when(orderServiceMock.getOrderByToken(anyString(), anyString())).thenReturn(of(order));
 
@@ -198,17 +198,17 @@ describe('Orders Effects', () => {
 
   describe('loadOrders$', () => {
     it('should call the orderService for loadOrders', done => {
-      const action = loadOrders({ amount: 30 });
+      const action = loadOrders({ query: { limit: 30 } });
       actions$ = of(action);
 
       effects.loadOrders$.subscribe(() => {
-        verify(orderServiceMock.getOrders(30)).once();
+        verify(orderServiceMock.getOrders(anything())).once();
         done();
       });
     });
 
     it('should load all orders of a user and dispatch a LoadOrdersSuccess action', () => {
-      const action = loadOrders({ amount: 30 });
+      const action = loadOrders({ query: { limit: 30 } });
       const completion = loadOrdersSuccess({ orders });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });
@@ -217,9 +217,9 @@ describe('Orders Effects', () => {
     });
 
     it('should dispatch a LoadOrdersFail action if a load error occurs', () => {
-      when(orderServiceMock.getOrders(anyNumber())).thenReturn(throwError(() => makeHttpError({ message: 'error' })));
+      when(orderServiceMock.getOrders(anything())).thenReturn(throwError(() => makeHttpError({ message: 'error' })));
 
-      const action = loadOrders({ amount: 30 });
+      const action = loadOrders({ query: { limit: 30 } });
       const completion = loadOrdersFail({ error: makeHttpError({ message: 'error' }) });
       actions$ = hot('-a-a-a', { a: action });
       const expected$ = cold('-c-c-c', { c: completion });

--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -6,16 +6,7 @@ import { Store, select } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { isEqual } from 'lodash-es';
 import { EMPTY, from, merge, race } from 'rxjs';
-import {
-  concatMap,
-  distinctUntilChanged,
-  filter,
-  map,
-  mergeMap,
-  switchMap,
-  take,
-  withLatestFrom,
-} from 'rxjs/operators';
+import { concatMap, distinctUntilChanged, filter, map, mergeMap, switchMap, take } from 'rxjs/operators';
 
 import { OrderService } from 'ish-core/services/order/order.service';
 import { ofUrl, selectQueryParam, selectQueryParams, selectRouteParam } from 'ish-core/store/core/router';
@@ -39,7 +30,7 @@ import {
   selectOrderAfterRedirect,
   selectOrderAfterRedirectFail,
 } from './orders.actions';
-import { getOrder, getSelectedOrder, getSelectedOrderId } from './orders.selectors';
+import { getOrder, getSelectedOrder } from './orders.selectors';
 
 @Injectable()
 export class OrdersEffects {
@@ -122,9 +113,9 @@ export class OrdersEffects {
   loadOrders$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadOrders),
-      mapToPayloadProperty('amount'),
-      switchMap(amount =>
-        this.orderService.getOrders(amount).pipe(
+      mapToPayloadProperty('query'),
+      switchMap(query =>
+        this.orderService.getOrders(query).pipe(
           map(orders => loadOrdersSuccess({ orders })),
           mapErrorToAction(loadOrdersFail)
         )
@@ -182,12 +173,7 @@ export class OrdersEffects {
     merge(
       this.store.pipe(ofUrl(/^\/account\/orders.*/), select(selectRouteParam('orderId'))),
       this.store.pipe(ofUrl(/^\/checkout\/receipt/), select(selectQueryParam('orderId')))
-    ).pipe(
-      withLatestFrom(this.store.pipe(select(getSelectedOrderId))),
-      filter(([fromAction, selectedOrderId]) => fromAction && fromAction !== selectedOrderId),
-      map(([orderId]) => orderId),
-      map(orderId => selectOrder({ orderId }))
-    )
+    ).pipe(map(orderId => selectOrder({ orderId })))
   );
 
   /**

--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -122,8 +122,9 @@ export class OrdersEffects {
   loadOrders$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadOrders),
-      switchMap(() =>
-        this.orderService.getOrders().pipe(
+      mapToPayloadProperty('amount'),
+      switchMap(amount =>
+        this.orderService.getOrders(amount).pipe(
           map(orders => loadOrdersSuccess({ orders })),
           mapErrorToAction(loadOrdersFail)
         )

--- a/src/app/core/store/customer/orders/orders.selectors.spec.ts
+++ b/src/app/core/store/customer/orders/orders.selectors.spec.ts
@@ -81,7 +81,7 @@ describe('Orders Selectors', () => {
 
   describe('loading orders', () => {
     beforeEach(() => {
-      store$.dispatch(loadOrders());
+      store$.dispatch(loadOrders({ amount: 30 }));
       store$.dispatch(loadProductSuccess({ product: { sku: 'sku' } as Product }));
     });
 

--- a/src/app/core/store/customer/orders/orders.selectors.spec.ts
+++ b/src/app/core/store/customer/orders/orders.selectors.spec.ts
@@ -81,7 +81,7 @@ describe('Orders Selectors', () => {
 
   describe('loading orders', () => {
     beforeEach(() => {
-      store$.dispatch(loadOrders({ amount: 30 }));
+      store$.dispatch(loadOrders({ query: { limit: 30 } }));
       store$.dispatch(loadProductSuccess({ product: { sku: 'sku' } as Product }));
     });
 

--- a/src/app/pages/account-order-history/account-order-history-page.component.html
+++ b/src/app/pages/account-order-history/account-order-history-page.component.html
@@ -1,4 +1,5 @@
 <h1>{{ 'account.order_history.heading' | translate }}</h1>
+<ish-error-message [error]="ordersError$ | async" />
 <p class="section">{{ 'account.order.subtitle' | translate }}</p>
 
 <ish-order-list

--- a/src/app/pages/account-order-history/account-order-history-page.component.html
+++ b/src/app/pages/account-order-history/account-order-history-page.component.html
@@ -1,7 +1,12 @@
 <h1>{{ 'account.order_history.heading' | translate }}</h1>
 <p class="section">{{ 'account.order.subtitle' | translate }}</p>
 
-<ish-order-list />
+<ish-order-list
+  [orders]="orders$ | async"
+  [columnsToDisplay]="['creationDate', 'orderNoWithLink', 'lineItems', 'status', 'destination', 'orderTotal']"
+  noOrdersMessageKey="account.orderlist.no_placed_orders_message"
+  [loading]="ordersLoading$ | async"
+/>
 
 <h4 class="form-text">{{ 'account.order.questions.title' | translate }}</h4>
 <p

--- a/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
+import { instance, mock } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { AccountFacade } from 'ish-core/facades/account.facade';
 import { OrderListComponent } from 'ish-shared/components/order/order-list/order-list.component';
 
 import { AccountOrderHistoryPageComponent } from './account-order-history-page.component';
@@ -20,6 +22,7 @@ describe('Account Order History Page Component', () => {
         MockDirective(ServerHtmlDirective),
       ],
       imports: [TranslateModule.forRoot()],
+      providers: [{ provide: AccountFacade, useFactory: () => instance(mock(AccountFacade)) }],
     }).compileComponents();
   });
 

--- a/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
@@ -5,6 +5,7 @@ import { instance, mock } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
 import { OrderListComponent } from 'ish-shared/components/order/order-list/order-list.component';
 
 import { AccountOrderHistoryPageComponent } from './account-order-history-page.component';
@@ -18,6 +19,7 @@ describe('Account Order History Page Component', () => {
     await TestBed.configureTestingModule({
       declarations: [
         AccountOrderHistoryPageComponent,
+        MockComponent(ErrorMessageComponent),
         MockComponent(OrderListComponent),
         MockDirective(ServerHtmlDirective),
       ],

--- a/src/app/pages/account-order-history/account-order-history-page.component.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.ts
@@ -1,4 +1,8 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { Order } from 'ish-core/models/order/order.model';
 
 /**
  * The Order History Page Component renders the account history page of a logged in user.
@@ -8,4 +12,14 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   templateUrl: './account-order-history-page.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AccountOrderHistoryPageComponent {}
+export class AccountOrderHistoryPageComponent implements OnInit {
+  orders$: Observable<Order[]>;
+  ordersLoading$: Observable<boolean>;
+
+  constructor(private accountfacade: AccountFacade) {}
+
+  ngOnInit(): void {
+    this.orders$ = this.accountfacade.orders$(30);
+    this.ordersLoading$ = this.accountfacade.ordersLoading$;
+  }
+}

--- a/src/app/pages/account-order-history/account-order-history-page.component.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.ts
@@ -19,7 +19,7 @@ export class AccountOrderHistoryPageComponent implements OnInit {
   constructor(private accountfacade: AccountFacade) {}
 
   ngOnInit(): void {
-    this.orders$ = this.accountfacade.orders$(30);
+    this.orders$ = this.accountfacade.orders$({ limit: 30, include: ['commonShipToAddress'] });
     this.ordersLoading$ = this.accountfacade.ordersLoading$;
   }
 }

--- a/src/app/pages/account-order-history/account-order-history-page.component.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { Order } from 'ish-core/models/order/order.model';
 
 /**
@@ -15,11 +16,13 @@ import { Order } from 'ish-core/models/order/order.model';
 export class AccountOrderHistoryPageComponent implements OnInit {
   orders$: Observable<Order[]>;
   ordersLoading$: Observable<boolean>;
+  ordersError$: Observable<HttpError>;
 
-  constructor(private accountfacade: AccountFacade) {}
+  constructor(private accountFacade: AccountFacade) {}
 
   ngOnInit(): void {
-    this.orders$ = this.accountfacade.orders$({ limit: 30, include: ['commonShipToAddress'] });
-    this.ordersLoading$ = this.accountfacade.ordersLoading$;
+    this.orders$ = this.accountFacade.orders$({ limit: 30, include: ['commonShipToAddress'] });
+    this.ordersLoading$ = this.accountFacade.ordersLoading$;
+    this.ordersError$ = this.accountFacade.ordersError$;
   }
 }

--- a/src/app/shared/components/order/order-list/order-list.component.html
+++ b/src/app/shared/components/order/order-list/order-list.component.html
@@ -1,100 +1,99 @@
 <div class="loading-container">
-  <ng-container *ngIf="orders$ | async as ordersToDisplay">
-    <ng-container *ngIf="ordersToDisplay?.length > 0; else emptyList">
-      <table
-        cdk-table
-        [dataSource]="ordersToDisplay"
-        class="table table-lg mobile-optimized"
-        data-testing-id="requisition-list"
-      >
-        <!-- Order creation date -->
-        <ng-container cdkColumnDef="creationDate">
-          <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-creation-date">
-            {{ 'account.orderlist.table.date_of_order' | translate }}
-          </th>
-          <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.date_of_order' | translate">
-            {{ order.creationDate | ishDate }}
-          </td>
-        </ng-container>
+  <ng-container *ngIf="orders?.length > 0; else emptyList">
+    <table cdk-table [dataSource]="orders" class="table table-lg mobile-optimized">
+      <!-- Order creation date -->
+      <ng-container cdkColumnDef="creationDate">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-creation-date">
+          {{ 'account.orderlist.table.date_of_order' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.date_of_order' | translate">
+          {{ order.creationDate | ishDate }}
+        </td>
+      </ng-container>
 
-        <!-- Order number -->
-        <ng-container cdkColumnDef="orderNo">
-          <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-number">
-            {{ 'account.orderlist.table.order_number' | translate }}
-          </th>
-          <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.order_number' | translate">
-            <ng-container *ngIf="orders?.length; else orderNumberWithLink">{{ order.documentNo }}</ng-container>
-            <ng-template #orderNumberWithLink>
-              <a [routerLink]="'/account/orders/' + order.id">{{ order.documentNo }}</a>
-            </ng-template>
-          </td>
-        </ng-container>
+      <!-- Order number -->
+      <ng-container cdkColumnDef="orderNo">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-number">
+          {{ 'account.orderlist.table.order_number' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.order_number' | translate">
+          {{ order.documentNo }}
+        </td>
+      </ng-container>
 
-        <!-- Buyer -->
-        <ng-container cdkColumnDef="buyer">
-          <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-buyer">
-            {{ 'account.orderlist.table.buyer' | translate }}
-          </th>
-          <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.buyer' | translate">
-            {{ getBuyerName(order.attributes) }}
-          </td>
-        </ng-container>
+      <ng-container cdkColumnDef="orderNoWithLink">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-number">
+          {{ 'account.orderlist.table.order_number' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.order_number' | translate">
+          <a [routerLink]="'/account/orders/' + order.id">{{ order.documentNo }}</a>
+        </td>
+      </ng-container>
 
-        <!-- Number of Items  -->
-        <ng-container cdkColumnDef="lineItems">
-          <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-items">
-            {{ 'account.orderlist.table.items' | translate }}
-          </th>
-          <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.items' | translate">
-            {{ order.totalProductQuantity }}
-          </td>
-        </ng-container>
+      <!-- Buyer -->
+      <ng-container cdkColumnDef="buyer">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-buyer">
+          {{ 'account.orderlist.table.buyer' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.buyer' | translate">
+          {{ getBuyerName(order.attributes) }}
+        </td>
+      </ng-container>
 
-        <!-- Status  -->
-        <ng-container cdkColumnDef="status">
-          <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-status">
-            {{ 'account.orderlist.table.order_status' | translate }}
-          </th>
-          <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.order_status' | translate">
-            <span class="badge badge-info">{{ order.status }}</span>
-          </td>
-        </ng-container>
+      <!-- Number of Items  -->
+      <ng-container cdkColumnDef="lineItems">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-items">
+          {{ 'account.orderlist.table.items' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.items' | translate">
+          {{ order.totalProductQuantity }}
+        </td>
+      </ng-container>
 
-        <!-- Destination  -->
-        <ng-container cdkColumnDef="destination">
-          <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-destination">
-            {{ 'account.orderlist.table.destination' | translate }}
-          </th>
-          <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.destination' | translate">
-            <ish-address [address]="order.commonShipToAddress" />
-          </td>
-        </ng-container>
+      <!-- Status  -->
+      <ng-container cdkColumnDef="status">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-status">
+          {{ 'account.orderlist.table.order_status' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.order_status' | translate">
+          <span class="badge badge-info">{{ order.status }}</span>
+        </td>
+      </ng-container>
 
-        <!-- Order total  -->
-        <ng-container cdkColumnDef="orderTotal">
-          <th cdk-header-cell *cdkHeaderCellDef class="text-right" data-testing-id="th-order-total">
-            {{ 'account.orderlist.table.order_total' | translate }}
-          </th>
-          <td
-            cdk-cell
-            *cdkCellDef="let order"
-            [attr.data-label]="'account.orderlist.table.order_total' | translate"
-            class="column-price"
-          >
-            {{ order.totals.total | ishPrice : 'gross' }}
-          </td>
-        </ng-container>
+      <!-- Destination  -->
+      <ng-container cdkColumnDef="destination">
+        <th cdk-header-cell *cdkHeaderCellDef data-testing-id="th-order-destination">
+          {{ 'account.orderlist.table.destination' | translate }}
+        </th>
+        <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.destination' | translate">
+          <ish-address [address]="order.commonShipToAddress" />
+        </td>
+      </ng-container>
 
-        <!-- Header and Row Declarations -->
-        <tr cdk-header-row *cdkHeaderRowDef="columnsToDisplay"></tr>
-        <tr cdk-row *cdkRowDef="let row; columns: columnsToDisplay"></tr>
-      </table>
-    </ng-container>
+      <!-- Order total  -->
+      <ng-container cdkColumnDef="orderTotal">
+        <th cdk-header-cell *cdkHeaderCellDef class="text-right" data-testing-id="th-order-total">
+          {{ 'account.orderlist.table.order_total' | translate }}
+        </th>
+        <td
+          cdk-cell
+          *cdkCellDef="let order"
+          [attr.data-label]="'account.orderlist.table.order_total' | translate"
+          class="column-price"
+        >
+          {{ order.totals.total | ishPrice : 'gross' }}
+        </td>
+      </ng-container>
 
-    <ng-template #emptyList>
-      <p data-testing-id="emptyList">{{ noOrdersMessageKey | translate }}</p>
-    </ng-template>
+      <!-- Header and Row Declarations -->
+      <tr cdk-header-row *cdkHeaderRowDef="columnsToDisplay"></tr>
+      <tr cdk-row *cdkRowDef="let row; columns: columnsToDisplay"></tr>
+    </table>
   </ng-container>
 
-  <ish-loading *ngIf="loading$ | async" />
+  <ng-template #emptyList>
+    <p data-testing-id="emptyList">{{ noOrdersMessageKey | translate }}</p>
+  </ng-template>
+
+  <ish-loading *ngIf="loading" />
 </div>

--- a/src/app/shared/components/order/order-list/order-list.component.spec.ts
+++ b/src/app/shared/components/order/order-list/order-list.component.spec.ts
@@ -1,15 +1,9 @@
 import { CdkTableModule } from '@angular/cdk/table';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent, MockPipe } from 'ng-mocks';
-import { of } from 'rxjs';
-import { instance, mock, when } from 'ts-mockito';
+import { MockComponent } from 'ng-mocks';
 
-import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Order } from 'ish-core/models/order/order.model';
-import { PricePipe } from 'ish-core/models/price/price.pipe';
-import { DatePipe } from 'ish-core/pipes/date.pipe';
 import { AddressComponent } from 'ish-shared/components/address/address/address.component';
 import { LoadingComponent } from 'ish-shared/components/common/loading/loading.component';
 
@@ -19,25 +13,15 @@ describe('Order List Component', () => {
   let component: OrderListComponent;
   let fixture: ComponentFixture<OrderListComponent>;
   let element: HTMLElement;
-  let accountFacade: AccountFacade;
   const orders = [
     { id: '00123', documentNo: '123', totals: {} },
     { id: '00124', documentNo: '124', totals: {} },
   ] as Order[];
 
   beforeEach(async () => {
-    accountFacade = mock(AccountFacade);
-
     await TestBed.configureTestingModule({
-      imports: [CdkTableModule, RouterTestingModule, TranslateModule.forRoot()],
-      declarations: [
-        MockComponent(AddressComponent),
-        MockComponent(LoadingComponent),
-        MockPipe(DatePipe),
-        MockPipe(PricePipe),
-        OrderListComponent,
-      ],
-      providers: [{ provide: AccountFacade, useFactory: () => instance(accountFacade) }],
+      imports: [CdkTableModule, TranslateModule.forRoot()],
+      declarations: [MockComponent(AddressComponent), MockComponent(LoadingComponent), OrderListComponent],
     }).compileComponents();
   });
 
@@ -45,21 +29,12 @@ describe('Order List Component', () => {
     fixture = TestBed.createComponent(OrderListComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
-
-    when(accountFacade.orders$()).thenReturn(of(orders));
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
-  });
-
-  it('should display empty list with user related text if there are no orders from store', () => {
-    when(accountFacade.orders$()).thenReturn(of([]));
-    fixture.detectChanges();
-    expect(element.querySelector('[data-testing-id=emptyList]')).toBeTruthy();
-    expect(component.noOrdersMessageKey).toBe('account.orderlist.no_placed_orders_message');
   });
 
   it('should display empty list with default text if there are no orders as component orders input', () => {
@@ -70,13 +45,14 @@ describe('Order List Component', () => {
   });
 
   it('should display loading overlay if orders are loading', () => {
-    when(accountFacade.ordersLoading$).thenReturn(of(true));
+    component.loading = true;
     fixture.detectChanges();
     expect(element.querySelector('ish-loading')).toBeTruthy();
   });
 
-  it('should display a list if there are orders in store', () => {
-    when(accountFacade.orders$()).thenReturn(of(orders));
+  it('should display a list with address if requested', () => {
+    component.orders = orders;
+    component.columnsToDisplay = ['destination'];
     fixture.detectChanges();
 
     expect(element.querySelector('table.cdk-table')).toBeTruthy();
@@ -96,15 +72,8 @@ describe('Order List Component', () => {
     expect(element.querySelectorAll('table tr.cdk-row')).toHaveLength(3);
   });
 
-  it('should display a certain number of items if maxItemsCount is set', () => {
-    component.maxListItems = 1;
-    fixture.detectChanges();
-
-    expect(element.querySelectorAll('table tr.cdk-row')).toHaveLength(1);
-  });
-
   it('should not display addresses if only creationDate is required to show', () => {
-    when(accountFacade.orders$()).thenReturn(of(orders));
+    component.orders = orders;
     component.columnsToDisplay = ['creationDate'];
     fixture.detectChanges();
 

--- a/src/app/shared/components/order/order-list/order-list.component.ts
+++ b/src/app/shared/components/order/order-list/order-list.component.ts
@@ -1,8 +1,5 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
 import { Order } from 'ish-core/models/order/order.model';
@@ -10,6 +7,7 @@ import { Order } from 'ish-core/models/order/order.model';
 type OrderColumnsType =
   | 'creationDate'
   | 'orderNo'
+  | 'orderNoWithLink'
   | 'buyer'
   | 'lineItems'
   | 'status'
@@ -18,14 +16,13 @@ type OrderColumnsType =
   | 'orderTotal';
 
 /**
- * The Order List Component displays the orders provided as input parameter. The number of displayed items can be limited by the maxListItems input parameter.
- * If no order data are provided all orders of the current user will be fetched from store and displayed.
+ * The Order List Component displays the orders provided as input parameter.
  *
  * @example
- * displays all orders of the current user in a more compact manner.
  * <ish-order-list
- *    maxListItems="0"
- *    [columnsToDisplay]="['creationDate', 'orderNo', 'lineItems', 'status', 'orderTotal']">
+ *   [orders]="orders$ | async"
+ *   [loading]="loading$ | async"
+ *   [columnsToDisplay]="['creationDate', 'orderNoWithLink', 'lineItems', 'status', 'orderTotal']">
  * </ish-order-list>
  */
 @Component({
@@ -33,53 +30,20 @@ type OrderColumnsType =
   templateUrl: './order-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OrderListComponent implements OnInit {
-  /**
-   * The maximum number of items to be displayed.
-   * Use 0, if you want to display all items without any restrictions.
-   * Default: 30 items will be displayed
-   */
-  @Input() maxListItems = 30;
+export class OrderListComponent {
   /**
    * The columns to be displayed.
-   * Default: All columns besides the buyer
    */
-  @Input() columnsToDisplay: OrderColumnsType[] = [
-    'creationDate',
-    'orderNo',
-    'lineItems',
-    'status',
-    'destination',
-    'orderTotal',
-  ];
+  @Input({ required: true }) columnsToDisplay: OrderColumnsType[];
 
   /**
    * The orders to be displayed.
-   * Default: Orders of the current user are shown.
    */
-  @Input() orders: Partial<Order>[];
+  @Input({ required: true }) orders: Partial<Order>[];
 
-  orders$: Observable<Partial<Order>[]>;
-  loading$: Observable<boolean>;
+  @Input() noOrdersMessageKey = 'account.orderlist.no_orders_message';
 
-  noOrdersMessageKey = 'account.orderlist.no_orders_message';
-
-  constructor(private accountFacade: AccountFacade) {}
-
-  ngOnInit() {
-    this.init();
-  }
-
-  init() {
-    this.orders$ = (this.orders ? of(this.orders) : this.accountFacade.orders$()).pipe(
-      map(orders => (this.maxListItems ? orders?.slice(0, this.maxListItems) : orders))
-    );
-    this.loading$ = this.accountFacade.ordersLoading$;
-
-    if (!this.orders) {
-      this.noOrdersMessageKey = 'account.orderlist.no_placed_orders_message';
-    }
-  }
+  @Input() loading: boolean;
 
   /**
    *  get buyer name from order attributes

--- a/src/app/shared/components/order/order-widget/order-widget.component.html
+++ b/src/app/shared/components/order/order-widget/order-widget.component.html
@@ -1,7 +1,9 @@
 <ish-info-box heading="account.order.most_recent.heading" class="infobox-wrapper" cssClass="infobox-widget">
   <ish-order-list
-    [maxListItems]="5"
-    [columnsToDisplay]="['creationDate', 'orderNo', 'lineItems', 'status', 'orderTotal']"
+    [orders]="orders$ | async"
+    [loading]="ordersLoading$ | async"
+    noOrdersMessageKey="account.orderlist.no_placed_orders_message"
+    [columnsToDisplay]="['creationDate', 'orderNoWithLink', 'lineItems', 'status', 'orderTotal']"
   />
 
   <a routerLink="/account/orders">{{ 'account.order.view_all_order.link' | translate }}</a>

--- a/src/app/shared/components/order/order-widget/order-widget.component.spec.ts
+++ b/src/app/shared/components/order/order-widget/order-widget.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent } from 'ng-mocks';
+import { instance, mock } from 'ts-mockito';
 
+import { AccountFacade } from 'ish-core/facades/account.facade';
 import { InfoBoxComponent } from 'ish-shared/components/common/info-box/info-box.component';
 import { OrderListComponent } from 'ish-shared/components/order/order-list/order-list.component';
 
@@ -16,6 +18,7 @@ describe('Order Widget Component', () => {
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
       declarations: [MockComponent(InfoBoxComponent), MockComponent(OrderListComponent), OrderWidgetComponent],
+      providers: [{ provide: AccountFacade, useFactory: () => instance(mock(AccountFacade)) }],
     }).compileComponents();
   });
 

--- a/src/app/shared/components/order/order-widget/order-widget.component.ts
+++ b/src/app/shared/components/order/order-widget/order-widget.component.ts
@@ -22,7 +22,7 @@ export class OrderWidgetComponent implements OnInit {
   constructor(private accountfacade: AccountFacade) {}
 
   ngOnInit(): void {
-    this.orders$ = this.accountfacade.orders$(5);
+    this.orders$ = this.accountfacade.orders$({ limit: 5 });
     this.ordersLoading$ = this.accountfacade.ordersLoading$;
   }
 }

--- a/src/app/shared/components/order/order-widget/order-widget.component.ts
+++ b/src/app/shared/components/order/order-widget/order-widget.component.ts
@@ -1,4 +1,8 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AccountFacade } from 'ish-core/facades/account.facade';
+import { Order } from 'ish-core/models/order/order.model';
 
 /**
  * The Order Widget Component - displays an overview of the latest orders as list.
@@ -11,4 +15,14 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   templateUrl: './order-widget.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OrderWidgetComponent {}
+export class OrderWidgetComponent implements OnInit {
+  orders$: Observable<Order[]>;
+  ordersLoading$: Observable<boolean>;
+
+  constructor(private accountfacade: AccountFacade) {}
+
+  ngOnInit(): void {
+    this.orders$ = this.accountfacade.orders$(5);
+    this.ordersLoading$ = this.accountfacade.ordersLoading$;
+  }
+}


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

`ish-order-list` has too many tasks:
- can be fed with a list of orders
- can alternatively fetch orders themself
- switches the no-orders message themself depending if supplied with order list
- truncates the list if supplied with input parameter
- implicitly disables linking to details page if orders supplied directly

Performance issue:
- for the account order widget 30 orders are fetched, but only 5 displayed
- all additional properties for orders are fetched even if not used

## What Is the New Behavior?

`ish-order-list` is strictly presentational, components using it supply the data.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] Yes
[ ] No

BREAKING CHANGE: orders API call now uses additionally the new `limit` parameter (requires ICM 11.6), the deprecated `page[limit]`will be removed soon

## Other Information


[AB#92479](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92479)