### PR TITLE
fix: improved NGINX route rewrite handling for '/home' and '/loading'

### DIFF
--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -34,9 +34,10 @@
 
         include /etc/nginx/conf.d/cache-settings.conf;
 
-        rewrite ^.*/index.html$ {{ $baseHref }}/loading;
-        rewrite ^(.*)/$ $1;
-        rewrite ^{{ $baseHref }}/?$ {{ $baseHref }}/home;
+        {{- $baseHrefTrailingSlash := $baseHref }}{{if not ($baseHrefTrailingSlash | strings.HasSuffix "/")}}{{ $baseHrefTrailingSlash = print $baseHrefTrailingSlash "/" }}{{ end }}
+        rewrite ^.*/index.html$ {{ $baseHrefTrailingSlash }}loading;
+        rewrite ^{{ $baseHref }}/*?$ {{ $baseHrefTrailingSlash }}home;
+        rewrite ^(.*?)(/+)$ $1;
 
         rewrite '^(?!.*;lang=.*)(.*)$' '$1;lang={{ $lang }}';
         rewrite '^(?!.*;currency=.*)(.*)$' '$1;currency={{ $currency }}';


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The fix for " trailing '/' in path results to a wrong multi channel configuration (#1553)" results in NGINX re-writting errors ("the rewritten URI has a zero length") for `MULTI_CHANNEL` configurations that use the default `baseHref` of `/` when accessing the root route with https://intershoppwa.azurewebsites.net instead of https://intershoppwa.azurewebsites.net/home.

In addition the canonical link element is not correctly generated at the root. The double `//` between the domain name and the `home` route can be interpreted by search enginesas a duplicate, and thus impact the SEO ranking of the website.

## What Is the New Behavior?

The NGINX route rewrite handling for '/home' and '/loading' was improved to work with `MULTI_CHANNEL` configurations with and without the default `baseHref` of `/`.
The NGINX rewriting removes now all trailing slashes.
The NGINX rewriting prevents canonical links with doubled `//` between the domain name and the rest of the path.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

[AB#92520](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92520)