### PR TITLE
refactor: fetching eligible basket addresses

### DIFF
--- a/src/app/core/services/basket/basket.service.spec.ts
+++ b/src/app/core/services/basket/basket.service.spec.ts
@@ -195,6 +195,15 @@ describe('Basket Service', () => {
     });
   });
 
+  it("should get eligible addresses for a basket when 'getBasketEligibleAddresses' is called", done => {
+    when(apiService.get(anything(), anything())).thenReturn(of({ data: [] }));
+
+    basketService.getBasketEligibleAddresses().subscribe(() => {
+      verify(apiService.get('eligible-addresses', anything())).once();
+      done();
+    });
+  });
+
   it("should get eligible shipping methods for a basket when 'getBasketEligibleShippingMethods' is called", done => {
     when(apiService.get(anything(), anything())).thenReturn(of({ data: [] }));
 

--- a/src/app/core/store/customer/addresses/addresses.reducer.ts
+++ b/src/app/core/store/customer/addresses/addresses.reducer.ts
@@ -3,12 +3,7 @@ import { createReducer, on } from '@ngrx/store';
 
 import { Address } from 'ish-core/models/address/address.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import {
-  createBasketAddress,
-  createBasketAddressSuccess,
-  deleteBasketShippingAddress,
-  updateBasketAddress,
-} from 'ish-core/store/customer/basket';
+import { deleteBasketShippingAddress, updateBasketAddress } from 'ish-core/store/customer/basket';
 import { setErrorOn, setLoadingOn, unsetLoadingAndErrorOn } from 'ish-core/utils/ngrx-creators';
 
 import {
@@ -43,7 +38,6 @@ export const addressesReducer = createReducer(
   setLoadingOn(
     loadAddresses,
     createCustomerAddress,
-    createBasketAddress,
     updateCustomerAddress,
     updateBasketAddress,
     deleteCustomerAddress,
@@ -53,12 +47,11 @@ export const addressesReducer = createReducer(
   unsetLoadingAndErrorOn(
     loadAddressesSuccess,
     createCustomerAddressSuccess,
-    createBasketAddressSuccess,
     updateCustomerAddressSuccess,
     deleteCustomerAddressSuccess
   ),
   on(loadAddressesSuccess, (state, action) => addressAdapter.setAll(action.payload.addresses, state)),
-  on(createCustomerAddressSuccess, createBasketAddressSuccess, updateCustomerAddressSuccess, (state, action) =>
+  on(createCustomerAddressSuccess, updateCustomerAddressSuccess, (state, action) =>
     addressAdapter.upsertOne(action.payload.address, state)
   ),
   on(deleteCustomerAddressSuccess, (state, action) => addressAdapter.removeOne(action.payload.addressId, state))

--- a/src/app/core/store/customer/addresses/addresses.selectors.spec.ts
+++ b/src/app/core/store/customer/addresses/addresses.selectors.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { Address } from 'ish-core/models/address/address.model';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
-import { createBasketAddress, createBasketAddressSuccess, updateBasketAddress } from 'ish-core/store/customer/basket';
+import { updateBasketAddress } from 'ish-core/store/customer/basket';
 import { CustomerStoreModule } from 'ish-core/store/customer/customer-store.module';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
@@ -102,46 +102,6 @@ describe('Addresses Selectors', () => {
       });
 
       it('should set loading to false and add address', () => {
-        expect(getAddressesLoading(store$.state)).toBeFalse();
-        expect(getAllAddresses(store$.state)).toEqual([address]);
-      });
-    });
-
-    describe('and reporting failure', () => {
-      beforeEach(() => {
-        store$.dispatch(createCustomerAddressFail({ error: makeHttpError({ message: 'error' }) }));
-      });
-
-      it('should not have loaded addresses on error', () => {
-        expect(getAddressesLoading(store$.state)).toBeFalse();
-        expect(getAllAddresses(store$.state)).toBeEmpty();
-        expect(getAddressesError(store$.state)).toMatchInlineSnapshot(`
-          {
-            "message": "error",
-            "name": "HttpErrorResponse",
-          }
-        `);
-      });
-    });
-  });
-
-  describe('create basket addresses', () => {
-    const address = BasketMockData.getAddress();
-
-    beforeEach(() => {
-      store$.dispatch(createBasketAddress({ address, scope: 'invoice' }));
-    });
-
-    it('should set the state to loading', () => {
-      expect(getAddressesLoading(store$.state)).toBeTrue();
-    });
-
-    describe('and reporting success', () => {
-      beforeEach(() => {
-        store$.dispatch(createBasketAddressSuccess({ address, scope: 'invoice' }));
-      });
-
-      it('should set loading to false and add basket address', () => {
         expect(getAddressesLoading(store$.state)).toBeFalse();
         expect(getAllAddresses(store$.state)).toEqual([address]);
       });

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -48,6 +48,8 @@ export const createBasketAddressSuccess = createAction(
   payload<{ address: Address; scope: 'invoice' | 'shipping' | 'any' }>()
 );
 
+export const createBasketAddressFail = createAction('[Basket API] Create Basket Address Fail', httpError());
+
 export const assignBasketAddress = createAction(
   '[Basket] Assign an Address to the Basket',
   payload<{ addressId: string; scope: 'invoice' | 'shipping' | 'any' }>()
@@ -204,6 +206,18 @@ export const deleteBasketAttribute = createAction(
 export const deleteBasketAttributeFail = createAction('[Basket API] Delete Basket Attribute Fail', httpError());
 
 export const deleteBasketAttributeSuccess = createAction('[Basket API] Delete Basket Attribute Success');
+
+export const loadBasketEligibleAddresses = createAction('[Basket Internal] Load Basket Eligible Addresses');
+
+export const loadBasketEligibleAddressesFail = createAction(
+  '[Basket API] Load Basket Eligible Addresses Fail',
+  httpError()
+);
+
+export const loadBasketEligibleAddressesSuccess = createAction(
+  '[Basket API] Load Basket Eligible Addresses Success',
+  payload<{ addresses: Address[] }>()
+);
 
 export const loadBasketEligibleShippingMethods = createAction(
   '[Basket Internal] Load Basket Eligible Shipping Methods'

--- a/src/app/core/store/customer/basket/basket.reducer.ts
+++ b/src/app/core/store/customer/basket/basket.reducer.ts
@@ -1,6 +1,7 @@
 import { createReducer, on } from '@ngrx/store';
 import { unionBy } from 'lodash-es';
 
+import { Address } from 'ish-core/models/address/address.model';
 import { BasketInfo } from 'ish-core/models/basket-info/basket-info.model';
 import { BasketValidationResultType } from 'ish-core/models/basket-validation/basket-validation.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
@@ -23,6 +24,9 @@ import {
   continueCheckoutFail,
   continueCheckoutSuccess,
   continueCheckoutWithIssues,
+  createBasketAddress,
+  createBasketAddressFail,
+  createBasketAddressSuccess,
   createBasketPayment,
   createBasketPaymentFail,
   createBasketPaymentSuccess,
@@ -39,6 +43,9 @@ import {
   loadBasket,
   loadBasketByAPIToken,
   loadBasketByAPITokenFail,
+  loadBasketEligibleAddresses,
+  loadBasketEligibleAddressesFail,
+  loadBasketEligibleAddressesSuccess,
   loadBasketEligiblePaymentMethods,
   loadBasketEligiblePaymentMethodsFail,
   loadBasketEligiblePaymentMethodsSuccess,
@@ -86,6 +93,7 @@ import {
 
 export interface BasketState {
   basket: Basket;
+  eligibleAddresses: Address[];
   eligibleShippingMethods: ShippingMethod[];
   eligiblePaymentMethods: PaymentMethod[];
   loading: boolean;
@@ -105,6 +113,7 @@ const initialValidationResults: BasketValidationResultType = {
 
 const initialState: BasketState = {
   basket: undefined,
+  eligibleAddresses: undefined,
   eligibleShippingMethods: undefined,
   eligiblePaymentMethods: undefined,
   loading: false,
@@ -134,6 +143,8 @@ export const basketReducer = createReducer(
     deleteBasketItem,
     setBasketAttribute,
     deleteBasketAttribute,
+    createBasketAddress,
+    loadBasketEligibleAddresses,
     loadBasketEligibleShippingMethods,
     loadBasketEligiblePaymentMethods,
     setBasketPayment,
@@ -158,12 +169,14 @@ export const basketReducer = createReducer(
     deleteBasketItemSuccess,
     addItemsToBasketSuccess,
     setBasketPaymentSuccess,
+    createBasketAddressSuccess,
     createBasketPaymentSuccess,
     updateBasketPaymentSuccess,
     deleteBasketPaymentSuccess,
     removePromotionCodeFromBasketSuccess,
     continueCheckoutSuccess,
     continueCheckoutWithIssues,
+    loadBasketEligibleAddressesSuccess,
     loadBasketEligibleShippingMethodsSuccess,
     loadBasketEligiblePaymentMethodsSuccess,
     updateConcardisCvcLastUpdatedSuccess,
@@ -182,6 +195,8 @@ export const basketReducer = createReducer(
     deleteBasketItemFail,
     setBasketAttributeFail,
     deleteBasketAttributeFail,
+    createBasketAddressFail,
+    loadBasketEligibleAddressesFail,
     loadBasketEligibleShippingMethodsFail,
     loadBasketEligiblePaymentMethodsFail,
     setBasketPaymentFail,
@@ -255,6 +270,22 @@ export const basketReducer = createReducer(
       validationResults: validation?.results,
     };
   }),
+  on(
+    loadBasketEligibleAddressesSuccess,
+    (state, action): BasketState => ({
+      ...state,
+      eligibleAddresses: action.payload.addresses,
+    })
+  ),
+  on(
+    createBasketAddressSuccess,
+    (state, action): BasketState => ({
+      ...state,
+      eligibleAddresses: state.eligibleAddresses
+        ? [...state.eligibleAddresses, action.payload.address]
+        : [action.payload.address],
+    })
+  ),
   on(
     loadBasketEligibleShippingMethodsSuccess,
     (state, action): BasketState => ({

--- a/src/app/core/store/customer/basket/basket.selectors.spec.ts
+++ b/src/app/core/store/customer/basket/basket.selectors.spec.ts
@@ -20,6 +20,9 @@ import {
   continueCheckoutSuccess,
   createBasketSuccess,
   loadBasket,
+  loadBasketEligibleAddresses,
+  loadBasketEligibleAddressesFail,
+  loadBasketEligibleAddressesSuccess,
   loadBasketEligiblePaymentMethods,
   loadBasketEligiblePaymentMethodsFail,
   loadBasketEligiblePaymentMethodsSuccess,
@@ -31,6 +34,7 @@ import {
   submitBasketSuccess,
 } from './basket.actions';
 import {
+  getBasketEligibleAddresses,
   getBasketEligiblePaymentMethods,
   getBasketEligibleShippingMethods,
   getBasketError,
@@ -180,6 +184,44 @@ describe('Basket Selectors', () => {
           "name": "HttpErrorResponse",
         }
       `);
+    });
+  });
+
+  describe('loading eligible addresses', () => {
+    beforeEach(() => {
+      store$.dispatch(loadBasketEligibleAddresses());
+    });
+
+    it('should set the state to loading', () => {
+      expect(getBasketLoading(store$.state)).toBeTrue();
+    });
+
+    describe('and reporting success', () => {
+      beforeEach(() => {
+        store$.dispatch(loadBasketEligibleAddressesSuccess({ addresses: [BasketMockData.getAddress()] }));
+      });
+
+      it('should set loading to false', () => {
+        expect(getBasketLoading(store$.state)).toBeFalse();
+        expect(getBasketEligibleAddresses(store$.state)).toEqual([BasketMockData.getAddress()]);
+      });
+    });
+
+    describe('and reporting failure', () => {
+      beforeEach(() => {
+        store$.dispatch(loadBasketEligibleAddressesFail({ error: makeHttpError({ message: 'error' }) }));
+      });
+
+      it('should not have loaded addresses on error', () => {
+        expect(getBasketLoading(store$.state)).toBeFalse();
+        expect(getBasketEligibleAddresses(store$.state)).toBeUndefined();
+        expect(getBasketError(store$.state)).toMatchInlineSnapshot(`
+          {
+            "message": "error",
+            "name": "HttpErrorResponse",
+          }
+        `);
+      });
     });
   });
 

--- a/src/app/core/store/customer/basket/basket.selectors.ts
+++ b/src/app/core/store/customer/basket/basket.selectors.ts
@@ -69,6 +69,8 @@ export const getBasketPromotionError = createSelector(getBasketState, basket => 
 
 export const getBasketLastTimeProductAdded = createSelector(getBasketState, basket => basket.lastTimeProductAdded);
 
+export const getBasketEligibleAddresses = createSelector(getBasketState, basket => basket.eligibleAddresses);
+
 export const getBasketEligibleShippingMethods = createSelector(
   getBasketState,
   basket => basket.eligibleShippingMethods

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.ts
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.ts
@@ -95,13 +95,15 @@ export class CheckoutAddressAnonymousComponent implements OnChanges {
         ? undefined
         : this.form.get('shippingAddress').value.address;
 
-    if (this.form.get('additionalAddressAttributes').value.taxationID) {
-      this.checkoutFacade.setBasketCustomAttribute({
-        name: 'taxationID',
-        value: this.form.get('additionalAddressAttributes').value.taxationID,
-      });
-    } else {
-      this.checkoutFacade.deleteBasketCustomAttribute('taxationID');
+    if (this.form.get('additionalAddressAttributes').get('taxationID')) {
+      if (this.form.get('additionalAddressAttributes').value.taxationID) {
+        this.checkoutFacade.setBasketCustomAttribute({
+          name: 'taxationID',
+          value: this.form.get('additionalAddressAttributes').value.taxationID,
+        });
+      } else {
+        this.checkoutFacade.deleteBasketCustomAttribute('taxationID');
+      }
     }
 
     if (shippingAddress) {

--- a/src/app/pages/checkout-address/checkout-address/checkout-address.component.html
+++ b/src/app/pages/checkout-address/checkout-address/checkout-address.component.html
@@ -16,6 +16,7 @@
   <!-- ------------------------------- invoice address ---------------------------------- -->
   <div class="col-md-6 col-lg-4" data-testing-id="invoiceToAddress">
     <ish-basket-invoice-address-widget
+      [eligibleAddresses$]="eligibleAddresses$"
       [showErrors]="nextDisabled"
       [collapse]="active === 'shipping'"
       (collapseChange)="invoiceCollapsed($event)"
@@ -25,6 +26,7 @@
   <!-- ------------------------------ shipping address ----------------------------------------- -->
   <div class="col-md-6 col-lg-4" data-testing-id="shipToAddress">
     <ish-basket-shipping-address-widget
+      [eligibleAddresses$]="eligibleAddresses$"
       [showErrors]="nextDisabled"
       [collapse]="active === 'invoice'"
       (collapseChange)="shippingCollapsed($event)"

--- a/src/app/pages/checkout-address/checkout-address/checkout-address.component.spec.ts
+++ b/src/app/pages/checkout-address/checkout-address/checkout-address.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
+import { of } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 import { BasketCostSummaryComponent } from 'ish-shared/components/basket/basket-cost-summary/basket-cost-summary.component';
@@ -20,6 +23,8 @@ describe('Checkout Address Component', () => {
   let element: HTMLElement;
 
   beforeEach(async () => {
+    const checkoutFacade = mock(CheckoutFacade);
+    when(checkoutFacade.eligibleAddresses$()).thenReturn(of([]));
     await TestBed.configureTestingModule({
       declarations: [
         CheckoutAddressComponent,
@@ -32,6 +37,7 @@ describe('Checkout Address Component', () => {
         MockDirective(ServerHtmlDirective),
       ],
       imports: [TranslateModule.forRoot()],
+      providers: [{ provide: CheckoutFacade, useFactory: () => instance(checkoutFacade) }],
     }).compileComponents();
   });
 

--- a/src/app/pages/checkout-address/checkout-address/checkout-address.component.ts
+++ b/src/app/pages/checkout-address/checkout-address/checkout-address.component.ts
@@ -1,5 +1,8 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Observable, shareReplay } from 'rxjs';
 
+import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
+import { Address } from 'ish-core/models/address/address.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 
@@ -11,14 +14,22 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
   templateUrl: './checkout-address.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CheckoutAddressComponent {
+export class CheckoutAddressComponent implements OnInit {
   @Input({ required: true }) basket: Basket;
   @Input() error: HttpError;
 
   @Output() nextStep = new EventEmitter<void>();
 
+  eligibleAddresses$: Observable<Address[]>;
+
   submitted = false;
   active: 'invoice' | 'shipping';
+
+  constructor(private checkoutFacade: CheckoutFacade) {}
+
+  ngOnInit(): void {
+    this.eligibleAddresses$ = this.checkoutFacade.eligibleAddresses$().pipe(shareReplay(1));
+  }
 
   /**
    * leads to next checkout page (checkout shipping)

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.spec.ts
@@ -34,7 +34,6 @@ describe('Basket Invoice Address Widget Component', () => {
     when(checkoutFacade.basketInvoiceAddress$).thenReturn(EMPTY);
 
     accountFacade = mock(AccountFacade);
-    when(accountFacade.addresses$()).thenReturn(EMPTY);
     when(accountFacade.isLoggedIn$).thenReturn(of(true));
 
     await TestBed.configureTestingModule({
@@ -85,7 +84,6 @@ describe('Basket Invoice Address Widget Component', () => {
   describe('with address on basket', () => {
     beforeEach(() => {
       when(checkoutFacade.basketInvoiceAddress$).thenReturn(of(BasketMockData.getAddress()));
-      when(accountFacade.addresses$()).thenReturn(of([BasketMockData.getAddress()]));
     });
 
     it('should render if invoice is set', () => {
@@ -165,7 +163,7 @@ describe('Basket Invoice Address Widget Component', () => {
 
     beforeEach(() => {
       when(checkoutFacade.basketInvoiceAddress$).thenReturn(of(addresses[1]));
-      when(accountFacade.addresses$()).thenReturn(of(addresses));
+      component.eligibleAddresses$ = of(addresses);
     });
 
     it('should only use valid addresses for selection display', done => {

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
-import { filter, map, shareReplay, take } from 'rxjs/operators';
+import { filter, map, take } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
@@ -22,6 +22,7 @@ import { FormsService } from 'ish-shared/forms/utils/forms.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BasketInvoiceAddressWidgetComponent implements OnInit {
+  @Input({ required: true }) eligibleAddresses$: Observable<Address[]>;
   @Input() showErrors = true;
 
   @Output() collapseChange = new BehaviorSubject(true);
@@ -35,7 +36,6 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit {
   }
   invoiceAddress$: Observable<Address>;
   addresses$: Observable<Address[]>;
-  customerAddresses$: Observable<Address[]>;
   isLoggedIn$: Observable<boolean>;
 
   form = new UntypedFormGroup({});
@@ -53,7 +53,6 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.customerAddresses$ = this.accountFacade.addresses$().pipe(shareReplay(1));
     this.invoiceAddress$ = this.checkoutFacade.basketInvoiceAddress$;
 
     this.invoiceAddress$
@@ -68,7 +67,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit {
       .subscribe(label => (this.emptyOptionLabel = label));
 
     // prepare data for invoice select drop down
-    this.addresses$ = combineLatest([this.customerAddresses$, this.invoiceAddress$]).pipe(
+    this.addresses$ = combineLatest([this.eligibleAddresses$, this.invoiceAddress$]).pipe(
       map(([addresses, invoiceAddress]) =>
         addresses?.filter(address => address.invoiceToAddress).filter(address => address.id !== invoiceAddress?.id)
       )

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.html
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.html
@@ -6,11 +6,12 @@
         <!-- edit shipping address -->
         <a
           *ngIf="collapseChange | async"
-          [routerLink]="[]"
           class="btn-tool"
           title="{{ 'checkout.address.update.shipping.label' | translate }}"
           (click)="showAddressForm(address)"
+          (keydown.enter)="showAddressForm(address)"
           data-testing-id="edit-shipping-address-link"
+          tabindex="0"
         >
           <fa-icon [icon]="['fas', 'pencil-alt']" />
         </a>
@@ -18,10 +19,11 @@
         <!-- delete shipping address -->
         <a
           *ngIf="(basketShippingAddressDeletable$ | async) && (collapseChange | async)"
-          [routerLink]="[]"
           class="btn-tool"
           title="{{ 'checkout.address.delete.button.label' | translate }}"
           (click)="modalDialog.show(address)"
+          (keydown.enter)="modalDialog.show(address)"
+          tabindex="0"
         >
           <fa-icon [icon]="['fas', 'trash-alt']" />
         </a>

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
@@ -38,15 +37,9 @@ describe('Basket Shipping Address Widget Component', () => {
     when(checkoutFacade.basketInvoiceAndShippingAddressEqual$).thenReturn(of(false));
 
     when(accountFacade.isLoggedIn$).thenReturn(of(true));
-    when(accountFacade.addresses$()).thenReturn(EMPTY);
 
     await TestBed.configureTestingModule({
-      imports: [
-        FeatureToggleModule.forTesting('addressDoctor'),
-        FormlyTestingModule,
-        RouterTestingModule,
-        TranslateModule.forRoot(),
-      ],
+      imports: [FeatureToggleModule.forTesting('addressDoctor'), FormlyTestingModule, TranslateModule.forRoot()],
       declarations: [
         BasketShippingAddressWidgetComponent,
         MockComponent(AddressComponent),
@@ -102,7 +95,7 @@ describe('Basket Shipping Address Widget Component', () => {
     beforeEach(() => {
       const address = BasketMockData.getAddress();
       when(checkoutFacade.basketShippingAddress$).thenReturn(of(address));
-      when(accountFacade.addresses$()).thenReturn(of([address, { ...address, id: 'test' }]));
+      component.eligibleAddresses$ = of([address, { ...address, id: 'test' }]);
     });
 
     it('should render if shipping is set', () => {
@@ -226,7 +219,7 @@ describe('Basket Shipping Address Widget Component', () => {
 
     beforeEach(() => {
       when(checkoutFacade.basketShippingAddress$).thenReturn(of(addresses[1]));
-      when(accountFacade.addresses$()).thenReturn(of(addresses));
+      component.eligibleAddresses$ = of(addresses);
     });
 
     it('should only use valid addresses for selection display', done => {

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core/lib/core';
 import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
-import { filter, map, shareReplay, take } from 'rxjs/operators';
+import { filter, map, take } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
@@ -22,6 +22,7 @@ import { FormsService } from 'ish-shared/forms/utils/forms.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BasketShippingAddressWidgetComponent implements OnInit {
+  @Input({ required: true }) eligibleAddresses$: Observable<Address[]>;
   @Input() showErrors = true;
 
   @Output() collapseChange = new BehaviorSubject(true);
@@ -36,7 +37,6 @@ export class BasketShippingAddressWidgetComponent implements OnInit {
 
   shippingAddress$: Observable<Address>;
   addresses$: Observable<Address[]>;
-  customerAddresses$: Observable<Address[]>;
   displayAddAddressLink$: Observable<boolean>;
 
   basketInvoiceAndShippingAddressEqual$: Observable<boolean>;
@@ -61,7 +61,6 @@ export class BasketShippingAddressWidgetComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.customerAddresses$ = this.accountFacade.addresses$().pipe(shareReplay(1));
     this.shippingAddress$ = this.checkoutFacade.basketShippingAddress$;
     this.basketInvoiceAndShippingAddressEqual$ = this.checkoutFacade.basketInvoiceAndShippingAddressEqual$;
     this.basketShippingAddressDeletable$ = this.checkoutFacade.basketShippingAddressDeletable$;
@@ -78,7 +77,7 @@ export class BasketShippingAddressWidgetComponent implements OnInit {
       .subscribe(label => (this.emptyOptionLabel = label));
 
     // prepare data for shipping select drop down
-    this.addresses$ = combineLatest([this.customerAddresses$, this.shippingAddress$]).pipe(
+    this.addresses$ = combineLatest([this.eligibleAddresses$, this.shippingAddress$]).pipe(
       map(([addresses, shippingAddress]) =>
         addresses?.filter(address => address.shipToAddress).filter(address => address.id !== shippingAddress?.id)
       )


### PR DESCRIPTION
## PR Type

[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?
If the user enters the checkout shipping page customer addresses were requested by the ICM. The result list contains a link list, so for each address a detail call has to be triggered. In case of many customer addresses this behavior causes a performance issue.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Relates to issue number: #1528

## What Is the New Behavior?
Now the REST call get /baskets/<basketId>/eligible-addresses is used to show addresses on checkout address page. 
All address information is returned by this call so there are no further requests necessary.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#92525](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92525)