### PR TITLE
fix: html injection on search page if there is no result

### DIFF
--- a/docs/concepts/localization.md
+++ b/docs/concepts/localization.md
@@ -12,7 +12,7 @@ In addition the dependency to Angular's internationalization tools (i18n) is nee
 
 For more information refer to:
 
-- [NGX-Translate: The internationalization (i18n) library for Angular](http://www.ngx-translate.com/)
+- [NGX-Translate: The internationalization (i18n) library for Angular](https://github.com/ngx-translate/core)
 - [Angular - Internationalization (i18n)](https://angular.io/guide/i18n)
 - [ng-bootstrap Angular 9 support](https://github.com/ng-bootstrap/ng-bootstrap/issues/3537#issuecomment-586472803)
 
@@ -147,6 +147,13 @@ Usage in HTML:
 ```html
 <span [innerHTML]="'common.header.contact_no.text' | translate"></span>
 ```
+
+> [!WARNING]  
+> Be aware to HTML encode possibly malicious HTML code since the `[innerHTML]` value will not automatically be sanitized.
+> This is especially important if non validated user input is rendered directly.
+> To HTML encode content we provide the `htmlEncode` pipe.
+>
+> example: `<p [innerHTML]="'search.noResult.message' | translate : { '0': searchTerm | htmlEncode }"></p>`
 
 ### Localization in the component(.ts) File
 

--- a/src/app/core/pipes.module.ts
+++ b/src/app/core/pipes.module.ts
@@ -5,6 +5,7 @@ import { PricePipe } from './models/price/price.pipe';
 import { DatePipe } from './pipes/date.pipe';
 import { FeatureTogglePipe } from './pipes/feature-toggle.pipe';
 import { HighlightPipe } from './pipes/highlight.pipe';
+import { HtmlEncodePipe } from './pipes/html-encode.pipe';
 import { MakeHrefPipe } from './pipes/make-href.pipe';
 import { SanitizePipe } from './pipes/sanitize.pipe';
 import { ServerSettingPipe } from './pipes/server-setting.pipe';
@@ -19,6 +20,7 @@ const pipes = [
   DatePipe,
   FeatureTogglePipe,
   HighlightPipe,
+  HtmlEncodePipe,
   MakeHrefPipe,
   PricePipe,
   ProductRoutePipe,

--- a/src/app/core/pipes/html-encode.pipe.spec.ts
+++ b/src/app/core/pipes/html-encode.pipe.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HtmlEncodePipe } from './html-encode.pipe';
+
+describe('Html Encode Pipe', () => {
+  let htmlEncodePipe: HtmlEncodePipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [HtmlEncodePipe],
+    });
+    htmlEncodePipe = TestBed.inject(HtmlEncodePipe);
+  });
+
+  it('should be created', () => {
+    expect(htmlEncodePipe).toBeTruthy();
+  });
+
+  it.each([
+    ['<img src=https://test.jpg>', '&lt;img src=https://test.jpg&gt;'],
+    ['?hello&world', '?hello&amp;world'],
+  ])(`should transform '%s' to '%s'`, (input, output) => {
+    expect(htmlEncodePipe.transform(input)).toEqual(output);
+  });
+});

--- a/src/app/core/pipes/html-encode.pipe.ts
+++ b/src/app/core/pipes/html-encode.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * The HTML encode pipe simply replaces HTML special characters like angle brackets (< and >) with HTML entities
+ * so they can be displayed as plain text in a web page.
+ * https://jasonwatmore.com/vanilla-js-html-encode-in-javascript
+ */
+@Pipe({ name: 'htmlEncode', pure: true })
+export class HtmlEncodePipe implements PipeTransform {
+  transform(value: string): string {
+    return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+}

--- a/src/app/pages/account-overview/account-overview/account-overview.component.html
+++ b/src/app/pages/account-overview/account-overview/account-overview.component.html
@@ -2,7 +2,7 @@
   <h1
     [innerHTML]="
       'account.overview.personal_message_b2b.text'
-        | translate : { '0': user.firstName + '&nbsp;' + user.lastName, '1': customer.companyName }
+        | translate : { '0': user.firstName + '&nbsp;' + user.lastName, '1': customer.companyName | htmlEncode }
     "
     data-testing-id="personal-message-b2b"
   ></h1>

--- a/src/app/pages/account-overview/account-overview/account-overview.component.spec.ts
+++ b/src/app/pages/account-overview/account-overview/account-overview.component.spec.ts
@@ -10,6 +10,7 @@ import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { User } from 'ish-core/models/user/user.model';
+import { HtmlEncodePipe } from 'ish-core/pipes/html-encode.pipe';
 import { ServerSettingPipe } from 'ish-core/pipes/server-setting.pipe';
 import { RoleToggleModule } from 'ish-core/role-toggle.module';
 import { OrderWidgetComponent } from 'ish-shared/components/order/order-widget/order-widget.component';
@@ -38,6 +39,7 @@ describe('Account Overview Component', () => {
         MockComponent(OrderWidgetComponent),
         MockDirective(AuthorizationToggleDirective),
         MockDirective(ServerHtmlDirective),
+        MockPipe(HtmlEncodePipe),
         MockPipe(ServerSettingPipe, () => true),
       ],
       imports: [FeatureToggleModule.forTesting(), RoleToggleModule.forTesting(), TranslateModule.forRoot()],

--- a/src/app/pages/search/search-no-result/search-no-result.component.html
+++ b/src/app/pages/search/search-no-result/search-no-result.component.html
@@ -11,7 +11,10 @@
     <ish-content-include includeId="include.searchnoresult.content.top.pagelet2-Include" />
   </div>
 
-  <p class="no-search-result-title" [innerHTML]="'search.noResult.message' | translate : { '0': searchTerm }"></p>
+  <p
+    class="no-search-result-title"
+    [innerHTML]="'search.noResult.message' | translate : { '0': searchTerm | htmlEncode }"
+  ></p>
 
   <div class="search-container main-search-container">
     <ish-search-box

--- a/src/app/pages/search/search-no-result/search-no-result.component.spec.ts
+++ b/src/app/pages/search/search-no-result/search-no-result.component.spec.ts
@@ -1,7 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockPipe } from 'ng-mocks';
 
+import { HtmlEncodePipe } from 'ish-core/pipes/html-encode.pipe';
 import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
 import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
 import { SearchBoxComponent } from 'ish-shared/components/search/search-box/search-box.component';
@@ -21,6 +22,7 @@ describe('Search No Result Component', () => {
         MockComponent(BreadcrumbComponent),
         MockComponent(ContentIncludeComponent),
         MockComponent(SearchBoxComponent),
+        MockPipe(HtmlEncodePipe, value => value),
         SearchNoResultComponent,
       ],
     }).compileComponents();

--- a/src/styles/pages/category/search-result.scss
+++ b/src/styles/pages/category/search-result.scss
@@ -15,7 +15,7 @@
 
 .no-search-result-title {
   span {
-    font-size: $font-size-lg;
+    font-family: $font-family-bold;
   }
 }
 


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Feature


## What Is the Current Behavior?
If the user enters a search term in the search bar, that contains HTML it is rendered on the search-no-result page. This represents a security risk.

## What Is the New Behavior?
The search term is not rendered as HTML but as an encoded string on the search-no-result page.

![image](https://github.com/intershop/intershop-pwa/assets/57660644/d4beaf7c-0d33-4c63-aad2-6d574bae8910)

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#92726](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92726)
[AB#92341](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/92341)