### PR TITLE
perf: lazily fetch products for CMS carousels

### DIFF
--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -3,9 +3,10 @@
     <ng-container *ngIf="listStyle === 'carousel'; else plainList">
       <div class="product-list">
         <swiper [config]="swiperConfig">
-          <ng-template *ngFor="let sku of products" swiperSlide>
+          <ng-template *ngFor="let sku of products" swiperSlide let-data>
             <div [ngClass]="listItemCSSClass">
               <ish-product-item
+                *ngIf="lazyFetch(data.isVisible, sku)"
                 ishProductContext
                 [sku]="sku"
                 [configuration]="listItemConfiguration"

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -32,6 +32,11 @@ export class ProductsListComponent implements OnChanges {
   productSKUs$: Observable<string[]>;
 
   /**
+   * track already fetched SKUs
+   */
+  private fetchedSKUs = new Set<string>();
+
+  /**
    * configuration of swiper carousel
    * https://swiperjs.com/swiper-api
    */
@@ -44,6 +49,7 @@ export class ProductsListComponent implements OnChanges {
     private shoppingFacade: ShoppingFacade
   ) {
     this.swiperConfig = {
+      watchSlidesProgress: true,
       direction: 'horizontal',
       navigation: true,
       pagination: {
@@ -62,6 +68,13 @@ export class ProductsListComponent implements OnChanges {
       distinctUntilChanged<[string[], string[]]>(isEqual),
       map(([skus, failed]) => skus.filter(x => !failed.includes(x)))
     );
+  }
+
+  lazyFetch(fetch: boolean, sku: string): boolean {
+    if (fetch) {
+      this.fetchedSKUs.add(sku);
+    }
+    return this.fetchedSKUs.has(sku);
   }
 
   /**


### PR DESCRIPTION
## PR Type

[x] Other: Performance Improvement

## What Is the Current Behavior?

All products given to `ish-products-list` are fetched even if not even displayed.

## What Is the New Behavior?

Lazy fetching when using slides.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
