### PR TITLE
fix: display dates that don't have a time specification

### DIFF
--- a/src/app/core/models/cost-center/cost-center.interface.ts
+++ b/src/app/core/models/cost-center/cost-center.interface.ts
@@ -6,7 +6,7 @@ import { CostCenter } from './cost-center.model';
 export type CostCenterData = Omit<CostCenter, 'orders'> & {
   orders?: {
     orderNo: string;
-    orderDate: number;
+    orderDate: number[];
     orderStatus: string;
     items: number;
     buyer: { attributes: Attribute[] };

--- a/src/app/core/models/cost-center/cost-center.mapper.spec.ts
+++ b/src/app/core/models/cost-center/cost-center.mapper.spec.ts
@@ -10,7 +10,7 @@ describe('Cost Center Mapper', () => {
           {
             orderNo: '1',
             items: 2,
-            orderDate: 1234,
+            orderDate: [2024, 1, 10],
             buyer: { attributes: [{ name: 'firstName', value: 'John' }] },
             orderTotalGross: { currency: 'USD', value: 1000.23 },
             orderTotalNet: { currency: 'USD', value: 800.87 },
@@ -18,7 +18,7 @@ describe('Cost Center Mapper', () => {
           {
             orderNo: '2',
             items: 4,
-            orderDate: 2341,
+            orderDate: [2024, 1, 10],
             buyer: { attributes: [{ name: 'firstName', value: 'Jack' }] },
             orderTotalGross: { currency: 'USD', value: 1000.23 },
             orderTotalNet: { currency: 'USD', value: 800.87 },

--- a/src/app/core/models/cost-center/cost-center.mapper.ts
+++ b/src/app/core/models/cost-center/cost-center.mapper.ts
@@ -9,7 +9,7 @@ export class CostCenterMapper {
         orders: data.orders?.map(order => ({
           documentNo: order.orderNo,
           status: order.orderStatus,
-          creationDate: order.orderDate,
+          creationDate: order.orderDate.toString(),
           attributes: order.buyer.attributes,
           totalProductQuantity: order.items,
           totals: {

--- a/src/app/core/models/order/order.interface.ts
+++ b/src/app/core/models/order/order.interface.ts
@@ -11,7 +11,7 @@ import { ShippingMethodData } from 'ish-core/models/shipping-method/shipping-met
 
 export interface OrderBaseData extends BasketBaseData {
   documentNumber: string;
-  creationDate: number;
+  creationDate: string;
   orderCreation: {
     status: 'COMPLETED' | 'ROLLED_BACK' | 'STOPPED' | 'CONTINUE';
     stopAction?: {

--- a/src/app/core/models/order/order.mapper.spec.ts
+++ b/src/app/core/models/order/order.mapper.spec.ts
@@ -8,7 +8,7 @@ import { OrderMapper } from './order.mapper';
 describe('Order Mapper', () => {
   const orderBaseData = {
     documentNumber: '4711',
-    creationDate: 0,
+    creationDate: '2024-01-26T09:52:16Z',
     status: 'New',
     statusCode: 'NEW',
     id: 'order_1234',

--- a/src/app/core/models/order/order.model.ts
+++ b/src/app/core/models/order/order.model.ts
@@ -11,7 +11,7 @@ type OrderBasket = Omit<AbstractBasket<OrderLineItem>, 'approval'>;
 
 export interface Order extends OrderBasket {
   documentNo: string;
-  creationDate: number;
+  creationDate: string;
   orderCreation: {
     status: 'COMPLETED' | 'ROLLED_BACK' | 'STOPPED' | 'CONTINUE';
     stopAction?: {

--- a/src/app/core/pipes/date.pipe.spec.ts
+++ b/src/app/core/pipes/date.pipe.spec.ts
@@ -38,11 +38,11 @@ describe('Date Pipe', () => {
   `('should transform $date to', ({ date, format, EN, DE }) => {
     test(`${EN} with format ${format} for english local`, () => {
       translateService.use('en');
-      expect(datePipe.transform(date, format)).toEqual(EN);
+      expect(datePipe.transform(date, format, '+0000')).toEqual(EN);
     });
     test(`${DE} with format ${format} for german locale`, () => {
       translateService.use('de');
-      expect(datePipe.transform(date, format)).toEqual(DE);
+      expect(datePipe.transform(date, format, '+0000')).toEqual(DE);
     });
   });
 });

--- a/src/app/core/pipes/date.pipe.ts
+++ b/src/app/core/pipes/date.pipe.ts
@@ -19,7 +19,8 @@ export function formatISHDate(
   } else {
     date = value;
   }
-  return formatDate(date, format, lang, timezone || '+0000');
+  // if no time zone is given take the user's current time zone
+  return formatDate(date, format, lang, timezone);
 }
 
 /**

--- a/src/app/extensions/order-templates/models/order-template/order-template.interface.ts
+++ b/src/app/extensions/order-templates/models/order-template/order-template.interface.ts
@@ -7,5 +7,5 @@ export interface OrderTemplateData extends OrderTemplateHeader {
   itemsCount?: number;
   name?: string;
   uri?: string;
-  creationDate?: Date;
+  creationDate?: number;
 }

--- a/src/app/extensions/order-templates/models/order-template/order-template.model.ts
+++ b/src/app/extensions/order-templates/models/order-template/order-template.model.ts
@@ -6,7 +6,7 @@ export interface OrderTemplate extends OrderTemplateHeader {
   id: string;
   items?: OrderTemplateItem[];
   itemsCount?: number;
-  creationDate?: Date;
+  creationDate?: number;
 }
 
 export interface OrderTemplateItem {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

1. Dates formatted by the date pipe are displayed in GMT if no timezone is given. If the user's timezone is GMT+1 and the date doesn't have a time the date of the previous day is shown to the user. You could see this behavior in the cost center order list. The dates differ from the order list dates by one day.

2. The data types for some data objects are not correct, e.g. the order creation date of the cost center orders are provided as a number array,  but they are defined as a number field.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
1. The dates are shown in the user's current time zone, if no specific time zone is provided to the date pipe.
2. The wrong date data types have been corrected.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#93286](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/93286)