### PR TITLE
fix: prevent rendering errors for text on enhanced image teaser caused by Angular hydration

### DIFF
--- a/src/app/shared/cms/components/cms-image-enhanced/cms-image-enhanced.component.html
+++ b/src/app/shared/cms/components/cms-image-enhanced/cms-image-enhanced.component.html
@@ -39,11 +39,11 @@
     <div class="enhanced-image-text">
       <h1 *ngIf="pagelet.hasParam('Heading1')">{{ pagelet.stringParam('Heading1') }}</h1>
       <h2 *ngIf="pagelet.hasParam('Heading2')">{{ pagelet.stringParam('Heading2') }}</h2>
-      <p
+      <div
         *ngIf="pagelet.hasParam('Description')"
         class="d-none d-sm-inline"
         [ishServerHtml]="pagelet.stringParam('Description')"
-      ></p>
+      ></div>
       <a
         *ngIf="pagelet.hasParam('Link') && pagelet.hasParam('LinkText')"
         [routerLink]="routerLink(pagelet, 'Link')"


### PR DESCRIPTION
## PR Type

[x] Bugfix

## Problem

* Angular hydration needs a valid HTML structure that was not given with the surrounding `<p>` tag for the text/description on the image since the standard freestyle HTML is included in `<p>` tags and `<p>` in `<p>` resulted in hydration errors
* use `<div>` instead of `<p>` element for freestyle HTML on enhanced image teaser to prevent rendering errors
* see https://angular.io/guide/hydration#valid-html-structure

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#93448](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/93448)