### PR TITLE
feat: Lazy Loading of Sub categories

### DIFF
--- a/src/app/core/store/shopping/categories/categories.effects.ts
+++ b/src/app/core/store/shopping/categories/categories.effects.ts
@@ -109,7 +109,7 @@ export class CategoriesEffects {
         personalizationStatusDetermined
       ),
       switchMap(() =>
-        this.categoryService.getTopLevelCategories(this.mainNavigationMaxSubCategoriesDepth).pipe(
+        this.categoryService.getTopLevelCategories(SSR ? 0 : this.mainNavigationMaxSubCategoriesDepth).pipe(
           map(categories => loadTopLevelCategoriesSuccess({ categories })),
           mapErrorToAction(loadTopLevelCategoriesFail)
         )

--- a/src/app/shell/header/header-navigation/header-navigation.component.html
+++ b/src/app/shell/header/header-navigation/header-navigation.component.html
@@ -18,7 +18,7 @@
     >
       {{ category.name }}
     </a>
-    <ng-container *ngIf="0 < mainNavigationMaxSubCategoriesDepth && category.hasChildren">
+    <ng-container *ngIf="!SSR && mainNavigationMaxSubCategoriesDepth > 0 && category.hasChildren">
       <a
         class="dropdown-toggle"
         (click)="toggleOpen(category.uniqueId)"

--- a/src/app/shell/header/header-navigation/header-navigation.component.ts
+++ b/src/app/shell/header/header-navigation/header-navigation.component.ts
@@ -18,6 +18,9 @@ export class HeaderNavigationComponent implements OnInit {
 
   private openedCategories: string[] = [];
 
+  // make variable SSR, that is used to check if the application is running in SSR or browser context, accessible in the template
+  SSR = SSR;
+
   constructor(
     private shoppingFacade: ShoppingFacade,
     @Inject(MAIN_NAVIGATION_MAX_SUB_CATEGORIES_DEPTH)


### PR DESCRIPTION
## PR Type

[x] Feature
[x] Other: performance improvement

## What Is the Current Behavior?

Currently, the configured level of main navigation categories (`mainNavigationMaxSubCategoriesDepth`) is loaded already on the server side. Therefore the SSR rendered HTML page contains a lot of unneeded category data (main navigation HTML, transfer state, transfered REST call content).

## What Is the New Behavior?
The goal is to reduce the load time/size of HTML pages in the project. Only the top-level categories are now being loaded and rendered on SSR while the sub-level categories are loaded and rendered on the client side.

* "lazy loading" of sub categories for the main navigation only on client side
* reduce rendered main navigation code in SSR rendered HTML
* reduce categories content of the transfer state
* decrease needed transfer size per SSR page

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#94097](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94097)