### PR TITLE
fix: prevent duplication on default canonical link

### DIFF
--- a/e2e/test-universal.sh
+++ b/e2e/test-universal.sh
@@ -29,7 +29,7 @@ universalTest 7 "${PWA_BASE_URL}/computers/notebooks-and-pcs/notebooks-ctgComput
 universalTest 8 "${PWA_BASE_URL}/home" "intershop-pwa-state"
 universalTest 9 "${PWA_BASE_URL}/home" "baseURL"
 universalTest 10 "${PWA_BASE_URL}/home" "<ish-content-include includeid=.include.homepage.content.pagelet2-Include"
-universalTest 11 "${PWA_BASE_URL}/home" "<link rel=.canonical. href=.${PWA_CANONICAL_BASE_URL}/home/.>"
+universalTest 11 "${PWA_BASE_URL}/home" "<link rel=.canonical. href=.${PWA_CANONICAL_BASE_URL}/home.>"
 universalTest 12 "${PWA_BASE_URL}/home" "<meta property=.og:image. content=./assets/img/og-image-default"
 universalTest 13 "${PWA_BASE_URL}/home" "<title>inTRONICS Home | Intershop PWA</title>"
 universalTest 14 "${PWA_BASE_URL}/prd6997041" "<link rel=.canonical. href=.${PWA_CANONICAL_BASE_URL}/computers/notebooks-and-pcs/notebooks/asus-eee-pc-1008p-karim-rashid-prd6997041-ctgComputers.1835.151.>"

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -75,7 +75,13 @@ export class SeoEffects {
             // DEFAULT
             this.appRef.isStable.pipe(
               whenTruthy(),
-              map(() => this.doc.URL.replace(/[;?].*/g, ''))
+              map(() => {
+                let cleanURL = this.doc.URL.replace(/[;?].*/g, '');
+                if (SSR) {
+                  cleanURL = cleanURL.slice(0, cleanURL.lastIndexOf('/'));
+                }
+                return cleanURL;
+              })
             ),
           ])
         ),
@@ -199,6 +205,7 @@ export class SeoEffects {
     // the canonical URL of a production system should always be with 'https:'
     // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
     const canonicalUrl = encodeURI(url.replace('http:', 'https:'));
+
     const canonicalLink = this.domService.getOrCreateElement('link[rel="canonical"]', 'link', this.doc.head);
 
     this.domService.setAttribute(canonicalLink, 'rel', 'canonical');


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[X] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The canonical link element is not correctly generated at the root. The double "/"(slash) between the domain name and the rest of the path can be interpreted by Google as a duplicate, and thus impact the SEO ranking of the website.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

Duplication is prevented on the default canonical link.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#94169](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94169)