### PR TITLE
fix: remove default search input field specific elements in Chrome

### DIFF
--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -140,7 +140,16 @@
       background: $color-primary;
       border: $border-width-default solid $border-color-default;
 
+      /* removes the 'x' inside the search input in IE */
       &::-ms-clear {
+        display: none;
+      }
+
+      /* removes the 'x' and other default search elements inside the search input in Chrome */
+      &::-webkit-search-decoration,
+      &::-webkit-search-cancel-button,
+      &::-webkit-search-results-button,
+      &::-webkit-search-results-decoration {
         display: none;
       }
 

--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -140,19 +140,6 @@
       background: $color-primary;
       border: $border-width-default solid $border-color-default;
 
-      /* removes the 'x' inside the search input in IE */
-      &::-ms-clear {
-        display: none;
-      }
-
-      /* removes the 'x' and other default search elements inside the search input in Chrome */
-      &::-webkit-search-decoration,
-      &::-webkit-search-cancel-button,
-      &::-webkit-search-results-button,
-      &::-webkit-search-results-decoration {
-        display: none;
-      }
-
       @include media-breakpoint-down(sm) {
         border: $border-width-default solid $border-color-default;
 

--- a/src/styles/global/forms.scss
+++ b/src/styles/global/forms.scss
@@ -88,6 +88,19 @@ input[type='checkbox'] {
   vertical-align: middle;
 }
 
+/* removes the 'x' inside the search input in IE */
+input[type='search']::-ms-clear {
+  display: none;
+}
+
+/* removes the 'x' and other default search elements inside the search input in Chrome */
+input[type='search']::-webkit-search-decoration,
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-results-button,
+input[type='search']::-webkit-search-results-decoration {
+  display: none;
+}
+
 input.form-check-input {
   margin-top: 0.25rem;
   margin-left: 0;

--- a/src/styles/pages/category/search-result.scss
+++ b/src/styles/pages/category/search-result.scss
@@ -36,7 +36,16 @@
     line-height: $search-container-height;
     border: $border-width-default solid $border-color-light;
 
+    /* removes the 'x' inside the search input in IE */
     &::-ms-clear {
+      display: none;
+    }
+
+    /* removes the 'x' and other default search elements inside the search input in Chrome */
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
       display: none;
     }
   }

--- a/src/styles/pages/category/search-result.scss
+++ b/src/styles/pages/category/search-result.scss
@@ -35,19 +35,6 @@
     padding-left: 14px;
     line-height: $search-container-height;
     border: $border-width-default solid $border-color-light;
-
-    /* removes the 'x' inside the search input in IE */
-    &::-ms-clear {
-      display: none;
-    }
-
-    /* removes the 'x' and other default search elements inside the search input in Chrome */
-    &::-webkit-search-decoration,
-    &::-webkit-search-cancel-button,
-    &::-webkit-search-results-button,
-    &::-webkit-search-results-decoration {
-      display: none;
-    }
   }
 
   button {


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Google Chrome is showing a small "x" inside the search input field `<input type="search">` when the user enters anything in the field. The field is shown in the header and on the "No search result" page. This element should be removed because there is already "x" as an icon to remove the user input.

## What Is the New Behavior?
The Chrome default "x" is removed. Other default Chrome styling and elements for this specific field are removed too.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No


[AB#94200](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94200)