### PR TITLE
feat: handle complex values of variation attributes

### DIFF
--- a/src/app/core/models/product-variation/product-variation.helper.spec.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.spec.ts
@@ -11,6 +11,7 @@ const productVariations = [
     variableVariationAttributes: [
       { name: 'Attr 1', value: 'A', variationAttributeId: 'a1' },
       { name: 'Attr 2', value: 'A', variationAttributeId: 'a2' },
+      { name: 'Attr 3', value: { value: 3, unit: 'm' }, variationAttributeId: 'a3' },
     ],
   },
   {
@@ -20,6 +21,7 @@ const productVariations = [
     variableVariationAttributes: [
       { name: 'Attr 1', value: 'A', variationAttributeId: 'a1' },
       { name: 'Attr 2', value: 'B', variationAttributeId: 'a2' },
+      { name: 'Attr 3', value: { value: 1, unit: 'm' }, variationAttributeId: 'a3' },
     ],
   },
   {
@@ -28,6 +30,7 @@ const productVariations = [
     variableVariationAttributes: [
       { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
       { name: 'Attr 2', value: 'A', variationAttributeId: 'a2' },
+      { name: 'Attr 3', value: { value: 2, unit: 'm' }, variationAttributeId: 'a3' },
     ],
   },
   {
@@ -36,6 +39,7 @@ const productVariations = [
     variableVariationAttributes: [
       { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
       { name: 'Attr 2', value: 'B', variationAttributeId: 'a2' },
+      { name: 'Attr 3', value: { value: 3, unit: 'm' }, variationAttributeId: 'a3' },
     ],
   },
   {
@@ -44,6 +48,7 @@ const productVariations = [
     variableVariationAttributes: [
       { name: 'Attr 1', value: 'B', variationAttributeId: 'a1' },
       { name: 'Attr 2', value: 'C', variationAttributeId: 'a2' },
+      { name: 'Attr 3', value: { value: 3, unit: 'm' }, variationAttributeId: 'a3' },
     ],
   },
 ] as VariationProduct[];
@@ -56,6 +61,9 @@ const productMaster = {
     { name: 'Attr 2', value: 'A', variationAttributeId: 'a2' },
     { name: 'Attr 2', value: 'B', variationAttributeId: 'a2' },
     { name: 'Attr 2', value: 'C', variationAttributeId: 'a2' },
+    { name: 'Attr 3', value: '1', variationAttributeId: 'a3' },
+    { name: 'Attr 3', value: '2', variationAttributeId: 'a3' },
+    { name: 'Attr 3', value: '3', variationAttributeId: 'a3' },
   ],
 } as VariationProductMaster;
 
@@ -73,58 +81,96 @@ const masterProductView = {
 describe('Product Variation Helper', () => {
   describe('buildVariationOptionGroups', () => {
     it('should build variation option groups for variation product', () => {
-      const expectedGroups = [
-        {
-          id: 'a1',
-          label: 'Attr 1',
-          options: [
-            {
-              label: 'A',
-              value: 'A',
-              type: 'a1',
-              alternativeCombination: false,
-              active: true,
-            },
-            {
-              label: 'B',
-              value: 'B',
-              type: 'a1',
-              alternativeCombination: false,
-              active: false,
-            },
-          ],
-        },
-        {
-          id: 'a2',
-          label: 'Attr 2',
-          options: [
-            {
-              label: 'A',
-              value: 'A',
-              type: 'a2',
-              alternativeCombination: false,
-              active: true,
-            },
-            {
-              label: 'B',
-              value: 'B',
-              type: 'a2',
-              alternativeCombination: false,
-              active: false,
-            },
-            {
-              label: 'C',
-              value: 'C',
-              type: 'a2',
-              alternativeCombination: true,
-              active: false,
-            },
-          ],
-        },
-      ];
-
       const result = ProductVariationHelper.buildVariationOptionGroups(variationProductView);
-      expect(result).toEqual(expectedGroups);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "attributeType": undefined,
+            "id": "a1",
+            "label": "Attr 1",
+            "options": [
+              {
+                "active": true,
+                "alternativeCombination": true,
+                "label": "A",
+                "metaData": undefined,
+                "type": "a1",
+                "value": "A",
+              },
+              {
+                "active": false,
+                "alternativeCombination": true,
+                "label": "B",
+                "metaData": undefined,
+                "type": "a1",
+                "value": "B",
+              },
+            ],
+          },
+          {
+            "attributeType": undefined,
+            "id": "a2",
+            "label": "Attr 2",
+            "options": [
+              {
+                "active": true,
+                "alternativeCombination": true,
+                "label": "A",
+                "metaData": undefined,
+                "type": "a2",
+                "value": "A",
+              },
+              {
+                "active": false,
+                "alternativeCombination": true,
+                "label": "B",
+                "metaData": undefined,
+                "type": "a2",
+                "value": "B",
+              },
+              {
+                "active": false,
+                "alternativeCombination": true,
+                "label": "C",
+                "metaData": undefined,
+                "type": "a2",
+                "value": "C",
+              },
+            ],
+          },
+          {
+            "attributeType": undefined,
+            "id": "a3",
+            "label": "Attr 3",
+            "options": [
+              {
+                "active": false,
+                "alternativeCombination": true,
+                "label": "1",
+                "metaData": undefined,
+                "type": "a3",
+                "value": "1",
+              },
+              {
+                "active": false,
+                "alternativeCombination": true,
+                "label": "2",
+                "metaData": undefined,
+                "type": "a3",
+                "value": "2",
+              },
+              {
+                "active": true,
+                "alternativeCombination": true,
+                "label": "3",
+                "metaData": undefined,
+                "type": "a3",
+                "value": "3",
+              },
+            ],
+          },
+        ]
+      `);
     });
   });
 
@@ -186,6 +232,19 @@ describe('Product Variation Helper', () => {
       } as FilterNavigation;
 
       expect(ProductVariationHelper.productVariationCount(masterProductView, filters)).toEqual(2);
+    });
+
+    it('should filter for products matching complex value attributes', () => {
+      const filters = {
+        filter: [
+          {
+            id: 'a1',
+            facets: [{ selected: true, name: 'a3=3' }],
+          },
+        ],
+      } as FilterNavigation;
+
+      expect(ProductVariationHelper.productVariationCount(masterProductView, filters)).toEqual(3);
     });
 
     it('should filter for products matching multiple selected attributes', () => {

--- a/src/app/core/models/product-variation/variation-attribute.model.ts
+++ b/src/app/core/models/product-variation/variation-attribute.model.ts
@@ -1,7 +1,7 @@
 export interface VariationAttribute {
   variationAttributeId: string;
   name: string;
-  value: string;
+  value: string | number | { value: number; unit: string };
   attributeType: VariationAttributeType;
   metaData?: string;
 }

--- a/src/app/core/pipes.module.ts
+++ b/src/app/core/pipes.module.ts
@@ -9,6 +9,7 @@ import { HtmlEncodePipe } from './pipes/html-encode.pipe';
 import { MakeHrefPipe } from './pipes/make-href.pipe';
 import { SanitizePipe } from './pipes/sanitize.pipe';
 import { ServerSettingPipe } from './pipes/server-setting.pipe';
+import { VariationAttributePipe } from './pipes/variation-attribute.pipe';
 import { CategoryRoutePipe } from './routing/category/category-route.pipe';
 import { ContentPageRoutePipe } from './routing/content-page/content-page-route.pipe';
 import { ProductRoutePipe } from './routing/product/product-route.pipe';
@@ -26,6 +27,7 @@ const pipes = [
   ProductRoutePipe,
   SanitizePipe,
   ServerSettingPipe,
+  VariationAttributePipe,
 ];
 
 @NgModule({

--- a/src/app/core/pipes/variation-attribute.pipe.spec.ts
+++ b/src/app/core/pipes/variation-attribute.pipe.spec.ts
@@ -1,0 +1,67 @@
+import { registerLocaleData } from '@angular/common';
+import localeDe from '@angular/common/locales/de';
+import { TestBed } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+import { VariationAttribute } from 'ish-core/models/product-variation/variation-attribute.model';
+
+import { VariationAttributePipe } from './variation-attribute.pipe';
+
+describe('Variation Attribute Pipe', () => {
+  let variationAttributePipe: VariationAttributePipe;
+  let translateService: TranslateService;
+
+  beforeEach(() => {
+    registerLocaleData(localeDe);
+
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [VariationAttributePipe],
+    });
+
+    variationAttributePipe = TestBed.inject(VariationAttributePipe);
+    translateService = TestBed.inject(TranslateService);
+    translateService.setDefaultLang('en');
+    translateService.use('en');
+  });
+
+  it('should be created', () => {
+    expect(variationAttributePipe).toBeTruthy();
+  });
+
+  it('should transform undefined to undefined', () => {
+    expect(variationAttributePipe.transform(undefined)).toMatchInlineSnapshot(`"undefined"`);
+  });
+
+  it('should transform string attribute to string', () => {
+    const attr = { value: 'test' } as VariationAttribute;
+    expect(variationAttributePipe.transform(attr)).toMatchInlineSnapshot(`"test"`);
+  });
+
+  it('should transform number attribute to number', () => {
+    const attr = { value: 123 } as VariationAttribute;
+    expect(variationAttributePipe.transform(attr)).toMatchInlineSnapshot(`"123"`);
+  });
+
+  it('should transform float attribute to formatted locale en', () => {
+    const attr = { value: 123.4 } as VariationAttribute;
+    expect(variationAttributePipe.transform(attr)).toMatchInlineSnapshot(`"123.4"`);
+  });
+
+  it('should transform float attribute to formatted locale de', () => {
+    translateService.use('de');
+    const attr = { value: 123.4 } as VariationAttribute;
+    expect(variationAttributePipe.transform(attr)).toMatchInlineSnapshot(`"123,4"`);
+  });
+
+  it('should transform object attribute to formatted locale en', () => {
+    const attr = { value: { value: 123.4, unit: 'mm' } } as VariationAttribute;
+    expect(variationAttributePipe.transform(attr)).toMatchInlineSnapshot(`"123.4\xA0mm"`);
+  });
+
+  it('should transform object attribute to formatted locale de', () => {
+    translateService.use('de');
+    const attr = { value: { value: 123.4, unit: 'mm' } } as VariationAttribute;
+    expect(variationAttributePipe.transform(attr)).toMatchInlineSnapshot(`"123,4\xA0mm"`);
+  });
+});

--- a/src/app/core/pipes/variation-attribute.pipe.ts
+++ b/src/app/core/pipes/variation-attribute.pipe.ts
@@ -4,6 +4,11 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { VariationAttribute } from 'ish-core/models/product-variation/variation-attribute.model';
 
+/**
+ * Pipe
+ *
+ * Used on a variation attribute (of type VariationAttribute), this pipe will return the corresponding display (string) value, considering the current locale for number attribute values.
+ */
 @Pipe({ name: 'ishVariationAttribute', pure: false })
 export class VariationAttributePipe implements PipeTransform {
   constructor(private translateService: TranslateService) {}

--- a/src/app/core/pipes/variation-attribute.pipe.ts
+++ b/src/app/core/pipes/variation-attribute.pipe.ts
@@ -1,0 +1,26 @@
+import { formatNumber } from '@angular/common';
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+import { VariationAttribute } from 'ish-core/models/product-variation/variation-attribute.model';
+
+@Pipe({ name: 'ishVariationAttribute', pure: false })
+export class VariationAttributePipe implements PipeTransform {
+  constructor(private translateService: TranslateService) {}
+
+  private toDecimal(val: number): string {
+    return formatNumber(val, this.translateService.currentLang);
+  }
+
+  transform(attr: VariationAttribute): string {
+    if (!this.translateService.currentLang) {
+      return 'undefined';
+    }
+
+    return typeof attr?.value === 'object'
+      ? `${this.toDecimal(attr.value.value)}\xA0${attr.value.unit}`
+      : typeof attr?.value === 'number'
+      ? this.toDecimal(attr.value)
+      : attr?.value || 'undefined';
+  }
+}

--- a/src/app/shared/components/product/product-variation-display/product-variation-display.component.html
+++ b/src/app/shared/components/product/product-variation-display/product-variation-display.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="product$ | async as product">
     <div *ngFor="let attr of product.variableVariationAttributes" class="product-variation read-only">
       <span class="product-variation-info span-separator">{{ attr.name }}</span>
-      <span>{{ attr.value }}</span>
+      <span>{{ attr | ishVariationAttribute }}</span>
     </div>
   </ng-container>
 </ng-container>


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Variation attribute values can be supplied in different data types by the ICM, like string, number or even a complex data type 'quantity' consisting of a number value and a unit, which is often used in customer projects.
The inSPIRED store currently only supports string attributes, other attribute data types don't work properly.

## What Is the New Behavior?
Number and complex values of variation attributes are supported.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#94653](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94653)