### PR TITLE
Use a prefix for internal token oauth storage

### DIFF
--- a/e2e/cypress/e2e/specs/account/login-user.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/account/login-user.b2c.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('Returning User', () => {
       });
 
       cy.getAllLocalStorage().then(
-        localStorage => expect(localStorage[Cypress.config('baseUrl')].access_token).to.not.be.empty
+        localStorage => expect(localStorage[Cypress.config('baseUrl')].icm_access_token).to.not.be.empty
       );
     });
 
@@ -61,7 +61,7 @@ describe('Returning User', () => {
       });
 
       cy.getAllLocalStorage().then(
-        localStorage => expect(localStorage[Cypress.config('baseUrl')].access_token).to.be.undefined
+        localStorage => expect(localStorage[Cypress.config('baseUrl')].icm_access_token).to.be.undefined
       );
     });
   });

--- a/src/app/core/services/token/token.service.spec.ts
+++ b/src/app/core/services/token/token.service.spec.ts
@@ -26,7 +26,7 @@ describe('Token Service', () => {
   when(oAuthService.configure(anything())).thenResolve();
   when(oAuthService.events).thenReturn(of(undefined));
 
-  when(instanceCreators.getOAuthServiceInstance(anything())).thenReturn(instance(oAuthService));
+  when(instanceCreators.getOAuthServiceInstance(anything(), anything())).thenReturn(instance(oAuthService));
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -16,7 +16,7 @@ import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { InstanceCreators } from 'ish-core/utils/instance-creators';
 import { whenTruthy } from 'ish-core/utils/operators';
 
-export function storageFactory(): OAuthStorage {
+function storageFactory(): OAuthStorage {
   const prefix = 'icm_' as const;
   if (!SSR) {
     return {

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -1,6 +1,13 @@
 import { HttpHeaders } from '@angular/common/http';
 import { Injectable, Injector } from '@angular/core';
-import { AuthConfig, OAuthInfoEvent, OAuthService, OAuthSuccessEvent, TokenResponse } from 'angular-oauth2-oidc';
+import {
+  AuthConfig,
+  OAuthInfoEvent,
+  OAuthService,
+  OAuthStorage,
+  OAuthSuccessEvent,
+  TokenResponse,
+} from 'angular-oauth2-oidc';
 import { BehaviorSubject, Observable, filter, first, from, map, noop, switchMap, take } from 'rxjs';
 
 import { FetchTokenOptions, GrantType } from 'ish-core/models/token/token.interface';
@@ -9,13 +16,29 @@ import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { InstanceCreators } from 'ish-core/utils/instance-creators';
 import { whenTruthy } from 'ish-core/utils/operators';
 
+export function storageFactory(): OAuthStorage {
+  if (!SSR) {
+    return {
+      getItem(key: string): string {
+        return localStorage.getItem(`token_${key}`);
+      },
+      removeItem(key: string): void {
+        return localStorage.removeItem(`token__${key}`);
+      },
+      setItem(key: string, data: string): void {
+        return localStorage.setItem(`token_${key}`, data);
+      },
+    };
+  }
+}
+
 @Injectable({ providedIn: 'root' })
 export class TokenService {
   private oAuthService: OAuthService;
   private serviceConfigured$ = new BehaviorSubject<boolean>(false);
 
   constructor(private apiService: ApiService, private apiTokenService: ApiTokenService, parent: Injector) {
-    this.oAuthService = InstanceCreators.getOAuthServiceInstance(parent);
+    this.oAuthService = InstanceCreators.getOAuthServiceInstance(parent,storageFactory);
 
     this.apiService
       .constructUrlForPath('token', {

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -17,16 +17,17 @@ import { InstanceCreators } from 'ish-core/utils/instance-creators';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 export function storageFactory(): OAuthStorage {
+  const prefix = 'icm_' as const;
   if (!SSR) {
     return {
       getItem(key: string): string {
-        return localStorage.getItem(`token_${key}`);
+        return localStorage.getItem(`${prefix}${key}`);
       },
       removeItem(key: string): void {
-        return localStorage.removeItem(`token__${key}`);
+        return localStorage.removeItem(`${prefix}${key}`);
       },
       setItem(key: string, data: string): void {
-        return localStorage.setItem(`token_${key}`, data);
+        return localStorage.setItem(`${prefix}${key}`, data);
       },
     };
   }
@@ -38,7 +39,7 @@ export class TokenService {
   private serviceConfigured$ = new BehaviorSubject<boolean>(false);
 
   constructor(private apiService: ApiService, private apiTokenService: ApiTokenService, parent: Injector) {
-    this.oAuthService = InstanceCreators.getOAuthServiceInstance(parent,storageFactory);
+    this.oAuthService = InstanceCreators.getOAuthServiceInstance(parent, storageFactory);
 
     this.apiService
       .constructUrlForPath('token', {

--- a/src/app/core/utils/instance-creators.ts
+++ b/src/app/core/utils/instance-creators.ts
@@ -1,9 +1,15 @@
 import { Injector } from '@angular/core';
-import { OAuthService } from 'angular-oauth2-oidc';
+import { OAuthService, OAuthStorage } from 'angular-oauth2-oidc';
 
 export class InstanceCreators {
-  static getOAuthServiceInstance(parent: Injector): OAuthService {
-    const injector = Injector.create({ providers: [{ provide: OAuthService }], parent });
+  static getOAuthServiceInstance(parent: Injector, storageFactory?: () => OAuthStorage): OAuthService {
+    const injector = Injector.create({
+      providers: [
+        ...(storageFactory ? [{ provide: OAuthStorage, useFactory: storageFactory }] : []),
+        { provide: OAuthService },
+      ],
+      parent,
+    });
     return injector.get(OAuthService);
   }
 }


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Currently, the pwa uses a dedicated instance of `OauthService` for `token.service.ts`.
But as it doesn't redefine the associated `OAuthStorage`, all persistent data is shared between SSO implementations (like the bearer token).

## What Is the New Behavior?

This fix adds the `token_` prefix in front of all keys read and written by `token.service.ts`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x ] No

## Other Information
