### PR TITLE
fix: product variation availability for more than 2 variation attributes combinations

### DIFF
--- a/src/app/core/models/product-variation/product-variation.helper.spec.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.spec.ts
@@ -91,7 +91,7 @@ describe('Product Variation Helper', () => {
             "options": [
               {
                 "active": true,
-                "alternativeCombination": true,
+                "alternativeCombination": false,
                 "label": "A",
                 "metaData": undefined,
                 "type": "a1",
@@ -114,7 +114,7 @@ describe('Product Variation Helper', () => {
             "options": [
               {
                 "active": true,
-                "alternativeCombination": true,
+                "alternativeCombination": false,
                 "label": "A",
                 "metaData": undefined,
                 "type": "a2",
@@ -161,7 +161,7 @@ describe('Product Variation Helper', () => {
               },
               {
                 "active": true,
-                "alternativeCombination": true,
+                "alternativeCombination": false,
                 "label": "3",
                 "metaData": undefined,
                 "type": "a3",


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If a product has more than 2 variation attributes in the variation select options all options are displayed as not available.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The calculation of the variation availabilty works now properly and only attribute (combinations) that are not available are shown as not available.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information

[AB#94629](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94629)
[AB#95151](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95151)