### PR TITLE
feat: migration to swiper 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "ngx-toastr": "^18.0.0",
         "pm2": "^5.3.1",
         "rxjs": "~7.8.1",
-        "swiper": "^8.4.7",
+        "swiper": "^11.0.7",
         "tslib": "^2.6.2",
         "typeface-roboto": "^1.1.13",
         "typeface-roboto-condensed": "^1.1.13",
@@ -12469,13 +12469,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom7": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^4.0.0"
-      }
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "funding": [
@@ -24621,10 +24614,6 @@
       "version": "1.1.2",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "license": "MIT"
-    },
     "node_modules/ssri": {
       "version": "10.0.5",
       "dev": true,
@@ -25625,7 +25614,9 @@
       "dev": true
     },
     "node_modules/swiper": {
-      "version": "8.4.7",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.7.tgz",
+      "integrity": "sha512-cDfglW1B6uSmB6eB6pNmzDTNLmZtu5bWWa1vak0RU7fOI9qHjMzl7gVBvYSl34b0RU2N11HxxETJqQ5LeqI1cA==",
       "funding": [
         {
           "type": "patreon",
@@ -25636,12 +25627,6 @@
           "url": "http://opencollective.com/swiper"
         }
       ],
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "dom7": "^4.0.4",
-        "ssr-window": "^4.0.2"
-      },
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ngx-toastr": "^18.0.0",
     "pm2": "^5.3.1",
     "rxjs": "~7.8.1",
-    "swiper": "^8.4.7",
+    "swiper": "^11.0.7",
     "tslib": "^2.6.2",
     "typeface-roboto": "^1.1.13",
     "typeface-roboto-condensed": "^1.1.13",

--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -15,7 +15,7 @@
   </div>
   <div *ngIf="getImageViewIDs$('L') | async as largeImages" class="col-12 col-lg-9 product-detail-img clearfix">
     <div class="product-image-container">
-      <swiper #carousel [navigation]="true">
+      <ish-swiper #carousel [config]="swiperConfig">
         <ng-container *ngFor="let imageView of largeImages; let i = index">
           <ng-template swiperSlide>
             <div (click)="openZoomModal(i)" (keydown.enter)="openZoomModal(i)" tabindex="0">
@@ -27,7 +27,7 @@
             </div>
           </ng-template>
         </ng-container>
-      </swiper>
+      </ish-swiper>
       <ish-product-label />
     </div>
   </div>

--- a/src/app/pages/product/product-images/product-images.component.spec.ts
+++ b/src/app/pages/product/product-images/product-images.component.spec.ts
@@ -2,13 +2,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
-import { SwiperComponent } from 'swiper/angular';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductImageComponent } from 'ish-shared/components/product/product-image/product-image.component';
 import { ProductLabelComponent } from 'ish-shared/components/product/product-label/product-label.component';
+import { SwiperComponent } from 'ish-shared/swiper/swiper.component';
 
 import { ProductImagesComponent } from './product-images.component';
 

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -1,16 +1,15 @@
 import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs';
 import { distinctUntilKeyChanged, map, shareReplay, tap } from 'rxjs/operators';
-import SwiperCore, { Navigation } from 'swiper';
-import { SwiperComponent } from 'swiper/angular';
+import { Navigation } from 'swiper/modules';
+import { SwiperOptions } from 'swiper/types';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductHelper } from 'ish-core/models/product/product.model';
 import { whenTruthy } from 'ish-core/utils/operators';
 import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
-
-SwiperCore.use([Navigation]);
+import { SwiperComponent } from 'ish-shared/swiper/swiper.component';
 
 /**
  * The Product Images Component
@@ -34,14 +33,19 @@ export class ProductImagesComponent implements OnInit {
   product$: Observable<ProductView>;
   zoomImageIds$: Observable<string[]>;
 
+  swiperConfig: SwiperOptions;
+
   constructor(private context: ProductContextFacade) {}
 
   ngOnInit() {
+    this.swiperConfig = {
+      modules: [Navigation],
+    };
     this.product$ = this.context.select('product').pipe(
       whenTruthy(),
       distinctUntilKeyChanged('sku'),
       tap(() => {
-        if (this.carousel?.swiperRef?.activeIndex) {
+        if (this.carousel?.swiper?.activeIndex) {
           this.setActiveSlide(0);
         }
       }),
@@ -63,7 +67,7 @@ export class ProductImagesComponent implements OnInit {
    * @param slideIndex The slide index to set the active slide
    */
   setActiveSlide(slideIndex: number) {
-    this.carousel?.swiperRef?.slideTo(slideIndex);
+    this.carousel?.swiper?.slideTo(slideIndex);
   }
 
   /**
@@ -73,7 +77,7 @@ export class ProductImagesComponent implements OnInit {
    * @returns True if the given slide index is the active slide, false otherwise
    */
   isActiveSlide(slideIndex: number): boolean {
-    return this.carousel?.swiperRef?.activeIndex === slideIndex;
+    return this.carousel?.swiper?.activeIndex === slideIndex;
   }
 
   getZoomImageAnchorId(i: number) {

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
@@ -3,11 +3,15 @@
     <h2>{{ productLinkTitle }}</h2>
 
     <div class="product-list">
-      <swiper [config]="swiperConfig">
-        <ng-template *ngFor="let sku$ of productSKUs" swiperSlide let-data>
-          <ish-product-item *ngIf="lazyFetch(data.isVisible, sku$) | async as sku" ishProductContext [sku]="sku" />
+      <ish-swiper [config]="swiperConfig">
+        <ng-template *ngFor="let sku$ of productSKUs" swiperSlide>
+          <ish-lazy-item>
+            <ng-template ishLazyLoadingContent>
+              <ish-product-item *ngIf="sku$ | async as sku" ishProductContext [sku]="sku" />
+            </ng-template>
+          </ish-lazy-item>
         </ng-template>
-      </swiper>
+      </ish-swiper>
     </div>
   </div>
 </ng-container>

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent } from 'ng-mocks';
 import { forkJoin, of, switchMap } from 'rxjs';
-import { SwiperComponent } from 'swiper/angular';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { SwiperComponent } from 'ish-shared/swiper/swiper.component';
 
 import { ProductLinksCarouselComponent } from './product-links-carousel.component';
 
@@ -38,7 +38,7 @@ describe('Product Links Carousel Component', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
-    expect(element.querySelector('swiper')).toBeTruthy();
+    expect(element.querySelector('ish-swiper')).toBeTruthy();
   });
 
   it('should render all product slides if stocks filtering is off', done => {

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, Inject, Input } from '@angular/core';
 import { RxState } from '@rx-angular/state';
-import { EMPTY, Observable, combineLatest, of } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
-import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
+import { Navigation, Pagination } from 'swiper/modules';
+import { SwiperOptions } from 'swiper/types';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
@@ -10,8 +11,6 @@ import { ProductLinks } from 'ish-core/models/product-links/product-links.model'
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { mapToProperty } from 'ish-core/utils/operators';
-
-SwiperCore.use([Navigation, Pagination]);
 
 /**
  * The Product Link Carousel Component
@@ -49,11 +48,6 @@ export class ProductLinksCarouselComponent {
   productSKUs$ = this.state.select('products$');
 
   /**
-   * track already fetched SKUs
-   */
-  private fetchedSKUs = new Set<Observable<string>>();
-
-  /**
    * configuration of swiper carousel
    * https://swiperjs.com/swiper-api
    */
@@ -76,6 +70,7 @@ export class ProductLinksCarouselComponent {
     }));
 
     this.swiperConfig = {
+      modules: [Navigation, Pagination],
       watchSlidesProgress: true,
       direction: 'horizontal',
       navigation: true,
@@ -126,15 +121,5 @@ export class ProductLinksCarouselComponent {
     ]).pipe(map(([products, hiddenSlides]) => products.filter((_, index) => !hiddenSlides.includes(index))));
 
     this.state.connect('products$', filteredProducts$);
-  }
-
-  lazyFetch(fetch: boolean, sku$: Observable<string>): Observable<string> {
-    if (fetch) {
-      this.fetchedSKUs.add(sku$);
-    }
-    if (this.fetchedSKUs.has(sku$)) {
-      return sku$;
-    }
-    return EMPTY;
   }
 }

--- a/src/app/shared/components/common/lazy-item/lazy-item.component.html
+++ b/src/app/shared/components/common/lazy-item/lazy-item.component.html
@@ -1,0 +1,5 @@
+<div ishIntersectionObserver (visibilityChange)="onVisibilityChange($event)" [ngClass]="cssClass">
+  <ng-container *ngIf="visible$ | async">
+    <ng-template [ngTemplateOutlet]="lazyContent.templateRef"></ng-template>
+  </ng-container>
+</div>

--- a/src/app/shared/components/common/lazy-item/lazy-item.component.spec.ts
+++ b/src/app/shared/components/common/lazy-item/lazy-item.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LazyItemComponent } from './lazy-item.component';
+
+describe('Lazy Item Component', () => {
+  let component: LazyItemComponent;
+  let fixture: ComponentFixture<LazyItemComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LazyItemComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LazyItemComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+});

--- a/src/app/shared/components/common/lazy-item/lazy-item.component.ts
+++ b/src/app/shared/components/common/lazy-item/lazy-item.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, ContentChild, Input } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import { IntersectionStatus } from 'ish-core/directives/intersection-observer.directive';
+import { LazyLoadingContentDirective } from 'ish-core/directives/lazy-loading-content.directive';
+
+@Component({
+  selector: 'ish-lazy-item',
+  templateUrl: './lazy-item.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LazyItemComponent {
+  @ContentChild(LazyLoadingContentDirective) lazyContent: LazyLoadingContentDirective;
+  @Input() cssClass: string;
+
+  visible$ = new BehaviorSubject<boolean>(false);
+
+  onVisibilityChange(event: IntersectionStatus) {
+    if (event === 'Visible') {
+      this.visible$.next(true);
+    }
+  }
+}

--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -2,19 +2,20 @@
   <ng-container *ngIf="products.length">
     <ng-container *ngIf="listStyle === 'carousel'; else plainList">
       <div class="product-list">
-        <swiper [config]="swiperConfig">
-          <ng-template *ngFor="let sku of products" swiperSlide let-data>
-            <div [ngClass]="listItemCSSClass">
-              <ish-product-item
-                *ngIf="lazyFetch(data.isVisible, sku)"
-                ishProductContext
-                [sku]="sku"
-                [configuration]="listItemConfiguration"
-                [displayType]="listItemStyle"
-              />
-            </div>
+        <ish-swiper [config]="swiperConfig">
+          <ng-template *ngFor="let sku of products" swiperSlide>
+            <ish-lazy-item [ngClass]="listItemCSSClass">
+              <ng-template ishLazyLoadingContent>
+                <ish-product-item
+                  ishProductContext
+                  [sku]="sku"
+                  [configuration]="listItemConfiguration"
+                  [displayType]="listItemStyle"
+                />
+              </ng-template>
+            </ish-lazy-item>
           </ng-template>
-        </swiper>
+        </ish-swiper>
       </div>
     </ng-container>
 

--- a/src/app/shared/components/product/products-list/products-list.component.spec.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.spec.ts
@@ -2,12 +2,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
-import { SwiperComponent } from 'swiper/angular';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
+import { SwiperComponent } from 'ish-shared/swiper/swiper.component';
 
 import { ProductsListComponent } from './products-list.component';
 
@@ -52,7 +52,7 @@ describe('Products List Component', () => {
     component.ngOnChanges();
     fixture.detectChanges();
 
-    expect(element).toMatchInlineSnapshot(`<div class="product-list"><swiper></swiper></div>`);
+    expect(element).toMatchInlineSnapshot(`<div class="product-list"><ish-swiper></ish-swiper></div>`);
   });
 
   it('should set displayType of product item to listItemStyle value', () => {

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -2,7 +2,8 @@ import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges } from '@a
 import { isEqual } from 'lodash-es';
 import { Observable, combineLatest, of } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-import SwiperCore, { Navigation, Pagination, SwiperOptions } from 'swiper';
+import { Navigation, Pagination } from 'swiper/modules';
+import { SwiperOptions } from 'swiper/types';
 
 import {
   LARGE_BREAKPOINT_WIDTH,
@@ -13,8 +14,6 @@ import { ProductContextDisplayProperties } from 'ish-core/facades/product-contex
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { ProductItemDisplayType } from 'ish-shared/components/product/product-item/product-item.component';
-
-SwiperCore.use([Pagination, Navigation]);
 
 @Component({
   selector: 'ish-products-list',
@@ -32,11 +31,6 @@ export class ProductsListComponent implements OnChanges {
   productSKUs$: Observable<string[]>;
 
   /**
-   * track already fetched SKUs
-   */
-  private fetchedSKUs = new Set<string>();
-
-  /**
    * configuration of swiper carousel
    * https://swiperjs.com/swiper-api
    */
@@ -49,6 +43,7 @@ export class ProductsListComponent implements OnChanges {
     private shoppingFacade: ShoppingFacade
   ) {
     this.swiperConfig = {
+      modules: [Pagination, Navigation],
       watchSlidesProgress: true,
       direction: 'horizontal',
       navigation: true,
@@ -68,13 +63,6 @@ export class ProductsListComponent implements OnChanges {
       distinctUntilChanged<[string[], string[]]>(isEqual),
       map(([skus, failed]) => skus.filter(x => !failed.includes(x)))
     );
-  }
-
-  lazyFetch(fetch: boolean, sku: string): boolean {
-    if (fetch) {
-      this.fetchedSKUs.add(sku);
-    }
-    return this.fetchedSKUs.has(sku);
   }
 
   /**

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -12,7 +12,6 @@ import {
 } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
-import { SwiperModule } from 'swiper/angular';
 
 import { AuthorizationToggleModule } from 'ish-core/authorization-toggle.module';
 import { DirectivesModule } from 'ish-core/directives.module';
@@ -92,6 +91,7 @@ import { ErrorMessageComponent } from './components/common/error-message/error-m
 import { InPlaceEditComponent } from './components/common/in-place-edit/in-place-edit.component';
 import { InfoBoxComponent } from './components/common/info-box/info-box.component';
 import { InfoMessageComponent } from './components/common/info-message/info-message.component';
+import { LazyItemComponent } from './components/common/lazy-item/lazy-item.component';
 import { LoadingComponent } from './components/common/loading/loading.component';
 import { ModalDialogLinkComponent } from './components/common/modal-dialog-link/modal-dialog-link.component';
 import { ModalDialogComponent } from './components/common/modal-dialog/modal-dialog.component';
@@ -152,6 +152,7 @@ import { SearchBoxComponent } from './components/search/search-box/search-box.co
 import { FormlyAddressFormsModule } from './formly-address-forms/formly-address-forms.module';
 import { FormlyModule } from './formly/formly.module';
 import { FormsSharedModule } from './forms/forms.module';
+import { SwiperModule } from './swiper/swiper.module';
 
 const importExportModules = [
   AddressDoctorExportsModule,
@@ -223,6 +224,7 @@ const declaredComponents = [
   FilterNavigationSidebarComponent,
   FilterSwatchImagesComponent,
   FilterTextComponent,
+  LazyItemComponent,
   LineItemEditComponent,
   LineItemEditDialogComponent,
   LineItemListElementComponent,
@@ -275,6 +277,7 @@ const exportedComponents = [
   InfoBoxComponent,
   InfoMessageComponent,
   InPlaceEditComponent,
+  LazyItemComponent,
   LineItemListComponent,
   LoadingComponent,
   LoginFormComponent,

--- a/src/app/shared/swiper/swiper-slide.directive.ts
+++ b/src/app/shared/swiper/swiper-slide.directive.ts
@@ -1,0 +1,11 @@
+import { Directive, Input, TemplateRef } from '@angular/core';
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: 'ng-template[swiperSlide]',
+})
+// eslint-disable-next-line ish-custom-rules/project-structure
+export class SwiperSlideDirective {
+  @Input() slideID: string | number;
+  constructor(public template: TemplateRef<unknown>) {}
+}

--- a/src/app/shared/swiper/swiper.component.html
+++ b/src/app/shared/swiper/swiper.component.html
@@ -1,0 +1,5 @@
+<swiper-container #swiper init="false">
+  <swiper-slide *ngFor="let slide of activeSlides">
+    <ng-template [ngTemplateOutlet]="slide.template"></ng-template>
+  </swiper-slide>
+</swiper-container>

--- a/src/app/shared/swiper/swiper.component.scss
+++ b/src/app/shared/swiper/swiper.component.scss
@@ -1,0 +1,2 @@
+@import 'swiper/scss';
+@import 'swiper/scss/pagination';

--- a/src/app/shared/swiper/swiper.component.ts
+++ b/src/app/shared/swiper/swiper.component.ts
@@ -1,0 +1,135 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  DestroyRef,
+  ElementRef,
+  Input,
+  NgZone,
+  OnInit,
+  QueryList,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs';
+import Swiper from 'swiper';
+import { SwiperOptions } from 'swiper/types';
+
+import { SwiperSlideDirective } from './swiper-slide.directive';
+
+@Component({
+  selector: 'ish-swiper',
+  templateUrl: './swiper.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styleUrls: ['./swiper.component.scss'],
+  // eslint-disable-next-line @angular-eslint/no-host-metadata-property
+  host: { ngSkipHydration: 'true' },
+})
+export class SwiperComponent implements OnInit, AfterViewInit {
+  @Input() config: SwiperOptions;
+
+  currentConfig: SwiperOptions;
+
+  @ViewChild('swiper') swiperEl: ElementRef;
+
+  initialSlides$: Observable<SwiperSlideDirective[]>;
+
+  private destroyRef = inject(DestroyRef);
+
+  constructor(private changeDetectorRef: ChangeDetectorRef, private zone: NgZone) {}
+
+  @ContentChildren(SwiperSlideDirective, { descendants: false, emitDistinctChangesOnly: true })
+  slidesEl: QueryList<SwiperSlideDirective>;
+
+  private slides: SwiperSlideDirective[];
+
+  get activeSlides() {
+    return this.slides;
+  }
+
+  ngOnInit(): void {
+    this.currentConfig = {
+      ...this.config,
+      injectStyles: [
+        `
+        .swiper {
+          padding-bottom: 20px;
+        }
+        .swiper-slide {
+          padding-right: $space-default;
+          padding-left: $space-default;
+        }
+
+        .swiper-button-next,
+        .swiper-button-prev {
+          position: absolute;
+          top: 0;
+          z-index: 10;
+          width: var(--swiper-navigation-icon-width);
+          height: 100%;
+          cursor: pointer;
+          background: no-repeat 50% / 100% 100%;
+          opacity: 0.5;
+
+          &:hover {
+            opacity: 1;
+          }
+
+          &.swiper-button-disabled {
+            opacity: 0;
+          }
+        }
+        .swiper-button-next {
+          background-image: var(--swiper-navigation-next-icon-bg);
+        }
+        .swiper-button-prev {
+          background-image: var(--swiper-navigation-prev-icon-bg);
+        }
+        .swiper-button-next svg,.swiper-button-prev svg {
+          display:none;
+        }
+        .swiper-button-next::after,
+        .swiper-button-prev::after {
+          content: "";
+        }
+        `,
+      ],
+    };
+  }
+
+  ngAfterViewInit() {
+    if (!SSR) {
+      this.zone.runOutsideAngular(() => {
+        this.childrenSlidesInit();
+
+        // eslint-disable-next-line ban/ban
+        Object.assign(this.swiperEl.nativeElement, this.currentConfig);
+
+        this.swiperEl?.nativeElement?.initialize();
+      });
+
+      this.changeDetectorRef.detectChanges();
+    }
+  }
+
+  get swiper(): Swiper {
+    return this.swiperEl?.nativeElement?.swiper;
+  }
+
+  private childrenSlidesInit() {
+    this.slidesChanges(this.slidesEl);
+    this.slidesEl.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(this.slidesChanges);
+  }
+
+  private slidesChanges = (val: QueryList<SwiperSlideDirective>) => {
+    this.slides = val.map((slide: SwiperSlideDirective, _index: number) => slide);
+
+    this.zone.run(() => {
+      this.changeDetectorRef.detectChanges();
+      this.swiper?.slideTo(0, 0);
+    });
+  };
+}

--- a/src/app/shared/swiper/swiper.module.ts
+++ b/src/app/shared/swiper/swiper.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import { register as SwiperRegister } from 'swiper/element/bundle';
+
+import { SwiperSlideDirective } from './swiper-slide.directive';
+import { SwiperComponent } from './swiper.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [SwiperComponent, SwiperSlideDirective],
+  exports: [SwiperComponent, SwiperSlideDirective],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class SwiperModule {
+  constructor() {
+    SwiperRegister();
+  }
+}

--- a/src/styles/global/swiper.scss
+++ b/src/styles/global/swiper.scss
@@ -1,59 +1,8 @@
-.swiper {
-  padding-bottom: 20px;
-
-  .swiper-pagination {
-    bottom: 0;
-
-    .swiper-pagination-bullet-active {
-      background: $text-color-primary;
-    }
-
-    .swiper-pagination-bullet {
-      &:only-child {
-        visibility: hidden;
-      }
-    }
-  }
-}
-
-.swiper-slide {
-  padding-right: $space-default;
-  padding-left: $space-default;
-}
-
-.swiper-button-next,
-.swiper-button-prev {
-  position: absolute;
-  top: 0;
-  z-index: 10;
-  width: $carousel-control-icon-width;
-  height: 100%;
-  cursor: pointer;
-  background: no-repeat 50% / 100% 100%;
-  opacity: 0.5;
-
-  &:hover {
-    opacity: 1;
-  }
-
-  &.swiper-button-disabled {
-    opacity: 0;
-  }
-}
-
-.swiper-button-next {
-  right: 0;
-  background-image: escape-svg($carousel-control-next-icon-bg);
-
-  &::after {
-    content: '';
-  }
-}
-
-.swiper-button-prev {
-  background-image: escape-svg($carousel-control-prev-icon-bg);
-
-  &::after {
-    content: '';
-  }
+:root {
+  --swiper-navigation-color: #{$text-color-primary};
+  --swiper-navigation-next-icon-bg: #{escape-svg($carousel-control-next-icon-bg)};
+  --swiper-navigation-prev-icon-bg: #{escape-svg($carousel-control-prev-icon-bg)};
+  --swiper-navigation-icon-width: #{$carousel-control-icon-width};
+  --swiper-pagination-bottom: '0';
+  --swiper-pagination-color: #{$text-color-primary};
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -16,10 +16,6 @@
 // import Angular Toastr bootstrap styles
 @import 'ngx-toastr/toastr-bs4-alert';
 
-// import Swiper default theme
-@import 'swiper/scss';
-@import 'swiper/scss/pagination';
-
 //
 // STYLING COMPATIBILITY LAYER
 
@@ -39,7 +35,6 @@
 @import 'global/panel';
 @import 'global/tables';
 @import 'global/toasts';
-@import 'global/swiper';
 @import 'global/forms';
 @import 'global/lists';
 @import 'global/share-tools';
@@ -47,6 +42,7 @@
 @import 'global/line-item';
 @import 'global/print';
 @import 'global/promotions';
+@import 'global/swiper';
 @import 'components/header/header';
 @import 'components/header/language-switch';
 @import 'components/header/search-container';


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Swiper library version not up to date

## What Is the New Behavior?

Swiper has been set to 11.
A new angular component `ish-swiper` has been introduce to wrap swiper web-elements.
Previous css has been migrate to css variable or css style injected to the shadow dom.

There was an improvement made in this commit (https://github.com/intershop/intershop-pwa/commit/cbe90723ca2097841542e436c6dba5f30cbb9313) to lazily fetch product. As this used a swiper function that no longer exists, a `ish-lazy-item` genetic component was introduced. This makes it possible to perform the same optimization with an intersectionObserver and an ng-template


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x ] Yes
[ ] No

## Other Information


[AB#117222](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117222)