### PR TITLE
fix: save address doctor configuration in the ngrx store

### DIFF
--- a/docs/guides/address-doctor.md
+++ b/docs/guides/address-doctor.md
@@ -18,21 +18,40 @@ You will also have to provide the endpoint and additional verification data.
 This can be done by defining it in [Angular CLI environment](../concepts/configuration.md#angular-cli-environments) files:
 
 ```typescript
-export const environment: Environment = {
-  ...ENVIRONMENT_DEFAULTS,
-
-  addressDoctor: {
-    url: '<addressDoctor-url>',
-    login: '<addressDoctor-login>',
-    password: '<addressDoctor-password>',
-    maxResultCount: 5,
-  },
+features: [
+  'addressDoctor'
+],
+addressDoctor: {
+  url: '<addressDoctor-url>',
+  login: '<addressDoctor-login>',
+  password: '<addressDoctor-password>',
+  maxResultCount: 5,
+},
 ```
 
-This configuration can also be supplied via environment variable `ADDRESS_DOCTOR` as stringified JSON:
+The Address Doctor configuration can also be supplied via environment variable `ADDRESS_DOCTOR` as stringified JSON:
 
 ```text
-ADDRESS_DOCTOR='{ "addressDoctor": { "url": "<addressDoctor-url>", "login": "<addressDoctor-login>", "password": "<addressDoctor-password>", "maxResultCount": "5" } }';
+ADDRESS_DOCTOR='{ "url": "<addressDoctor-url>", "login": "<addressDoctor-login>", "password": "<addressDoctor-password>", "maxResultCount": "5" }';
+```
+
+The Address Doctor configuration for `docker-compose` looks like this:
+
+```yaml
+pwa:
+  environment:
+    ADDRESS_DOCTOR: '{ "url": "<addressDoctor-url>", "login": "<addressDoctor-login>", "password": "<addressDoctor-password>", "maxResultCount": "5" }'
+```
+
+For the current PWA Helm Chart that is also used in the PWA Flux deployments, the Address Doctor configuration looks like this.:
+
+```yaml
+environment:
+  - name: ADDRESS_DOCTOR
+    value: |
+      {
+        "url": "<addressDoctor-url>", "login": "<addressDoctor-login>", "password": "<addressDoctor-password>", "maxResultCount": "5"
+      }
 ```
 
 ## Workflow

--- a/src/app/extensions/address-doctor/exports/address-doctor-exports.module.ts
+++ b/src/app/extensions/address-doctor/exports/address-doctor-exports.module.ts
@@ -2,10 +2,23 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
+import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { LAZY_FEATURE_MODULE } from 'ish-core/utils/module-loader/module-loader.service';
+
 import { LazyAddressDoctorComponent } from './lazy-address-doctor/lazy-address-doctor.component';
 
 @NgModule({
-  imports: [CommonModule, TranslateModule],
+  imports: [CommonModule, FeatureToggleModule, TranslateModule],
+  providers: [
+    {
+      provide: LAZY_FEATURE_MODULE,
+      useValue: {
+        feature: 'addressDoctor',
+        location: () => import('../store/address-doctor-store.module').then(m => m.AddressDoctorStoreModule),
+      },
+      multi: true,
+    },
+  ],
   declarations: [LazyAddressDoctorComponent],
   exports: [LazyAddressDoctorComponent],
 })

--- a/src/app/extensions/address-doctor/services/address-doctor/address-doctor.service.spec.ts
+++ b/src/app/extensions/address-doctor/services/address-doctor/address-doctor.service.spec.ts
@@ -1,13 +1,11 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { pick } from 'lodash-es';
-import { of } from 'rxjs';
-import { instance, mock, when } from 'ts-mockito';
 
 import { Address } from 'ish-core/models/address/address.model';
-import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
 
-import { AddressDoctorConfig } from '../../models/address-doctor/address-doctor-config.model';
+import { getAddressDoctorConfig } from '../../store/address-doctor';
 
 import { AddressDoctorService } from './address-doctor.service';
 
@@ -121,28 +119,29 @@ const response = {
 describe('Address Doctor Service', () => {
   let addressDoctorService: AddressDoctorService;
   let controller: HttpTestingController;
-  let statePropertiesService: StatePropertiesService;
 
   beforeEach(() => {
-    statePropertiesService = mock(StatePropertiesService);
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [{ provide: StatePropertiesService, useFactory: () => instance(statePropertiesService) }],
+      providers: [
+        provideMockStore({
+          selectors: [
+            {
+              selector: getAddressDoctorConfig,
+              value: {
+                login: 'login',
+                password: 'password',
+                maxResultCount: 5,
+                url: 'http://address-doctor.com',
+              },
+            },
+          ],
+        }),
+      ],
     });
     addressDoctorService = TestBed.inject(AddressDoctorService);
 
     controller = TestBed.inject(HttpTestingController);
-
-    when(
-      statePropertiesService.getStateOrEnvOrDefault<AddressDoctorConfig>('ADDRESS_DOCTOR', 'addressDoctor')
-    ).thenReturn(
-      of({
-        login: 'login',
-        password: 'password',
-        maxResultCount: 5,
-        url: 'http://address-doctor.com',
-      })
-    );
   });
 
   afterEach(() => {

--- a/src/app/extensions/address-doctor/store/address-doctor-store.module.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor-store.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { EffectsModule } from '@ngrx/effects';
+import { ActionReducerMap, StoreModule } from '@ngrx/store';
+import { pick } from 'lodash-es';
+
+import { AddressDoctorState } from './address-doctor-store';
+import { AddressDoctorEffects } from './address-doctor/address-doctor.effects';
+import { addressDoctorReducer } from './address-doctor/address-doctor.reducer';
+
+const addressDoctorReducers: ActionReducerMap<AddressDoctorState> = {
+  addressDoctorConfig: addressDoctorReducer,
+};
+
+const addressDoctorEffects = [AddressDoctorEffects];
+
+@NgModule({
+  imports: [
+    EffectsModule.forFeature(addressDoctorEffects),
+    StoreModule.forFeature('addressDoctor', addressDoctorReducers),
+  ],
+})
+export class AddressDoctorStoreModule {
+  static forTesting(...reducers: (keyof ActionReducerMap<AddressDoctorState>)[]) {
+    return StoreModule.forFeature('addressDoctor', pick(addressDoctorReducers, reducers));
+  }
+}

--- a/src/app/extensions/address-doctor/store/address-doctor-store.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor-store.ts
@@ -1,0 +1,9 @@
+import { createFeatureSelector } from '@ngrx/store';
+
+import { AddressDoctorConfig } from '../models/address-doctor/address-doctor-config.model';
+
+export interface AddressDoctorState {
+  addressDoctorConfig: AddressDoctorConfig;
+}
+
+export const getAddressDoctorState = createFeatureSelector<AddressDoctorState>('addressDoctor');

--- a/src/app/extensions/address-doctor/store/address-doctor/address-doctor.actions.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/address-doctor.actions.ts
@@ -1,0 +1,13 @@
+import { createActionGroup, emptyProps } from '@ngrx/store';
+
+import { payload } from 'ish-core/utils/ngrx-creators';
+
+import { AddressDoctorConfig } from '../../models/address-doctor/address-doctor-config.model';
+
+export const addressDoctorInternalActions = createActionGroup({
+  source: 'Address Doctor Internal',
+  events: {
+    'Load Address Doctor Config': emptyProps(),
+    'Set Address Doctor Config': payload<{ config: AddressDoctorConfig }>(),
+  },
+});

--- a/src/app/extensions/address-doctor/store/address-doctor/address-doctor.effects.spec.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/address-doctor.effects.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { cold, hot } from 'jasmine-marbles';
+import { Observable, of } from 'rxjs';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
+
+import { AddressDoctorStoreModule } from '../address-doctor-store.module';
+
+import { addressDoctorInternalActions } from './address-doctor.actions';
+import { AddressDoctorEffects } from './address-doctor.effects';
+
+describe('Address Doctor Effects', () => {
+  let actions$: Observable<Action>;
+  let statePropertiesService: StatePropertiesService;
+  let effects: AddressDoctorEffects;
+
+  const config = {
+    login: 'login',
+    password: 'password',
+    maxResultCount: 5,
+    url: 'http://address-doctor.com',
+  };
+
+  beforeEach(() => {
+    statePropertiesService = mock(StatePropertiesService);
+
+    TestBed.configureTestingModule({
+      imports: [AddressDoctorStoreModule.forTesting('addressDoctorConfig'), CoreStoreModule.forTesting()],
+      providers: [
+        { provide: StatePropertiesService, useFactory: () => instance(statePropertiesService) },
+        AddressDoctorEffects,
+        provideMockActions(() => actions$),
+      ],
+    });
+
+    effects = TestBed.inject(AddressDoctorEffects);
+  });
+
+  describe('loadAddressDoctorConfiguration$', () => {
+    beforeEach(() => {
+      when(statePropertiesService.getStateOrEnvOrDefault(anything(), anything())).thenReturn(of(config));
+    });
+
+    it('should call the StatePropertiesService for loadAddressDoctorConfiguration', done => {
+      const action = addressDoctorInternalActions.loadAddressDoctorConfig();
+      actions$ = of(action);
+
+      effects.loadAddressDoctorConfiguration$.subscribe(() => {
+        verify(statePropertiesService.getStateOrEnvOrDefault(anything(), anything())).once();
+        done();
+      });
+    });
+
+    it('should map to action of type setAddressDoctorConfiguration', () => {
+      const action = addressDoctorInternalActions.loadAddressDoctorConfig();
+      const completion = addressDoctorInternalActions.setAddressDoctorConfig({
+        config,
+      });
+      actions$ = hot('-a-a-a', { a: action });
+      const expected$ = cold('-c-c-c', { c: completion });
+
+      expect(effects.loadAddressDoctorConfiguration$).toBeObservable(expected$);
+    });
+  });
+
+  describe('loadAddressDoctorConfigOnInit$', () => {
+    it('should map to action of type loadAddressDoctorConfiguration on init', done => {
+      effects.loadAddressDoctorConfigOnInit$.subscribe(actions => {
+        expect(actions).toMatchInlineSnapshot(`[Address Doctor Internal] Load Address Doctor Config`);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/extensions/address-doctor/store/address-doctor/address-doctor.effects.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/address-doctor.effects.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store, select } from '@ngrx/store';
+import { map, switchMap } from 'rxjs/operators';
+
+import { whenFalsy } from 'ish-core/utils/operators';
+import { StatePropertiesService } from 'ish-core/utils/state-transfer/state-properties.service';
+
+import { AddressDoctorConfig } from '../../models/address-doctor/address-doctor-config.model';
+
+import { addressDoctorInternalActions } from './address-doctor.actions';
+import { getAddressDoctorConfig } from './address-doctor.selectors';
+
+@Injectable()
+export class AddressDoctorEffects {
+  constructor(
+    private actions$: Actions,
+    private store: Store,
+    private statePropertiesService: StatePropertiesService
+  ) {}
+
+  loadAddressDoctorConfiguration$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(addressDoctorInternalActions.loadAddressDoctorConfig),
+      switchMap(() =>
+        this.statePropertiesService
+          .getStateOrEnvOrDefault<AddressDoctorConfig>('ADDRESS_DOCTOR', 'addressDoctor')
+          .pipe(map(config => addressDoctorInternalActions.setAddressDoctorConfig({ config })))
+      )
+    )
+  );
+
+  loadAddressDoctorConfigOnInit$ = createEffect(() =>
+    this.store.pipe(
+      select(getAddressDoctorConfig),
+      whenFalsy(),
+      map(() => addressDoctorInternalActions.loadAddressDoctorConfig())
+    )
+  );
+}

--- a/src/app/extensions/address-doctor/store/address-doctor/address-doctor.reducer.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/address-doctor.reducer.ts
@@ -1,0 +1,10 @@
+import { createReducer, on } from '@ngrx/store';
+
+import { AddressDoctorConfig } from '../../models/address-doctor/address-doctor-config.model';
+
+import { addressDoctorInternalActions } from './address-doctor.actions';
+
+export const addressDoctorReducer = createReducer(
+  undefined,
+  on(addressDoctorInternalActions.setAddressDoctorConfig, (_, action): AddressDoctorConfig => action.payload.config)
+);

--- a/src/app/extensions/address-doctor/store/address-doctor/address-doctor.selectors.spec.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/address-doctor.selectors.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
+
+import { AddressDoctorStoreModule } from '../address-doctor-store.module';
+
+import { addressDoctorInternalActions } from './address-doctor.actions';
+import { getAddressDoctorConfig } from './address-doctor.selectors';
+
+describe('Address Doctor Selectors', () => {
+  let store$: StoreWithSnapshots;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AddressDoctorStoreModule.forTesting('addressDoctorConfig'), CoreStoreModule.forTesting()],
+      providers: [provideStoreSnapshots()],
+    });
+
+    store$ = TestBed.inject(StoreWithSnapshots);
+  });
+
+  describe('initial state', () => {
+    it('should be empty when in initial state', () => {
+      expect(getAddressDoctorConfig(store$.state)).toBeUndefined();
+    });
+  });
+
+  describe('after loading', () => {
+    const action = addressDoctorInternalActions.setAddressDoctorConfig({
+      config: {
+        login: 'login',
+        password: 'password',
+        maxResultCount: 5,
+        url: 'http://address-doctor.com',
+      },
+    });
+
+    beforeEach(() => {
+      store$.dispatch(action);
+    });
+
+    it('should set store value to true', () => {
+      expect(getAddressDoctorConfig(store$.state)).toBeTruthy();
+    });
+  });
+});

--- a/src/app/extensions/address-doctor/store/address-doctor/address-doctor.selectors.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/address-doctor.selectors.ts
@@ -1,0 +1,5 @@
+import { createSelector } from '@ngrx/store';
+
+import { getAddressDoctorState } from '../address-doctor-store';
+
+export const getAddressDoctorConfig = createSelector(getAddressDoctorState, state => state?.addressDoctorConfig);

--- a/src/app/extensions/address-doctor/store/address-doctor/index.ts
+++ b/src/app/extensions/address-doctor/store/address-doctor/index.ts
@@ -1,0 +1,3 @@
+// API to access ngrx address doctor state
+export * from './address-doctor.actions';
+export * from './address-doctor.selectors';


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The Address Doctor has to be configured in the `environment.ts` file. The feature does not take effect when providing the necessary configurations in a YAML file for a Flux deployment or in a `docker_compose` file. 

## What Is the New Behavior?

The address doctor can be configured in a YAML file for a Flux deployment or in a `docker_compose` file as well.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

[AB#95679](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95679)