### PR TITLE
docs: update default icmBaseUrl in doc files

### DIFF
--- a/docs/guides/customizations.md
+++ b/docs/guides/customizations.md
@@ -74,7 +74,7 @@ CREATE src/app/shared/components/basket/custom-basket-display/custom-basket-disp
 > The Intershop PWA project is configured to work against a publicly available Intershop Commerce Management server by default (see `environment.model.ts`).
 >
 > ```
-> icmBaseURL: 'https://pwa-ish-demo.test.intershop.com',
+> icmBaseURL: 'https://develop.icm.intershop.de',
 > ```
 >
 > To configure your PWA project to use an own default ICM server, set the `icmBaseURL` in your projects `environment.model.ts` accordingly.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -41,7 +41,7 @@ ng serve --open
 > By default, the project is configured to work against a publicly available Intershop Commerce Management server (see `environment.model.ts`).
 >
 > ```
-> icmBaseURL: 'https://pwa-ish-demo.test.intershop.com',
+> icmBaseURL: 'https://develop.icm.intershop.de',
 > ```
 >
 > To run your PWA against an own ICM server, configure the `icmBaseURL` in your local `environment.development.ts` or set the `icmBaseURL` in your projects `environment.model.ts` to your own ICM default server.
@@ -65,7 +65,7 @@ For production and production-like deployments we provide an [Intershop PWA Helm
 >
 > ```yaml
 > upstream:
->   icmBaseURL: https://pwa-ish-demo.test.intershop.com
+>   icmBaseURL: https://develop.icm.intershop.de
 > ```
 
 For a simple production-like development or testing deployment of the current project state, the project includes a `docker-compose.yml` that can be deployed with `docker compose up --build` in the project root.
@@ -78,7 +78,7 @@ This will deploy both containers of the Intershop PWA - the pwa (SSR) container 
 > services:
 >   pwa:
 >     environment:
->       ICM_BASE_URL: 'https://pwa-ish-demo.test.intershop.com'
+>       ICM_BASE_URL: 'https://develop.icm.intershop.de'
 > ```
 
 You can also manually build the docker image supplied with the `Dockerfile` in the root folder of the project.


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[x] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The icmBaseUrl was outdated in some documentation files.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The ismBaseUrl has been updated  so it is up to date now in the documentation files.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#95680](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95680)