### PR TITLE
feat: exclusive ICM url for SSR process

### DIFF
--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -50,6 +50,7 @@ Make sure to use them as written in the table below.
 |                     | CONCURRENCY_SSR       | number \| max        | Concurrency for SSR instances per theme (default: 2)                                             |
 |                     | CACHE_ICM_CALLS       | recommended \| JSON  | Enable caching for ICM calls, see [Local ICM Cache](#local-icm-cache) (default: disabled)        |
 | **General**         | ICM_BASE_URL          | string               | Sets the base URL for the ICM                                                                    |
+|                     | ICM_BASE_URL_SSR      | string               | Sets the base URL for the ICM used in SSR (optional)                                             |
 |                     | ICM_CHANNEL           | string               | Overrides the default channel                                                                    |
 |                     | ICM_APPLICATION       | string               | Overrides the default application                                                                |
 |                     | FEATURES              | comma-separated list | Overrides active features                                                                        |

--- a/scripts/icm-cache.js
+++ b/scripts/icm-cache.js
@@ -42,16 +42,6 @@ if (localICMCacheActive) {
   content += `      ICM_BASE_URL_SSR: http://localhost:10000
     `;
 }
------
- *
- * Code snippet to adapt 'src\app\core\store\core\configuration\configuration.selectors.ts':
------
-const ssrBaseUrl = typeof process !== 'undefined' && process.env.ICM_BASE_URL_SSR;
-
-export const getICMServerURL = createSelector(getConfigurationState, state =>
-  state.baseURL && state.server ? `${ssrBaseUrl || state.baseURL}/${state.server}` : undefined
-);
------
  *
  */
 

--- a/src/app/core/store/core/configuration/configuration.selectors.ts
+++ b/src/app/core/store/core/configuration/configuration.selectors.ts
@@ -16,8 +16,10 @@ export const getResponsiveStarterStoreApplication = createSelector(
   state => state.hybridApplication || '-'
 );
 
+const ssrBaseUrl = SSR && process.env.ICM_BASE_URL_SSR;
+
 export const getICMServerURL = createSelector(getConfigurationState, state =>
-  state.baseURL && state.server ? `${state.baseURL}/${state.server}` : undefined
+  state.baseURL && state.server ? `${ssrBaseUrl || state.baseURL}/${state.server}` : undefined
 );
 
 export const getRestEndpoint = createSelector(


### PR DESCRIPTION

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

SSR process uses the same external URL for the ICM as the browser application.

## What Is the New Behavior?

Introduced `ICM_BASE_URL_SSR` which can be optionally set to use a different URL for the ICM in the SSR process.
This is useful for testing and could be used in deployments, were the ICM runs in the same Kubernetes cluster as the PWA deployment.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#95720](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95720)