### PR TITLE
refactor: replace lodash flatten with built-in function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -216,7 +216,7 @@
               "message": "use star imports only for aggregation of deeper lying imports"
             },
             {
-              "importNamePattern": "^(?!(range|uniq|memoize|once|groupBy|countBy|flatten|isEqual|intersection|pick|differenceBy|unionBy|mergeWith|snakeCase|capitalize)$).*",
+              "importNamePattern": "^(?!(range|uniq|memoize|once|groupBy|countBy|isEqual|intersection|pick|differenceBy|unionBy|mergeWith|snakeCase|capitalize)$).*",
               "name": "lodash.*",
               "filePattern": "^.*/src/app/(?!.*\\.spec\\.ts$).*\\.ts$",
               "message": "importing this operator from lodash is forbidden"

--- a/src/app/core/models/product-variation/product-variation.helper.ts
+++ b/src/app/core/models/product-variation/product-variation.helper.ts
@@ -1,4 +1,4 @@
-import { flatten, groupBy } from 'lodash-es';
+import { groupBy } from 'lodash-es';
 
 import { FilterNavigation } from 'ish-core/models/filter-navigation/filter-navigation.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
@@ -99,9 +99,10 @@ export class ProductVariationHelper {
       return product.variations?.length;
     }
 
-    const selectedFacets = flatten(
-      filters.filter.map(filter => filter.facets.filter(facet => facet.selected).map(facet => facet.name))
-    ).map(selected => selected.split('='));
+    const selectedFacets = filters.filter
+      .map(filter => filter.facets.filter(facet => facet.selected).map(facet => facet.name))
+      .flat()
+      .map(selected => selected.split('='));
 
     if (!selectedFacets.length) {
       return product.variations?.length;

--- a/src/app/core/models/product/product.mapper.ts
+++ b/src/app/core/models/product/product.mapper.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { flatten } from 'lodash-es';
 
 import { AttachmentMapper } from 'ish-core/models/attachment/attachment.mapper';
 import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.model';
@@ -72,10 +71,14 @@ export class ProductMapper {
         type: 'VariationProductMaster',
         sku,
         completenessLevel: 0,
-        variationAttributeValues: flatten(variations.map(v => v.variableVariationAttributes)).filter(
-          (val, idx, arr) =>
-            arr.findIndex(el => el.variationAttributeId === val.variationAttributeId && el.value === val.value) === idx
-        ),
+        variationAttributeValues: variations
+          .map(v => v.variableVariationAttributes)
+          .flat()
+          .filter(
+            (val, idx, arr) =>
+              arr.findIndex(el => el.variationAttributeId === val.variationAttributeId && el.value === val.value) ===
+              idx
+          ),
       }
     );
   }

--- a/src/app/core/services/products/products.service.ts
+++ b/src/app/core/services/products/products.service.ts
@@ -1,6 +1,6 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { flatten, range } from 'lodash-es';
+import { range } from 'lodash-es';
 import { Observable, from, identity, of, throwError } from 'rxjs';
 import { defaultIfEmpty, map, mergeMap, switchMap, toArray, withLatestFrom } from 'rxjs/operators';
 
@@ -289,7 +289,7 @@ export class ProductsService {
                 }),
                 mergeMap(identity, 2),
                 toArray(),
-                map(resp2 => [...resp.elements, ...flatten(resp2)])
+                map(resp2 => [...resp.elements, ...resp2.flat()])
               )
         ),
         map((links: ProductVariationLink[]) => ({

--- a/src/app/core/store/shopping/product-listing/product-listing.selectors.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.selectors.ts
@@ -1,6 +1,6 @@
 import { Dictionary } from '@ngrx/entity';
 import { createSelector, createSelectorFactory, resultMemoize } from '@ngrx/store';
-import { flatten, isEqual, memoize, once, range } from 'lodash-es';
+import { isEqual, memoize, once, range } from 'lodash-es';
 import { identity } from 'rxjs';
 
 import {
@@ -28,7 +28,7 @@ const getProductListingSettings = createSelector(getProductListingState, state =
 const { selectEntities: getProductListingEntities } = adapter.getSelectors(getProductListingState);
 
 function mergeAllPages(data: ProductListingType) {
-  return flatten(data.pages.map(page => data[page]));
+  return data.pages.map(page => data[page]).flat();
 }
 
 function calculatePageIndices(currentPage: number, itemCount: number, itemsPerPage: number) {

--- a/src/app/extensions/quoting/services/quoting/quoting.service.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.ts
@@ -1,6 +1,6 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { flatten, pick } from 'lodash-es';
+import { pick } from 'lodash-es';
 import { EMPTY, Observable, concat, defer, forkJoin, iif, of, throwError } from 'rxjs';
 import { concatMap, defaultIfEmpty, expand, filter, last, map, take } from 'rxjs/operators';
 
@@ -48,7 +48,7 @@ export class QuotingService {
           map(qrs => qrs.reverse()),
           map((quotes: QuoteData[]) => quotes.map(data => this.quoteMapper.fromData(data, 'Quote')))
         ),
-    ]).pipe(map(flatten));
+    ]).pipe(map(quotes => quotes.flat()));
   }
 
   getQuoteDetails(id: string, type: 'Quote' | 'QuoteRequest', completenessLevel: QuoteCompletenessLevel) {

--- a/src/app/extensions/wishlists/store/wishlist/wishlist.selectors.ts
+++ b/src/app/extensions/wishlists/store/wishlist/wishlist.selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector, createSelectorFactory, resultMemoize } from '@ngrx/store';
-import { flatten, uniq } from 'lodash-es';
+import { uniq } from 'lodash-es';
 
 import { isArrayEqual } from 'ish-core/utils/functions';
 
@@ -37,5 +37,5 @@ export const getPreferredWishlist = createSelector(getAllWishlists, entities => 
 export const getAllWishlistsItemsSkus = createSelectorFactory<object, string[]>(projector =>
   resultMemoize(projector, isArrayEqual)
 )(getAllWishlists, (wishlists: Wishlist[]): string[] =>
-  uniq(flatten(wishlists.map(wishlist => wishlist.items.map(items => items.sku))))
+  uniq(wishlists.map(wishlist => wishlist.items.map(items => items.sku)).flat())
 );


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Lodash [`flatten`](https://lodash.com/docs/4.17.15#flatten) is used.

## What Is the New Behavior?

Lodash `flatten` is disallowed and replaced by the new TypeScript [`Array.flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#95730](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95730)