### PR TITLE
feat(nginx): make `worker_processes` and `worker_connections` configurable

### DIFF
--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -269,7 +269,7 @@ The two NGINX modules
 - `ngx_http_brotli_filter_module.so` – for compressing responses on-the-fly
 - `ngx_http_brotli_static_module.so` - for serving pre-compressed files
 
-are built in the [`Dockerfile`](../../nginx/Dockerfile) using an NGINX archive in a version which matches the openresty Docker image version and are referenced in [`nginx.conf`](../../nginx/nginx.conf).
+are built in the [`Dockerfile`](../../nginx/Dockerfile) using an NGINX archive in a version which matches the openresty Docker image version and are referenced in [`nginx.conf.tmpl`](../../nginx/nginx.conf.tmpl).
 The archive needs to be used because it includes the `configure` command.
 The `./configure` [arguments](https://github.com/google/ngx_brotli?tab=readme-ov-file#dynamically-loaded) are taken from the current openresty configuration using `nginx -V` (`--add-module` arguments are excluded), see [ngx_brotli
 ](https://github.com/google/ngx_brotli?tab=readme-ov-file#dynamically-loaded).
@@ -279,6 +279,22 @@ The modules can also be built using an openresty archive, but in this case the b
 - `wget` the openresty archive version which matches the Docker image version
 - replace `make modules` with `make && make install`
 - the two Brotli modules are built into the folder _/build/nginx-<version>/objs/_
+
+## Environment Variables
+
+NGINX environment variables need to be configured in the `cache.extraEnvVars` section of the [PWA Helm Chart](https://github.com/intershop/helm-charts/tree/main/charts/pwa), e.g.
+
+```yaml
+cache:
+  extraEnvVars:
+    - name: NGINX_WORKER_PROCESSES
+      value: auto
+```
+
+| parameter                | format | default | comment                                                  |
+| ------------------------ | ------ | ------- | -------------------------------------------------------- |
+| NGINX_WORKER_PROCESSES   | string | `auto`  | overwrite the default `worker_processes` configuration   |
+| NGINX_WORKER_CONNECTIONS | string | `1024`  | overwrite the default `worker_connections` configuration |
 
 ## Further References
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils libnss3-tools \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf.tmpl /etc/nginx/nginx.conf.tmpl
 COPY features /etc/nginx/features/
 COPY templates /etc/nginx/templates/
 COPY docker-entrypoint.d/*.sh /docker-entrypoint.d/

--- a/nginx/docker-entrypoint.d/40-gomplate.sh
+++ b/nginx/docker-entrypoint.d/40-gomplate.sh
@@ -40,3 +40,5 @@ then
 fi
 
 /gomplate -d "domains=$MULTI_CHANNEL_SOURCE" -d "overrideIdentityProviders=$OVERRIDE_IDENTITY_PROVIDERS_SOURCE" -d "cachingIgnoreParams=$CACHING_IGNORE_PARAMS_SOURCE" -d "additionalHeaders=$ADDITIONAL_HEADERS_SOURCE" -d 'ipwhitelist=env:///BASIC_AUTH_IP_WHITELIST?type=application/yaml' --input-dir="/etc/nginx/templates" --output-map='/etc/nginx/conf.d/{{ .in | strings.ReplaceAll ".conf.tmpl" ".conf" }}'
+
+/gomplate -f /etc/nginx/nginx.conf.tmpl -o /etc/nginx/nginx.conf

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -1,6 +1,6 @@
 
 user nginx;
-worker_processes auto;
+worker_processes {{ getenv "NGINX_WORKER_PROCESSES" "auto" }};
 
 error_log /var/log/nginx-error.log warn;
 error_log /dev/stdout;
@@ -12,7 +12,7 @@ load_module /etc/nginx/modules/ngx_http_brotli_filter_module.so;
 load_module /etc/nginx/modules/ngx_http_brotli_static_module.so;
 
 events {
-    worker_connections 1024;
+    worker_connections {{ getenv "NGINX_WORKER_CONNECTIONS" "1024" }};
 }
 
 env REDIS_URI;


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

`worker_processes auto` and `worker_connections 1024` is currently hard coded in the `nginx.conf` and cannot easily be changed via deployment.

## What Is the New Behavior?

`nginx.conf` is changed to a gomplate template and `worker_processes` and `worker_connections` are now configurable via environment variables `NGINX_WORKER_PROCESSES` and `NGINX_WORKER_CONNECTIONS`.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#95876](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95876)