### PR TITLE
fix: disable hydration HTTP transfer cache

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { APP_ID, NgModule, TransferState } from '@angular/core';
-import { BrowserModule, provideClientHydration } from '@angular/platform-browser';
+import { BrowserModule, provideClientHydration, withNoHttpTransferCache } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UrlSerializer } from '@angular/router';
 
@@ -46,7 +46,7 @@ import { ShellModule } from './shell/shell.module';
   providers: [
     { provide: UrlSerializer, useClass: PWAUrlSerializer },
     { provide: APP_ID, useValue: 'intershop-pwa' },
-    provideClientHydration(),
+    provideClientHydration(withNoHttpTransferCache()),
   ],
 })
 export class AppModule {


### PR DESCRIPTION
## PR Type

[X] Application / infrastructure changes

## What Is the Current Behavior?

The introduction of SSR hydration with the last Angular Upgrade also activated HTTP Cache transfer which is not desired in all cases. The PWA version before was designed to specifically refetch certain resources when booting up on the client (i.e. CMS and Product Data).

## What Is the New Behavior?

HTTP Client Cache is disabled again.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#95994](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95994)