### PR TITLE
feat: use template for environment.development.ts if avalable

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -56,6 +56,9 @@ This environment file references two more files:
 - `environment.model.ts` where "ENVIRONMENT_DEFAULTS" are taken from
 - `environment.development.ts` where you can add your own configuration only for the local development environment, see overrides explanation above.
 
+To provide a common `environment.development.ts` base configuration for projects one can add the file `src/environments/environment.development.ts.template` to the project sources and pre-configure it for the projects context.
+This template will then be used by the initial `npm install` instead of our standard development configuration.
+
 ## Development Server
 
 Run `ng serve` or `ng s` for a development server.

--- a/scripts/init-development-environment.js
+++ b/scripts/init-development-environment.js
@@ -1,32 +1,17 @@
+const fs = require('fs');
+
 const force = process.argv.length > 2 && process.argv.slice(2).find(arg => arg === '-f' || arg === '--force');
 const empty = process.argv.length > 2 && process.argv.slice(2).find(arg => arg === '--empty');
 
-const envDevFile = 'src/environments/environment.development.ts';
+const envDevPath = 'src/environments/environment.development.ts';
+const envDevTemplatePath = 'src/environments/environment.development.ts.template';
 
-const fs = require('fs');
-
-if (empty) {
-  console.log('writing empty ' + envDevFile);
-
-  fs.writeFileSync(
-    envDevFile,
-    `import { Environment } from "./environment.model";
-
-export const overrides: Partial<Environment> = {};
-`
-  );
-} else if (!fs.existsSync(envDevFile) || force) {
-  if (fs.existsSync(envDevFile)) {
-    const environmentLocalBackupPath = envDevFile + '.bak';
-    console.log('creating backup ' + environmentLocalBackupPath);
-    fs.renameSync(envDevFile, environmentLocalBackupPath);
-  }
-
-  console.log('writing ' + envDevFile);
-
-  fs.writeFileSync(
-    envDevFile,
-    `import { Environment } from "./environment.model";
+/** @type string */
+let envDevTemplate;
+if (fs.existsSync(envDevTemplatePath)) {
+  envDevTemplate = fs.readFileSync('src/environments/environment.development.ts.template', 'utf8');
+} else {
+  envDevTemplate = `import { Environment } from "./environment.model";
 
 /* eslint-disable */
 
@@ -40,8 +25,29 @@ export const overrides: Partial<Environment> = {
 
   // features: ['compare'],
 };
+`;
+}
+
+if (empty) {
+  console.log('writing empty ' + envDevPath);
+
+  fs.writeFileSync(
+    envDevPath,
+    `import { Environment } from "./environment.model";
+
+export const overrides: Partial<Environment> = {};
 `
   );
+} else if (!fs.existsSync(envDevPath) || force) {
+  if (fs.existsSync(envDevPath)) {
+    const environmentLocalBackupPath = envDevPath + '.bak';
+    console.log('creating backup ' + environmentLocalBackupPath);
+    fs.renameSync(envDevPath, environmentLocalBackupPath);
+  }
+
+  console.log('writing ' + envDevPath);
+
+  fs.writeFileSync(envDevPath, envDevTemplate);
 } else {
-  console.log('not overwriting existing ' + envDevFile);
+  console.log('not overwriting existing ' + envDevPath);
 }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

When the template for `environment.development.ts` has to be customized for a project, it has to be done in the script.

## What Is the New Behavior?

The script searches for a template file first.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ ] No

## Other Information


[AB#96075](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96075)