### PR TITLE
fix: URI components are not encoded correctly (#1640)

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -21,6 +21,12 @@ A few Stylelint rules were changed and the `.scss` files were adapted.
 In addition empty comments in `.scss` files are no longer allowed and removed.
 In migration projects either keep the Stylelint rules with the old settings or migrate all your styling files accordingly running `npm run format`.
 
+The method [`encodeResourceID`](../../src/app/core/utils/url-resource-ids.ts) is now used to encode all dynamic resource IDs in any REST API call.
+This was previously only done for the login but is now consistently used for all resource IDs.
+For ICM 7.10 and ICM 11 this is done by default with a duplicated `encodeURIComponent` encoding.
+For ICM 12 and newer this needs to be changed to a single `encodeURIComponent` with additional `+` character handling.
+The ICM 12 handling is already prepared in [`encodeResourceID`](../../src/app/core/utils/url-resource-ids.ts) and needs to be activated in the source code if the Intershop PWA is used together with ICM 12.
+
 ## From 5.0 to 5.1
 
 The OrderListComponent is strictly presentational, components using it have to supply the data.

--- a/projects/organization-management/src/app/services/cost-centers/cost-centers.service.spec.ts
+++ b/projects/organization-management/src/app/services/cost-centers/cost-centers.service.spec.ts
@@ -7,12 +7,15 @@ import { CostCenterBase, CostCenterBuyer } from 'ish-core/models/cost-center/cos
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { CostCentersService } from './cost-centers.service';
 
 describe('Cost Centers Service', () => {
   let apiService: ApiService;
   let costCentersService: CostCentersService;
+  const millersEMail = 'pmiller@test.intershop.de';
+  const millersCostcenterEndpoint = `customers/4711/costcenters/123/buyers/${encodeResourceID(millersEMail)}`;
 
   beforeEach(() => {
     apiService = mock(ApiService);
@@ -107,23 +110,19 @@ describe('Cost Centers Service', () => {
   });
 
   it('should call the updateCostCenterBuyer of the customer API for updating a cost center buyer', done => {
-    const costCenterBuyer = { login: 'pmiller@test.intershop.de' } as CostCenterBuyer;
+    const costCenterBuyer = { login: millersEMail } as CostCenterBuyer;
 
     costCentersService.updateCostCenterBuyer('123', costCenterBuyer).subscribe(() => {
       verify(apiService.patch(anything(), anything())).once();
-      expect(capture(apiService.patch).last()[0]).toMatchInlineSnapshot(
-        `"customers/4711/costcenters/123/buyers/pmiller%2540test.intershop.de"`
-      );
+      expect(capture(apiService.patch).last()[0]).toMatchInlineSnapshot(`"${millersCostcenterEndpoint}"`);
       done();
     });
   });
 
   it('should call the deleteCostCenterBuyer of the customer API for deleting a cost center buyer', done => {
-    costCentersService.deleteCostCenterBuyer('123', 'pmiller@test.intershop.de').subscribe(() => {
+    costCentersService.deleteCostCenterBuyer('123', millersEMail).subscribe(() => {
       verify(apiService.delete(anything())).once();
-      expect(capture(apiService.delete).last()[0]).toMatchInlineSnapshot(
-        `"customers/4711/costcenters/123/buyers/pmiller%2540test.intershop.de"`
-      );
+      expect(capture(apiService.delete).last()[0]).toMatchInlineSnapshot(`"${millersCostcenterEndpoint}"`);
       done();
     });
   });

--- a/projects/organization-management/src/app/services/cost-centers/cost-centers.service.ts
+++ b/projects/organization-management/src/app/services/cost-centers/cost-centers.service.ts
@@ -25,7 +25,7 @@ export class CostCentersService {
   getCostCenters(): Observable<CostCenter[]> {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
-        this.apiService.get(`customers/${customer.customerNo}/costcenters`).pipe(
+        this.apiService.get(`customers/${encodeResourceID(customer.customerNo)}/costcenters`).pipe(
           this.apiService.resolveLinks<CostCenterData>(),
           map(ccData => ccData.map(CostCenterMapper.fromData))
         )
@@ -47,7 +47,9 @@ export class CostCentersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .get<CostCenterData>(`customers/${customer.customerNo}/costcenters/${costCenterId}`)
+          .get<CostCenterData>(
+            `customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(costCenterId)}`
+          )
           .pipe(map(CostCenterMapper.fromData))
       )
     );
@@ -67,7 +69,7 @@ export class CostCentersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .post<CostCenterData>(`customers/${customer.customerNo}/costcenters`, costCenter)
+          .post<CostCenterData>(`customers/${encodeResourceID(customer.customerNo)}/costcenters`, costCenter)
           .pipe(concatMap(() => this.getCostCenter(costCenter.costCenterId)))
       )
     );
@@ -87,7 +89,10 @@ export class CostCentersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .patch<CostCenterData>(`customers/${customer.customerNo}/costcenters/${costCenter.id}`, costCenter)
+          .patch<CostCenterData>(
+            `customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(costCenter.id)}`,
+            costCenter
+          )
           .pipe(map(CostCenterMapper.fromData))
       )
     );
@@ -104,7 +109,9 @@ export class CostCentersService {
     }
 
     return this.currentCustomer$.pipe(
-      switchMap(customer => this.apiService.delete(`customers/${customer.customerNo}/costcenters/${id}`))
+      switchMap(customer =>
+        this.apiService.delete(`customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(id)}`)
+      )
     );
   }
 
@@ -127,7 +134,10 @@ export class CostCentersService {
       concatMap(customer =>
         forkJoin(
           buyers.map(buyer =>
-            this.apiService.post(`customers/${customer.customerNo}/costcenters/${costCenterId}/buyers`, buyer)
+            this.apiService.post(
+              `customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(costCenterId)}/buyers`,
+              buyer
+            )
           )
         ).pipe(concatMap(() => this.getCostCenter(costCenterId)))
       )
@@ -153,7 +163,9 @@ export class CostCentersService {
       switchMap(customer =>
         this.apiService
           .patch(
-            `customers/${customer.customerNo}/costcenters/${costCenterId}/buyers/${encodeResourceID(buyer.login)}`,
+            `customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(
+              costCenterId
+            )}/buyers/${encodeResourceID(buyer.login)}`,
             buyer
           )
           .pipe(concatMap(() => this.getCostCenter(costCenterId)))
@@ -179,7 +191,11 @@ export class CostCentersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .delete(`customers/${customer.customerNo}/costcenters/${costCenterId}/buyers/${encodeResourceID(login)}`)
+          .delete(
+            `customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(
+              costCenterId
+            )}/buyers/${encodeResourceID(login)}`
+          )
           .pipe(concatMap(() => this.getCostCenter(costCenterId)))
       )
     );

--- a/projects/organization-management/src/app/services/users/users.service.spec.ts
+++ b/projects/organization-management/src/app/services/users/users.service.spec.ts
@@ -7,6 +7,7 @@ import { AppFacade } from 'ish-core/facades/app.facade';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { B2bRoleData } from '../../models/b2b-role/b2b-role.interface';
 import { B2bUser } from '../../models/b2b-user/b2b-user.model';
@@ -18,6 +19,8 @@ describe('Users Service', () => {
   let apiService: ApiService;
   let usersService: UsersService;
   let appFacade: AppFacade;
+  const millersEMail = 'pmiller@test.intershop.de';
+  const millersEndpoint = `customers/4711/users/${encodeResourceID(millersEMail)}`;
 
   beforeEach(() => {
     apiService = mock(ApiService);
@@ -59,11 +62,11 @@ describe('Users Service', () => {
   });
 
   it('should call the getUser of customer API when fetching user', done => {
-    usersService.getUser('pmiller@test.intershop.de').subscribe(() => {
+    usersService.getUser(millersEMail).subscribe(() => {
       verify(apiService.get(anything())).once();
       expect(capture(apiService.get).last()).toMatchInlineSnapshot(`
         [
-          "customers/4711/users/pmiller%2540test.intershop.de",
+          "${millersEndpoint}",
         ]
       `);
       done();
@@ -71,11 +74,11 @@ describe('Users Service', () => {
   });
 
   it('should call delete method of customer API when delete user', done => {
-    usersService.deleteUser('pmiller@test.intershop.de').subscribe(() => {
+    usersService.deleteUser(millersEMail).subscribe(() => {
       verify(apiService.delete(anything())).once();
       expect(capture(apiService.delete).last()).toMatchInlineSnapshot(`
         [
-          "customers/4711/users/pmiller%2540test.intershop.de",
+          "${millersEndpoint}",
         ]
       `);
       done();
@@ -83,7 +86,7 @@ describe('Users Service', () => {
   });
 
   it('should call the addUser for creating a new b2b user', done => {
-    const user = { login: 'pmiller@test.intershop.de' } as B2bUser;
+    const user = { login: millersEMail } as B2bUser;
 
     usersService.addUser(user).subscribe(() => {
       verify(apiService.post(anything(), anything())).once();
@@ -93,13 +96,11 @@ describe('Users Service', () => {
   });
 
   it('should call the updateUser for updating a b2b user', done => {
-    const user = { login: 'pmiller@test.intershop.de' } as B2bUser;
+    const user = { login: millersEMail } as B2bUser;
 
     usersService.updateUser(user).subscribe(() => {
       verify(apiService.put(anything(), anything())).once();
-      expect(capture(apiService.put).last()[0]).toMatchInlineSnapshot(
-        `"customers/4711/users/pmiller%2540test.intershop.de"`
-      );
+      expect(capture(apiService.put).last()[0]).toMatchInlineSnapshot(`"${millersEndpoint}"`);
       done();
     });
   });
@@ -107,7 +108,7 @@ describe('Users Service', () => {
   it('should put the roles onto user when calling setUserRoles', done => {
     when(apiService.put(anyString(), anything())).thenReturn(of({ userRoles: [{ roleID: 'BUYER' }] as B2bRoleData[] }));
 
-    usersService.setUserRoles('pmiller@test.intershop.de', []).subscribe(data => {
+    usersService.setUserRoles(millersEMail, []).subscribe(data => {
       expect(data).toMatchInlineSnapshot(`
         [
           "BUYER",
@@ -116,7 +117,7 @@ describe('Users Service', () => {
       verify(apiService.put(anything(), anything())).once();
       expect(capture(apiService.put).last()).toMatchInlineSnapshot(`
         [
-          "customers/4711/users/pmiller%2540test.intershop.de/roles",
+          "${millersEndpoint}/roles",
           {
             "userRoles": [],
           },
@@ -130,7 +131,7 @@ describe('Users Service', () => {
     when(apiService.put(anyString(), anything())).thenReturn(of({}));
 
     usersService
-      .setUserBudget('pmiller@test.intershop.de', {
+      .setUserBudget(millersEMail, {
         orderSpentLimit: undefined,
         budget: { value: 2000, currency: 'USD' },
         budgetPeriod: 'monthly',
@@ -140,7 +141,7 @@ describe('Users Service', () => {
         verify(apiService.put(anything(), anything())).once();
         expect(capture(apiService.put).last()).toMatchInlineSnapshot(`
           [
-            "customers/4711/users/pmiller%2540test.intershop.de/budgets",
+            "${millersEndpoint}/budgets",
             {
               "budget": {
                 "currency": "USD",

--- a/projects/organization-management/src/app/services/users/users.service.ts
+++ b/projects/organization-management/src/app/services/users/users.service.ts
@@ -37,7 +37,7 @@ export class UsersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .get(`customers/${customer.customerNo}/users`)
+          .get(`customers/${encodeResourceID(customer.customerNo)}/users`)
           .pipe(unpackEnvelope(), map(B2bUserMapper.fromListData))
       )
     );
@@ -53,7 +53,7 @@ export class UsersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .get(`customers/${customer.customerNo}/users/${encodeResourceID(login)}`)
+          .get(`customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(login)}`)
           .pipe(map(B2bUserMapper.fromData))
       )
     );
@@ -74,7 +74,7 @@ export class UsersService {
       withLatestFrom(this.appFacade.currentLocale$),
       switchMap(([customer, currentLocale]) =>
         this.apiService
-          .post<B2bUser>(`customers/${customer.customerNo}/users`, {
+          .post<B2bUser>(`customers/${encodeResourceID(customer.customerNo)}/users`, {
             elements: [
               {
                 ...customer,
@@ -120,7 +120,7 @@ export class UsersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .put(`customers/${customer.customerNo}/users/${encodeResourceID(user.login)}`, {
+          .put(`customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}`, {
             ...customer,
             ...user,
             preferredInvoiceToAddress: { urn: user.preferredInvoiceToAddressUrn },
@@ -147,14 +147,16 @@ export class UsersService {
     }
 
     return this.currentCustomer$.pipe(
-      switchMap(customer => this.apiService.delete(`customers/${customer.customerNo}/users/${encodeResourceID(login)}`))
+      switchMap(customer =>
+        this.apiService.delete(`customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(login)}`)
+      )
     );
   }
 
   getAvailableRoles(): Observable<B2bRole[]> {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
-        this.apiService.get(`customers/${customer.customerNo}/roles`).pipe(
+        this.apiService.get(`customers/${encodeResourceID(customer.customerNo)}/roles`).pipe(
           unpackEnvelope<B2bRoleData>('userRoles'),
           map(data => this.b2bRoleMapper.fromData(data))
         )
@@ -171,7 +173,9 @@ export class UsersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .put(`customers/${customer.customerNo}/users/${encodeResourceID(login)}/roles`, { userRoles })
+          .put(`customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(login)}/roles`, {
+            userRoles,
+          })
           .pipe(
             unpackEnvelope<B2bRoleData>('userRoles'),
             map(data => data.map(r => r.roleID))
@@ -195,7 +199,7 @@ export class UsersService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService.put<UserBudget>(
-          `customers/${customer.customerNo}/users/${encodeResourceID(login)}/budgets`,
+          `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(login)}/budgets`,
           budget
         )
       )

--- a/src/app/core/services/address/address.service.ts
+++ b/src/app/core/services/address/address.service.ts
@@ -7,6 +7,7 @@ import { AddressMapper } from 'ish-core/models/address/address.mapper';
 import { Address } from 'ish-core/models/address/address.model';
 import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 /**
  * The Address Service handles the interaction with the REST API concerning addresses.
@@ -25,7 +26,7 @@ export class AddressService {
     return this.appFacade.customerRestResource$.pipe(
       first(),
       concatMap(restResource =>
-        this.apiService.get(`${restResource}/${customerId}/addresses`).pipe(
+        this.apiService.get(`${restResource}/${encodeResourceID(customerId)}/addresses`).pipe(
           unpackEnvelope<Link>(),
           this.apiService.resolveLinks<Address>(),
           map(addressesData => addressesData.map(AddressMapper.fromData))
@@ -51,7 +52,7 @@ export class AddressService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .post(`${restResource}/${customerId}/addresses`, customerAddress)
+          .post(`${restResource}/${encodeResourceID(customerId)}/addresses`, customerAddress)
           .pipe(this.apiService.resolveLink<Address>(), map(AddressMapper.fromData))
       )
     );
@@ -73,7 +74,10 @@ export class AddressService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .put(`${restResource}/${customerId}/addresses/${address.id}`, customerAddress)
+          .put(
+            `${restResource}/${encodeResourceID(customerId)}/addresses/${encodeResourceID(address.id)}`,
+            customerAddress
+          )
           .pipe(map(AddressMapper.fromData))
       )
     );
@@ -90,7 +94,9 @@ export class AddressService {
     return this.appFacade.customerRestResource$.pipe(
       first(),
       concatMap(restResource =>
-        this.apiService.delete(`${restResource}/${customerId}/addresses/${addressId}`).pipe(map(() => addressId))
+        this.apiService
+          .delete(`${restResource}/${encodeResourceID(customerId)}/addresses/${encodeResourceID(addressId)}`)
+          .pipe(map(() => addressId))
       )
     );
   }

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -326,26 +326,36 @@ export class ApiService {
       get: <T>(path: string, options?: AvailableOptions) =>
         ids$.pipe(
           concatMap(([user, customer]) =>
-            this.get<T>(`customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/${path}`, options)
+            this.get<T>(
+              `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/${path}`,
+              options
+            )
           )
         ),
       delete: <T>(path: string, options?: AvailableOptions) =>
         ids$.pipe(
           concatMap(([user, customer]) =>
-            this.delete<T>(`customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/${path}`, options)
+            this.delete<T>(
+              `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/${path}`,
+              options
+            )
           )
         ),
       put: <T>(path: string, body = {}, options?: AvailableOptions) =>
         ids$.pipe(
           concatMap(([user, customer]) =>
-            this.put<T>(`customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/${path}`, body, options)
+            this.put<T>(
+              `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/${path}`,
+              body,
+              options
+            )
           )
         ),
       patch: <T>(path: string, body = {}, options?: AvailableOptions) =>
         ids$.pipe(
           concatMap(([user, customer]) =>
             this.patch<T>(
-              `customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/${path}`,
+              `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/${path}`,
               body,
               options
             )
@@ -355,7 +365,7 @@ export class ApiService {
         ids$.pipe(
           concatMap(([user, customer]) =>
             this.post<T>(
-              `customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/${path}`,
+              `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/${path}`,
               body,
               options
             )

--- a/src/app/core/services/authorization/authorization.service.ts
+++ b/src/app/core/services/authorization/authorization.service.ts
@@ -22,7 +22,9 @@ export class AuthorizationService {
     }
 
     return this.apiService
-      .get<AuthorizationData>(`customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/roles`)
+      .get<AuthorizationData>(
+        `customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/roles`
+      )
       .pipe(map(data => this.authorizationMapper.fromData(data)));
   }
 }

--- a/src/app/core/services/newsletter/newsletter.service.spec.ts
+++ b/src/app/core/services/newsletter/newsletter.service.spec.ts
@@ -6,6 +6,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getNewsletterSubscriptionStatus } from 'ish-core/store/customer/user';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { NewsletterService } from './newsletter.service';
 
@@ -14,7 +15,8 @@ describe('Newsletter Service', () => {
   let apiServiceMock: ApiService;
   let store$: MockStore;
 
-  let userEmail: string;
+  const userEmail = 'user@test.com';
+  const usersSubscriptionEndpoint = `subscriptions/${encodeResourceID(userEmail)}`;
 
   beforeEach(() => {
     apiServiceMock = mock(ApiService);
@@ -23,9 +25,6 @@ describe('Newsletter Service', () => {
     });
     newsletterService = TestBed.inject(NewsletterService);
     store$ = TestBed.inject(MockStore);
-
-    userEmail = 'user@test.com';
-
     store$.overrideSelector(getNewsletterSubscriptionStatus, false);
   });
 
@@ -48,7 +47,7 @@ describe('Newsletter Service', () => {
     const newStatus = false;
 
     newsletterService.updateNewsletterSubscriptionStatus(newStatus, userEmail).subscribe(subscriptionStatus => {
-      verify(apiServiceMock.delete(`subscriptions/${userEmail}`)).once();
+      verify(apiServiceMock.delete(usersSubscriptionEndpoint)).once();
       expect(subscriptionStatus).toBeFalse();
       done();
     });
@@ -61,7 +60,7 @@ describe('Newsletter Service', () => {
     const newStatus = true;
 
     newsletterService.updateNewsletterSubscriptionStatus(newStatus, userEmail).subscribe(subscriptionStatus => {
-      verify(apiServiceMock.delete(`subscriptions/${userEmail}`)).never();
+      verify(apiServiceMock.delete(usersSubscriptionEndpoint)).never();
       expect(subscriptionStatus).toBeTrue();
       done();
     });
@@ -71,7 +70,7 @@ describe('Newsletter Service', () => {
     when(apiServiceMock.get(anything())).thenReturn(of({ active: true }));
 
     newsletterService.getSubscription(userEmail).subscribe(subscriptionStatus => {
-      verify(apiServiceMock.get(`subscriptions/${userEmail}`)).once();
+      verify(apiServiceMock.get(usersSubscriptionEndpoint)).once();
       expect(subscriptionStatus).toBeTrue();
       done();
     });
@@ -79,7 +78,7 @@ describe('Newsletter Service', () => {
     when(apiServiceMock.get(anything())).thenReturn(of({ active: false }));
 
     newsletterService.getSubscription(userEmail).subscribe(subscriptionStatus => {
-      verify(apiServiceMock.get(`subscriptions/${userEmail}`)).once();
+      verify(apiServiceMock.get(usersSubscriptionEndpoint)).once();
       expect(subscriptionStatus).toBeFalse();
       done();
     });
@@ -91,7 +90,7 @@ describe('Newsletter Service', () => {
     );
 
     newsletterService.getSubscription(userEmail).subscribe(subscriptionStatus => {
-      verify(apiServiceMock.get(`subscriptions/${userEmail}`)).once();
+      verify(apiServiceMock.get(usersSubscriptionEndpoint)).once();
       expect(subscriptionStatus).toBeFalse();
       done();
     });
@@ -99,7 +98,7 @@ describe('Newsletter Service', () => {
     when(apiServiceMock.get(anything())).thenReturn(of({ active: false }));
 
     newsletterService.getSubscription(userEmail).subscribe(subscriptionStatus => {
-      verify(apiServiceMock.get(`subscriptions/${userEmail}`)).once();
+      verify(apiServiceMock.get(usersSubscriptionEndpoint)).once();
       expect(subscriptionStatus).toBeFalse();
       done();
     });

--- a/src/app/core/services/newsletter/newsletter.service.ts
+++ b/src/app/core/services/newsletter/newsletter.service.ts
@@ -4,6 +4,7 @@ import { Observable, catchError, map, of, switchMap, take, throwError } from 'rx
 
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getNewsletterSubscriptionStatus } from 'ish-core/store/customer/user';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 /**
  * The Newsletter Service handles the newsletter related interaction with the 'subscriptions' REST API.
@@ -22,7 +23,7 @@ export class NewsletterService {
    *                     Returns 'false' when a 404-error is thrown, which is the APIs response for "no subscription found".
    */
   getSubscription(userEmail: string): Observable<boolean> {
-    return this.apiService.get(`subscriptions/${userEmail}`).pipe(
+    return this.apiService.get(`subscriptions/${encodeResourceID(userEmail)}`).pipe(
       map((params: { active: boolean }) => params.active),
       catchError(error => {
         if (error.status === 404) {
@@ -73,6 +74,6 @@ export class NewsletterService {
    * always returns 'false'
    */
   private unsubscribeFromNewsletter(userEmail: string): Observable<boolean> {
-    return this.apiService.delete(`subscriptions/${userEmail}`).pipe(map(() => false));
+    return this.apiService.delete(`subscriptions/${encodeResourceID(userEmail)}`).pipe(map(() => false));
   }
 }

--- a/src/app/core/services/payment/payment.service.ts
+++ b/src/app/core/services/payment/payment.service.ts
@@ -20,6 +20,7 @@ import { PaymentMethod } from 'ish-core/models/payment-method/payment-method.mod
 import { Payment } from 'ish-core/models/payment/payment.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
 import { getCurrentLocale } from 'ish-core/store/core/configuration';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 /**
  * The Payment Service handles the interaction with the 'baskets' and 'users' REST API concerning payment functionality.
@@ -209,9 +210,12 @@ export class PaymentService {
     }
 
     // basket payment instrument, payment will be deleted automatically, if necessary
-    return this.apiService.delete(`baskets/${basket.id}/payment-instruments/${paymentInstrument.id}`, {
-      headers: this.basketHeaders,
-    });
+    return this.apiService.delete(
+      `baskets/${encodeResourceID(basket.id)}/payment-instruments/${encodeResourceID(paymentInstrument.id)}`,
+      {
+        headers: this.basketHeaders,
+      }
+    );
   }
 
   /**
@@ -227,9 +231,12 @@ export class PaymentService {
       return of();
     }
 
-    return this.apiService.delete(`baskets/${basket.id}/payments/${basket.payment.id}`, {
-      headers: this.basketHeaders,
-    });
+    return this.apiService.delete(
+      `baskets/${encodeResourceID(basket.id)}/payments/${encodeResourceID(basket.payment.id)}`,
+      {
+        headers: this.basketHeaders,
+      }
+    );
   }
 
   /**
@@ -246,11 +253,11 @@ export class PaymentService {
     return this.appFacade.customerRestResource$.pipe(
       first(),
       concatMap(restResource =>
-        this.apiService.get(`${restResource}/${customer.customerNo}/payments`).pipe(
+        this.apiService.get(`${restResource}/${encodeResourceID(customer.customerNo)}/payments`).pipe(
           unpackEnvelope<Link>(),
           this.apiService.resolveLinks<PaymentInstrumentData>(),
           concatMap(instruments =>
-            this.apiService.options(`${restResource}/${customer.customerNo}/payments`).pipe(
+            this.apiService.options(`${restResource}/${encodeResourceID(customer.customerNo)}/payments`).pipe(
               unpackEnvelope<PaymentMethodOptionsDataType>('methods'),
               map(methods => PaymentMethodMapper.fromOptions({ methods, instruments }))
             )
@@ -292,7 +299,7 @@ export class PaymentService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .post(`${restResource}/${customerNo}/payments`, body)
+          .post(`${restResource}/${encodeResourceID(customerNo)}/payments`, body)
           .pipe(this.apiService.resolveLink<PaymentInstrument>())
       )
     );
@@ -363,7 +370,7 @@ export class PaymentService {
       };
 
       return this.apiService
-        .put(`customers/-/payments/${paymentInstrument.id}`, body)
+        .put(`customers/-/payments/${encodeResourceID(paymentInstrument.id)}`, body)
         .pipe(map(() => paymentInstrument));
     }
   }

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -291,7 +291,9 @@ export class UserService {
       select(getLoggedInCustomer),
       map(customer => customer?.customerNo || '-'),
       take(1),
-      concatMap(customerNo => this.apiService.get(`customers/${customerNo}/users/-`).pipe(map(UserMapper.fromData)))
+      concatMap(customerNo =>
+        this.apiService.get(`customers/${encodeResourceID(customerNo)}/users/-`).pipe(map(UserMapper.fromData))
+      )
     );
   }
 
@@ -333,10 +335,12 @@ export class UserService {
     ]).pipe(
       take(1),
       switchMap(([customer, user]) =>
-        this.apiService.get(`customers/${customer.customerNo}/users/${encodeResourceID(user.login)}/costcenters`).pipe(
-          unpackEnvelope(),
-          map((costCenters: UserCostCenter[]) => costCenters)
-        )
+        this.apiService
+          .get(`customers/${encodeResourceID(customer.customerNo)}/users/${encodeResourceID(user.login)}/costcenters`)
+          .pipe(
+            unpackEnvelope(),
+            map((costCenters: UserCostCenter[]) => costCenters)
+          )
       )
     );
   }
@@ -359,7 +363,9 @@ export class UserService {
       take(1),
       switchMap(([customer, permissions]) => {
         if (permissions.includes('APP_B2B_VIEW_COSTCENTER')) {
-          return this.apiService.get<CostCenter>(`customers/${customer.customerNo}/costcenters/${id}`);
+          return this.apiService.get<CostCenter>(
+            `customers/${encodeResourceID(customer.customerNo)}/costcenters/${encodeResourceID(id)}`
+          );
         } else {
           return of(undefined);
         }

--- a/src/app/core/utils/url-resource-ids.ts
+++ b/src/app/core/utils/url-resource-ids.ts
@@ -7,8 +7,10 @@
  * @returns             The encoded resource ID.
  */
 export function encodeResourceID(resourceID: string): string {
+  // ICM 7.10 & ICM 11 resource ID encoding
   return encodeURIComponent(encodeURIComponent(resourceID));
-  // ICM 12.0.0 (estimated release)
+
+  // ICM 12 and above resource ID encoding
   // encodeURIComponent replaces spaces with '+' that's not RFC conform.
   // Therefore, we encode existing '+' with '%2B', converting the string with encodeURIComponent,
   // and converting '%2B' ('%252B' after encodeURIComponent) to '+' back.

--- a/src/app/core/utils/url-resource-ids.ts
+++ b/src/app/core/utils/url-resource-ids.ts
@@ -1,10 +1,13 @@
 /**
- * Encodes a given resource ID in a way that can be processed by ICM.
- * To support e.g. special characters in email addresses, like '+', double encoding is necessary.
+ * To support special characters (slash, percent and plus char) of user defined URI Components (like login, email, ...).
+ * This method encodes a given resource ID in a way that can be processed by ICM.
+ * REST API of ICM version pre 12.0 encode the URI components twice, because of former restriction of the httpd.
  *
  * @param resourceID    The resource ID to be encoded.
  * @returns             The encoded resource ID.
  */
 export function encodeResourceID(resourceID: string): string {
   return encodeURIComponent(encodeURIComponent(resourceID));
+  // ICM 12.0.0 (estimated release)
+  // return encodeURIComponent(resourceID);
 }

--- a/src/app/core/utils/url-resource-ids.ts
+++ b/src/app/core/utils/url-resource-ids.ts
@@ -9,5 +9,8 @@
 export function encodeResourceID(resourceID: string): string {
   return encodeURIComponent(encodeURIComponent(resourceID));
   // ICM 12.0.0 (estimated release)
+  // encodeURIComponent replaces spaces with '+' that's not RFC conform.
+  // Therefore, we encode existing '+' with '%2B', converting the string with encodeURIComponent,
+  // and converting '%2B' ('%252B' after encodeURIComponent) to '+' back.
   // return encodeURIComponent(resourceID.replaceAll('+', '%2B')).replaceAll('\\+', '%20').replaceAll('%252B', '+');
 }

--- a/src/app/core/utils/url-resource-ids.ts
+++ b/src/app/core/utils/url-resource-ids.ts
@@ -9,5 +9,5 @@
 export function encodeResourceID(resourceID: string): string {
   return encodeURIComponent(encodeURIComponent(resourceID));
   // ICM 12.0.0 (estimated release)
-  // return encodeURIComponent(resourceID);
+  // return encodeURIComponent(resourceID.replaceAll('+', '%2B')).replaceAll('\\+', '%20').replaceAll('%252B', '+');
 }

--- a/src/app/extensions/order-templates/services/order-template/order-template.service.ts
+++ b/src/app/extensions/order-templates/services/order-template/order-template.service.ts
@@ -3,6 +3,7 @@ import { Observable, forkJoin, of, throwError } from 'rxjs';
 import { concatMap, map, switchMap } from 'rxjs/operators';
 
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { OrderTemplateData } from '../../models/order-template/order-template.interface';
 import { OrderTemplateMapper } from '../../models/order-template/order-template.mapper';
@@ -64,7 +65,7 @@ export class OrderTemplateService {
     if (!orderTemplateId) {
       return throwError(() => new Error('deleteOrderTemplate() called without orderTemplateId'));
     }
-    return this.apiService.delete(`customers/-/users/-/wishlists/${orderTemplateId}`);
+    return this.apiService.delete(`customers/-/users/-/wishlists/${encodeResourceID(orderTemplateId)}`);
   }
 
   /**
@@ -75,7 +76,7 @@ export class OrderTemplateService {
    */
   updateOrderTemplate(orderTemplate: OrderTemplate): Observable<OrderTemplate> {
     return this.apiService
-      .put(`customers/-/users/-/wishlists/${orderTemplate.id}`, orderTemplate)
+      .put(`customers/-/users/-/wishlists/${encodeResourceID(orderTemplate.id)}`, orderTemplate)
       .pipe(map((response: OrderTemplate) => this.orderTemplateMapper.fromUpdate(response, orderTemplate.id)));
   }
 
@@ -95,7 +96,11 @@ export class OrderTemplateService {
       return throwError(() => new Error('addProductToOrderTemplate() called without sku'));
     }
     return this.apiService
-      .post(`customers/-/users/-/wishlists/${orderTemplateId}/products/${sku}?quantity=${quantity}`)
+      .post(
+        `customers/-/users/-/wishlists/${encodeResourceID(orderTemplateId)}/products/${encodeResourceID(
+          sku
+        )}?quantity=${quantity}`
+      )
       .pipe(concatMap(() => this.getOrderTemplate(orderTemplateId)));
   }
 
@@ -114,7 +119,7 @@ export class OrderTemplateService {
       return throwError(() => new Error('removeProductFromOrderTemplate() called without sku'));
     }
     return this.apiService
-      .delete(`customers/-/users/-/wishlists/${orderTemplateId}/products/${sku}`)
+      .delete(`customers/-/users/-/wishlists/${encodeResourceID(orderTemplateId)}/products/${encodeResourceID(sku)}`)
       .pipe(concatMap(() => this.getOrderTemplate(orderTemplateId)));
   }
 }

--- a/src/app/extensions/product-notifications/services/product-notifications/product-notifications.service.ts
+++ b/src/app/extensions/product-notifications/services/product-notifications/product-notifications.service.ts
@@ -6,6 +6,7 @@ import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { whenTruthy } from 'ish-core/utils/operators';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { ProductNotificationData } from '../../models/product-notification/product-notification.interface';
 import { ProductNotificationMapper } from '../../models/product-notification/product-notification.mapper';
@@ -33,8 +34,10 @@ export class ProductNotificationsService {
         this.apiService
           .get(
             customer.isBusinessCustomer
-              ? `customers/${customer.customerNo}/users/-/notifications/${notificationType}`
-              : `privatecustomers/-/notifications/${notificationType}`
+              ? `customers/${encodeResourceID(customer.customerNo)}/users/-/notifications/${encodeResourceID(
+                  notificationType
+                )}`
+              : `privatecustomers/-/notifications/${encodeResourceID(notificationType)}`
           )
           .pipe(
             unpackEnvelope<Link>(),
@@ -63,8 +66,10 @@ export class ProductNotificationsService {
         this.apiService
           .post(
             customer.isBusinessCustomer
-              ? `customers/${customer.customerNo}/users/-/notifications/${productNotification.type}`
-              : `privatecustomers/-/notifications/${productNotification.type}`,
+              ? `customers/${encodeResourceID(customer.customerNo)}/users/-/notifications/${encodeResourceID(
+                  productNotification.type
+                )}`
+              : `privatecustomers/-/notifications/${encodeResourceID(productNotification.type)}`,
             productNotification
           )
           .pipe(
@@ -95,8 +100,12 @@ export class ProductNotificationsService {
         this.apiService
           .put(
             customer.isBusinessCustomer
-              ? `customers/${customer.customerNo}/users/-/notifications/${productNotification.type}/${sku}`
-              : `privatecustomers/-/notifications/${productNotification.type}/${sku}`,
+              ? `customers/${encodeResourceID(customer.customerNo)}/users/-/notifications/${encodeResourceID(
+                  productNotification.type
+                )}/${sku}`
+              : `privatecustomers/-/notifications/${encodeResourceID(productNotification.type)}/${encodeResourceID(
+                  sku
+                )}`,
             productNotification
           )
           .pipe(
@@ -126,8 +135,10 @@ export class ProductNotificationsService {
       switchMap(customer =>
         this.apiService.delete(
           customer.isBusinessCustomer
-            ? `customers/${customer.customerNo}/users/-/notifications/${productNotificationType}/${sku}`
-            : `privatecustomers/-/notifications/${productNotificationType}/${sku}`
+            ? `customers/${encodeResourceID(customer.customerNo)}/users/-/notifications/${encodeResourceID(
+                productNotificationType
+              )}/${sku}`
+            : `privatecustomers/-/notifications/${encodeResourceID(productNotificationType)}/${encodeResourceID(sku)}`
         )
       )
     );

--- a/src/app/extensions/punchout/services/punchout/punchout.service.ts
+++ b/src/app/extensions/punchout/services/punchout/punchout.service.ts
@@ -54,13 +54,15 @@ export class PunchoutService {
   getPunchoutTypes(): Observable<PunchoutType[]> {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
-        this.apiService.get(`customers/${customer.customerNo}/punchouts`, { headers: this.punchoutHeaders }).pipe(
-          unpackEnvelope<Link>(),
-          this.apiService.resolveLinks<{ punchoutType: PunchoutType; version: string }>({
-            headers: this.punchoutHeaders,
-          }),
-          map(types => types?.map(type => type.punchoutType))
-        )
+        this.apiService
+          .get(`customers/${encodeResourceID(customer.customerNo)}/punchouts`, { headers: this.punchoutHeaders })
+          .pipe(
+            unpackEnvelope<Link>(),
+            this.apiService.resolveLinks<{ punchoutType: PunchoutType; version: string }>({
+              headers: this.punchoutHeaders,
+            }),
+            map(types => types?.map(type => type.punchoutType))
+          )
       )
     );
   }
@@ -81,9 +83,14 @@ export class PunchoutService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .get(`customers/${customer.customerNo}/punchouts/${this.getResourceType(punchoutType)}/users`, {
-            headers: this.punchoutHeaders,
-          })
+          .get(
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType(punchoutType)
+            )}/users`,
+            {
+              headers: this.punchoutHeaders,
+            }
+          )
           .pipe(
             unpackEnvelope<Link>(),
             this.apiService.resolveLinks<PunchoutUser>({ headers: this.punchoutHeaders }),
@@ -107,9 +114,15 @@ export class PunchoutService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .post(`customers/${customer.customerNo}/punchouts/${this.getResourceType(user.punchoutType)}/users`, user, {
-            headers: this.punchoutHeaders,
-          })
+          .post(
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType(user.punchoutType)
+            )}/users`,
+            user,
+            {
+              headers: this.punchoutHeaders,
+            }
+          )
           .pipe(
             this.apiService.resolveLink<PunchoutUser>({ headers: this.punchoutHeaders }),
             map(createdUser => ({ ...createdUser, punchoutType: user.punchoutType, password: undefined }))
@@ -133,8 +146,8 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .put<PunchoutUser>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType(
-              user.punchoutType
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType(user.punchoutType)
             )}/users/${encodeResourceID(user.login)}`,
             user,
             {
@@ -159,8 +172,8 @@ export class PunchoutService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService.delete<void>(
-          `customers/${customer.customerNo}/punchouts/${this.getResourceType(
-            user.punchoutType
+          `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+            this.getResourceType(user.punchoutType)
           )}/users/${encodeResourceID(user.login)}`,
           {
             headers: this.punchoutHeaders,
@@ -217,7 +230,9 @@ export class PunchoutService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService.get<PunchoutSession>(
-          `customers/${customer.customerNo}/punchouts/${this.getResourceType('cxml')}/sessions/${sid}`,
+          `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+            this.getResourceType('cxml')
+          )}/sessions/${encodeResourceID(sid)}`,
           {
             headers: this.punchoutHeaders,
           }
@@ -245,7 +260,9 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .post<string>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType('cxml')}/transfer`,
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('cxml')
+            )}/transfer`,
             undefined,
             {
               headers: new HttpHeaders({ Accept: 'text/xml' }),
@@ -306,7 +323,9 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .post<{ data: Attribute<string>[] }>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType('oci')}/transfer`,
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('oci')
+            )}/transfer`,
             undefined,
             {
               headers: this.punchoutHeaders,
@@ -335,7 +354,9 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .get<{ data: Attribute<string>[] }>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType('oci')}/validate`,
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('oci')
+            )}/validate`,
             {
               headers: this.punchoutHeaders,
               params: new HttpParams().set('productId', productId).set('quantity', quantity),
@@ -362,7 +383,9 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .get<{ data: Attribute<string>[] }>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType('oci')}/background-search`,
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('oci')
+            )}/background-search`,
             {
               headers: this.punchoutHeaders,
               params: new HttpParams().set('searchString', searchString),
@@ -423,7 +446,9 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .get<{ items: OciConfigurationItem[] }>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType('oci')}/configurations`,
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('oci')
+            )}/configurations`,
             {
               headers: this.punchoutHeaders,
             }
@@ -442,9 +467,14 @@ export class PunchoutService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .options<OciOptionsData>(`customers/${customer.customerNo}/punchouts/${this.getResourceType('oci')}`, {
-            headers: this.punchoutHeaders,
-          })
+          .options<OciOptionsData>(
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('oci')
+            )}`,
+            {
+              headers: this.punchoutHeaders,
+            }
+          )
           .pipe(map(OciOptionsMapper.fromData))
       )
     );
@@ -465,7 +495,9 @@ export class PunchoutService {
       switchMap(customer =>
         this.apiService
           .put<{ items: OciConfigurationItem[] }>(
-            `customers/${customer.customerNo}/punchouts/${this.getResourceType('oci')}/configurations`,
+            `customers/${encodeResourceID(customer.customerNo)}/punchouts/${encodeResourceID(
+              this.getResourceType('oci')
+            )}/configurations`,
             { items: ociConfiguration },
             {
               headers: this.punchoutHeaders,

--- a/src/app/extensions/rating/services/reviews/reviews.service.ts
+++ b/src/app/extensions/rating/services/reviews/reviews.service.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 
 import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { ProductReview, ProductReviewCreationType } from '../../models/product-reviews/product-review.model';
 import { ProductReviewsMapper } from '../../models/product-reviews/product-reviews.mapper';
@@ -24,7 +25,7 @@ export class ReviewsService {
       return throwError(() => new Error('getProductReviews() called without sku'));
     }
 
-    return this.apiService.get(`products/${sku}/reviews?attrs=own`, { sendSPGID: true }).pipe(
+    return this.apiService.get(`products/${encodeResourceID(sku)}/reviews?attrs=own`, { sendSPGID: true }).pipe(
       unpackEnvelope<Link>(),
       this.apiService.resolveLinks<ProductReview>(),
       map(reviews => ProductReviewsMapper.fromData(sku, reviews))
@@ -46,10 +47,12 @@ export class ReviewsService {
       return throwError(() => new Error('createProductReview() called without review'));
     }
 
-    return this.apiService.post(`products/${sku}/reviews`, { ...review, showAuthorNameFlag: true }).pipe(
-      this.apiService.resolveLink<ProductReview>(),
-      map(review => ProductReviewsMapper.fromData(sku, [{ ...review, own: true }]))
-    );
+    return this.apiService
+      .post(`products/${encodeResourceID(sku)}/reviews`, { ...review, showAuthorNameFlag: true })
+      .pipe(
+        this.apiService.resolveLink<ProductReview>(),
+        map(review => ProductReviewsMapper.fromData(sku, [{ ...review, own: true }]))
+      );
   }
 
   /**
@@ -66,6 +69,6 @@ export class ReviewsService {
       return throwError(() => new Error('deleteProductReview() called without reviewId'));
     }
 
-    return this.apiService.delete(`products/${sku}/reviews/${reviewId}`);
+    return this.apiService.delete(`products/${encodeResourceID(sku)}/reviews/${encodeResourceID(reviewId)}`);
   }
 }

--- a/src/app/extensions/wishlists/services/wishlist/wishlist.service.ts
+++ b/src/app/extensions/wishlists/services/wishlist/wishlist.service.ts
@@ -4,6 +4,7 @@ import { concatMap, first, map, switchMap } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import { encodeResourceID } from 'ish-core/utils/url-resource-ids';
 
 import { WishlistData } from '../../models/wishlist/wishlist.interface';
 import { WishlistMapper } from '../../models/wishlist/wishlist.mapper';
@@ -45,7 +46,7 @@ export class WishlistService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .get<WishlistData>(`${restResource}/-/wishlists/${wishlistId}`)
+          .get<WishlistData>(`${restResource}/-/wishlists/${encodeResourceID(wishlistId)}`)
           .pipe(map(wishlistData => this.wishlistMapper.fromData(wishlistData, wishlistId)))
       )
     );
@@ -80,7 +81,9 @@ export class WishlistService {
     }
     return this.appFacade.customerRestResource$.pipe(
       first(),
-      concatMap(restResource => this.apiService.delete<void>(`${restResource}/-/wishlists/${wishlistId}`))
+      concatMap(restResource =>
+        this.apiService.delete<void>(`${restResource}/-/wishlists/${encodeResourceID(wishlistId)}`)
+      )
     );
   }
 
@@ -95,7 +98,7 @@ export class WishlistService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .put(`${restResource}/-/wishlists/${wishlist.id}`, wishlist)
+          .put(`${restResource}/-/wishlists/${encodeResourceID(wishlist.id)}`, wishlist)
           .pipe(map((response: Wishlist) => this.wishlistMapper.fromUpdate(response, wishlist.id)))
       )
     );
@@ -120,7 +123,9 @@ export class WishlistService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .post(`${restResource}/-/wishlists/${wishlistId}/products/${sku}`, { quantity })
+          .post(`${restResource}/-/wishlists/${encodeResourceID(wishlistId)}/products/${encodeResourceID(sku)}`, {
+            quantity,
+          })
           .pipe(concatMap(() => this.getWishlist(wishlistId)))
       )
     );
@@ -144,7 +149,7 @@ export class WishlistService {
       first(),
       concatMap(restResource =>
         this.apiService
-          .delete(`${restResource}/-/wishlists/${wishlistId}/products/${sku}`)
+          .delete(`${restResource}/-/wishlists/${encodeResourceID(wishlistId)}/products/${encodeResourceID(sku)}`)
           .pipe(concatMap(() => this.getWishlist(wishlistId)))
       )
     );


### PR DESCRIPTION
* encode all URI components
* only constants doesn't need to be encoded

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1640

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The PR provides a central function to select two behavior:
* duplicated component encoding (for former ICM releases)
* single component encoding (for future fixed versions)

see encodeResourceID at src/app/core/utils/url-resource-ids.ts
[] Yes
[X] No

## Other Information

To be able to use "single" encoded URI components a new versions of ICM application server and HTTPD configuration are necessary. 
ICM-AS fix required - removes duplicate decoding (12.0.0)
ICM-WA fix required - allow encoded slashes in URIs


[AB#96081](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96081)