### PR TITLE
build: reevaluate has-conflicts label on PR push

### DIFF
--- a/.github/workflows/mark-conflicts.yml
+++ b/.github/workflows/mark-conflicts.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 jobs:
   triage:


### PR DESCRIPTION
## PR Type

[X] CI-related changes

## What Is the Current Behavior?

When resolving conflicts on PRs, the `has conflicts` label is not automatically removed.

## What Is the New Behavior?

The workflow is retriggered for PR updates.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#96290](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96290)