### PR TITLE
fix: show Design View editing frame highlighting inside the component to avoid cut display

### DIFF
--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
@@ -10,9 +10,9 @@ $design-view-color-include: #ce5399;
 
   > .design-view-wrapper-actions {
     position: absolute;
-    top: -2px;
-    left: -2px;
-    z-index: 1000;
+    top: 0;
+    left: 0;
+    z-index: 2;
     display: none;
     align-items: center;
     justify-content: flex-end;
@@ -36,10 +36,20 @@ $design-view-color-include: #ce5399;
      * The class .last-design-view-wrapper is applied in TypeScript because &.pagelet:not(:has(.design-view-wrapper))
      * does not work in Firefox yet. So it cannot be done in CSS only.
     */
+
     &:hover {
-      outline-width: 3px;
-      outline-style: solid;
-      outline-offset: -1px;
+      &::before {
+        // create highlighted wrapping element which overlays the component
+        position: absolute;
+        top: 0;
+        z-index: 2;
+        display: block;
+        width: 100%;
+        height: 100%;
+        pointer-events: none; // important not to block mouse events on included components
+        content: '';
+        border: 2px solid $design-view-color-pagelet;
+      }
 
       > .design-view-wrapper-actions {
         display: flex;

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
@@ -10,7 +10,7 @@ $design-view-color-include: #ce5399;
 
   > .design-view-wrapper-actions {
     position: absolute;
-    top: -43px;
+    top: -2px;
     left: -2px;
     z-index: 1000;
     display: none;


### PR DESCRIPTION
## PR Type
[x] Bugfix

## What Is the Current Behavior?
The border and the edit tab / panel of the highlighted component in the Design View is shown outside the component area. If a component is formatted using the CSS property `overflow: hidden;`, the highlight (surrounding) border and the edit tab / panel was cut and not shown.

## What Is the New Behavior?
The border and the edit tab / panel of the highlighted component in the Design View is shown **inside** the component area to always show it when hovering the component even if the CSS property `overflow: hidden;` is used.

## Does this PR Introduce a Breaking Change?
[x] No

## Other Information


[AB#96418](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96418)