### PR TITLE
fix: localization - avoid NoSuchElementException when adding a new locale

### DIFF
--- a/src/app/core/utils/translate/icm-translate-loader.ts
+++ b/src/app/core/utils/translate/icm-translate-loader.ts
@@ -4,7 +4,7 @@ import { routerNavigationAction } from '@ngrx/router-store';
 import { TranslateLoader } from '@ngx-translate/core';
 import { memoize } from 'lodash-es';
 import { Subject, combineLatest, defer, from, iif, of } from 'rxjs';
-import { catchError, filter, first, map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { catchError, filter, map, shareReplay, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 
 import { LocalizationsService } from 'ish-core/services/localizations/localizations.service';
 import { InjectSingle } from 'ish-core/utils/injection';
@@ -41,7 +41,7 @@ export class ICMTranslateLoader implements TranslateLoader {
       // the localization call should wait until all server supplied configuration parameter are applied to the state
       this.actions$.pipe(
         ofType(routerNavigationAction),
-        first(),
+        take(1),
         switchMap(() =>
           this.localizations.getServerTranslations(lang).pipe(
             tap(data => {


### PR DESCRIPTION
## PR Type
[x] Bugfix

## What Is the Current Behavior?
The fix addresses the issue https://github.com/intershop/intershop-pwa/issues/1646 when adding a new locale.

## What Is the New Behavior?
`first()` expects the source Observable to emit at least one item. If the Observable completes without any emissions, `first()` will throw a NoSuchElementException to indicate that no elements were emitted. In the context of the issue, if the Observable is expected to emit at least one value but doesn't, `first()` enforces the emission of at least one item. This could happen if, for example, the translation data isn't loaded as expected due to a network issue, incorrect configuration, or if the data is filtered out before it reaches `first()`. It is now changed to `take(1)`. 

## Does this PR Introduce a Breaking Change?
[x] No

## Other Information


[AB#96420](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96420)