### PR TITLE
fix: implement input mask for IBAN and BIC

### DIFF
--- a/src/app/pages/checkout-payment/payment-parameter-form/payment-parameter-form.component.ts
+++ b/src/app/pages/checkout-payment/payment-parameter-form/payment-parameter-form.component.ts
@@ -28,7 +28,17 @@ export class PaymentParameterFormComponent implements OnInit, OnChanges {
   ngOnInit() {
     this.fields = [];
     this.paymentMethod.parameters.forEach(param => this.fields.push({ ...param }));
-    this.fields.forEach(field => (this.model[field.key as string] = field.props?.options ? undefined : ''));
+    this.fields.forEach(field => {
+      if (field.key === 'IBAN') {
+        field.props.mask = 'UU00 AAAA 0000 0009 9999 9999 9999 9999 99';
+        field.props.placeholder = 'XX00 0000 0000 000';
+        // max length of IBAN is 34, but the 8 spaces of the mask must be added
+        field.props.maxLength = 42;
+      } else if (field.key === 'BIC') {
+        field.props.mask = 'AAAAAAAA||AAAAAAAAAAA';
+      }
+      this.model[field.key as string] = field.props?.options ? undefined : '';
+    });
   }
 
   /**


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?
Currently input masking  is used only for budgets and price notifications.

Issue Number: Closes #1645

## What Is the New Behavior?
Consistent behavior would be great. Implement input masking also for IBAN and BIC.

## Does this PR Introduce a Breaking Change?
[x] No

## Other Information
There is currently no solution to use ngbdatepicker, formly and ngx-mask together. We have therefore decided not to use a mask for dates.  


[AB#96479](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96479)