### PR TITLE
fix: do not display "add to cart" button if product has no price

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -32,6 +32,9 @@ Each integrated view context triggers a REST call that will potentially decrease
 For that reason the examples were commented out in the source code and have to be activated in the project source code if needed.
 See [CMS Integration - View Contexts](../concepts/cms-integration.md#view-contexts) for more information.
 
+The `ExternalDisplayPropertiesProvider` `setup` notation was changed from providing only the `product` context to providing a combined `{ product, prices }` context object.
+For that reason any custom `ContextDisplayPropertiesService` that implements the `ExternalDisplayPropertiesProvider` needs to be adapted accordingly (see the changes of #1657).
+
 ## From 5.0 to 5.1
 
 The OrderListComponent is strictly presentational, components using it have to supply the data.

--- a/src/app/core/facades/product-context.facade.spec.ts
+++ b/src/app/core/facades/product-context.facade.spec.ts
@@ -715,6 +715,45 @@ describe('Product Context Facade', () => {
       `);
     });
   });
+
+  describe('add to basket handling', () => {
+    let product: ProductView;
+
+    beforeEach(() => {
+      product = {
+        sku: '123',
+        completenessLevel: ProductCompletenessLevel.Detail,
+        available: true,
+      } as ProductView;
+
+      when(shoppingFacade.product$(anything(), anything())).thenReturn(of(product));
+
+      context.set('sku', () => '123');
+    });
+
+    it('should set "addToBasket" to "false" for a product without a price', () => {
+      expect(context.get('displayProperties', 'addToBasket')).toMatchInlineSnapshot(`false`);
+    });
+
+    it('should set "addToBasket" to "true" for a product with price', () => {
+      context.set('prices', () => ({ salePrice: PriceHelper.empty() }));
+      expect(context.get('displayProperties', 'addToBasket')).toMatchInlineSnapshot(`true`);
+    });
+
+    it('should set "addToBasket" to "true" for a retail set independend from a price', () => {
+      when(shoppingFacade.product$(anything(), anything())).thenReturn(
+        of({
+          sku: '456',
+          completenessLevel: ProductCompletenessLevel.Detail,
+          type: 'RetailSet',
+          available: true,
+        } as ProductView)
+      );
+      context.set('sku', () => '456');
+
+      expect(context.get('displayProperties', 'addToBasket')).toMatchInlineSnapshot(`true`);
+    });
+  });
 });
 
 describe('Product Context Facade', () => {

--- a/src/app/core/facades/product-context.facade.spec.ts
+++ b/src/app/core/facades/product-context.facade.spec.ts
@@ -9,6 +9,7 @@ import { AttributeGroup } from 'ish-core/models/attribute-group/attribute-group.
 import { AttributeGroupTypes } from 'ish-core/models/attribute-group/attribute-group.types';
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 import { Category } from 'ish-core/models/category/category.model';
+import { PriceHelper } from 'ish-core/models/price/price.helper';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 
@@ -16,6 +17,7 @@ import { AppFacade } from './app.facade';
 import {
   EXTERNAL_DISPLAY_PROPERTY_PROVIDER,
   ExternalDisplayPropertiesProvider,
+  ProductContext,
   ProductContextDisplayProperties,
   ProductContextFacade,
 } from './product-context.facade';
@@ -325,6 +327,7 @@ describe('Product Context Facade', () => {
 
     describe('display properties', () => {
       it('should set correct display properties for product', () => {
+        context.set('prices', () => ({ salePrice: PriceHelper.empty() }));
         expect(context.get('displayProperties')).toMatchInlineSnapshot(`
           {
             "addToBasket": true,
@@ -350,6 +353,7 @@ describe('Product Context Facade', () => {
       });
 
       it('should include external displayProperty overrides when calculating', () => {
+        context.set('prices', () => ({ salePrice: PriceHelper.empty() }));
         context.config = {
           readOnly: true,
           name: false,
@@ -575,6 +579,7 @@ describe('Product Context Facade', () => {
           { sku: 'p2', quantity: 2 },
         ])
       );
+      context.set('prices', () => ({ salePrice: PriceHelper.empty() }));
       context.set('sku', () => '123');
     });
 
@@ -638,6 +643,7 @@ describe('Product Context Facade', () => {
       } as ProductView;
       when(shoppingFacade.product$(anything(), anything())).thenReturn(of(product));
 
+      context.set('prices', () => ({ salePrice: PriceHelper.empty() }));
       context.set('sku', () => '123');
     });
 
@@ -720,10 +726,12 @@ describe('Product Context Facade', () => {
     let someOther$: Subject<boolean>;
 
     class ProviderA implements ExternalDisplayPropertiesProvider {
-      setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
-        return product$.pipe(
-          map(p =>
-            p?.sku === '456'
+      setup(
+        context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
+      ): Observable<Partial<ProductContextDisplayProperties<false>>> {
+        return context$.pipe(
+          map(({ product }) =>
+            product?.sku === '456'
               ? {
                   addToBasket: false,
                   addToCompare: false,
@@ -738,8 +746,10 @@ describe('Product Context Facade', () => {
     }
 
     class ProviderB implements ExternalDisplayPropertiesProvider {
-      setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
-        return product$.pipe(
+      setup(
+        context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
+      ): Observable<Partial<ProductContextDisplayProperties<false>>> {
+        return context$.pipe(
           map(() => ({
             shipment: false,
             promotions: false,
@@ -749,8 +759,10 @@ describe('Product Context Facade', () => {
     }
 
     class ProviderC implements ExternalDisplayPropertiesProvider {
-      setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
-        return product$.pipe(
+      setup(
+        context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
+      ): Observable<Partial<ProductContextDisplayProperties<false>>> {
+        return context$.pipe(
           switchMap(() => someOther$),
           map(prop => (prop ? { price: false } : {}))
         );
@@ -795,6 +807,7 @@ describe('Product Context Facade', () => {
     });
 
     it('should set correct display properties respecting overrides from providers for product 123', () => {
+      context.set('prices', () => ({ salePrice: PriceHelper.empty() }));
       context.set('sku', () => '123');
 
       expect(context.get('displayProperties')).toMatchInlineSnapshot(`

--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -390,7 +390,8 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
           skipWhile(children => !children || !Object.values(children)?.length),
           map(() => true)
         ),
-        this.select('parts').pipe(
+        this.select().pipe(
+          map(context => context.parts),
           skipWhile(parts => !parts?.length),
           map(() => true)
         ),

--- a/src/app/core/utils/product-context-display-properties/product-context-display-properties.service.ts
+++ b/src/app/core/utils/product-context-display-properties/product-context-display-properties.service.ts
@@ -4,17 +4,19 @@ import { map } from 'rxjs/operators';
 
 import {
   ExternalDisplayPropertiesProvider,
+  ProductContext,
   ProductContextDisplayProperties,
 } from 'ish-core/facades/product-context.facade';
-import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductHelper } from 'ish-core/models/product/product.helper';
 
 @Injectable({ providedIn: 'root' })
 export class ProductContextDisplayPropertiesService implements ExternalDisplayPropertiesProvider {
-  setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
-    return product$.pipe(
-      map(product => {
-        const canBeOrdered = !ProductHelper.isMasterProduct(product) && product.available;
+  setup(
+    context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
+  ): Observable<Partial<ProductContextDisplayProperties<false>>> {
+    return context$.pipe(
+      map(({ product }) => {
+        const canBeOrdered = !ProductHelper.isMasterProduct(product) && product?.available;
 
         const canBeOrderedNotRetail = canBeOrdered && !ProductHelper.isRetailSet(product);
 
@@ -26,8 +28,8 @@ export class ProductContextDisplayPropertiesService implements ExternalDisplayPr
           retailSetParts: ProductHelper.isRetailSet(product),
           shipment:
             canBeOrderedNotRetail &&
-            Number.isInteger(product.readyForShipmentMin) &&
-            Number.isInteger(product.readyForShipmentMax),
+            Number.isInteger(product?.readyForShipmentMin) &&
+            Number.isInteger(product?.readyForShipmentMax),
           addToBasket: canBeOrdered,
           addToWishlist: !ProductHelper.isMasterProduct(product),
           addToOrderTemplate: canBeOrdered,

--- a/src/app/core/utils/product-context-display-properties/product-context-display-properties.service.ts
+++ b/src/app/core/utils/product-context-display-properties/product-context-display-properties.service.ts
@@ -15,9 +15,9 @@ export class ProductContextDisplayPropertiesService implements ExternalDisplayPr
     context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
   ): Observable<Partial<ProductContextDisplayProperties<false>>> {
     return context$.pipe(
-      map(({ product }) => {
+      map(({ product, prices }) => {
         const canBeOrdered = !ProductHelper.isMasterProduct(product) && product?.available;
-
+        const canBeOrderedWithPrice = canBeOrdered && (!!prices?.salePrice || ProductHelper.isRetailSet(product));
         const canBeOrderedNotRetail = canBeOrdered && !ProductHelper.isRetailSet(product);
 
         const calc = {
@@ -30,7 +30,7 @@ export class ProductContextDisplayPropertiesService implements ExternalDisplayPr
             canBeOrderedNotRetail &&
             Number.isInteger(product?.readyForShipmentMin) &&
             Number.isInteger(product?.readyForShipmentMax),
-          addToBasket: canBeOrdered,
+          addToBasket: canBeOrderedWithPrice,
           addToWishlist: !ProductHelper.isMasterProduct(product),
           addToOrderTemplate: canBeOrdered,
           addToCompare: !ProductHelper.isMasterProduct(product),

--- a/src/app/extensions/punchout/exports/punchout-product-context-display-properties/punchout-product-context-display-properties.service.ts
+++ b/src/app/extensions/punchout/exports/punchout-product-context-display-properties/punchout-product-context-display-properties.service.ts
@@ -4,17 +4,19 @@ import { map, switchMap } from 'rxjs/operators';
 
 import {
   ExternalDisplayPropertiesProvider,
+  ProductContext,
   ProductContextDisplayProperties,
 } from 'ish-core/facades/product-context.facade';
-import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { RoleToggleService } from 'ish-core/role-toggle.module';
 
 @Injectable({ providedIn: 'root' })
 export class PunchoutProductContextDisplayPropertiesService implements ExternalDisplayPropertiesProvider {
   constructor(private roleToggleService: RoleToggleService) {}
 
-  setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
-    return product$.pipe(
+  setup(
+    context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
+  ): Observable<Partial<ProductContextDisplayProperties<false>>> {
+    return context$.pipe(
       switchMap(() => this.roleToggleService.hasRole(['APP_B2B_CXML_USER', 'APP_B2B_OCI_USER'])),
       map(isPunchoutUser =>
         isPunchoutUser

--- a/src/app/extensions/tacton/exports/tacton-product-context-display-properties/tacton-product-context-display-properties.service.ts
+++ b/src/app/extensions/tacton/exports/tacton-product-context-display-properties/tacton-product-context-display-properties.service.ts
@@ -4,15 +4,17 @@ import { map } from 'rxjs/operators';
 
 import {
   ExternalDisplayPropertiesProvider,
+  ProductContext,
   ProductContextDisplayProperties,
 } from 'ish-core/facades/product-context.facade';
-import { ProductView } from 'ish-core/models/product-view/product-view.model';
 
 @Injectable()
 export class TactonProductContextDisplayPropertiesService implements ExternalDisplayPropertiesProvider {
-  setup(product$: Observable<ProductView>): Observable<Partial<ProductContextDisplayProperties<false>>> {
-    return product$.pipe(
-      map(product =>
+  setup(
+    context$: Observable<Pick<ProductContext, 'product' | 'prices'>>
+  ): Observable<Partial<ProductContextDisplayProperties<false>>> {
+    return context$.pipe(
+      map(({ product }) =>
         product?.type === 'TactonProduct'
           ? {
               addToBasket: false,


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

On product detail pages and product listings products without a sale price display an "Add to Cart" button that will result in an error message regarding the failed action because of the missing price.


## What Is the New Behavior?

Products without a sale price no longer have an "Add to Cart" button.

## Does this PR Introduce a Breaking Change?

The `ExternalDisplayPropertiesProvider` `setup` notation was changed from providing only the `product` context to providing a combined `{ product, prices }` context object to be able to depend the visibility of the add to basket button on an existing price.
For that reason any custom `ContextDisplayPropertiesService` that implements the `ExternalDisplayPropertiesProvider` needs to be adapted accordingly.

[x] Yes

## Other Information


[AB#96517](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96517)