### PR TITLE
fix: handle setting price notification for products without a price

### DIFF
--- a/src/app/extensions/product-notifications/shared/product-notification-edit-form/product-notification-edit-form.component.ts
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-form/product-notification-edit-form.component.ts
@@ -66,7 +66,7 @@ export class ProductNotificationEditFormComponent implements OnChanges {
         : {
             alertType: undefined,
             email: this.userEmail,
-            priceValue: this.productPrices.salePrice.value,
+            priceValue: this.productPrices?.salePrice?.value || 99.99,
           };
 
       // differentiate form with or without a product notification


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Trying to set a price notification for a product without a price is currently not possible because a dialog without the needed form inputs is presented and it results in browser Javascript errors.

## What Is the New Behavior?

If the product has no price `99.99` is used as initial value and the price notification form is presented as expected in the dialog. No Javascript errors are logged.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#96603](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96603)