### PR TITLE
feat(schematics): skip creating tests for components

### DIFF
--- a/docs/guides/customizations.md
+++ b/docs/guides/customizations.md
@@ -161,6 +161,18 @@ If possible, use the Jest update feature **update snapshots** when adapting test
 When you upgrade the PWA to a new version, those snapshots will most likely have merge conflicts in them.
 Here you can just accept either modification and update the test snapshots.
 
+You can disable creating component tests by adding the following snippet to your `angular.json`:
+
+```json
+  "projects": {
+    "intershop-pwa": {
+      "schematics": {
+        "intershop-schematics:component": {
+          "skipTests": true
+        }
+      },
+```
+
 ### Styling
 
 Changing the styling by applying changes to SCSS files should be done in the custom theme folder `src/styles/themes/<theme-prefix>`.

--- a/schematics/src/component/factory.ts
+++ b/schematics/src/component/factory.ts
@@ -8,7 +8,6 @@ import {
   filter,
   mergeWith,
   move,
-  noop,
   url,
 } from '@angular-devkit/schematics';
 import { PWAComponentOptionsSchema as Options } from 'schemas/component/schema';
@@ -37,7 +36,14 @@ export function createComponent(options: Options): Rule {
     operations.push(
       mergeWith(
         apply(url('./files'), [
-          options.styleFile ? noop() : filter(path => !path.includes('.scss')),
+          filter(path => {
+            if (path.endsWith('.scss.template')) {
+              return options.styleFile;
+            } else if (path.endsWith('.spec.ts.template')) {
+              return !options.skipTests;
+            }
+            return true;
+          }),
           applyTemplates({
             ...strings,
             ...options,

--- a/schematics/src/component/factory_spec.ts
+++ b/schematics/src/component/factory_spec.ts
@@ -105,6 +105,17 @@ describe('Component Schematic', () => {
     expect(componentSource).toContain(`styleUrls: ['./foo.component.scss']`);
   });
 
+  it('should create a component without test file if requested', async () => {
+    const options = { ...defaultOptions, skipTests: true };
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
+    expect(tree.files.filter(x => x.search('foo.component') >= 0)).toMatchInlineSnapshot(`
+      [
+        "/src/app/foo/foo.component.html",
+        "/src/app/foo/foo.component.ts",
+      ]
+    `);
+  });
+
   it('should find the closest module', async () => {
     const options = { ...defaultOptions };
     const fooModule = '/src/app/foo/foo.module.ts';

--- a/schematics/src/component/schema.json
+++ b/schematics/src/component/schema.json
@@ -64,6 +64,11 @@
       "description": "When true, does not import this component into the owning NgModule.",
       "default": false
     },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create test.",
+      "default": false
+    },
     "export": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
## PR Type

[X] Feature

## What Is the Current Behavior?

When creating components via schematics, you cannot skip creating tests.

## What Is the New Behavior?

You can skip creating tests with `--skip-tests`

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information


[AB#96750](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96750)