### PR TITLE
refactor: rework account-profile-user component

### DIFF
--- a/src/app/pages/account-profile-user/account-profile-user-page.component.html
+++ b/src/app/pages/account-profile-user/account-profile-user-page.component.html
@@ -1,9 +1,7 @@
-<ng-container *ngIf="currentUser$">
-  <ish-account-profile-user
-    [currentUser$]="currentUser$"
-    [error]="userError$ | async"
-    (updateUserProfile)="updateUserProfile($event)"
-  />
+<ish-account-profile-user
+  [currentUser]="currentUser$ | async"
+  [error]="userError$ | async"
+  (updateUserProfile)="updateUserProfile($event)"
+/>
 
-  <ish-loading *ngIf="userLoading$ | async" />
-</ng-container>
+<ish-loading *ngIf="userLoading$ | async" />

--- a/src/app/pages/account-profile-user/account-profile-user-page.component.spec.ts
+++ b/src/app/pages/account-profile-user/account-profile-user-page.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
 import { instance, mock } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 
 import { AccountProfileUserPageComponent } from './account-profile-user-page.component';
+import { AccountProfileUserComponent } from './account-profile-user/account-profile-user.component';
 
 describe('Account Profile User Page Component', () => {
   let component: AccountProfileUserPageComponent;
@@ -12,7 +14,7 @@ describe('Account Profile User Page Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AccountProfileUserPageComponent],
+      declarations: [AccountProfileUserPageComponent, MockComponent(AccountProfileUserComponent)],
       providers: [{ provide: AccountFacade, useFactory: () => instance(mock(AccountFacade)) }],
     }).compileComponents();
   });

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.html
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.html
@@ -4,30 +4,32 @@
 <ish-error-message [error]="error" />
 
 <p>{{ 'account.update_profile.text' | translate }}</p>
-<ng-container *ngIf="currentUser$ | async as user">
-  <div class="row">
-    <div class="col-md-10 col-xl-8">
-      <div class="section">
-        <p class="indicates-required">
-          <span class="required">*</span>{{ 'account.required_field.message' | translate }}
-        </p>
-        <form
-          [formGroup]="accountProfileUserForm"
-          (ngSubmit)="submitForm(user)"
-          class="form-horizontal"
-          novalidate="novalidate"
-        >
-          <formly-form [form]="accountProfileUserForm" [fields]="fields$ | async" [model]="model$ | async" />
-          <div class="row">
-            <div class="offset-md-4 col-md-8">
-              <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">
-                {{ 'account.update.button.label' | translate }}
-              </button>
-              <a routerLink="/account/profile" class="btn btn-secondary">{{ 'account.cancel.link' | translate }}</a>
-            </div>
+<div class="row">
+  <div class="col-md-10 col-xl-8">
+    <div class="section">
+      <p class="indicates-required">
+        <span class="required">*</span>{{ 'account.required_field.message' | translate }}
+      </p>
+      <form
+        [formGroup]="accountProfileUserForm"
+        (ngSubmit)="submitForm()"
+        class="form-horizontal"
+        novalidate="novalidate"
+      >
+        <formly-form
+          [form]="accountProfileUserForm"
+          [fields]="select('fields') | async"
+          [model]="select('model') | async"
+        />
+        <div class="row">
+          <div class="offset-md-4 col-md-8">
+            <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">
+              {{ 'account.update.button.label' | translate }}
+            </button>
+            <a routerLink="/account/profile" class="btn btn-secondary">{{ 'account.cancel.link' | translate }}</a>
           </div>
-        </form>
-      </div>
+        </div>
+      </form>
     </div>
   </div>
-</ng-container>
+</div>

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
@@ -69,7 +69,7 @@ describe('Account Profile User Component', () => {
     element = fixture.nativeElement;
 
     currentUser = { firstName: 'Patricia', lastName: 'Miller' } as User;
-    component.currentUser$ = of(currentUser);
+    component.currentUser = currentUser;
 
     invalidUser = { firstName: '', lastName: '' } as User;
 
@@ -113,7 +113,7 @@ describe('Account Profile User Component', () => {
 
     fixture.detectChanges();
 
-    component.submitForm(currentUser);
+    component.submitForm();
 
     verify(eventEmitter$.emit(anything())).once();
   });
@@ -121,23 +121,23 @@ describe('Account Profile User Component', () => {
   it('should not emit updateUserProfile event if form is invalid', () => {
     const eventEmitter$ = spy(component.updateUserProfile);
 
-    component.currentUser$ = of(invalidUser);
+    component.currentUser = invalidUser;
 
     fixture.detectChanges();
 
-    component.submitForm(anything());
+    component.submitForm();
 
     verify(eventEmitter$.emit(anything())).never();
   });
 
   it('should disable submit button when the user submits an invalid form', () => {
-    component.currentUser$ = of(invalidUser);
+    component.currentUser = invalidUser;
 
     fixture.detectChanges();
 
     expect(component.buttonDisabled).toBeFalse();
 
-    component.submitForm(anything());
+    component.submitForm();
 
     expect(component.buttonDisabled).toBeTrue();
   });

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
+import { RxState } from '@rx-angular/state';
 import { pick } from 'lodash-es';
-import { Observable, concatMap, map, of, withLatestFrom } from 'rxjs';
+import { concatMap, map, of, withLatestFrom } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
@@ -10,6 +11,12 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
 import { FieldLibrary } from 'ish-shared/formly/field-library/field-library';
 import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
+
+interface ComponentState {
+  currentUser: User;
+  model: Partial<User>;
+  fields: FormlyFieldConfig[];
+}
 
 /**
  * The Account Profile User Page Component displays a form for changing the user's profile data
@@ -20,8 +27,10 @@ import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
   templateUrl: './account-profile-user.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AccountProfileUserComponent implements OnInit {
-  @Input({ required: true }) currentUser$: Observable<User>;
+export class AccountProfileUserComponent extends RxState<ComponentState> implements OnInit {
+  @Input({ required: true }) set currentUser(val: User) {
+    this.set('currentUser', () => val);
+  }
   @Input() error: HttpError;
 
   @Output() updateUserProfile = new EventEmitter<User>();
@@ -29,35 +38,41 @@ export class AccountProfileUserComponent implements OnInit {
   private submitted = false;
 
   accountProfileUserForm = new FormGroup({});
-  model$: Observable<Partial<User>>;
-  fields$: Observable<FormlyFieldConfig[]>;
 
-  constructor(private fieldLibrary: FieldLibrary, private accountFacade: AccountFacade, private appFacade: AppFacade) {}
+  constructor(private fieldLibrary: FieldLibrary, private accountFacade: AccountFacade, private appFacade: AppFacade) {
+    super();
+  }
 
   ngOnInit() {
     // only retrieves and sets the newsletter-subscription-status in the model if the server-setting for it is enabled
-    this.model$ = this.currentUser$.pipe(
-      map(user => pick(user, 'title', 'firstName', 'lastName', 'phoneHome')),
-      withLatestFrom(this.appFacade.serverSetting$<boolean>('marketing.newsletterSubscriptionEnabled')),
-      concatMap(([userAttributes, newsletterSubscriptionEnabled]) =>
-        this.accountFacade.subscribedToNewsletter$.pipe(
-          map(subscribedToNewsletter =>
-            newsletterSubscriptionEnabled
-              ? {
-                  ...userAttributes,
-                  newsletter: subscribedToNewsletter,
-                }
-              : userAttributes
+    this.connect(
+      'model',
+      this.select('currentUser').pipe(
+        map(user => pick(user, 'title', 'firstName', 'lastName', 'phoneHome')),
+        withLatestFrom(this.appFacade.serverSetting$<boolean>('marketing.newsletterSubscriptionEnabled')),
+        concatMap(([userAttributes, newsletterSubscriptionEnabled]) =>
+          this.accountFacade.subscribedToNewsletter$.pipe(
+            map(subscribedToNewsletter =>
+              newsletterSubscriptionEnabled
+                ? {
+                    ...userAttributes,
+                    newsletter: subscribedToNewsletter,
+                  }
+                : userAttributes
+            )
           )
         )
       )
     );
 
     // only displays the newsletter-subscription-field if the server-setting for the newsletter is enabled
-    this.fields$ = of(this.fieldLibrary.getConfigurationGroup('personalInfo')).pipe(
-      withLatestFrom(this.appFacade.serverSetting$<boolean>('marketing.newsletterSubscriptionEnabled')),
-      map(([fields, newsletterSubscriptionEnabled]) =>
-        newsletterSubscriptionEnabled ? [...fields, this.newsletterCheckboxField()] : fields
+    this.connect(
+      'fields',
+      of(this.fieldLibrary.getConfigurationGroup('personalInfo')).pipe(
+        withLatestFrom(this.appFacade.serverSetting$<boolean>('marketing.newsletterSubscriptionEnabled')),
+        map(([fields, newsletterSubscriptionEnabled]) =>
+          newsletterSubscriptionEnabled ? [...fields, this.newsletterCheckboxField()] : fields
+        )
       )
     );
   }
@@ -75,7 +90,7 @@ export class AccountProfileUserComponent implements OnInit {
   /**
    * Submits form and throws update event when form is valid
    */
-  submitForm(currentUser: User) {
+  submitForm() {
     if (this.accountProfileUserForm.invalid) {
       this.submitted = true;
       markAsDirtyRecursive(this.accountProfileUserForm);
@@ -87,7 +102,7 @@ export class AccountProfileUserComponent implements OnInit {
       this.accountFacade.updateNewsletterSubscription(subscribedToNewsletter);
     }
 
-    this.updateUserProfile.emit({ ...currentUser, ...this.accountProfileUserForm.value });
+    this.updateUserProfile.emit({ ...this.get('currentUser'), ...this.accountProfileUserForm.value });
   }
 
   get buttonDisabled() {


### PR DESCRIPTION
## PR Type

[X] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

AccountProfileUserComponent uses `currentUser$` as an Observable input and subscribes to it on the template to use it synchronouslly in the TS file. Both of this is considered bad practice.

## What Is the New Behavior?

Refactored using RxState and reintroduced normal Component Input.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[X] No

## Other Information


[AB#96966](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96966)