### PR TITLE
chore: sort i18n files in format task

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "e2e": "cd e2e && npm install && node open-cypress",
     "lint": "ng lint",
     "lint-hard": "node scripts/eslint-hard",
-    "format": "node docs/check-sentence-newline && stylelint \"**/*.{css,scss}\" --fix && prettier --loglevel warn --write \"**/*.*\"",
+    "sort-i18n": "node scripts/sort-i18n.mjs",
+    "format": "node docs/check-sentence-newline && stylelint \"**/*.{css,scss}\" --fix && prettier --loglevel warn --write \"**/*.*\" && npm run sort-i18n",
     "compile": "tsc --project tsconfig.all.json --noEmit",
     "dead-code": "npx ts-node scripts/find-dead-code.ts",
     "clean-localizations": "node scripts/clean-up-localizations",
@@ -218,7 +219,7 @@
       "jest --ci --bail --findRelatedTests --passWithNoTests"
     ],
     "src/assets/i18n/*.json": [
-      "sort-json --indent-size=2"
+      "npm run sort-i18n"
     ]
   },
   "commitlint": {

--- a/scripts/sort-i18n.mjs
+++ b/scripts/sort-i18n.mjs
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import * as glob from 'glob';
+import sort from 'sort-json';
+
+/** @type string[] */
+let files;
+
+if (process.argv.length > 2) {
+  files = process.argv.slice(2);
+} else {
+  files = glob.sync('src/assets/i18n/*.json');
+}
+
+files.forEach(file => {
+  console.log('sorting', file);
+
+  const content = JSON.parse(fs.readFileSync(file, { encoding: 'utf-8' }));
+  const sorted = sort(content);
+  fs.writeFileSync(file, `${JSON.stringify(sorted, undefined, 2)}\n`);
+});


### PR DESCRIPTION
## PR Type

[X] CI-related changes

## What Is the Current Behavior?

Language files are not sorted in npm `format` task, only in pre-commit hook.

## What Is the New Behavior?

Language files are also sorted in `format` task.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[X] No

## Other Information

[AB#96980](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96980)