### PR TITLE
fix: suppress the wrong display of Search-No-Results page after a search

### DIFF
--- a/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.spec.ts
@@ -70,7 +70,7 @@ describe('Product Listing Effects', () => {
     it('should fire all necessary actions for search page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: 'term' } }));
 
-      tick(0);
+      tick(5);
 
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
@@ -92,7 +92,7 @@ describe('Product Listing Effects', () => {
     it('should fire all necessary actions for family page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'category', value: 'cat' } }));
 
-      tick(0);
+      tick(5);
 
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
@@ -122,7 +122,7 @@ describe('Product Listing Effects', () => {
     it('should fire all necessary actions for search page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: 'term' } }));
 
-      tick(0);
+      tick(5);
 
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:
@@ -147,7 +147,7 @@ describe('Product Listing Effects', () => {
     it('should fire all necessary actions for family page', fakeAsync(() => {
       store$.dispatch(loadMoreProducts({ id: { type: 'category', value: 'cat' } }));
 
-      tick(0);
+      tick(5);
 
       expect(store$.actionsArray()).toMatchInlineSnapshot(`
         [Product Listing] Load More Products:

--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { isEqual } from 'lodash-es';
-import { distinctUntilChanged, filter, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map, switchMap, take, withLatestFrom } from 'rxjs/operators';
 
 import {
   DEFAULT_PRODUCT_LISTING_VIEW_TYPE,
@@ -125,6 +125,8 @@ export class ProductListingEffects {
         );
       }),
       distinctUntilChanged(isEqual),
+      // prevent an unnecessary loadMoreProductsForParamsAction in case a new search is triggered and a query parameter like a filter had been previously been set
+      debounceTime(1),
       map(({ id, filters, sorting, page }) => loadMoreProductsForParams({ id, filters, sorting, page }))
     )
   );

--- a/src/app/core/store/shopping/search/search.effects.spec.ts
+++ b/src/app/core/store/shopping/search/search.effects.spec.ts
@@ -231,9 +231,11 @@ describe('Search Effects', () => {
       verify(productsServiceMock.searchProducts(searchTerm, 12, anything(), 0)).once();
 
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: searchTerm }, page: 2 }));
+      tick(5);
       verify(productsServiceMock.searchProducts(searchTerm, 12, anything(), 12)).once();
 
       store$.dispatch(loadMoreProducts({ id: { type: 'search', value: searchTerm }, page: 3 }));
+      tick(5);
       verify(productsServiceMock.searchProducts(searchTerm, 12, anything(), 24)).once();
     }));
   });

--- a/src/app/core/store/shopping/shopping-store.spec.ts
+++ b/src/app/core/store/shopping/shopping-store.spec.ts
@@ -572,6 +572,11 @@ describe('Shopping Store', () => {
               id: {"type":"category","value":"A.123.456"}
             [Viewconf Internal] Set Breadcrumb Data:
               breadcrumbData: [{"text":"nA","link":"/na-ctgA"},{"text":"nA123","link":"/na...
+            @ngrx/router-store/navigated: /category/A.123.456
+            [Product Listing] Load More Products:
+              id: {"type":"category","value":"A.123.456"}
+            [Viewconf Internal] Set Breadcrumb Data:
+              breadcrumbData: [{"text":"nA","link":"/na-ctgA"},{"text":"nA123","link":"/na...
             [Product Listing Internal] Load More Products For Params:
               id: {"type":"category","value":"A.123.456"}
               filters: undefined
@@ -594,11 +599,6 @@ describe('Shopping Store', () => {
               sortableAttributes: []
             [Filter API] Load Filter Success:
               filterNavigation: {}
-            @ngrx/router-store/navigated: /category/A.123.456
-            [Product Listing] Load More Products:
-              id: {"type":"category","value":"A.123.456"}
-            [Viewconf Internal] Set Breadcrumb Data:
-              breadcrumbData: [{"text":"nA","link":"/na-ctgA"},{"text":"nA123","link":"/na...
           `);
         }));
       });
@@ -697,6 +697,11 @@ describe('Shopping Store', () => {
             id: {"type":"category","value":"A.123.456"}
           [Viewconf Internal] Set Breadcrumb Data:
             breadcrumbData: [{"text":"nA","link":"/na-ctgA"},{"text":"nA123","link":"/na...
+          @ngrx/router-store/navigated: /category/A.123.456
+          [Product Listing] Load More Products:
+            id: {"type":"category","value":"A.123.456"}
+          [Viewconf Internal] Set Breadcrumb Data:
+            breadcrumbData: [{"text":"nA","link":"/na-ctgA"},{"text":"nA123","link":"/na...
           [Product Listing Internal] Load More Products For Params:
             id: {"type":"category","value":"A.123.456"}
             filters: undefined
@@ -719,11 +724,6 @@ describe('Shopping Store', () => {
             sortableAttributes: []
           [Filter API] Load Filter Success:
             filterNavigation: {}
-          @ngrx/router-store/navigated: /category/A.123.456
-          [Product Listing] Load More Products:
-            id: {"type":"category","value":"A.123.456"}
-          [Viewconf Internal] Set Breadcrumb Data:
-            breadcrumbData: [{"text":"nA","link":"/na-ctgA"},{"text":"nA123","link":"/na...
         `);
       }));
     });


### PR DESCRIPTION

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When searching for a search term in the PWA and applying a filter afterwards, a subsequent search leads to a short display of "NO RESULTS FOUND" before the correct search results are returned. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The "NO RESULTS FOUND" is not shown in this case any more.

##Steps to repeat
1. Open the PWA storefront and search for a search term (e.g. "PC").
2. Select a filter (e.g. Color = "Red").
3. Search for another search term (e.g. "HDMI").

    -> "NO RESULTS FOUND" is displayed for a short time before the correct results are returned.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No



## Other Information


[AB#97249](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/97249)