### PR TITLE
fix: encode product urls

### DIFF
--- a/src/app/core/facades/selected-product-context.facade.ts
+++ b/src/app/core/facades/selected-product-context.facade.ts
@@ -42,7 +42,7 @@ export class SelectedProductContextFacade extends ProductContextFacade {
         withLatestFrom(appFacade.routingInProgress$),
         filter(([, progress]) => !progress)
       ),
-      ([url]) => router.navigateByUrl(url)
+      ([url]) => router.navigateByUrl(encodeURI(url), { replaceUrl: true })
     );
   }
 }

--- a/src/app/core/utils/routing.ts
+++ b/src/app/core/utils/routing.ts
@@ -34,7 +34,7 @@ export function addGlobalGuard(
  * RegEx that finds reserved characters that should not be contained in non functional parts of routes/URLs (e.g product slugs for SEO)
  */
 // not-dead-code
-export const reservedCharactersRegEx = /[ &\(\)=%]/g;
+export const reservedCharactersRegEx = /[ &\(\)=]/g;
 
 /**
  * Sanitize slug data (remove reserved characters, clean up obsolete '-', lower case, capitalize identifiers)


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Product URLs are not encoded if they are called programmatically. This might cause issues if the URL contains special characters like % signs if a variation product is switched on product detail page.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

Product URLs are encoded if they are called programmatically. 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#97578](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/97578)