### PR TITLE
fix: error message in the checkout after basket has expired

### DIFF
--- a/src/app/core/store/customer/basket/basket-validation.effects.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.ts
@@ -25,6 +25,7 @@ import {
   continueCheckoutWithIssues,
   loadBasketEligiblePaymentMethods,
   loadBasketEligibleShippingMethods,
+  loadBasketFail,
   startCheckout,
   startCheckoutFail,
   startCheckoutSuccess,
@@ -191,6 +192,22 @@ export class BasketValidationEffects {
             .map(info => loadProduct({ sku: info.parameters.productSku }));
         }
       })
+    )
+  );
+
+  // if the basket is expired or doesn't exist - clear the basket and go to cart page
+  handleBasketNotFoundError$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(startCheckoutFail, continueCheckoutFail),
+      mapToPayloadProperty('error'),
+      filter(error => error?.code === 'basket.not_found.error' || error?.errors[0]?.code === 'basket.not_found.error'),
+      concatMap(error =>
+        from(
+          this.router.navigate([this.validationSteps[CheckoutStepType.BeforeCheckout].route], {
+            queryParams: { error: true },
+          })
+        ).pipe(map(() => loadBasketFail({ error })))
+      )
     )
   );
 

--- a/src/app/core/store/customer/basket/basket.reducer.ts
+++ b/src/app/core/store/customer/basket/basket.reducer.ts
@@ -342,7 +342,13 @@ export const basketReducer = createReducer(
       validationResults: initialValidationResults,
     })
   ),
-
+  on(
+    loadBasketFail,
+    (state): BasketState => ({
+      ...state,
+      basket: undefined,
+    })
+  ),
   on(
     resetBasketErrors,
     (state): BasketState => ({

--- a/src/app/pages/basket/shopping-basket/shopping-basket.component.html
+++ b/src/app/pages/basket/shopping-basket/shopping-basket.component.html
@@ -18,7 +18,6 @@
   <div>
     <!-- Error message -->
     <ish-error-message *ngIf="error?.message" [error]="error" />
-
     <ish-basket-error-message [error]="error" />
 
     <!-- Basket Info messages -->

--- a/src/app/pages/checkout-address/checkout-address/checkout-address.component.html
+++ b/src/app/pages/checkout-address/checkout-address/checkout-address.component.html
@@ -2,6 +2,7 @@
   <!-- Error Message -->
   <div *ngIf="error" class="col-md-12">
     <ish-error-message [error]="error" [toast]="false" />
+    <ish-basket-error-message [error]="error" />
   </div>
 
   <div *ngIf="nextDisabled && !error" class="col-md-12">

--- a/src/app/pages/checkout-address/checkout-address/checkout-address.component.spec.ts
+++ b/src/app/pages/checkout-address/checkout-address/checkout-address.component.spec.ts
@@ -9,6 +9,7 @@ import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 import { BasketCostSummaryComponent } from 'ish-shared/components/basket/basket-cost-summary/basket-cost-summary.component';
+import { BasketErrorMessageComponent } from 'ish-shared/components/basket/basket-error-message/basket-error-message.component';
 import { BasketItemsSummaryComponent } from 'ish-shared/components/basket/basket-items-summary/basket-items-summary.component';
 import { BasketValidationResultsComponent } from 'ish-shared/components/basket/basket-validation-results/basket-validation-results.component';
 import { BasketInvoiceAddressWidgetComponent } from 'ish-shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component';
@@ -29,6 +30,7 @@ describe('Checkout Address Component', () => {
       declarations: [
         CheckoutAddressComponent,
         MockComponent(BasketCostSummaryComponent),
+        MockComponent(BasketErrorMessageComponent),
         MockComponent(BasketInvoiceAddressWidgetComponent),
         MockComponent(BasketItemsSummaryComponent),
         MockComponent(BasketShippingAddressWidgetComponent),

--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
@@ -2,6 +2,7 @@
   <div class="col-md-12">
     <!-- Messages -->
     <ish-error-message [error]="error" [toast]="false" />
+    <ish-basket-error-message [error]="error" />
     <ish-basket-validation-results />
 
     <div *ngIf="redirectStatus" role="alert" class="alert alert-danger">

--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.spec.ts
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.spec.ts
@@ -14,6 +14,7 @@ import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 import { BasketAddressSummaryComponent } from 'ish-shared/components/basket/basket-address-summary/basket-address-summary.component';
 import { BasketCostSummaryComponent } from 'ish-shared/components/basket/basket-cost-summary/basket-cost-summary.component';
+import { BasketErrorMessageComponent } from 'ish-shared/components/basket/basket-error-message/basket-error-message.component';
 import { BasketItemsSummaryComponent } from 'ish-shared/components/basket/basket-items-summary/basket-items-summary.component';
 import { BasketPromotionCodeComponent } from 'ish-shared/components/basket/basket-promotion-code/basket-promotion-code.component';
 import { BasketValidationResultsComponent } from 'ish-shared/components/basket/basket-validation-results/basket-validation-results.component';
@@ -38,6 +39,7 @@ describe('Checkout Payment Component', () => {
         CheckoutPaymentComponent,
         MockComponent(BasketAddressSummaryComponent),
         MockComponent(BasketCostSummaryComponent),
+        MockComponent(BasketErrorMessageComponent),
         MockComponent(BasketItemsSummaryComponent),
         MockComponent(BasketPromotionCodeComponent),
         MockComponent(BasketValidationResultsComponent),

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
@@ -18,6 +18,7 @@
   <!-- Error Message-->
   <div class="col-md-12">
     <ish-error-message [error]="error" [toast]="false" />
+    <ish-basket-error-message [error]="error" />
     <div *ngIf="multipleBuckets" role="alert" class="alert alert-danger">
       {{ 'checkout.shipping.no_methods.message' | translate }}
     </div>

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.spec.ts
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.spec.ts
@@ -15,6 +15,7 @@ import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
 import { AddressComponent } from 'ish-shared/components/address/address/address.component';
 import { BasketApprovalInfoComponent } from 'ish-shared/components/basket/basket-approval-info/basket-approval-info.component';
 import { BasketCostSummaryComponent } from 'ish-shared/components/basket/basket-cost-summary/basket-cost-summary.component';
+import { BasketErrorMessageComponent } from 'ish-shared/components/basket/basket-error-message/basket-error-message.component';
 import { BasketMerchantMessageViewComponent } from 'ish-shared/components/basket/basket-merchant-message-view/basket-merchant-message-view.component';
 import { BasketShippingMethodComponent } from 'ish-shared/components/basket/basket-shipping-method/basket-shipping-method.component';
 import { BasketValidationResultsComponent } from 'ish-shared/components/basket/basket-validation-results/basket-validation-results.component';
@@ -40,6 +41,7 @@ describe('Checkout Review Component', () => {
         MockComponent(AddressComponent),
         MockComponent(BasketApprovalInfoComponent),
         MockComponent(BasketCostSummaryComponent),
+        MockComponent(BasketErrorMessageComponent),
         MockComponent(BasketMerchantMessageViewComponent),
         MockComponent(BasketShippingMethodComponent),
         MockComponent(BasketValidationResultsComponent),
@@ -113,6 +115,7 @@ describe('Checkout Review Component', () => {
       [
         "ish-modal-dialog-link",
         "ish-error-message",
+        "ish-basket-error-message",
         "ish-basket-validation-results",
         "ish-basket-merchant-message-view",
         "ish-info-box",

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.html
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.html
@@ -4,7 +4,10 @@
   <div class="row">
     <!-- Messages -->
     <div class="col-md-12">
-      <ish-error-message [error]="basketError$ | async" [toast]="false" />
+      <ng-container *ngIf="basketError$ | async as error">
+        <ish-error-message [error]="error" [toast]="false" />
+        <ish-basket-error-message [error]="error" />
+      </ng-container>
       <ish-basket-validation-results />
     </div>
     <!-- Shipping method form-->

--- a/src/app/pages/checkout-shipping/checkout-shipping-page.component.spec.ts
+++ b/src/app/pages/checkout-shipping/checkout-shipping-page.component.spec.ts
@@ -12,6 +12,7 @@ import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 import { BasketAddressSummaryComponent } from 'ish-shared/components/basket/basket-address-summary/basket-address-summary.component';
 import { BasketCostSummaryComponent } from 'ish-shared/components/basket/basket-cost-summary/basket-cost-summary.component';
+import { BasketErrorMessageComponent } from 'ish-shared/components/basket/basket-error-message/basket-error-message.component';
 import { BasketItemsSummaryComponent } from 'ish-shared/components/basket/basket-items-summary/basket-items-summary.component';
 import { BasketMerchantMessageComponent } from 'ish-shared/components/basket/basket-merchant-message/basket-merchant-message.component';
 import { BasketValidationResultsComponent } from 'ish-shared/components/basket/basket-validation-results/basket-validation-results.component';
@@ -33,6 +34,7 @@ describe('Checkout Shipping Page Component', () => {
         CheckoutShippingPageComponent,
         MockComponent(BasketAddressSummaryComponent),
         MockComponent(BasketCostSummaryComponent),
+        MockComponent(BasketErrorMessageComponent),
         MockComponent(BasketItemsSummaryComponent),
         MockComponent(BasketMerchantMessageComponent),
         MockComponent(BasketValidationResultsComponent),

--- a/src/app/shared/components/common/error-message/error-message.component.html
+++ b/src/app/shared/components/common/error-message/error-message.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="error && !toast" role="alert" class="alert alert-danger">
+<div *ngIf="(error?.message || error?.code) && !toast" role="alert" class="alert alert-danger">
   <span *ngIf="error.message; else translationMissing" [ishServerHtml]="error.message"></span>
   <ng-template #translationMissing>
     <span [ishServerHtml]="error.code | translate"></span>

--- a/src/app/shell/header/mini-basket/mini-basket.component.html
+++ b/src/app/shell/header/mini-basket/mini-basket.component.html
@@ -17,10 +17,32 @@
   </div>
 </div>
 
-<a routerLink="/basket" *ngIf="view === 'small'" class="item-count-container position-relative">
-  <fa-icon [icon]="['fas', 'shopping-cart']" class="header-icon" />
-  <span class="badge badge-pill" [ngClass]="basketAnimation$ | async">{{ itemCount$ | async }}</span>
-</a>
+<ng-container *ngIf="view === 'small'">
+  <a
+    *ngIf="itemCount$ | async as itemCount; else emptyMobileCart"
+    routerLink="/basket"
+    class="item-count-container position-relative"
+  >
+    <fa-icon [icon]="['fas', 'shopping-cart']" class="header-icon" />
+    <span class="badge badge-pill" [ngClass]="basketAnimation$ | async">{{ itemCount }}</span>
+  </a>
+  <ng-template #emptyMobileCart>
+    <a
+      class="item-count-container position-relative"
+      [autoClose]="'outside'"
+      [ngbPopover]="'shopping_cart.ministatus.empty_cart.text' | translate"
+      placement="bottom"
+      triggers="manual"
+      #p="ngbPopover"
+      (click)="p.open()"
+      (keyup.enter)="p.open()"
+      tabindex="0"
+    >
+      <fa-icon [icon]="['fas', 'shopping-cart']" class="header-icon" />
+      <span class="badge badge-pill" [ngClass]="basketAnimation$ | async">0</span>
+    </a>
+  </ng-template>
+</ng-container>
 
 <!-- dummy element tracking basket loading for cypress tests -->
 <span *ngIf="basketLoading$ | async" class="loading" style="display: none"></span>

--- a/src/app/shell/shell.module.ts
+++ b/src/app/shell/shell.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Injector, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { NgbCollapseModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbCollapseModule, NgbDropdownModule, NgbPopoverModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { AuthorizationToggleModule } from 'ish-core/authorization-toggle.module';
@@ -51,6 +51,7 @@ const exportedComponents = [CookiesBannerComponent, FooterComponent, HeaderCompo
     IconModule,
     NgbCollapseModule,
     NgbDropdownModule,
+    NgbPopoverModule,
     PipesModule,
     QuickorderExportsModule,
     RoleToggleModule,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
1. If an error occurs because the basket has expired an error message 'undefined' is shown on checkout pages.  
2. If the user clicks on the mini cart icon of an empty cart in mobile view the empty cart page is shown with an error message.
Find a more detailed bug descriptions in the issues below.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1669 , #1675

## What Is the New Behavior?
1. The message 'The cart could not be found' is shown instead. If the user tries to continue checkout he is navigated to the (empty) cart page.
2. Clicking the cart icon shows a popup message instead.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#97978](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/97978)