### PR TITLE
fix: change facade method for eligible address determination (#98413)

### DIFF
--- a/src/app/core/facades/checkout.facade.ts
+++ b/src/app/core/facades/checkout.facade.ts
@@ -300,6 +300,10 @@ export class CheckoutFacade {
     )
   );
 
+  /**
+   * Determines the eligible addresses of baskets that have an invoice address.
+   * This ensures that the basket has at least one address.
+   */
   eligibleAddresses$() {
     return this.basket$.pipe(
       whenTruthy(),

--- a/src/app/core/facades/checkout.facade.ts
+++ b/src/app/core/facades/checkout.facade.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store, createSelector, select } from '@ngrx/store';
 import { formatISO } from 'date-fns';
 import { Subject, combineLatest, merge } from 'rxjs';
-import { debounceTime, distinctUntilChanged, map, sample, switchMap, take, tap } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map, sample, switchMap, take, tap } from 'rxjs/operators';
 
 import { Address } from 'ish-core/models/address/address.model';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
@@ -303,6 +303,7 @@ export class CheckoutFacade {
   eligibleAddresses$() {
     return this.basket$.pipe(
       whenTruthy(),
+      filter(basket => basket.invoiceToAddress !== undefined),
       take(1),
       tap(() => this.store.dispatch(loadBasketEligibleAddresses())),
       switchMap(() => this.store.pipe(select(getBasketEligibleAddresses)))


### PR DESCRIPTION
## PR Type

[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

After user login on the checkout address page the determination of the eligible addresses failed. The reason for this that the corresponding rest request is executed against the wrong basket. 

![image](https://github.com/user-attachments/assets/520f8681-cab9-4eab-bd2f-26ff1926a7b8)

Issue Number: Closes #98413

## Does this PR Introduce a Breaking Change?
[ ] Yes
[x ] No


[AB#98417](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/98417)