### PR TITLE
deps: use "Better NPM Audit" to check for production vulnerabilities with allowed exceptions

### DIFF
--- a/.github/workflows/automated-update.yml
+++ b/.github/workflows/automated-update.yml
@@ -6,8 +6,8 @@ on:
     types: [opened, synchronize]
     paths:
       - scripts/update-pwa.js
-  schedule:
-    - cron: '0 0 * * 1'
+  # schedule:
+  #   - cron: '0 0 * * 1'
 
 env:
   NODE_VERSION: 18.16.0

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -2,9 +2,9 @@ name: DeadCode
 
 on:
   workflow_dispatch:
-  schedule:
-    # every sunday at midnight
-    - cron: '0 0 * * 0'
+  # schedule:
+  #   # every sunday at midnight
+  #   - cron: '0 0 * * 0'
 
 env:
   NODE_VERSION: 18.16.0

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -1,13 +1,14 @@
 name: Updates
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop
       - upgrade/**
       - update/**
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+  #   - cron: '0 0 * * *'
 
 env:
   NODE_VERSION: 18.16.0

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -39,8 +39,12 @@ jobs:
         if: always()
         run: npm outdated --long || true
 
-      - name: Must Have Updates for PWA
-        run: npm audit --omit=dev
+      - name: Production npm audit
+        run: npm audit --omit=dev || true
+        if: always()
+
+      - name: Better NPM Audit (for relevant vulnerability checking)
+        run: npm run audit --production
         if: always()
 
       - name: Peer Dependency Incompatibilities

--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "GHSA-vc8w-jr9v-vj7f": "Ignored since we don't use Bootstrap Javascript (only Bootstrap styling with ng-bootstrap)"
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,7 @@
 .gitattributes
 .editorconfig
 .nvmrc
+.nsprc
 package*.json
 Dockerfile*
 .browserslistrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "@types/webpack": "^5.28.5",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "better-npm-audit": "^3.8.3",
         "comment-json": "^4.2.3",
         "conventional-changelog-cli": "^4.1.0",
         "cspell": "^8.13.2",
@@ -9615,6 +9616,34 @@
         "bytesish": "^0.4.1",
         "caseless": "~0.12.0",
         "is-stream": "^2.0.0"
+      }
+    },
+    "node_modules/better-npm-audit": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/better-npm-audit/-/better-npm-audit-3.8.3.tgz",
+      "integrity": "sha512-DY1VwwxUF/Bc5Rgh1kP0S8Jg63YyBICG+6/KGYjo9cqZ50jzF+bMSqez3yQ6Bvvf4vd9TRs/nw/GT/ZZEaLbvg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^8.0.0",
+        "dayjs": "^1.10.6",
+        "lodash.get": "^4.4.2",
+        "semver": "^7.6.3",
+        "table": "^6.7.1"
+      },
+      "bin": {
+        "better-npm-audit": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.12"
+      }
+    },
+    "node_modules/better-npm-audit/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/big.js": {
@@ -19343,6 +19372,12 @@
       "version": "4.0.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.isfinite": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "serve": "node dist/server/main.js",
     "start": "npm-run-all build serve",
     "start:ssr-dev": "ng run intershop-pwa:serve-ssr",
-    "xliff": "node scripts/convert-to-xliff.js"
+    "xliff": "node scripts/convert-to-xliff.js",
+    "audit": "better-npm-audit audit"
   },
   "dependencies": {
     "@angular-devkit/schematics": "^16.2.14",
@@ -142,6 +143,7 @@
     "@types/webpack": "^5.28.5",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "better-npm-audit": "^3.8.3",
     "comment-json": "^4.2.3",
     "conventional-changelog-cli": "^4.1.0",
     "cspell": "^8.13.2",


### PR DESCRIPTION
* `npm audit --omit=dev` will result always in a vulnerability issue as long as we have a dependency to Bootstrap 4.6.2
* since we only use the styling of Bootstrap in combination with ng-bootstrap the vulnerability should not be an issue
* so we now use a vulnerability checker that allows for exceptions for checking for vulnerabilities in the develop branch

## PR Type

[x] Other: deps checking

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#99145](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/99145)