### PR TITLE
fix: decode search urls to avoid double encoding in canonical links

### DIFF
--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -72,6 +72,11 @@ export class SeoEffects {
             this.categoryPage$.pipe(
               map((category: CategoryView) => this.baseURL + generateCategoryUrl(category).substring(1))
             ),
+            // SEARCH RESULT PAGE
+            this.store.pipe(
+              ofUrl(/^\/search.*/),
+              map(() => decodeURI(this.doc.URL))
+            ),
             // DEFAULT
             this.appRef.isStable.pipe(
               whenTruthy(),


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[x] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

search ulrs are encoded twice in canonical URL

Issue Number: Closes #1711

## What Is the New Behavior?

search ulrs are encoded only once in canonical URL

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#99736](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/99736)