### PR TITLE
refactor: replace options calls by appropriate get requests

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -22,6 +22,7 @@ With ICM 12.2.0, 11.11.1 or 7.10.41.3 the ICM server itself provides an OCI punc
 For that reason the provided OCI Punchout URL is now pointing to the ICM pipeline `ViewOCICatalogPWA-Start` that handles the different functionalities and redirects to the PWA (configured as _External Base URL_ in ICM) only for catalog browsing and the detail function.
 
 The OPTION REST call to fetch the oci punchout configurations has been replaced by a GET REST request to avoid possible CORS errors (requires ICM 12.2.1 or above).
+The OPTION REST call to fetch the customer payment methods has been replaced by a GET REST requests to avoid possible CORS errors (requires ICM 11.10.0 or above).
 
 ## From 5.1 to 5.2
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -21,6 +21,8 @@ If your ICM doesn't support the new standard the method `getCustomerRestResource
 With ICM 12.2.0, 11.11.1 or 7.10.41.3 the ICM server itself provides an OCI punchout URL (Pipeline) that works better for the OCI punchout functions `BACKGROUND_SEARCH` and `VALIDATE` than the similar now deprecated functionality in the PWA.
 For that reason the provided OCI Punchout URL is now pointing to the ICM pipeline `ViewOCICatalogPWA-Start` that handles the different functionalities and redirects to the PWA (configured as _External Base URL_ in ICM) only for catalog browsing and the detail function.
 
+The OPTION REST call to fetch the oci punchout configurations has been replaced by a GET REST request to avoid possible CORS errors (requires ICM 12.2.1 or above).
+
 ## From 5.1 to 5.2
 
 > [!NOTE]

--- a/e2e/cypress/e2e/pages/meta-data.module.ts
+++ b/e2e/cypress/e2e/pages/meta-data.module.ts
@@ -42,24 +42,24 @@ export class MetaDataModule {
     };
 
     if (expected.title) {
-      this.title.should(this.checkStrategy(expected.title), expected.title);
-      this.meta('og:title').should(this.checkStrategy(expected.title), expected.title);
+      this.title.should('equal', expected.title);
+      this.meta('og:title').should('equal', expected.title);
       this.title.then(title => {
         this.meta('og:title').should('equal', title);
       });
     }
 
     if (expected.url) {
-      this.canonicalLink.should(this.checkStrategy(expected.url), expected.url);
-      this.meta('og:url').should(this.checkStrategy(expected.url), expected.url);
+      this.canonicalLink.should('match', expected.url);
+      this.meta('og:url').should('match', expected.url);
       this.canonicalLink.then(url => {
         this.meta('og:url').should('equal', url);
       });
     }
 
     if (expected.description) {
-      this.meta('description').should(this.checkStrategy(expected.description), expected.description);
-      this.meta('og:description').should(this.checkStrategy(expected.description), expected.description);
+      this.meta('description').should('contain', expected.description);
+      this.meta('og:description').should('contain', expected.description);
 
       (this.meta('description') as Cypress.Chainable<unknown>).then(description => {
         this.meta('og:description').should('equal', description);

--- a/e2e/cypress/e2e/specs/system/seo-product-detail-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/system/seo-product-detail-page.b2c.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('Page Meta', () => {
       page.metaData.check({
         title: 'Smart Home - Home Entertainment | Intershop PWA',
         url: /.*\/smart-home-ctgHome-Entertainment.SmartHome$/,
-        description: 'Smart Home, Hands-free help from the Google AssistantSmart HomeHome Entertainment',
+        description: 'Smart HomeHome Entertainment',
       });
     });
   });

--- a/src/app/core/services/api/api.service.spec.ts
+++ b/src/app/core/services/api/api.service.spec.ts
@@ -64,6 +64,7 @@ describe('Api Service', () => {
     });
 
     it('should call the httpClient.options method when apiService.options method is called.', done => {
+      // eslint-disable-next-line etc/no-deprecated
       apiService.options('data').subscribe({
         next: data => {
           expect(data).toBeTruthy();
@@ -79,6 +80,7 @@ describe('Api Service', () => {
     it('should create Error Action if httpClient.options throws Error.', () => {
       const statusText = 'ERROR';
 
+      // eslint-disable-next-line etc/no-deprecated
       apiService.options('data').subscribe({ next: fail, error: fail });
       const req = httpTestingController.expectOne(`${REST_URL}/data`);
 

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -217,8 +217,9 @@ export class ApiService {
     );
   }
 
+  // not-dead-code
   /**
-   * http options request
+   * @deprecated http options request - will be removed with the next major release (6.0)
    */
   options<T>(path: string, options?: AvailableOptions): Observable<T> {
     return this.execute(

--- a/src/app/core/services/payment/payment.service.spec.ts
+++ b/src/app/core/services/payment/payment.service.spec.ts
@@ -214,7 +214,6 @@ describe('Payment Service', () => {
     it("should get a user's payment method data when 'getUserPaymentMethods' is called for b2c/b2x applications", done => {
       when(apiServiceMock.get(anyString())).thenReturn(of([]));
       when(apiServiceMock.resolveLinks()).thenReturn(() => of([]));
-      when(apiServiceMock.options(anyString())).thenReturn(of([]));
       const customer = {
         customerNo: '4711',
         isBusinessCustomer: false,
@@ -222,7 +221,7 @@ describe('Payment Service', () => {
 
       paymentService.getUserPaymentMethods(customer).subscribe(() => {
         verify(apiServiceMock.get('customers/4711/payments')).once();
-        verify(apiServiceMock.options('customers/4711/payments')).once();
+        verify(apiServiceMock.get('customers/4711/eligible-payment-methods')).once();
         done();
       });
     });
@@ -230,7 +229,6 @@ describe('Payment Service', () => {
     it("should get a user's payment method data when 'getUserPaymentMethods' is called for rest applications", done => {
       when(apiServiceMock.get(anyString())).thenReturn(of([]));
       when(apiServiceMock.resolveLinks()).thenReturn(() => of([]));
-      when(apiServiceMock.options(anyString())).thenReturn(of([]));
       when(appFacadeMock.customerRestResource$).thenReturn(of('privatecustomers'));
       const customer = {
         customerNo: '4711',
@@ -239,7 +237,7 @@ describe('Payment Service', () => {
 
       paymentService.getUserPaymentMethods(customer).subscribe(() => {
         verify(apiServiceMock.get('privatecustomers/4711/payments')).once();
-        verify(apiServiceMock.options('privatecustomers/4711/payments')).once();
+        verify(apiServiceMock.get('privatecustomers/4711/eligible-payment-methods')).once();
         done();
       });
     });

--- a/src/app/core/services/payment/payment.service.ts
+++ b/src/app/core/services/payment/payment.service.ts
@@ -289,7 +289,9 @@ export class PaymentService {
           this.apiService.resolveLinks<PaymentInstrumentData>(),
           concatMap(instruments =>
             this.apiService
-              .options(`${restResource}/${this.apiService.encodeResourceId(customer.customerNo)}/payments`)
+              // replace the get request by an options request if your ICM version is lower than 11.10.0
+              // .options(`${restResource}/${this.apiService.encodeResourceId(customer.customerNo)}/payments`)
+              .get(`${restResource}/${this.apiService.encodeResourceId(customer.customerNo)}/eligible-payment-methods`)
               .pipe(
                 unpackEnvelope<PaymentMethodOptionsDataType>('methods'),
                 map(methods => PaymentMethodMapper.fromOptions({ methods, instruments }))

--- a/src/app/extensions/punchout/services/punchout/punchout.service.spec.ts
+++ b/src/app/extensions/punchout/services/punchout/punchout.service.spec.ts
@@ -19,7 +19,6 @@ describe('Punchout Service', () => {
   beforeEach(() => {
     apiServiceMock = mock(ApiService);
 
-    when(apiServiceMock.options(anything(), anything())).thenReturn(of({}));
     when(apiServiceMock.get(anything(), anything())).thenReturn(of({}));
     when(apiServiceMock.resolveLinks(anything())).thenReturn(() => of([]));
     when(apiServiceMock.post(anything(), anything(), anything())).thenReturn(of({}));
@@ -102,8 +101,8 @@ describe('Punchout Service', () => {
 
   it("should get oci options when 'getOciConfigurationOptions' is called", done => {
     punchoutService.getOciConfigurationOptions().subscribe(() => {
-      verify(apiServiceMock.options(anything(), anything())).once();
-      expect(capture(apiServiceMock.options).last()[0]).toMatchInlineSnapshot(`"customers/4711/punchouts/oci5"`);
+      verify(apiServiceMock.get(anything(), anything())).once();
+      expect(capture(apiServiceMock.get).last()[0]).toMatchInlineSnapshot(`"customers/4711/punchouts/oci5"`);
       done();
     });
   });

--- a/src/app/extensions/punchout/services/punchout/punchout.service.ts
+++ b/src/app/extensions/punchout/services/punchout/punchout.service.ts
@@ -518,7 +518,8 @@ export class PunchoutService {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
         this.apiService
-          .options<OciOptionsData>(
+          // replace the get request by an options request if your ICM version is lower than 12.2.1
+          .get<OciOptionsData>(
             `customers/${this.apiService.encodeResourceId(customer.customerNo)}/punchouts/${this.getResourceType(
               'oci'
             )}`,


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

**Wait for the GA release of ICM 12.2.1 before this PR can be merged**

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
Options calls are used to fetch the oci punchout configurations as well as the customer payment methods. This is not the way to go anymore and can cause CORS issues if the ICM web adapter is not configured properly.

Issue Number: Closes #

## What Is the New Behavior?
Alternative 'get' requests are used to fetch the data mentioned above.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
Required ICM versions:
11.10.0 and above to fetch the customer payment methods
12.2.1 and above to fetch the oci punchout configuration


