### PR TITLE
fix: eslint-rule "no-intelligence-in-artifacts" also checks components of different themes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -399,7 +399,7 @@
         "ish-custom-rules/no-intelligence-in-artifacts": [
           "warn",
           {
-            "(component|pipe|directive)(\\.spec)?\\.ts$": {
+            "(component|pipe|directive)(\\..*)?\\.ts$": {
               // "router": "Angular artifacts should rely use the Router directly.",
               "ngrx": "Angular artifacts should rely on facades only.",
               "service": "Angular artifacts should rely on facades only."


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The eslint-rule `no-intelligence-in-artifacts` only checks component files with the pattern `*.component.ts` and `*.component.spec.ts`. That's why files for specific themes, like `*.component.b2b.ts`, are not being checked by this lint rule.

## What Is the New Behavior?

The eslint-rule `no-intelligence-in-artifacts` checks basic component files as well as components of arbitrary specific themes.

## Does this PR Introduce a Breaking Change?

[x] No

[AB#100457](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/100457)