### PR TITLE
perf: load the main product image eagerly on PDP

### DIFF
--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -23,6 +23,7 @@
                 [ngClass]="{ 'product-image-zoom': zoomImageIds$ | async }"
                 imageType="L"
                 [imageView]="imageView"
+                [loading]="i === 0 ? 'eager' : 'lazy'"
               />
             </div>
           </ng-template>

--- a/src/app/shared/components/product/product-image/product-image.component.html
+++ b/src/app/shared/components/product/product-image/product-image.component.html
@@ -13,7 +13,7 @@
   <ng-container *ngIf="productImage$ | async as image; else noImage">
     <img
       *ngIf="image.effectiveUrl; else noImage"
-      loading="lazy"
+      [attr.loading]="loading"
       class="product-image"
       [src]="image.effectiveUrl"
       [attr.height]="image.imageActualHeight"
@@ -25,7 +25,7 @@
 
   <ng-template #noImage>
     <img
-      loading="lazy"
+      [attr.loading]="loading"
       class="product-image"
       src="/assets/img/not-available.svg"
       [attr.alt]="'product.image.not_available.alttext' | translate"

--- a/src/app/shared/components/product/product-image/product-image.component.ts
+++ b/src/app/shared/components/product/product-image/product-image.component.ts
@@ -39,6 +39,10 @@ export class ProductImageComponent implements OnInit {
    * A custom alt text for the img tag.
    */
   @Input() altText: string;
+  /**
+   * The image loading strategy.
+   */
+  @Input() loading: 'lazy' | 'eager' | 'auto' = 'lazy';
 
   productURL$: Observable<string>;
   productImage$: Observable<Image>;


### PR DESCRIPTION
* because it is the LCP on this page

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: Performance improvements

## What Is the Current Behavior?
The main product image on PDP is lazily loaded. On mobile devices and also sometimes on desktop this image is the LCP of the product detail page and for performance reasons it should be loaded as fast as possible.

Issue Number: Closes #

## What Is the New Behavior?
The main product image on PDP is loaded eagerly. Especially on mobile devices the LCP will decrease significantly.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#100535](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/100535)