### PR TITLE
fix: display product image twice on PDP

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,8 @@
             "style": "camelCase"
           }
         ],
+        // ToDo: no-host-metadata-property rule will be deprecated in Angular 18 and switching off the rule will be the default behavior and can be removed.
+        "@angular-eslint/no-host-metadata-property": "off",
         "@angular-eslint/pipe-prefix": [
           "error",
           {

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -26,6 +26,7 @@ SwiperCore.use([Navigation]);
   selector: 'ish-product-images',
   templateUrl: './product-images.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { ngSkipHydration: 'true' },
 })
 export class ProductImagesComponent implements OnInit {
   @ViewChild('carousel') carousel: SwiperComponent;


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: eslint change

## What Is the Current Behavior?
On a production-like deployed PWA (with SSR) the product image is shortly shown twice on product detail page. This is due to an hydration issue regarding the swiper (image slider).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The hydration is switched off for the product images component. This leads also to an improved performance (lighthouse score) for mobile devices.
The eslint rule '@angular-eslint/no-host-metadata-property' has been switched off because it will be deprecated with Angular 18.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#100538](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/100538)