### PR TITLE
refactor: load eligible payment methods on basket page

### DIFF
--- a/src/app/core/facades/checkout.facade.ts
+++ b/src/app/core/facades/checkout.facade.ts
@@ -269,6 +269,9 @@ export class CheckoutFacade {
   }
 
   eligibleFastCheckoutPaymentMethods$ = this.store.pipe(select(getEligibleFastCheckoutPaymentMethods));
+  loadEligiblePaymentMethods() {
+    this.store.dispatch(loadBasketEligiblePaymentMethods());
+  }
 
   priceType$ = this.store.pipe(select(getServerConfigParameter<'gross' | 'net'>('pricing.priceType')));
 

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -40,7 +40,6 @@ import {
   loadBasket,
   loadBasketByAPIToken,
   loadBasketByAPITokenFail,
-  loadBasketEligiblePaymentMethods,
   loadBasketEligibleShippingMethods,
   loadBasketEligibleShippingMethodsFail,
   loadBasketEligibleShippingMethodsSuccess,
@@ -375,20 +374,6 @@ export class BasketEffects {
             map(() => loadBasket())
           )
         )
-      )
-    );
-
-  /**
-   * Load eligible payment methods on cart page after the cart has been updated to show fastpay methods.
-   */
-  loadEligiblePayMethodsOnBasketPage$ =
-    !SSR &&
-    createEffect(() =>
-      this.actions$.pipe(
-        ofType(loadBasketSuccess),
-        map(() => this.router.url),
-        filter(url => /^\/basket/.test(url)),
-        map(() => loadBasketEligiblePaymentMethods())
       )
     );
 

--- a/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.ts
+++ b/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.ts
@@ -27,6 +27,7 @@ export class ShoppingBasketPaymentComponent implements OnInit {
 
   ngOnInit(): void {
     this.priceType$ = this.checkoutFacade.priceType$;
+    this.checkoutFacade.loadEligiblePaymentMethods();
     this.paymentMethods$ = this.checkoutFacade.eligibleFastCheckoutPaymentMethods$;
     // if page is shown after cancelled/faulty redirect determine error message variable
     this.redirectStatus = this.route.snapshot.queryParamMap.get('redirect');


### PR DESCRIPTION
* move the loading to the fastpay component to avoid REST requests if the component is not used

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The eligible payment methods are always loaded if the user enters the basket page, no matter if it is needed (only needed for the display of the fastpay payment methods)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The eligible payment methods are loaded by the shoppingBasketPaymentComponent - if this component is not used by a project the REST call will not be executed.


## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#100622](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/100622)