### PR TITLE
fix: use new redirect url

### DIFF
--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -222,7 +222,7 @@ export class BasketService {
    */
   validateBasket(scopes: BasketValidationScopeType[] = ['']): Observable<BasketValidation> {
     const body = {
-      adjustmentsAllowed: !scopes.some(scope => scope === 'All'), // don't allow adjustments for 'All' validation steps, because you cannot show them to the user at once
+      adjustmentsAllowed: true,
       scopes,
     };
 

--- a/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-validation.effects.spec.ts
@@ -32,6 +32,7 @@ import {
   startCheckoutSuccess,
   startFastCheckout,
   submitBasket,
+  updateBasketPaymentRedirectUrl,
   validateBasket,
 } from './basket.actions';
 
@@ -211,6 +212,42 @@ describe('Basket Validation Effects', () => {
         complete: done,
       });
     });
+
+    it('should call updateBasketPaymentRedirectUrl if payment redirectUrl is present', done => {
+      const basketValidationWithRedirect: BasketValidation = {
+        ...basketValidation,
+        basket: {
+          ...basketValidation.basket,
+          payment: {
+            redirectUrl: 'https://redirect.url',
+            id: '',
+            paymentInstrument: undefined,
+          },
+        },
+      };
+      const action = startCheckoutSuccess({ basketValidation: basketValidationWithRedirect });
+      actions$ = of(action);
+
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidationWithRedirect));
+
+      effects.continueCheckoutWithAcceleration$.subscribe(action => {
+        expect(action).toEqual(updateBasketPaymentRedirectUrl({ redirectUrl: 'https://redirect.url' }));
+        done();
+      });
+    });
+
+    it('should not call updateBasketPaymentRedirectUrl if payment redirectUrl is not present', done => {
+      const action = startCheckoutSuccess({ basketValidation });
+      actions$ = of(action);
+
+      effects.continueCheckoutWithAcceleration$.subscribe({
+        next: () => {
+          verify(updateBasketPaymentRedirectUrl({ redirectUrl: 'https://redirect.url' })).never();
+        },
+        error: fail,
+        complete: done,
+      });
+    });
   });
 
   describe('validateBasket$', () => {
@@ -279,6 +316,42 @@ describe('Basket Validation Effects', () => {
       const expected$ = cold('-c', { c: completion });
 
       expect(effects.validateBasket$).toBeObservable(expected$);
+    });
+
+    it('should call updateBasketPaymentRedirectUrl if payment redirectUrl is present', done => {
+      const basketValidationWithRedirect: BasketValidation = {
+        ...basketValidation,
+        basket: {
+          ...basketValidation.basket,
+          payment: {
+            redirectUrl: 'https://redirect.url',
+            id: '',
+            paymentInstrument: undefined,
+          },
+        },
+      };
+      const action = validateBasket({ scopes: ['Products'] });
+      actions$ = of(action);
+
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidationWithRedirect));
+
+      effects.validateBasket$.subscribe(action => {
+        expect(action).toEqual(updateBasketPaymentRedirectUrl({ redirectUrl: 'https://redirect.url' }));
+        done();
+      });
+    });
+
+    it('should not call updateBasketPaymentRedirectUrl if payment redirectUrl is not present', done => {
+      const action = validateBasket({ scopes: ['Products'] });
+      actions$ = of(action);
+
+      effects.validateBasket$.subscribe({
+        next: () => {
+          verify(updateBasketPaymentRedirectUrl({ redirectUrl: 'https://redirect.url' })).never();
+        },
+        error: fail,
+        complete: done,
+      });
     });
   });
 
@@ -460,6 +533,42 @@ describe('Basket Validation Effects', () => {
       const expected$ = cold('-c', { c: completion });
 
       expect(effects.validateBasketAndContinueCheckout$).toBeObservable(expected$);
+    });
+
+    it('should call updateBasketPaymentRedirectUrl if payment redirectUrl is present', done => {
+      const basketValidationWithRedirect: BasketValidation = {
+        ...basketValidation,
+        basket: {
+          ...basketValidation.basket,
+          payment: {
+            redirectUrl: 'https://redirect.url',
+            id: '',
+            paymentInstrument: undefined,
+          },
+        },
+      };
+      const action = continueCheckout({ targetStep: CheckoutStepType.Addresses });
+      actions$ = of(action);
+
+      when(basketServiceMock.validateBasket(anything())).thenReturn(of(basketValidationWithRedirect));
+
+      effects.validateBasketAndContinueCheckout$.subscribe(action => {
+        expect(action).toEqual(updateBasketPaymentRedirectUrl({ redirectUrl: 'https://redirect.url' }));
+        done();
+      });
+    });
+
+    it('should not call updateBasketPaymentRedirectUrl if payment redirectUrl is not present', done => {
+      const action = continueCheckout({ targetStep: CheckoutStepType.Addresses });
+      actions$ = of(action);
+
+      effects.validateBasketAndContinueCheckout$.subscribe({
+        next: () => {
+          verify(updateBasketPaymentRedirectUrl({ redirectUrl: 'https://redirect.url' })).never();
+        },
+        error: fail,
+        complete: done,
+      });
     });
 
     describe('handleBasketNotFoundError$', () => {

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -326,11 +326,11 @@ export const setBasketDesiredDeliveryDateSuccess = createAction(
 );
 
 export const navigateBasedOnValidation = createAction(
-  '[Basket] Navigate Based On Validation',
+  '[Basket Internal] Navigate Based On Validation',
   payload<{ results: BasketValidationResultType }>()
 );
 
 export const updateBasketPaymentRedirectUrl = createAction(
-  '[Basket] Update Payment Redirect URL',
+  '[Basket Internal] Update Payment Redirect URL',
   payload<{ redirectUrl: string }>()
 );

--- a/src/app/core/store/customer/basket/basket.actions.ts
+++ b/src/app/core/store/customer/basket/basket.actions.ts
@@ -4,7 +4,11 @@ import { createAction } from '@ngrx/store';
 import { Address } from 'ish-core/models/address/address.model';
 import { Attribute } from 'ish-core/models/attribute/attribute.model';
 import { BasketInfo } from 'ish-core/models/basket-info/basket-info.model';
-import { BasketValidation, BasketValidationScopeType } from 'ish-core/models/basket-validation/basket-validation.model';
+import {
+  BasketValidation,
+  BasketValidationResultType,
+  BasketValidationScopeType,
+} from 'ish-core/models/basket-validation/basket-validation.model';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { CheckoutStepType } from 'ish-core/models/checkout/checkout-step.type';
 import { ErrorFeedback } from 'ish-core/models/http-error/http-error.model';
@@ -319,4 +323,14 @@ export const setBasketDesiredDeliveryDateFail = createAction(
 
 export const setBasketDesiredDeliveryDateSuccess = createAction(
   '[Basket API] Add or Update Basket Desired Delivery Date Success'
+);
+
+export const navigateBasedOnValidation = createAction(
+  '[Basket] Navigate Based On Validation',
+  payload<{ results: BasketValidationResultType }>()
+);
+
+export const updateBasketPaymentRedirectUrl = createAction(
+  '[Basket] Update Payment Redirect URL',
+  payload<{ redirectUrl: string }>()
 );

--- a/src/app/core/store/customer/basket/basket.reducer.ts
+++ b/src/app/core/store/customer/basket/basket.reducer.ts
@@ -84,6 +84,7 @@ import {
   updateBasketItemSuccess,
   updateBasketPayment,
   updateBasketPaymentFail,
+  updateBasketPaymentRedirectUrl,
   updateBasketPaymentSuccess,
   updateBasketShippingMethod,
   updateConcardisCvcLastUpdated,
@@ -357,6 +358,19 @@ export const basketReducer = createReducer(
       info: undefined,
       promotionError: undefined,
       validationResults: initialValidationResults,
+    })
+  ),
+  on(
+    updateBasketPaymentRedirectUrl,
+    (state, { payload: { redirectUrl } }): BasketState => ({
+      ...state,
+      basket: {
+        ...state.basket,
+        payment: {
+          ...state.basket.payment,
+          redirectUrl,
+        },
+      },
     })
   )
 );


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

For a redirect before checkout payment, the customer is redirected to the PSP using the redirect URL that the ICM generates.
When the customer is back in the PWA and the redirect was successful, he can add further products to the basket, which then triggers a new basket validation in the checkout.
This basket validation returns that a new redirect is necessary (depending on the payment connector implementation) but does not return a new redirect URL.

## What Is the New Behavior?

This bug has been fixed in ICM version 12.3.0 and the ICM now returns a new redirect URL on basket validation if adjustments are allowed and if a new redirect is needed.

This PR takes the newly generated URL and stores it in the Store to then perform the redirect with the newly generated URL.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

Requires ICM 12.3.0
Azure DevOps Issue: 97415



[AB#100804](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/100804)