### PR TITLE
fix: double header display in checkout

### DIFF
--- a/src/app/core/guards/no-server-side-rendering.guard.ts
+++ b/src/app/core/guards/no-server-side-rendering.guard.ts
@@ -1,15 +1,15 @@
 import { inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
 
 /**
  * guards a route against server side rendering (e.g. if the logic requires information only available in browser rendering)
  */
-export function noServerSideRenderingGuard() {
+export function noServerSideRenderingGuard(route: ActivatedRouteSnapshot) {
   const router = inject(Router);
 
   // prevent any handling in the server side rendering (SSR) and instead show loading
   if (SSR) {
-    return router.parseUrl('/loading');
+    return router.parseUrl(route.data.headerType === 'checkout' ? '/loading/checkout' : '/loading');
   }
 
   // if not in SSR just return true and continue

--- a/src/app/pages/loading/loading-page.module.ts
+++ b/src/app/pages/loading/loading-page.module.ts
@@ -14,6 +14,13 @@ const loadingPageRoutes: Routes = [
       headerType: 'simple',
     },
   },
+  {
+    path: 'checkout',
+    component: LoadingPageComponent,
+    data: {
+      headerType: 'checkout',
+    },
+  },
 ];
 
 @NgModule({


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
If the user is on a checkout page and refreshes the browser (F5) he sees the header twice for a short time (due to an hydration issue)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
The header is shown on once.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#100906](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/100906)