### PR TITLE
fix: password check for user email update

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,12 @@ kb_sync_latest_only
 
 # Migrations
 
+## From 5.2 to 5.3
+
+The `updateUser` method of the UserService has been slightly refactored.
+It now sends the user password in the request body to enable password validation on e-mail change.
+The Authorization header has also been removed as authorization is done via session token.
+
 ## From 5.1 to 5.2
 
 > [!NOTE]

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -1,4 +1,3 @@
-import { HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { pick } from 'lodash-es';
@@ -188,13 +187,6 @@ export class UserService {
       return throwError(() => new Error('updateUser() called without required body data'));
     }
 
-    const headers = credentials
-      ? new HttpHeaders().set(
-          ApiService.AUTHORIZATION_HEADER_KEY,
-          `BASIC ${window.btoa(`${credentials.login}:${credentials.password}`)}`
-        )
-      : undefined;
-
     const changedUser: object = {
       type: body.customer.isBusinessCustomer ? 'SMBCustomer' : 'PrivateCustomer',
       ...body.customer,
@@ -208,14 +200,15 @@ export class UserService {
       preferredShipToAddressUrn: undefined,
       preferredPaymentInstrumentId: undefined,
       preferredLanguage: body.user.preferredLanguage || 'en_US',
+      ...(credentials?.password ? { password: credentials.password } : {}), // Required for email change validation
     };
 
     return this.appFacade.customerRestResource$.pipe(
       first(),
       concatMap(restResource =>
         body.customer.isBusinessCustomer
-          ? this.apiService.put<User>('customers/-/users/-', changedUser, { headers }).pipe(map(UserMapper.fromData))
-          : this.apiService.put<User>(`${restResource}/-`, changedUser, { headers }).pipe(map(UserMapper.fromData))
+          ? this.apiService.put<User>('customers/-/users/-', changedUser, {}).pipe(map(UserMapper.fromData))
+          : this.apiService.put<User>(`${restResource}/-`, changedUser, {}).pipe(map(UserMapper.fromData))
       )
     );
   }


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

It is possible to change the e-mail address in the user profile of the My Account without correct password, while there is a need to enter the password. The password is sent in the request header of the user put request, but is is not checked by the ICM any more.

## What Is the New Behavior?

The password is sent to the ICM in the request body of the user put request (updateUser method of the user.service.ts) now.
There the password is validated by the ICM when the user's email is changed. 

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information

Requires ICM 13.0, 12.3.1, or 7.10.41.7 or higher to fix this issue. 

[AD](https://dev.azure.com/intershop-com/Products/_workitems/edit/101261)
