### PR TITLE
fix: remove double slashes in cost center REST call

### DIFF
--- a/src/app/core/services/user/user.service.spec.ts
+++ b/src/app/core/services/user/user.service.spec.ts
@@ -395,7 +395,7 @@ describe('User Service', () => {
 
     it("should get eligible cost centers for business user when 'getEligibleCostCenters' is called", done => {
       userService.getEligibleCostCenters().subscribe(() => {
-        verify(apiServiceMock.get(`/costcenters`)).once();
+        verify(apiServiceMock.get(`costcenters`)).once();
         done();
       });
     });

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -332,7 +332,7 @@ export class UserService {
   getEligibleCostCenters(): Observable<UserCostCenter[]> {
     return this.apiService
       .b2bUserEndpoint()
-      .get(`/costcenters`)
+      .get(`costcenters`)
       .pipe(
         unpackEnvelope(),
         map((costCenters: UserCostCenter[]) => costCenters)


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
On cart page the eligible cost centers are fetched from the ICM using a call like this:
/customers/OilCorp/users/bboldner%40test.intershop.de//costcenters

There is an unwanted double slash in it.
This leads to a 404 error on cart page for b2b users if ICM version 13 is used.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

The double slash is changed into a single slash

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#101454](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/101454)