### PR TITLE
fix: cost center loading and display

### DIFF
--- a/projects/organization-management/src/app/services/cost-centers/cost-centers.service.spec.ts
+++ b/projects/organization-management/src/app/services/cost-centers/cost-centers.service.spec.ts
@@ -22,7 +22,6 @@ describe('Cost Centers Service', () => {
     when(apiService.post(anything(), anything())).thenReturn(of({}));
     when(apiService.patch(anything(), anything())).thenReturn(of({}));
     when(apiService.delete(anything())).thenReturn(of({}));
-    when(apiService.resolveLinks()).thenReturn(() => of([]));
     when(apiService.encodeResourceId(anything())).thenCall(id => id);
 
     TestBed.configureTestingModule({

--- a/projects/organization-management/src/app/services/cost-centers/cost-centers.service.ts
+++ b/projects/organization-management/src/app/services/cost-centers/cost-centers.service.ts
@@ -6,6 +6,7 @@ import { concatMap, map, switchMap, take } from 'rxjs/operators';
 import { CostCenterData } from 'ish-core/models/cost-center/cost-center.interface';
 import { CostCenterMapper } from 'ish-core/models/cost-center/cost-center.mapper';
 import { CostCenter, CostCenterBase, CostCenterBuyer } from 'ish-core/models/cost-center/cost-center.model';
+import { Link } from 'ish-core/models/link/link.model';
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { whenTruthy } from 'ish-core/utils/operators';
@@ -24,10 +25,9 @@ export class CostCentersService {
   getCostCenters(): Observable<CostCenter[]> {
     return this.currentCustomer$.pipe(
       switchMap(customer =>
-        this.apiService.get(`customers/${this.apiService.encodeResourceId(customer.customerNo)}/costcenters`).pipe(
-          this.apiService.resolveLinks<CostCenterData>(),
-          map(ccData => ccData.map(CostCenterMapper.fromData))
-        )
+        this.apiService
+          .get<Link[]>(`customers/${this.apiService.encodeResourceId(customer.customerNo)}/costcenters`)
+          .pipe(map(CostCenterMapper.fromListData))
       )
     );
   }

--- a/src/app/core/models/cost-center/cost-center.mapper.spec.ts
+++ b/src/app/core/models/cost-center/cost-center.mapper.spec.ts
@@ -1,7 +1,219 @@
+import { Link } from 'ish-core/models/link/link.model';
+
 import { CostCenterData } from './cost-center.interface';
 import { CostCenterMapper } from './cost-center.mapper';
 
 describe('Cost Center Mapper', () => {
+  describe('fromListData', () => {
+    it(`should return costCenters when getting CostCenterLinks`, () => {
+      const costCenterListData = [
+        {
+          attributes: [
+            {
+              name: 'name',
+              value: 'Oil Corp Headquarter',
+            },
+            {
+              name: 'costCenterId',
+              value: '100400',
+            },
+            {
+              name: 'budgetPeriod',
+              value: 'monthly',
+            },
+            {
+              name: 'active',
+              value: true,
+            },
+            {
+              name: 'budget',
+              value: {
+                type: 'Money',
+                value: 20000.0,
+                currencyMnemonic: 'USD',
+                currency: 'USD',
+              },
+            },
+            {
+              name: 'pendingOrders',
+              value: 0,
+            },
+            {
+              name: 'approvedOrders',
+              value: 0,
+            },
+            {
+              name: 'costCenterOwner',
+              value: {
+                email: 'jlink@test.intershop.de',
+                firstName: 'Jack',
+                lastName: 'Link',
+                login: 'jlink@test.intershop.de',
+              },
+            },
+            {
+              name: 'spentBudget',
+              value: {
+                type: 'Money',
+                value: 0.0,
+                currencyMnemonic: 'USD',
+                currency: 'USD',
+              },
+            },
+            {
+              name: 'remainingBudget',
+              value: {
+                type: 'Money',
+                value: 20000.0,
+                currencyMnemonic: 'USD',
+                currency: 'USD',
+              },
+            },
+          ],
+          itemId: 'LmpA8AVnGzEAAAGRxuAADVoP',
+        },
+        {
+          attributes: [
+            {
+              name: 'name',
+              value: 'Oil Corp Subsidiary 1',
+            },
+            {
+              name: 'costCenterId',
+              value: '100401',
+            },
+            {
+              name: 'budgetPeriod',
+              value: 'monthly',
+            },
+            {
+              name: 'active',
+              value: true,
+            },
+            {
+              name: 'budget',
+              value: {
+                type: 'Money',
+                value: 5000.0,
+                currencyMnemonic: 'USD',
+                currency: 'USD',
+              },
+            },
+            {
+              name: 'pendingOrders',
+              value: 1,
+            },
+            {
+              name: 'approvedOrders',
+              value: 4,
+            },
+            {
+              name: 'costCenterOwner',
+              value: {
+                email: 'bboldner@test.intershop.de',
+                firstName: 'Bernhard',
+                lastName: 'Boldner',
+                login: 'bboldner@test.intershop.de',
+              },
+            },
+            {
+              name: 'spentBudget',
+              value: {
+                type: 'Money',
+                value: 156759.02,
+                currencyMnemonic: 'USD',
+                currency: 'USD',
+              },
+            },
+            {
+              name: 'remainingBudget',
+              value: {
+                type: 'Money',
+                value: -151759.02,
+                currencyMnemonic: 'USD',
+                currency: 'USD',
+              },
+            },
+          ],
+          itemId: 'XopA8AVnEKUAAAGR0OAADVoP',
+        },
+      ] as Link[];
+      const costCenters = CostCenterMapper.fromListData(costCenterListData);
+
+      expect(costCenters).toBeTruthy();
+      expect(costCenters).toMatchInlineSnapshot(`
+        [
+          {
+            "active": true,
+            "approvedOrders": 0,
+            "budget": {
+              "currency": "USD",
+              "currencyMnemonic": "USD",
+              "type": "Money",
+              "value": 20000,
+            },
+            "budgetPeriod": "monthly",
+            "costCenterId": "100400",
+            "costCenterOwner": {
+              "email": "jlink@test.intershop.de",
+              "firstName": "Jack",
+              "lastName": "Link",
+              "login": "jlink@test.intershop.de",
+            },
+            "id": "LmpA8AVnGzEAAAGRxuAADVoP",
+            "name": "Oil Corp Headquarter",
+            "pendingOrders": 0,
+            "remainingBudget": {
+              "currency": "USD",
+              "currencyMnemonic": "USD",
+              "type": "Money",
+              "value": 20000,
+            },
+            "spentBudget": {
+              "currency": "USD",
+              "currencyMnemonic": "USD",
+              "type": "Money",
+              "value": 0,
+            },
+          },
+          {
+            "active": true,
+            "approvedOrders": 4,
+            "budget": {
+              "currency": "USD",
+              "currencyMnemonic": "USD",
+              "type": "Money",
+              "value": 5000,
+            },
+            "budgetPeriod": "monthly",
+            "costCenterId": "100401",
+            "costCenterOwner": {
+              "email": "bboldner@test.intershop.de",
+              "firstName": "Bernhard",
+              "lastName": "Boldner",
+              "login": "bboldner@test.intershop.de",
+            },
+            "id": "XopA8AVnEKUAAAGR0OAADVoP",
+            "name": "Oil Corp Subsidiary 1",
+            "pendingOrders": 1,
+            "remainingBudget": {
+              "currency": "USD",
+              "currencyMnemonic": "USD",
+              "type": "Money",
+              "value": -151759.02,
+            },
+            "spentBudget": {
+              "currency": "USD",
+              "currencyMnemonic": "USD",
+              "type": "Money",
+              "value": 156759.02,
+            },
+          },
+        ]
+      `);
+    });
+  });
+
   describe('fromData', () => {
     it(`should return a CostCenter when getting CostCenterData`, () => {
       const costCenterData = {

--- a/src/app/core/models/cost-center/cost-center.mapper.spec.ts
+++ b/src/app/core/models/cost-center/cost-center.mapper.spec.ts
@@ -30,7 +30,7 @@ describe('Cost Center Mapper', () => {
       expect(costCenter).toBeTruthy();
       expect(costCenter.costCenterId).toBe('100400');
       expect(costCenter.orders).toHaveLength(2);
-      expect(costCenter.orders[0].attributes).toHaveLength(1);
+      expect(costCenter.orders[0].user.firstName).toBe('John');
       expect(costCenter.orders[1].totals.total.gross).toBe(1000.23);
     });
   });

--- a/src/app/core/models/cost-center/cost-center.mapper.ts
+++ b/src/app/core/models/cost-center/cost-center.mapper.ts
@@ -1,3 +1,5 @@
+import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
+
 import { CostCenterData } from './cost-center.interface';
 import { CostCenter } from './cost-center.model';
 
@@ -10,7 +12,10 @@ export class CostCenterMapper {
           documentNo: order.orderNo,
           status: order.orderStatus,
           creationDate: order.orderDate.toString(),
-          attributes: order.buyer.attributes,
+          user: {
+            firstName: AttributeHelper.getAttributeValueByAttributeName(order.buyer?.attributes, 'firstName'),
+            lastName: AttributeHelper.getAttributeValueByAttributeName(order.buyer?.attributes, 'lastName'),
+          },
           totalProductQuantity: order.items,
           totals: {
             total: {

--- a/src/app/core/models/cost-center/cost-center.mapper.ts
+++ b/src/app/core/models/cost-center/cost-center.mapper.ts
@@ -1,9 +1,31 @@
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
+import { Link } from 'ish-core/models/link/link.model';
 
 import { CostCenterData } from './cost-center.interface';
 import { CostCenter } from './cost-center.model';
 
 export class CostCenterMapper {
+  /* map cost center data from link list attributes,
+  some data are missing like orders or buyer assignments that have to be fetched with the details call */
+  static fromListData(data: Link[]): CostCenter[] {
+    if (!data?.length) {
+      return [];
+    }
+    return data.map(cc => ({
+      id: cc.itemId,
+      costCenterId: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'costCenterId'),
+      name: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'name'),
+      active: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'active'),
+      costCenterOwner: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'costCenterOwner'),
+      budget: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'budget'),
+      budgetPeriod: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'budgetPeriod'),
+      pendingOrders: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'pendingOrders'),
+      approvedOrders: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'approvedOrders'),
+      spentBudget: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'spentBudget'),
+      remainingBudget: AttributeHelper.getAttributeValueByAttributeName(cc.attributes, 'remainingBudget'),
+    }));
+  }
+
   static fromData(data: CostCenterData): CostCenter {
     if (data) {
       return {

--- a/src/app/core/models/cost-center/cost-center.model.ts
+++ b/src/app/core/models/cost-center/cost-center.model.ts
@@ -34,5 +34,8 @@ export interface CostCenter extends CostCenterBase {
   spentBudget?: Price;
   remainingBudget?: Price;
   buyers?: CostCenterBuyer[];
-  orders?: Pick<Order, 'documentNo' | 'creationDate' | 'status' | 'attributes' | 'totalProductQuantity' | 'totals'>[];
+  orders?: Pick<
+    Order,
+    'documentNo' | 'creationDate' | 'status' | 'attributes' | 'user' | 'totalProductQuantity' | 'totals'
+  >[];
 }

--- a/src/app/core/store/customer/orders/orders.effects.ts
+++ b/src/app/core/store/customer/orders/orders.effects.ts
@@ -128,7 +128,7 @@ export class OrdersEffects {
     this.actions$.pipe(
       ofType(loadMoreOrders),
       concatLatestFrom(() => this.store.pipe(select(getOrderListQuery))),
-      map(([, query]) => loadOrders({ query: { ...query, offset: (query.offset ?? 0) + query.limit } }))
+      map(([, query]) => loadOrders({ query: { ...query, offset: (query?.offset ?? 0) + query.limit } }))
     )
   );
 

--- a/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.ts
+++ b/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.ts
@@ -15,7 +15,7 @@ import { UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbDateAdapter, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { Observable, distinctUntilChanged, map, shareReplay, takeUntil, tap } from 'rxjs';
+import { Observable, distinctUntilChanged, map, shareReplay, takeUntil } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { OrderListQuery } from 'ish-core/models/order-list-query/order-list-query.model';
@@ -252,11 +252,9 @@ export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
   }
 
   private getModel(params?: UrlModel): Observable<FormModel> {
+    this.modelChange.emit(urlToQuery(params));
     return this.isAdmin$.pipe(
       distinctUntilChanged(),
-      tap(() => {
-        this.modelChange.emit(urlToQuery(params));
-      }),
       map(isAdmin => ({
         date:
           params?.from || params?.to

--- a/src/app/shared/components/order/order-list/order-list.component.html
+++ b/src/app/shared/components/order/order-list/order-list.component.html
@@ -36,7 +36,7 @@
           {{ 'account.orderlist.table.buyer' | translate }}
         </th>
         <td cdk-cell *cdkCellDef="let order" [attr.data-label]="'account.orderlist.table.buyer' | translate">
-          {{ order.user.firstName }} {{ order.user.lastName }}
+          {{ order.user?.firstName }} {{ order.user?.lastName }}
         </td>
       </ng-container>
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
1. On cost center list/widget there is a get REST request for every single cost center to provide the list data. This is really slow if a project has many cost centers and leads to performance issues on the cost center list page and the myAccount overview page (cost center widget).
2. On the cost center details page the related orders and assigned buyers are not shown.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
2. The cost center data that are needed for the list are read from the attributes costcenters get REST response, there is no need to fetch every single cost center to show the list data. If the user navigates to a detail page the cost center details call is triggered (this functionality doesn't change)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#102131](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/102131)

[AB#102079](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/102079)