### PR TITLE
feat: save punchout information in session storage instead of in cookies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
     # command: ['node', 'dist/b2c/run-standalone']
     # command: ['node', 'dist/b2b/run-standalone']
     environment:
-      # ICM_BASE_URL:
+      ICM_BASE_URL: 'https://develop.icm.intershop.de'
       LOGGING: 'true'
       # LOG_ALL: 'false'
       SOURCE_MAPS: 'true'
-      TRUST_ICM: 'true'
+      # TRUST_ICM: 'true'
       # PROXY_ICM: 'true'
       # PROMETHEUS: 'true'
       # MULTI_SITE_LOCALE_MAP: |
@@ -29,15 +29,15 @@ services:
       #   - compare
       #   - rating
       # IDENTITY_PROVIDER: 'Auth0'
-      # IDENTITY_PROVIDERS: |
+      IDENTITY_PROVIDERS: |
+        Punchout:
+          type: PUNCHOUT
+        CoBrowse:
+          type: cobrowse
       #   Auth0:
       #     type: auth0
       #     domain: some-domain.auth0.com
       #     clientID: ASDF12345
-      #   Punchout:
-      #     type: PUNCHOUT
-      #   CoBrowse:
-      #     type: cobrowse
 
     # Logging to an External Device (see logging.md)
     # volumes:
@@ -77,6 +77,7 @@ services:
       # - '9113:9113'
     environment:
       UPSTREAM_PWA: 'http://pwa:4200'
+      ICM_BASE_URL: 'https://develop.icm.intershop.de'
       NGINX_ENTRYPOINT_QUIET_LOGS: ANYVALUE
       CACHE: 0
       # REDIS_URI: redis://redis:6379
@@ -93,12 +94,20 @@ services:
       # BASIC_AUTH: 'developer:!InterShop00!'
       # BASIC_AUTH_IP_WHITELIST: |
       #   - 1.2.3.4
-      # OVERRIDE_IDENTITY_PROVIDERS: |
-      #   .+:
-      #     - path: /en/punchout
-      #       type: Punchout
-      #     - path: /en/cobrowse
-      #       type: CoBrowse
+      OVERRIDE_IDENTITY_PROVIDERS: |
+        .+:
+          - path: /en/punchout
+            type: Punchout
+          - path: /de/punchout
+            type: Punchout
+          - path: /fr/punchout
+            type: Punchout
+          - path: /en/cobrowse
+            type: CoBrowse
+          - path: /de/cobrowse
+            type: CoBrowse
+          - path: /fr/cobrowse
+            type: CoBrowse
       MULTI_CHANNEL: |
         .+:
           - baseHref: /en

--- a/docs/guides/cookie-consent.md
+++ b/docs/guides/cookie-consent.md
@@ -37,10 +37,6 @@ cookieConsentOptions: {
     'apiToken',
     'cookieConsent',
     'preferredLocale',
-    'punchout_SID',
-    'punchout_BasketID',
-    'punchout_ReturnURL',
-    'punchout_HookURL',
   ],
 },
 ```
@@ -108,15 +104,11 @@ This route can be linked to from anywhere within the application.
 
 ## PWA Required Cookies
 
-| Name               | Expiration | Provider      | Description                                                       | Category    |
-| ------------------ | ---------- | ------------- | ----------------------------------------------------------------- | ----------- |
-| apiToken           | 1 hour     | Intershop PWA | The API token used by the Intershop Commerce Management REST API. | First Party |
-| cookieConsent      | 1 year     | Intershop PWA | Saves the user's cookie consent settings.                         | First Party |
-| preferredLocale    | 1 year     | Intershop PWA | Saves the user's language selection.                              | First Party |
-| punchout_SID       | Session    | Intershop PWA | Saves punchout session related data - Session ID.                 | First Party |
-| punchout_BasketID  | Session    | Intershop PWA | Saves punchout session related data - Basket ID.                  | First Party |
-| punchout_ReturnURL | Session    | Intershop PWA | Saves punchout session related data - Return URL.                 | First Party |
-| punchout_HookURL   | Session    | Intershop PWA | Saves punchout session related data - Hook URL.                   | First Party |
+| Name            | Expiration | Provider      | Description                                                       | Category    |
+| --------------- | ---------- | ------------- | ----------------------------------------------------------------- | ----------- |
+| apiToken        | 1 hour     | Intershop PWA | The API token used by the Intershop Commerce Management REST API. | First Party |
+| cookieConsent   | 1 year     | Intershop PWA | Saves the user's cookie consent settings.                         | First Party |
+| preferredLocale | 1 year     | Intershop PWA | Saves the user's language selection.                              | First Party |
 
 ## Disabling the Integrated Cookie Consent Handling
 

--- a/src/app/core/identity-provider/auth0.identity-provider.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.ts
@@ -103,13 +103,13 @@ export class Auth0IdentityProvider implements IdentityProvider {
         ),
         whenTruthy(),
         switchMap(idToken => {
-          const inviteUserId = window.sessionStorage.getItem('invite-userid');
-          const inviteHash = window.sessionStorage.getItem('invite-hash');
+          const inviteUserId = sessionStorage.getItem('invite-userid');
+          const inviteHash = sessionStorage.getItem('invite-hash');
           return inviteUserId && inviteHash
             ? this.inviteRegistration(idToken, inviteUserId, inviteHash).pipe(
                 tap(() => {
-                  window.sessionStorage.removeItem('invite-userid');
-                  window.sessionStorage.removeItem('invite-hash');
+                  sessionStorage.removeItem('invite-userid');
+                  sessionStorage.removeItem('invite-hash');
                 })
               )
             : this.normalSignInRegistration(idToken);
@@ -222,8 +222,8 @@ export class Auth0IdentityProvider implements IdentityProvider {
 
   triggerInvite(route: ActivatedRouteSnapshot): TriggerReturnType {
     this.router.navigateByUrl('/loading');
-    window.sessionStorage.setItem('invite-userid', route.queryParams.uid);
-    window.sessionStorage.setItem('invite-hash', route.queryParams.Hash);
+    sessionStorage.setItem('invite-userid', route.queryParams.uid);
+    sessionStorage.setItem('invite-hash', route.queryParams.Hash);
     return this.oauthService.loadDiscoveryDocumentAndLogin({
       state: route.queryParams.returnUrl,
     });

--- a/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.spec.ts
@@ -56,7 +56,7 @@ describe('Co Browse Identity Provider', () => {
     resetCalls(accountFacade);
     resetCalls(checkoutFacade);
 
-    window.sessionStorage.clear();
+    sessionStorage.clear();
   });
 
   describe('init', () => {
@@ -69,7 +69,7 @@ describe('Co Browse Identity Provider', () => {
     it('should add basket-id to session storage, when basket is available', () => {
       when(checkoutFacade.basket$).thenReturn(of(BasketMockData.getBasket()));
       identityProvider.init();
-      expect(window.sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
+      expect(sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
     });
   });
 
@@ -82,12 +82,12 @@ describe('Co Browse Identity Provider', () => {
     });
 
     it('should remove api token and basket-id on logout', done => {
-      expect(window.sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
+      expect(sessionStorage.getItem('basket-id')).toEqual(BasketMockData.getBasket().id);
 
       const logoutTrigger$ = identityProvider.triggerLogout() as Observable<UrlTree>;
 
       logoutTrigger$.subscribe(() => {
-        expect(window.sessionStorage.getItem('basket-id')).toBeNull();
+        expect(sessionStorage.getItem('basket-id')).toBeNull();
         verify(accountFacade.logoutUser()).once();
         done();
       });

--- a/src/app/core/identity-provider/co-browse.identity-provider.ts
+++ b/src/app/core/identity-provider/co-browse.identity-provider.ts
@@ -43,7 +43,7 @@ export class CoBrowseIdentityProvider implements IdentityProvider {
     this.apiTokenService.restore$(['user', 'order']).subscribe(noop);
 
     this.checkoutFacade.basket$.pipe(whenTruthy(), first()).subscribe(basketView => {
-      window.sessionStorage.setItem('basket-id', basketView.id);
+      sessionStorage.setItem('basket-id', basketView.id);
     });
   }
 
@@ -93,7 +93,7 @@ export class CoBrowseIdentityProvider implements IdentityProvider {
   }
 
   triggerLogout(): TriggerReturnType {
-    window.sessionStorage.removeItem('basket-id');
+    sessionStorage.removeItem('basket-id');
     this.accountFacade.logoutUser(); // user will be logged out and related refresh token is revoked on server
     return this.accountFacade.isLoggedIn$.pipe(
       // wait until the user is logged out before you go to homepage to prevent unnecessary REST calls

--- a/src/app/core/identity-provider/icm.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/icm.identity-provider.spec.ts
@@ -41,7 +41,7 @@ describe('Icm Identity Provider', () => {
     resetCalls(apiTokenService);
     resetCalls(accountFacade);
 
-    window.sessionStorage.clear();
+    sessionStorage.clear();
   });
 
   describe('init', () => {

--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -127,11 +127,11 @@ describe('Basket Effects', () => {
 
     describe('with basket-id in session storage', () => {
       beforeEach(() => {
-        window.sessionStorage.clear();
+        sessionStorage.clear();
       });
 
       it('should map to action of type LoadBasketWithId', () => {
-        window.sessionStorage.setItem('basket-id', 'BID');
+        sessionStorage.setItem('basket-id', 'BID');
         const action = loadBasket();
         const completion = loadBasketWithId({ basketId: 'BID' });
         actions$ = hot('-a-a-a', { a: action });

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -85,8 +85,8 @@ export class BasketEffects {
     this.actions$.pipe(
       ofType(loadBasket),
       mergeMap(() =>
-        !SSR && window.sessionStorage.getItem('basket-id')
-          ? of(loadBasketWithId({ basketId: window.sessionStorage.getItem('basket-id') }))
+        !SSR && sessionStorage.getItem('basket-id')
+          ? of(loadBasketWithId({ basketId: sessionStorage.getItem('basket-id') }))
           : this.basketService.getBasket().pipe(
               map(basket => loadBasketSuccess({ basket })),
               mapErrorToAction(loadBasketFail)

--- a/src/app/extensions/punchout/services/punchout/punchout.service.spec.ts
+++ b/src/app/extensions/punchout/services/punchout/punchout.service.spec.ts
@@ -6,7 +6,6 @@ import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { ApiService } from 'ish-core/services/api/api.service';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
-import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 
 import { PunchoutUser } from '../../models/punchout-user/punchout-user.model';
 
@@ -14,13 +13,11 @@ import { PunchoutService } from './punchout.service';
 
 describe('Punchout Service', () => {
   let apiServiceMock: ApiService;
-  let cookiesServiceMock: CookiesService;
   let punchoutService: PunchoutService;
   const punchoutUser = { login: 'ociuser', punchoutType: 'oci' } as PunchoutUser;
 
   beforeEach(() => {
     apiServiceMock = mock(ApiService);
-    cookiesServiceMock = mock(CookiesService);
 
     when(apiServiceMock.options(anything(), anything())).thenReturn(of({}));
     when(apiServiceMock.get(anything(), anything())).thenReturn(of({}));
@@ -35,7 +32,6 @@ describe('Punchout Service', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: ApiService, useFactory: () => instance(apiServiceMock) },
-        { provide: CookiesService, useFactory: () => instance(cookiesServiceMock) },
         provideMockStore({
           selectors: [
             { selector: getLoggedInCustomer, value: { customerNo: '4711', isBusinessCustomer: true } as Customer },

--- a/src/app/extensions/punchout/store/punchout-functions/punchout-functions.effects.ts
+++ b/src/app/extensions/punchout/store/punchout-functions/punchout-functions.effects.ts
@@ -33,7 +33,7 @@ export class PunchoutFunctionsEffects {
     () =>
       this.actions$.pipe(
         ofType(transferPunchoutBasketSuccess),
-        map(() => window.sessionStorage.removeItem('basket-id'))
+        map(() => sessionStorage.removeItem('basket-id'))
       ),
     { dispatch: false }
   );

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -196,15 +196,7 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
         description: 'cookie.consent.option.tracking.description',
       },
     },
-    allowedCookies: [
-      'apiToken',
-      'cookieConsent',
-      'preferredLocale',
-      'punchout_SID',
-      'punchout_BasketID',
-      'punchout_ReturnURL',
-      'punchout_HookURL',
-    ],
+    allowedCookies: ['apiToken', 'cookieConsent', 'preferredLocale'],
   },
   cookieConsentVersion: 1,
 


### PR DESCRIPTION
## PR Type

[x] Feature
[x] Refactoring (no functional changes, no API changes)

## What Is the Current Behavior?

Customer tested OCI punchout from a punchout system. Login to the webshop was successful but returning to the punchout system from the basket with the HOOK_URL failed.
Reason: The integrated browser within the punchout client is not able to set cookies. But the HOOK_URL is saved as a cookie within the PWA.

## What Is the New Behavior?

To avoid problems with OCI and cXML punchout clients that are not able to set cookies, we now save the punchout information in session storage.

Additionally, errors regarding missing punchout information that is supposed to be available in the session storage (`punchout_SID, punchout_ReturnURL, punchout_HookURL`) are now presented in the UI on basket transfer and in the error log.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#102803](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/102803)
[AB#91485](https://dev.azure.com/intershop-com/_workitems/edit/91485)