### PR TITLE
fix: SSR rendered pages with status code 404 or 503 should be returned

### DIFF
--- a/nginx/features/cache.conf
+++ b/nginx/features/cache.conf
@@ -2,9 +2,9 @@ proxy_cache_path /tmp/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inact
 proxy_cache my_cache;
 proxy_cache_use_stale error timeout http_500 http_502 http_504;
 
+# combine the upstream_cache_status (NGINX) and srcache_fetch_status (REDIS) info into a single cache_status variable
 map "$upstream_cache_status:$srcache_fetch_status" $cache_status {
     ":BYPASS" "BYPASS";
-    "~HIT" "HIT";
-    "~^MISS" "MISS";
-    default "-";
+    "~:BYPASS$" $upstream_cache_status;
+    default $upstream_cache_status:$srcache_fetch_status;
 }

--- a/nginx/features/cache.conf
+++ b/nginx/features/cache.conf
@@ -1,6 +1,6 @@
 proxy_cache_path /tmp/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
 proxy_cache my_cache;
-proxy_cache_use_stale error timeout http_404 http_500 http_502 http_503 http_504;
+proxy_cache_use_stale error timeout http_500 http_502 http_504;
 
 map "$upstream_cache_status:$srcache_fetch_status" $cache_status {
     ":BYPASS" "BYPASS";


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

If the connected ICM goes in maintenance mode the PWA is supposed to return the maintenance page with status code 503.
This works fine if the SSR process is directly answering the request.

In production like systems an active NGINX caching is usually enabled to increase the rendering performance. But with an active cache it is likely that the result is fetched from the cache and with this it is likely a previous rendering with status code 200 is returned at least as long as the NGINX cache setting `CACHE_DURATION_NGINX_OK` lasts.

Unfortunately the current NGINX cache configuration returned responses with status 200 even much longer than the `CACHE_DURATION_NGINX_OK` configurations since it is configured to return stale/expired cache results if the SSR process returns 503 status renderings or 404.

## What Is the New Behavior?

With the change the NGINX cache will not return cached results longer than the `CACHE_DURATION_NGINX_OK` period for SSR results with status 503 or 404.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#102859](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/102859)
[AB#92487](https://dev.azure.com/intershop-com/Products/_workitems/edit/92487)