### PR TITLE
ci: fix demoserver workflow

### DIFF
--- a/.github/scripts/docker-compose.py
+++ b/.github/scripts/docker-compose.py
@@ -1,5 +1,4 @@
 import sys
-import easyargs
 from os.path import join
 from os import _exit
 from typing import Dict
@@ -10,15 +9,13 @@ except ImportError:
     from yaml import Loader, Dumper
 
 def dockerComposeFile(dir: str='.', mode: str='r'):
-  f = join(dir, 'docker-compose.yml');
+  f = join(dir, 'docker-compose.yml')
   try:
       return open(f, mode)
   except IOError as error:
       print(error)
       _exit(1)
 
-
-@easyargs
 def main(icm, ssrimage, nginximage):
   data: Dict = load(dockerComposeFile(), Loader=Loader)
   data['services']['pwa'].pop('build')
@@ -30,4 +27,10 @@ def main(icm, ssrimage, nginximage):
   dump(data, dockerComposeFile('./dist','w'), Dumper=Dumper)
 
 if __name__ == "__main__":
-	main()
+  if len(sys.argv) != 4:
+      print("Usage: python docker-compose.py <icm> <ssrimage> <nginximage>")
+      _exit(1)
+  icm = sys.argv[1]
+  ssrimage = sys.argv[2]
+  nginximage = sys.argv[3]
+  main(icm, ssrimage, nginximage)

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,2 +1,1 @@
-easyargs == 0.9.4
-PyYAML == 5.4.1
+PyYAML == 5.3.1


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ X ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Demoserver Up workflow is broken as `PyYAML==5.4.1` cannot be installed on Python 3.12.
See [PyYAML #724](https://github.com/yaml/pyyaml/issues/724)

## What Is the New Behavior?

Demoserver Up workflow is working again.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[X] No

## Other Information
I rewritten part of the script to not be dependent on the discontinued python package `easyargs`