### PR TITLE
feat: add Sparque (advanced) suggest IAD and VD

### DIFF
--- a/src/app/core/standalone/component/suggest/advanced-search-box/advanced-search-box.component.html
+++ b/src/app/core/standalone/component/suggest/advanced-search-box/advanced-search-box.component.html
@@ -1,15 +1,21 @@
-<div class="search clearfix">
+<div
+  #searchBox
+  class="search advanced-search clearfix"
+  [ngClass]="{ focus: searchBoxFocus, 'scaled-up': searchBoxScaledUp }"
+>
   <input
     #searchInput
     [placeholder]="configuration?.placeholder || ''"
     autocomplete="off"
     type="search"
+    id="header-search-input"
     class="form-control searchTerm"
     (input)="searchSuggest($event.target)"
     [value]="inputSearchTerms$ | async"
-    (blur)="blur()"
-    (keydown)="focus()"
-    (keydown.esc)="blur()"
+    (focus)="handleFocus()"
+    (blur)="handleBlur($event)"
+    (keydown)="handleFocus()"
+    (keydown.esc)="handleEscKey()"
     (keydown.arrowleft)="selectSuggestedTerm(-1)"
     (keydown.arrowright)="selectSuggestedTerm(-1)"
     (keydown.arrowdown)="selectSuggestedTerm(activeIndex + 1)"
@@ -19,27 +25,34 @@
 
   <div class="buttons">
     <button
+      #searchInputReset
       *ngIf="inputSearchTerms$ | async"
       class="btn-reset btn btn-primary"
       type="reset"
       name="reset"
       [title]="'search.searchbox.button.reset.title' | translate"
-      style="right: 40px"
-      (click)="searchSuggest(''); searchInput.focus()"
+      (focus)="handleFocus()"
+      (click)="handleReset()"
+      (blur)="handleBlur($event)"
+      (keydown.esc)="handleEscKey()"
     >
-      <fa-icon [icon]="['fas', 'times-circle']" />
+      <fa-icon [icon]="['fas', 'times']" />
     </button>
 
     <button
+      #searchInputSubmit
       class="btn-search btn btn-primary"
       type="submit"
       name="search"
       [title]="'search.searchbox.button.title' | translate"
+      (keydown)="handleFocus()"
       (click)="submitSearch(searchInput.value)"
+      (blur)="handleBlur($event)"
+      (keydown.esc)="handleEscKey()"
     >
       <!-- search button with icon -->
       <ng-container *ngIf="!configuration?.buttonText; else textBlock">
-        <fa-icon [icon]="['fas', usedIcon]" />
+        <fa-icon [icon]="['fas', 'search']" />
       </ng-container>
       <!-- search button with text -->
       <ng-template #textBlock> {{ configuration?.buttonText }} </ng-template>
@@ -47,7 +60,7 @@
   </div>
 
   <ng-container *ngIf="searchResults$ | async as results">
-    <ul *ngIf="results.length && inputFocused" class="search-suggest-results">
+    <ul *ngIf="results.length && searchBoxFocus" class="search-suggest-results">
       <li
         *ngFor="let result of results | slice : 0 : configuration?.maxAutoSuggests; let liIndex = index"
         [class.active-suggestion]="activeIndex === liIndex"
@@ -62,4 +75,5 @@
       </li>
     </ul>
   </ng-container>
+  <div class="search-suggest-backdrop" [ngClass]="{ show: searchBoxFocus }"></div>
 </div>

--- a/src/app/core/standalone/component/suggest/advanced-search-box/advanced-search-box.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/advanced-search-box/advanced-search-box.component.spec.ts
@@ -1,13 +1,9 @@
 /* eslint-disable ish-custom-rules/ban-imports-file-pattern */
-import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { ReplaySubject, Subject } from 'rxjs';
 
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
-import { IconModule } from 'ish-core/icon.module';
-import { PipesModule } from 'ish-core/pipes.module';
 
 import { AdvancedSearchBoxComponent } from './advanced-search-box.component';
 
@@ -25,7 +21,7 @@ describe('Advanced Search Box Component', () => {
     searchTerm$.next(undefined);
 
     await TestBed.configureTestingModule({
-      imports: [CommonModule, IconModule, PipesModule, RouterTestingModule, TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot()],
       providers: [
         {
           provide: ShoppingFacade,
@@ -41,7 +37,7 @@ describe('Advanced Search Box Component', () => {
     element = fixture.nativeElement;
 
     // activate
-    component.inputFocused = true;
+    component.searchBoxFocus = true;
     component.configuration = { maxAutoSuggests: 4 };
   });
 
@@ -53,7 +49,7 @@ describe('Advanced Search Box Component', () => {
 
   describe('with no results', () => {
     beforeEach(() => {
-      searchResults$.next(undefined);
+      searchResults$.next([]);
     });
 
     it('should show no results when no suggestions are found', () => {
@@ -70,6 +66,8 @@ describe('Advanced Search Box Component', () => {
     });
 
     it('should show results when suggestions are available', () => {
+      component.searchBoxFocus = true;
+      searchTerm$.next('ca');
       fixture.detectChanges();
 
       const ul = element.querySelector('.search-suggest-results');
@@ -77,6 +75,8 @@ describe('Advanced Search Box Component', () => {
     });
 
     it('should show no results when suggestions are available but maxAutoSuggests is 0', () => {
+      component.searchBoxFocus = true;
+      searchTerm$.next('ca');
       component.configuration.maxAutoSuggests = 0;
       fixture.detectChanges();
 
@@ -85,10 +85,42 @@ describe('Advanced Search Box Component', () => {
     });
 
     it('should show no results when suggestions are available but input has no focus', () => {
-      component.inputFocused = false;
+      component.searchBoxFocus = false;
       fixture.detectChanges();
 
       expect(element.querySelector('.search-suggest-results')).toBeFalsy();
+    });
+
+    it('should show no results when input is less than 2 characters', () => {
+      component.searchBoxFocus = true;
+      component.inputSearchTerms$.next('a');
+      fixture.detectChanges();
+
+      const ul = fixture.nativeElement.querySelector('.search-suggest-results');
+      expect(ul).toBeFalsy();
+    });
+
+    it('should show results when input is 2 or more characters', () => {
+      component.searchBoxFocus = true;
+      searchTerm$.next('ca');
+      component.inputSearchTerms$.next('ca');
+      fixture.detectChanges();
+
+      const ul = fixture.nativeElement.querySelector('.search-suggest-results');
+      expect(ul.querySelectorAll('li')).toHaveLength(2);
+    });
+
+    it('should clear results when input is cleared', () => {
+      component.searchBoxFocus = true;
+
+      component.inputSearchTerms$.next('ca');
+      fixture.detectChanges();
+
+      component.inputSearchTerms$.next('');
+      fixture.detectChanges();
+
+      const ul = fixture.nativeElement.querySelector('.search-suggest-results');
+      expect(ul).toBeFalsy();
     });
   });
 

--- a/src/app/core/standalone/component/suggest/simple-search-box/simple-search-box.component.html
+++ b/src/app/core/standalone/component/suggest/simple-search-box/simple-search-box.component.html
@@ -27,7 +27,7 @@
       style="right: 40px"
       (click)="searchSuggest(''); searchInput.focus()"
     >
-      <fa-icon [icon]="['fas', 'times-circle']" />
+      <fa-icon [icon]="['fas', 'times']" />
     </button>
 
     <button

--- a/src/app/core/standalone/component/suggest/simple-search-box/simple-search-box.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/simple-search-box/simple-search-box.component.spec.ts
@@ -1,13 +1,9 @@
 /* eslint-disable ish-custom-rules/ban-imports-file-pattern */
-import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { ReplaySubject, Subject } from 'rxjs';
 
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
-import { IconModule } from 'ish-core/icon.module';
-import { PipesModule } from 'ish-core/pipes.module';
 
 import { SimpleSearchBoxComponent } from './simple-search-box.component';
 
@@ -25,7 +21,7 @@ describe('Simple Search Box Component', () => {
     searchTerm$.next(undefined);
 
     await TestBed.configureTestingModule({
-      imports: [CommonModule, IconModule, PipesModule, RouterTestingModule, TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot()],
       providers: [
         {
           provide: ShoppingFacade,

--- a/src/app/core/store/customer/customer-store.spec.ts
+++ b/src/app/core/store/customer/customer-store.spec.ts
@@ -27,7 +27,6 @@ import { PaymentService } from 'ish-core/services/payment/payment.service';
 import { PricesService } from 'ish-core/services/prices/prices.service';
 import { ProductsService } from 'ish-core/services/products/products.service';
 import { PromotionsService } from 'ish-core/services/promotions/promotions.service';
-import { SuggestionService } from 'ish-core/services/suggestion/suggestion.service';
 import { TokenService } from 'ish-core/services/token/token.service';
 import { UserService } from 'ish-core/services/user/user.service';
 import { WarrantyService } from 'ish-core/services/warranty/warranty.service';
@@ -186,7 +185,6 @@ describe('Customer Store', () => {
         { provide: PricesService, useFactory: () => instance(productPriceServiceMock) },
         { provide: ProductsService, useFactory: () => instance(productsServiceMock) },
         { provide: PromotionsService, useFactory: () => instance(promotionsServiceMock) },
-        { provide: SuggestionService, useFactory: () => instance(mock(SuggestionService)) },
         { provide: TokenService, useFactory: () => instance(mock(TokenService)) },
         { provide: UserService, useFactory: () => instance(userServiceMock) },
         { provide: WarrantyService, useFactory: () => instance(mock(WarrantyService)) },

--- a/src/app/shell/header/header-default/__snapshots__/header-default.component.spec.ts.snap
+++ b/src/app/shell/header/header-default/__snapshots__/header-default.component.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`Header Default Component should render normal header adequately for des
       class="d-md-none"
     ></ish-mini-basket>
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -43,7 +43,6 @@ exports[`Header Default Component should render normal header adequately for des
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right"><ish-lazy-quickorder-link></ish-lazy-quickorder-link></div>
     <div class="col-md-4">
       <div class="search-container header-search-container">
         <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box>
@@ -80,7 +79,7 @@ exports[`Header Default Component should render normal header adequately for mob
   </ul>
   <div class="header-utility">
     <a class="search-toggler active-search"
-      ><div class="search-container header-search-container show" ng-reflect-collapsed="false">
+      ><div class="search-container header-search-container" ng-reflect-collapsed="false">
         <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box></div
     ></a>
     <div class="language-switch-container d-none d-md-block">
@@ -102,7 +101,7 @@ exports[`Header Default Component should render normal header adequately for mob
       class="d-md-none"
     ></ish-mini-basket>
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -115,7 +114,6 @@ exports[`Header Default Component should render normal header adequately for mob
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right"><ish-lazy-quickorder-link></ish-lazy-quickorder-link></div>
     <div class="col-md-4"></div>
   </div>
   <button type="button" class="navbar-toggler">
@@ -167,7 +165,7 @@ exports[`Header Default Component should render normal header adequately for tab
       class="d-md-none"
     ></ish-mini-basket>
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -180,7 +178,6 @@ exports[`Header Default Component should render normal header adequately for tab
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right"><ish-lazy-quickorder-link></ish-lazy-quickorder-link></div>
     <div class="col-md-4">
       <div class="search-container header-search-container">
         <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box>
@@ -210,7 +207,7 @@ exports[`Header Default Component should render sticky header adequately for des
 <div class="header container desktop" ng-reflect-ng-class="desktop">
   <div class="header-utility">
     <a class="search-toggler active-search"
-      ><fa-icon class="header-icon" ng-reflect-icon="fas,search"></fa-icon>
+      ><fa-icon tabindex="0" class="header-icon" ng-reflect-icon="fas,search"></fa-icon>
       <div class="search-container header-search-container" ng-reflect-collapsed="false">
         <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box></div
     ></a>
@@ -231,7 +228,7 @@ exports[`Header Default Component should render sticky header adequately for des
       class="d-lg-none"
     ></ish-mini-basket>
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -244,8 +241,11 @@ exports[`Header Default Component should render sticky header adequately for des
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right"><ish-lazy-quickorder-link></ish-lazy-quickorder-link></div>
-    <div class="col-md-4"></div>
+    <div class="col-md-4">
+      <div class="search-container header-search-container">
+        <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box>
+      </div>
+    </div>
   </div>
   <button type="button" class="navbar-toggler">
     <span class="sr-only">common.button.navbarCollapsed.text</span>
@@ -270,7 +270,7 @@ exports[`Header Default Component should render sticky header adequately for mob
 <div class="header container mobile" ng-reflect-ng-class="mobile">
   <div class="header-utility">
     <a class="search-toggler active-search"
-      ><fa-icon class="header-icon" ng-reflect-icon="fas,search"></fa-icon>
+      ><fa-icon tabindex="0" class="header-icon" ng-reflect-icon="fas,search"></fa-icon>
       <div class="search-container header-search-container" ng-reflect-collapsed="false">
         <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box></div
     ></a>
@@ -291,7 +291,7 @@ exports[`Header Default Component should render sticky header adequately for mob
       class="d-lg-none"
     ></ish-mini-basket>
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -304,7 +304,6 @@ exports[`Header Default Component should render sticky header adequately for mob
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right"><ish-lazy-quickorder-link></ish-lazy-quickorder-link></div>
     <div class="col-md-4"></div>
   </div>
   <button type="button" class="navbar-toggler">
@@ -330,7 +329,7 @@ exports[`Header Default Component should render sticky header adequately for tab
 <div class="header container tablet" ng-reflect-ng-class="tablet">
   <div class="header-utility">
     <a class="search-toggler active-search"
-      ><fa-icon class="header-icon" ng-reflect-icon="fas,search"></fa-icon>
+      ><fa-icon tabindex="0" class="header-icon" ng-reflect-icon="fas,search"></fa-icon>
       <div class="search-container header-search-container" ng-reflect-collapsed="false">
         <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box></div
     ></a>
@@ -351,7 +350,7 @@ exports[`Header Default Component should render sticky header adequately for tab
       class="d-lg-none"
     ></ish-mini-basket>
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -364,8 +363,11 @@ exports[`Header Default Component should render sticky header adequately for tab
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right"><ish-lazy-quickorder-link></ish-lazy-quickorder-link></div>
-    <div class="col-md-4"></div>
+    <div class="col-md-4">
+      <div class="search-container header-search-container">
+        <ish-simple-search-box data-testing-id="search-box-desktop"></ish-simple-search-box>
+      </div>
+    </div>
   </div>
   <button type="button" class="navbar-toggler">
     <span class="sr-only">common.button.navbarCollapsed.text</span>

--- a/src/app/shell/header/header-default/header-default.component.html
+++ b/src/app/shell/header/header-default/header-default.component.html
@@ -1,6 +1,6 @@
 <ng-template #searchBoxTemplate let-icon="icon">
   <ish-advanced-search-box
-    *ngIf="isSparqueActive === true; else ICMSearchBox"
+    *ngIf="isSparqueSuggestActive; else simpleSearchBox"
     data-testing-id="search-box-desktop"
     [configuration]="{
       placeholder: 'search.searchbox.instructional_text' | translate,
@@ -10,7 +10,7 @@
       showLastSearchTerm: true
     }"
   />
-  <ng-template #ICMSearchBox>
+  <ng-template #simpleSearchBox>
     <ish-simple-search-box
       data-testing-id="search-box-desktop"
       [configuration]="{
@@ -32,23 +32,65 @@
     <li *ishFeature="'compare'" class="d-none d-md-block">
       <ish-lazy-product-compare-status data-testing-id="compare-status-desktop" />
     </li>
+    <li *ishFeature="'quickorder'" class="d-none d-md-block">
+      <ish-lazy-quickorder-link />
+    </li>
     <li *ishFeature="'wishlists'" class="d-none d-md-block">
       <ish-lazy-wishlists-link />
     </li>
   </ul>
 
   <div class="header-utility">
-    <a class="search-toggler" [ngClass]="{ 'active-search': showSearch }">
-      <fa-icon *ngIf="isSticky" class="header-icon" [icon]="['fas', 'search']" (click)="toggle('search')" />
-      <div
-        *ngIf="isSticky || showSearch"
-        class="search-container header-search-container"
-        [ngbCollapse]="!showSearch"
-        [ngClass]="{ show: !isSticky }"
-      >
-        <ng-container *ngTemplateOutlet="searchBoxTemplate; context: { icon: 'angle-right' }" />
-      </div>
-    </a>
+    <ng-container *ngIf="isSparqueSuggestActive; else simpleSuggest">
+      <a *ngIf="isSticky && deviceType !== 'mobile'; else mobileSearch">
+        <fa-icon
+          class="header-icon"
+          [icon]="['fas', 'search']"
+          (click)="scrollTopAndFocusSearch()"
+          (keydown.enter)="scrollTopAndFocusSearch()"
+          tabindex="0"
+        />
+      </a>
+
+      <ng-template #mobileSearch>
+        <a class="search-toggler" [ngClass]="{ 'active-search': showSearch }">
+          <fa-icon
+            *ngIf="isSticky"
+            class="header-icon"
+            [icon]="['fas', 'search']"
+            (click)="scrollTopAndFocusSearch()"
+          />
+          <div
+            *ngIf="isSticky || showSearch"
+            class="search-container header-search-container"
+            [ngbCollapse]="!showSearch"
+            [ngClass]="{ show: !isSticky }"
+          >
+            <ng-container *ngTemplateOutlet="searchBoxTemplate" />
+          </div>
+        </a>
+      </ng-template>
+    </ng-container>
+
+    <ng-template #simpleSuggest>
+      <a class="search-toggler" [ngClass]="{ 'active-search': showSearch }">
+        <fa-icon
+          *ngIf="isSticky"
+          class="header-icon"
+          [icon]="['fas', 'search']"
+          (click)="toggle('search')"
+          (keydown.enter)="toggle('search')"
+          tabindex="0"
+        />
+        <div
+          *ngIf="isSticky || showSearch"
+          class="search-container header-search-container"
+          [ngbCollapse]="!showSearch"
+        >
+          <ng-container *ngTemplateOutlet="searchBoxTemplate; context: { icon: 'angle-right' }" />
+        </div>
+      </a>
+    </ng-template>
     <div class="language-switch-container d-none d-md-block">
       <ish-language-switch *ngIf="!isSticky" data-testing-id="language-switch-desktop" />
     </div>
@@ -66,7 +108,7 @@
       [ngClass]="isSticky ? 'd-lg-none' : 'd-md-none'"
     />
   </div>
-  <div class="mid-header row align-items-center">
+  <div class="mid-header row align-items-center justify-content-between">
     <div class="col-md-3 logo-col">
       <div class="logo-wrapper">
         <a
@@ -89,11 +131,8 @@
         ></a>
       </div>
     </div>
-    <div class="col-md-5 text-right">
-      <ish-lazy-quickorder-link />
-    </div>
     <div class="col-md-4">
-      <div *ngIf="!isSticky && deviceType !== 'mobile'" class="search-container header-search-container">
+      <div *ngIf="deviceType !== 'mobile'" class="search-container header-search-container">
         <ng-container *ngTemplateOutlet="searchBoxTemplate" />
       </div>
     </div>

--- a/src/app/shell/header/header-default/header-default.component.spec.ts
+++ b/src/app/shell/header/header-default/header-default.component.spec.ts
@@ -16,7 +16,6 @@ import { MiniBasketComponent } from 'ish-shell/header/mini-basket/mini-basket.co
 import { UserInformationMobileComponent } from 'ish-shell/header/user-information-mobile/user-information-mobile.component';
 
 import { LazyProductCompareStatusComponent } from '../../../extensions/compare/exports/lazy-product-compare-status/lazy-product-compare-status.component';
-import { LazyQuickorderLinkComponent } from '../../../extensions/quickorder/exports/lazy-quickorder-link/lazy-quickorder-link.component';
 
 import { HeaderDefaultComponent } from './header-default.component';
 
@@ -35,7 +34,6 @@ describe('Header Default Component', () => {
         MockComponent(HeaderNavigationComponent),
         MockComponent(LanguageSwitchComponent),
         MockComponent(LazyProductCompareStatusComponent),
-        MockComponent(LazyQuickorderLinkComponent),
         MockComponent(LoginStatusComponent),
         MockComponent(MiniBasketComponent),
         MockComponent(SimpleSearchBoxComponent),

--- a/src/app/shell/header/header-default/header-default.component.ts
+++ b/src/app/shell/header/header-default/header-default.component.ts
@@ -31,10 +31,10 @@ export class HeaderDefaultComponent implements OnChanges {
   @Input() reset: unknown;
 
   private activeComponent: CollapsibleComponent = 'search';
-  isSparqueActive = false;
+  isSparqueSuggestActive = false;
 
   constructor(appFacade: AppFacade) {
-    this.isSparqueActive = appFacade.isSparqueSuggestActive();
+    this.isSparqueSuggestActive = appFacade.isSparqueSuggestActive();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -87,6 +87,27 @@ export class HeaderDefaultComponent implements OnChanges {
       this.activeComponent = !this.isSticky ? 'search' : undefined;
     } else {
       this.activeComponent = component;
+
+      if (component === 'search') {
+        this.focusSearch();
+      }
     }
+  }
+
+  // scroll to the top and set focus to search input
+  scrollTopAndFocusSearch() {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    const checkInterval = setInterval(() => {
+      if (window.scrollY === 0) {
+        // wait until page has scrolled to top
+        clearInterval(checkInterval);
+        this.focusSearch();
+      }
+    }, 500);
+  }
+
+  private focusSearch() {
+    const searchInput = document.getElementById('header-search-input');
+    (searchInput as HTMLElement).focus();
   }
 }

--- a/src/styles/components/header/header-sticky.scss
+++ b/src/styles/components/header/header-sticky.scss
@@ -49,12 +49,6 @@
         }
       }
 
-      .mid-header {
-        .quickorder-link {
-          display: none !important;
-        }
-      }
-
       .navbar-toggler {
         @include media-breakpoint-down(md) {
           display: block;
@@ -83,25 +77,20 @@
         }
       }
 
+      .mid-header {
+        .header-search-container {
+          @include media-breakpoint-up(md) {
+            display: none;
+          }
+        }
+      }
+
       .header-utility {
         order: 10;
         background: $color-inverse;
 
         @include media-breakpoint-down(md) {
           line-height: $header-height-mobile;
-        }
-
-        .header-search-container {
-          &.show {
-            height: $search-container-height;
-            overflow: unset;
-            transition: height 500ms ease-in-out;
-          }
-
-          &:not(.show) {
-            display: block; //required for animation
-            height: 0;
-          }
         }
       }
     }

--- a/src/styles/components/header/header.scss
+++ b/src/styles/components/header/header.scss
@@ -69,16 +69,6 @@ header {
     }
   }
 
-  .mid-header {
-    .quickorder-link {
-      .header-icon {
-        font-size: $font-size-corporate;
-        color: $CORPORATE-PRIMARY;
-        vertical-align: middle;
-      }
-    }
-  }
-
   &.homepage {
     margin-bottom: 0;
   }
@@ -164,6 +154,12 @@ header {
 .separator {
   padding-right: ($space-default * 0.5);
   padding-left: ($space-default * 0.5);
+}
+
+.quickorder-link {
+  .header-icon {
+    top: 2px;
+  }
 }
 
 .ng-fa-icon.header-icon {

--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -1,5 +1,6 @@
 /*********** SEARCH CONTAINER **********/
 
+// general search container (used in header and main content)
 .search-container {
   position: relative;
 
@@ -17,35 +18,49 @@
       box-shadow: none !important;
     }
 
-    &.btn-reset {
-      opacity: 0.6;
-    }
-
     &.btn-reset,
     &.btn-search {
       position: absolute;
       right: 0;
       width: auto;
+      height: $search-container-height;
       font-size: $font-size-lg;
-      background: 0;
-      border: 0;
+      color: $text-color-corporate;
+      background: $color-inverse;
+      border: $border-width-default solid $button-default-border;
 
       span::before {
         font-size: $font-size-lg;
         color: $text-color-inverse;
       }
     }
+
+    &.btn-reset {
+      right: $space-default * 3;
+      color: $text-color-quaternary;
+      border: none;
+      border-top: $border-width-default solid $border-color-light;
+      border-bottom: $border-width-default solid $border-color-light;
+      opacity: 1;
+    }
   }
 
   ul.search-suggest-results {
     position: absolute;
-    top: 37px;
+    top: 38px;
     z-index: 9999;
+    // preserve space for onscreen keyboard on mobile devices
+    max-height: calc(60vh - #{$header-height-mobile + $search-container-height * 3});
     padding: 0;
     margin: 0;
+    overflow-y: auto;
     list-style: none;
     background: $color-inverse;
     border: $border-width-default solid $border-color-light;
+
+    @media (min-width: $screen-sm) {
+      max-height: calc(100vh - 15 * #{$space-default});
+    }
 
     li {
       width: 100%;
@@ -90,7 +105,7 @@
         font-family: $font-family-regular;
         font-size: 13px;
         line-height: 47px;
-        color: $text-color-quaternary;
+        color: $text-color-tertiary;
         text-align: left;
         background: none;
         border: 0;
@@ -110,10 +125,18 @@
 
       + .buttons {
         button {
-          color: $text-color-primary;
+          color: $text-color-corporate;
 
           .ng-fa-icon {
-            color: $text-color-primary;
+            color: $text-color-corporate;
+          }
+
+          &.btn-reset {
+            color: $text-color-quaternary;
+
+            .ng-fa-icon {
+              color: $text-color-quaternary;
+            }
           }
         }
       }
@@ -121,30 +144,91 @@
   }
 }
 
+// header search container
 .header-search-container {
   @include media-breakpoint-only(xs) {
     height: $search-container-height;
   }
 
-  @include media-breakpoint-only(md) {
-    height: 0;
+  .search {
+    &.advanced-search {
+      @media (min-width: $screen-sm) {
+        position: absolute;
+        top: calc($search-container-height / -2);
+        right: 0;
+        width: 100%;
+        transition: width 0.3s ease 0.1s;
+
+        &.focus {
+          width: 250%;
+        }
+
+        ul.search-suggest-results {
+          // suggest layer is not shown by default
+          display: none;
+        }
+
+        &.scaled-up {
+          ul.search-suggest-results {
+            // suggest layer is only shown when search box is scaled up to expanded width
+            display: block;
+          }
+        }
+      }
+
+      .search-suggest-backdrop {
+        position: fixed;
+        top: calc($header-height-mobile + $search-container-height);
+        right: 0;
+        z-index: 2;
+        width: 100%;
+        width: 100vw;
+        height: 0; // prevent overlaying any other elements
+        visibility: hidden; // combined with opacity
+        background: $color-dark;
+        opacity: 0;
+        transition: opacity 0.15s linear, visibility 0.15s linear; // similar to bootstrap modal
+
+        @media (min-width: $screen-sm) {
+          top: 170px;
+          height: calc(100vh - 170px);
+        }
+
+        &.show {
+          height: calc(100vh - #{$header-height-mobile + $search-container-height});
+          visibility: visible;
+          opacity: 0.5;
+
+          @media (min-width: $screen-sm) {
+            height: calc(100vh - 170px);
+          }
+        }
+      }
+    }
   }
 
   input {
     &.form-control {
       float: right;
       height: $search-container-height;
+      padding-right: $space-default * 5;
       padding-left: ($search-container-height * 0.5);
       font-size: 14px;
-      color: $white;
-      background: $color-primary;
-      border: $border-width-default solid $border-color-default;
+      color: $text-color-primary;
+      background: $color-inverse;
+      border: $border-width-default solid $border-color-light;
+
+      &::placeholder {
+        // specific lighter color to have a better contrast
+        color: $text-color-quaternary;
+      }
 
       @include media-breakpoint-down(sm) {
-        border: $border-width-default solid $border-color-default;
+        font-size: 16px !important; // prevent page zoom on mobile devices
+        border: $border-width-default solid $border-color-light;
 
         &:focus {
-          background: $color-tertiary;
+          background: $color-inverse;
         }
       }
     }
@@ -155,6 +239,10 @@
       background: $color-inverse;
       border: $border-width-default solid $border-color-light;
       box-shadow: none;
+
+      &::placeholder {
+        color: $input-placeholder-color;
+      }
     }
   }
 
@@ -163,6 +251,7 @@
   }
 }
 
+// search container with toggle icon (mobile, desktop fixed header)
 .header-utility {
   .search-container {
     position: absolute;
@@ -174,51 +263,48 @@
     background: $color-inverse;
     box-shadow: 0 4px 7px rgb(0 0 0 / 0.23);
 
-    .btn-search {
+    &.header-search-container {
       @include media-breakpoint-down(md) {
-        right: divide($space-default * 2, 3);
-        margin-right: 0;
+        top: $header-height-mobile;
+        width: 100%;
+        padding: 0;
       }
     }
 
-    @include media-breakpoint-up(lg) {
-      height: 0;
-      overflow: hidden;
+    .btn-search {
+      @include media-breakpoint-down(md) {
+        right: 0;
+        margin-right: 0;
+      }
     }
   }
 
   .search-toggler {
     position: relative;
 
-    &.active-search {
-      background-color: $color-primary;
+    @include media-breakpoint-down(md) {
+      position: static;
+    }
 
-      .ng-fa-icon {
-        color: $text-color-inverse;
+    &.active-search {
+      color: $text-color-quaternary;
+      background-color: $color-inverse;
+
+      > .ng-fa-icon {
+        color: $text-color-primary;
       }
     }
   }
+}
 
-  @include media-breakpoint-down(md) {
-    .search-container.header-search-container {
-      top: $header-height-mobile;
-      display: block;
-      width: 100%;
-      padding: 0;
-      overflow: hidden;
-      transition: height 500ms ease-in-out;
-    }
-
-    .search-toggler {
-      position: static;
-    }
+// main search container
+.main-search-container {
+  ul.search-suggest-results {
+    width: 100%;
   }
 }
 
-.main-search-container ul.search-suggest-results {
-  width: 100%;
-}
-
+// error page search container
 .error-search-container {
   ul.search-suggest-results {
     top: 33px;
@@ -226,6 +312,7 @@
   }
 }
 
+// no search result page search container
 .no-search-result {
   + .search-container {
     .buttons button {

--- a/src/styles/pages/errorpage/errorpage.scss
+++ b/src/styles/pages/errorpage/errorpage.scss
@@ -36,20 +36,27 @@
     input {
       &.form-control {
         height: $search-container-height;
-        color: $white;
-        background: $color-primary;
-        border: $border-width-default solid $border-color-default;
+        border: $border-width-default solid $border-color-light;
 
         &:focus {
           color: $text-color-primary;
           background: $color-inverse;
-          border: $border-width-default solid $border-color-light;
           box-shadow: none;
 
-          + button {
-            &.btn-search {
-              span::before {
-                color: $text-color-primary;
+          + .buttons {
+            button {
+              color: $text-color-corporate;
+
+              .ng-fa-icon {
+                color: $text-color-corporate;
+              }
+
+              &.btn-reset {
+                color: $text-color-quaternary;
+
+                .ng-fa-icon {
+                  color: $text-color-quaternary;
+                }
               }
             }
           }
@@ -59,7 +66,7 @@
 
     .btn-primary {
       right: 0;
-      bottom: 1px;
+      bottom: 0;
       margin-bottom: 0;
       font-weight: normal;
     }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Solr is used for the suggest only.

## What Is the New Behavior?

Suggest terms are shown using Sparque in the header suggest. The PR includes the first changes for the new visual design and interaction:
- apply new basic styling for both Solr and Sparque search box in the header and main content (no search result page, error page)
- apply Sparque specific suggest IAD to the header suggest search box 
  - show / hide suggest (focus handling)
  - scroll inside suggest layer and outside suggest (page)
  - responsive behavior
  - sticky header behavior
  - gray background 
- move "Quick Order" to top header 

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
