### PR TITLE
fix: remove evaluation of both punchout type transfers to prevent false error messages (#1737)

### DIFF
--- a/.github/workflows/azure-devops-issue-sync.yml
+++ b/.github/workflows/azure-devops-issue-sync.yml
@@ -16,8 +16,8 @@ jobs:
           github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'
           ado_organization: 'intershop-com'
           ado_project: 'Products'
-          ado_area_path: "Products\\RESTbased Storefront"
-          ado_iteration_path: "Products\\PWA Rngrx"
+          ado_area_path: "Products\\PWA"
+          ado_iteration_path: 'Products'
           ado_wit: 'Issue'
           ado_new_state: 'New'
           ado_active_state: 'Active'

--- a/.github/workflows/azure-devops-pr-sync.yml
+++ b/.github/workflows/azure-devops-pr-sync.yml
@@ -19,8 +19,7 @@ jobs:
           github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'
           ado_organization: 'intershop-com'
           ado_project: 'Products'
-          ado_area_path: "Products\\RESTbased Storefront"
-          # ado_iteration_path: "Products\\PWA Rngrx" # not working yet
+          ado_area_path: "Products\\PWA"
           ado_wit: 'Issue'
           ado_new_state: 'New'
           ado_active_state: 'Active'

--- a/src/app/extensions/punchout/services/punchout/punchout.service.ts
+++ b/src/app/extensions/punchout/services/punchout/punchout.service.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { EMPTY, Observable, iif, throwError } from 'rxjs';
+import { EMPTY, Observable, throwError } from 'rxjs';
 import { concatMap, filter, map, switchMap, take } from 'rxjs/operators';
 
 import { MessageFacade } from 'ish-core/facades/message.facade';
@@ -191,11 +191,11 @@ export class PunchoutService {
     return this.store.pipe(select(getUserPermissions)).pipe(
       whenTruthy(),
       switchMap(permissions =>
-        iif(
-          () => permissions.includes('APP_B2B_SEND_CXML_BASKET'),
-          this.transferCxmlPunchoutBasket(),
-          iif(() => permissions.includes('APP_B2B_SEND_OCI_BASKET'), this.transferOciPunchoutBasket(), EMPTY)
-        )
+        permissions.includes('APP_B2B_SEND_CXML_BASKET')
+          ? this.transferCxmlPunchoutBasket()
+          : permissions.includes('APP_B2B_SEND_OCI_BASKET')
+          ? this.transferOciPunchoutBasket()
+          : EMPTY
       )
     );
   }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

After adding error messages in the UI regarding missing punchout information for the Hook URL or Return URL false error messages popped up that where not supposed to be even relevant.

## What Is the New Behavior?

Not using the `iif` operator prevents the false evaluation and false error messages.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

The second commit fixes the ADO sync workflows.


[AB#103134](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/103134)