### PR TITLE
chore: use v4 of upload and download github actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm run build:multi
 
       - name: Upload Build Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -74,7 +74,7 @@ jobs:
           cache: npm
 
       - name: Download Build Output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -115,7 +115,7 @@ jobs:
         run: cd e2e && npm i
 
       - name: Download Build Output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -150,14 +150,14 @@ jobs:
           command: npx ts-node cypress-ci-e2e **/*${{ matrix.test }}*.e2e-spec.ts
 
       - name: Upload Screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: screenshots
           path: e2e/cypress/screenshots
 
       - name: Upload Videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: videos


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[x] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The github integration pipeline failed with the following error message:
'This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?
We use the v4 versiom fpr the github actions upload-artifact and download-artifact.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#103177](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/103177)