### PR TITLE
fix: don't send shipping method in POST items request when ICM runs in single-shipment-mode

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm run build:multi
 
       - name: Upload Build Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -74,7 +74,7 @@ jobs:
           cache: npm
 
       - name: Download Build Output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -115,7 +115,7 @@ jobs:
         run: cd e2e && npm i
 
       - name: Download Build Output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -150,14 +150,14 @@ jobs:
           command: npx ts-node cypress-ci-e2e **/*${{ matrix.test }}*.e2e-spec.ts
 
       - name: Upload Screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: screenshots
           path: e2e/cypress/screenshots
 
       - name: Upload Videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: videos

--- a/src/app/core/services/basket-items/basket-items.service.spec.ts
+++ b/src/app/core/services/basket-items/basket-items.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
-import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
+import { anyString, anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
 import { LineItemData } from 'ish-core/models/line-item/line-item.interface';
 import { LineItem } from 'ish-core/models/line-item/line-item.model';
 import { ApiService } from 'ish-core/services/api/api.service';
+import { getServerConfig } from 'ish-core/store/core/server-config';
 import { getCurrentBasket } from 'ish-core/store/customer/basket';
 import { BasketMockData } from 'ish-core/utils/dev/basket-mock-data';
 
@@ -14,6 +15,7 @@ import { BasketItemUpdateType, BasketItemsService } from './basket-items.service
 describe('Basket Items Service', () => {
   let basketItemsService: BasketItemsService;
   let apiServiceMock: ApiService;
+  let store$: MockStore;
 
   const lineItemMockData = {
     id: 'test',
@@ -39,20 +41,63 @@ describe('Basket Items Service', () => {
       providers: [
         { provide: ApiService, useFactory: () => instance(apiServiceMock) },
         provideMockStore({
-          selectors: [{ selector: getCurrentBasket, value: { id: '123' } }],
+          selectors: [
+            {
+              selector: getCurrentBasket,
+              value: { id: '123', commonShippingMethod: { id: BasketMockData.getShippingMethod().id } },
+            },
+            { selector: getServerConfig, value: { shipping: { multipleShipmentsSupported: true } } },
+          ],
         }),
       ],
     });
 
     basketItemsService = TestBed.inject(BasketItemsService);
+    store$ = TestBed.inject(MockStore);
   });
 
-  it("should post item to basket when 'addItemsToBasket' is called", done => {
+  interface TestAddLineItemType {
+    product: string;
+    quantity: {
+      value: number;
+      unit: string;
+    };
+    warrantySku?: string;
+    shippingMethod?: string;
+  }
+
+  type TestData = {
+    multipleShipment: boolean;
+    expectedPayload: TestAddLineItemType[];
+  };
+
+  it.each<TestData>([
+    {
+      multipleShipment: true,
+      expectedPayload: [
+        {
+          product: itemMockData.sku,
+          quantity: { value: itemMockData.quantity, unit: itemMockData.unit },
+          shippingMethod: BasketMockData.getShippingMethod().id,
+        },
+      ],
+    },
+    {
+      multipleShipment: false,
+      expectedPayload: [
+        {
+          product: itemMockData.sku,
+          quantity: { value: itemMockData.quantity, unit: itemMockData.unit },
+        },
+      ],
+    },
+  ])("should post item to basket when 'addItemsToBasket' is called", (testData: TestData, done) => {
     when(apiServiceMock.post(anyString(), anything(), anything())).thenReturn(of({ data: [], infos: undefined }));
+    store$.overrideSelector(getServerConfig, { shipping: { multipleShipmentsSupported: testData.multipleShipment } });
 
     basketItemsService.addItemsToBasket([itemMockData]).subscribe(() => {
       // basket-endpoint 'baskets/current' is not considered in the verify, only data that comes after it
-      verify(apiServiceMock.post(`items`, anything(), anything())).once();
+      verify(apiServiceMock.post(`items`, deepEqual(testData.expectedPayload), anything())).once();
       done();
     });
   });


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

The common shipping method is send within the POST /basket/:id/items request every time. 
This is necessary to avoid the creation of multiple buckets if the ICM shipping preference `multipleShipmentsSupported` is set to true. 
However, if the ICM shipping preference `multipleShipmentsSupported` is set to false this causes a 422 response from ICM.

## What Is the New Behavior?

The PWA uses the configuration preference `multipleShipmentsSupported` to distinct between both usecases.
The commonShippingMethod is only send if `multipleShipmentsSupported` is true.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#103178](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/103178)