### PR TITLE
chore: configure VS Code localization extension 'Lingua'  for the project

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,8 @@
         "esbenp.prettier-vscode",
         "stylelint.vscode-stylelint",
         "dbaeumer.vscode-eslint",
+        // localization
+        "chr33z.lingua-vscode",
         // testing
         "andys8.jest-snippets",
         // documentation

--- a/.lingua
+++ b/.lingua
@@ -1,0 +1,8 @@
+{
+  "translationFiles": [
+    {
+      "lang": "en_US",
+      "uri": "src/assets/i18n/en_US.json"
+    }
+  ]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,6 +28,7 @@
 .husky
 .gitattributes
 .editorconfig
+.lingua
 .nvmrc
 .nsprc
 package*.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,6 +15,8 @@
     "esbenp.prettier-vscode",
     "stylelint.vscode-stylelint",
     "dbaeumer.vscode-eslint",
+    // localization
+    "chr33z.lingua-vscode",
     // testing
     "andys8.jest-snippets",
     // documentation

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,8 @@
   "eslint.options": {
     "extensions": [".ts", ".html"]
   },
-  "eslint.validate": ["javascript", "typescript", "html"]
+  "eslint.validate": ["javascript", "typescript", "html"],
+
+  "lingua.flatTranslationKeys": true,
+  "lingua.defaultLanguage": "en_US"
 }


### PR DESCRIPTION
* Lingua - Managing ngx-translations
* https://marketplace.visualstudio.com/items?itemName=chr33z.lingua-vscode
* configure only for 'en_US' by default for more convenient localization editing

## PR Type

[x] Other: add VS Code extension

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
