### PR TITLE
feat(accessibility): set focus on the first invalid form field

### DIFF
--- a/docs/guides/forms.md
+++ b/docs/guides/forms.md
@@ -76,7 +76,7 @@ If functionality is implemented as an extension, the form models and services ca
 - Form validation:
   - If a form is shown, there should not be any validation error messages.
   - If a user starts to enter data in an input field, this field will be validated immediately.
-  - If the user presses the submit button, all form controls of the form are validated; the submit button will be disabled as long as there is any unhandled form error.
+  - If the user presses the submit button, all form controls of the form are validated and in case of validation errors the focus is set to the first invalid form field; the submit button will be disabled as long as there is any unhandled form error.
 
 ## General Rules
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,14 @@ kb_sync_latest_only
 
 # Migrations
 
+## From 5.3 to 6.0
+
+The Intershop PWA 6.0 release contains functionality to improve the **accessibility** of the PWA:
+
+A directive `ishFormSubmit` has been introduced for form html elements.
+In case of validation errors the focus is set to the first invalid form field after submit.
+The logic to disable the submit buttons as long as the form is invalid has been simplified, the usage of the function `markAsDirtyRecursive` is no longer necessary for formly forms.
+
 ## From 5.2 to 5.3
 
 The `updateUser` method of the `UserService` has been slightly refactored.

--- a/e2e/cypress/e2e/pages/shopping/product-review.module.ts
+++ b/e2e/cypress/e2e/pages/shopping/product-review.module.ts
@@ -21,7 +21,7 @@ export class ProductReviewModule {
   }
 
   get reviewCreationForm() {
-    return cy.get('#createProductReviewForm');
+    return cy.get('[data-testing-id="create-product-review-form"]');
   }
 
   get ownProductReview() {
@@ -42,14 +42,14 @@ export class ProductReviewModule {
     Object.keys(data)
       .filter(key => data[key] !== undefined && key !== 'rating')
       .forEach((key: keyof ProductReviewForm) => {
-        fillFormField('#createProductReviewForm', key, data[key]);
+        fillFormField('[data-testing-id="create-product-review-form"]', key, data[key]);
       });
 
     return this;
   }
 
   submitReviewCreationForm() {
-    cy.get('button[form=createProductReviewForm]').click();
+    cy.get('[data-testing-id="create-product-review-form"] button[type=submit]').click();
   }
 
   deleteOwnReview() {

--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.html
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.html
@@ -6,7 +6,7 @@
     </button>
   </div>
 
-  <form [formGroup]="costCenterBuyerForm" (ngSubmit)="submitCostCenterBuyerForm()">
+  <form [formGroup]="costCenterBuyerForm" ishFormSubmit #form="ngForm" (ngSubmit)="submitCostCenterBuyerForm()">
     <div class="modal-body">
       <formly-form [form]="costCenterBuyerForm" [fields]="fields" [model]="model" />
     </div>
@@ -15,7 +15,7 @@
       <button
         type="submit"
         class="btn btn-primary"
-        [disabled]="formDisabled"
+        [disabled]="costCenterBuyerForm.invalid && form.submitted"
         data-testing-id="cost-center-buyer-edit-dialog-submit"
       >
         {{ 'account.costcenter.details.buyers.action.save' | translate }}

--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.ts
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.ts
@@ -6,7 +6,6 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { CostCenterBuyer } from 'ish-core/models/cost-center/cost-center.model';
 import { PriceHelper } from 'ish-core/models/price/price.helper';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { FormsService } from 'ish-shared/forms/utils/forms.service';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
@@ -23,7 +22,6 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
 
   costCenterBuyerForm = new FormGroup({});
   fields: FormlyFieldConfig[];
-  private submitted = false;
 
   buyer: CostCenterBuyer;
 
@@ -84,26 +82,18 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
   }
 
   submitCostCenterBuyerForm() {
-    if (this.costCenterBuyerForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.costCenterBuyerForm);
-      return;
+    if (this.costCenterBuyerForm.valid) {
+      const changedBuyer: CostCenterBuyer = {
+        login: this.buyer.login,
+        firstName: this.buyer.firstName,
+        lastName: this.buyer.lastName,
+        budget: PriceHelper.getPrice(this.buyer.budget.currency, this.model.budgetValue ?? 0),
+        budgetPeriod: this.model.budgetPeriod,
+      };
+
+      this.organizationManagementFacade.updateCostCenterBuyer(changedBuyer);
+      this.hide();
     }
-
-    const changedBuyer: CostCenterBuyer = {
-      login: this.buyer.login,
-      firstName: this.buyer.firstName,
-      lastName: this.buyer.lastName,
-      budget: PriceHelper.getPrice(this.buyer.budget.currency, this.model.budgetValue ?? 0),
-      budgetPeriod: this.model.budgetPeriod,
-    };
-
-    this.organizationManagementFacade.updateCostCenterBuyer(changedBuyer);
-    this.hide();
-  }
-
-  get formDisabled() {
-    return this.costCenterBuyerForm.invalid && this.submitted;
   }
 
   /** Opens the modal. */

--- a/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.html
+++ b/projects/organization-management/src/app/pages/cost-center-buyers/cost-center-buyers-page.component.html
@@ -28,12 +28,17 @@
         </div>
       </div>
 
-      <form (ngSubmit)="submitForm()" [formGroup]="form">
+      <form [formGroup]="form" (ngSubmit)="submitForm()" #buyersForm="ngForm" novalidate>
         <div class="list-body">
           <formly-form [model]="model" [fields]="fields" [form]="form" class="pt-1" />
         </div>
         <div class="row justify-content-end">
-          <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="add-buyers-submit">
+          <button
+            type="submit"
+            class="btn btn-primary"
+            [disabled]="formDisabled || (buyersForm.submitted && form.invalid)"
+            data-testing-id="add-buyers-submit"
+          >
             {{ 'account.costcenter.details.buyers.action.add' | translate }}
           </button>
           <a routerLink="../" class="btn btn-secondary" data-testing-id="add-cost-center-buyers-cancel">{{

--- a/projects/organization-management/src/app/pages/cost-center-create/cost-center-create-page.component.html
+++ b/projects/organization-management/src/app/pages/cost-center-create/cost-center-create-page.component.html
@@ -1,13 +1,13 @@
 <h1>{{ 'account.costcenter.create.heading' | translate }}</h1>
 
-<form [formGroup]="form" (ngSubmit)="submitForm()" class="form-horizontal" novalidate="novalidate">
+<form [formGroup]="form" (ngSubmit)="submitForm()" ishFormSubmit #ccForm="ngForm" class="form-horizontal" novalidate>
   <ish-cost-center-form [form]="form" />
   <div class="row">
     <div class="offset-md-4 col-md-8">
       <button
         type="submit"
         class="btn btn-primary"
-        [disabled]="formDisabled"
+        [disabled]="form.invalid && ccForm.submitted"
         data-testing-id="create-cost-center-submit"
       >
         {{ 'account.costcenter.create.button.label' | translate }}

--- a/projects/organization-management/src/app/pages/cost-center-create/cost-center-create-page.component.spec.ts
+++ b/projects/organization-management/src/app/pages/cost-center-create/cost-center-create-page.component.spec.ts
@@ -50,26 +50,4 @@ describe('Cost Center Create Page Component', () => {
 
     expect(element.querySelector('ish-cost-center-form')).toBeTruthy();
   });
-
-  it('should not submit a form when the user does not fill all required fields', () => {
-    component.form = fb.group({
-      costCenterId: ['', [Validators.required]],
-    });
-
-    fixture.detectChanges();
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm();
-
-    expect(component.formDisabled).toBeTrue();
-  });
-
-  it('should submit a form when the user fills all required fields', () => {
-    fixture.detectChanges();
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm();
-
-    expect(component.formDisabled).toBeFalse();
-  });
 });

--- a/projects/organization-management/src/app/pages/cost-center-create/cost-center-create-page.component.ts
+++ b/projects/organization-management/src/app/pages/cost-center-create/cost-center-create-page.component.ts
@@ -3,7 +3,6 @@ import { UntypedFormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 import { CostCenterBase } from 'ish-core/models/cost-center/cost-center.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
 
@@ -15,7 +14,6 @@ import { OrganizationManagementFacade } from '../../facades/organization-managem
 export class CostCenterCreatePageComponent implements OnInit {
   loading$: Observable<boolean>;
 
-  private submitted = false;
   form = new UntypedFormGroup({});
 
   constructor(private organizationManagementFacade: OrganizationManagementFacade) {}
@@ -25,28 +23,20 @@ export class CostCenterCreatePageComponent implements OnInit {
   }
 
   submitForm() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      const formValue = this.form.value;
+
+      const costCenter: CostCenterBase = {
+        id: undefined,
+        costCenterId: formValue.costCenterId,
+        name: formValue.name,
+        budget: { value: formValue.budgetValue, currency: formValue.currency, type: 'Money' },
+        budgetPeriod: formValue.budgetPeriod,
+        costCenterOwner: { login: formValue.costCenterManager },
+        active: formValue.active,
+      };
+
+      this.organizationManagementFacade.addCostCenter(costCenter);
     }
-
-    const formValue = this.form.value;
-
-    const costCenter: CostCenterBase = {
-      id: undefined,
-      costCenterId: formValue.costCenterId,
-      name: formValue.name,
-      budget: { value: formValue.budgetValue, currency: formValue.currency, type: 'Money' },
-      budgetPeriod: formValue.budgetPeriod,
-      costCenterOwner: { login: formValue.costCenterManager },
-      active: formValue.active,
-    };
-
-    this.organizationManagementFacade.addCostCenter(costCenter);
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/projects/organization-management/src/app/pages/cost-center-edit/cost-center-edit-page.component.html
+++ b/projects/organization-management/src/app/pages/cost-center-edit/cost-center-edit-page.component.html
@@ -1,14 +1,21 @@
 <h1>{{ 'account.costcenter.details.edit.heading' | translate }}</h1>
 
 <div *ngIf="costCenter$ | async as costCenter">
-  <form [formGroup]="form" (ngSubmit)="submitForm(costCenter)" class="form-horizontal" novalidate="novalidate">
+  <form
+    [formGroup]="form"
+    (ngSubmit)="submitForm(costCenter)"
+    ishFormSubmit
+    #ccForm="ngForm"
+    class="form-horizontal"
+    novalidate
+  >
     <ish-cost-center-form [form]="form" [costCenter]="costCenter" />
     <div class="row">
       <div class="offset-md-4 col-md-8">
         <button
           type="submit"
           class="btn btn-primary"
-          [disabled]="formDisabled"
+          [disabled]="form.invalid && ccForm.submitted"
           data-testing-id="edit-cost-center-submit"
         >
           {{ 'account.update.button.label' | translate }}

--- a/projects/organization-management/src/app/pages/cost-center-edit/cost-center-edit-page.component.spec.ts
+++ b/projects/organization-management/src/app/pages/cost-center-edit/cost-center-edit-page.component.spec.ts
@@ -64,26 +64,4 @@ describe('Cost Center Edit Page Component', () => {
 
     expect(element.querySelector('ish-cost-center-form')).toBeTruthy();
   });
-
-  it('should not submit a form when the user does not fill all required fields', () => {
-    component.form = fb.group({
-      costCenterId: ['', [Validators.required]],
-    });
-
-    fixture.detectChanges();
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm(costCenter);
-
-    expect(component.formDisabled).toBeTrue();
-  });
-
-  it('should submit a form when the user fills all required fields', () => {
-    fixture.detectChanges();
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm(costCenter);
-
-    expect(component.formDisabled).toBeFalse();
-  });
 });

--- a/projects/organization-management/src/app/pages/cost-center-edit/cost-center-edit-page.component.ts
+++ b/projects/organization-management/src/app/pages/cost-center-edit/cost-center-edit-page.component.ts
@@ -3,7 +3,6 @@ import { UntypedFormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 import { CostCenter, CostCenterBase } from 'ish-core/models/cost-center/cost-center.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
 
@@ -16,7 +15,6 @@ export class CostCenterEditPageComponent implements OnInit {
   loading$: Observable<boolean>;
   costCenter$: Observable<CostCenter>;
 
-  private submitted = false;
   form = new UntypedFormGroup({});
 
   constructor(private organizationManagementFacade: OrganizationManagementFacade) {}
@@ -27,27 +25,19 @@ export class CostCenterEditPageComponent implements OnInit {
   }
 
   submitForm(cc: CostCenter) {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      const formValue = this.form.value;
+
+      const costCenter: CostCenterBase = {
+        id: cc.id,
+        costCenterId: formValue.costCenterId,
+        name: formValue.name,
+        budget: { value: formValue.budgetValue, currency: cc.budget.currency, type: 'Money' },
+        budgetPeriod: formValue.budgetPeriod,
+        costCenterOwner: { login: formValue.costCenterManager },
+        active: formValue.active,
+      };
+      this.organizationManagementFacade.updateCostCenter(costCenter);
     }
-
-    const formValue = this.form.value;
-
-    const costCenter: CostCenterBase = {
-      id: cc.id,
-      costCenterId: formValue.costCenterId,
-      name: formValue.name,
-      budget: { value: formValue.budgetValue, currency: cc.budget.currency, type: 'Money' },
-      budgetPeriod: formValue.budgetPeriod,
-      costCenterOwner: { login: formValue.costCenterManager },
-      active: formValue.active,
-    };
-    this.organizationManagementFacade.updateCostCenter(costCenter);
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/projects/organization-management/src/app/pages/organization-settings-company/organization-settings-company/organization-settings-company.component.html
+++ b/projects/organization-management/src/app/pages/organization-settings-company/organization-settings-company/organization-settings-company.component.html
@@ -10,11 +10,21 @@
       <p class="indicates-required">
         <span class="required">*</span>{{ 'account.required_field.message' | translate }}
       </p>
-      <form class="form-horizontal" [formGroup]="organizationSettingsCompanyForm" (ngSubmit)="submit()">
+      <form
+        [formGroup]="organizationSettingsCompanyForm"
+        ishFormSubmit
+        #form="ngForm"
+        class="form-horizontal"
+        (ngSubmit)="submit()"
+      >
         <formly-form [form]="organizationSettingsCompanyForm" [fields]="fields" [model]="model" />
         <div class="row">
           <div class="offset-md-4 col-md-8">
-            <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">
+            <button
+              type="submit"
+              class="btn btn-primary"
+              [disabled]="form.submitted && organizationSettingsCompanyForm.invalid"
+            >
               {{ 'account.update.button.label' | translate }}
             </button>
             <a routerLink="/account/organization/settings" class="btn btn-secondary">{{

--- a/projects/organization-management/src/app/pages/organization-settings-company/organization-settings-company/organization-settings-company.component.spec.ts
+++ b/projects/organization-management/src/app/pages/organization-settings-company/organization-settings-company/organization-settings-company.component.spec.ts
@@ -76,12 +76,4 @@ describe('Organization Settings Company Component', () => {
 
     verify(eventEmitter$.emit(anything())).never();
   });
-
-  it('should disable submit button when the user submits an invalid form', () => {
-    fixture.detectChanges();
-
-    expect(component.buttonDisabled).toBeFalse();
-    component.submit();
-    expect(component.buttonDisabled).toBeTrue();
-  });
 });

--- a/projects/organization-management/src/app/pages/organization-settings-company/organization-settings-company/organization-settings-company.component.ts
+++ b/projects/organization-management/src/app/pages/organization-settings-company/organization-settings-company/organization-settings-company.component.ts
@@ -6,7 +6,6 @@ import { pick } from 'lodash-es';
 import { Customer } from 'ish-core/models/customer/customer.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { FieldLibrary } from 'ish-shared/formly/field-library/field-library';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 /**
  * The Organization Settings Company Page Component displays a form for changing a business customers' company data
@@ -21,8 +20,6 @@ export class OrganizationSettingsCompanyComponent implements OnInit {
   @Input({ required: true }) currentCustomer: Customer;
   @Input() error: HttpError;
   @Output() updateCompanyProfile = new EventEmitter<Customer>();
-
-  private submitted = false;
 
   organizationSettingsCompanyForm = new FormGroup({});
   model: Partial<Customer>;
@@ -39,19 +36,12 @@ export class OrganizationSettingsCompanyComponent implements OnInit {
    * Submits form and throws update event when form is valid
    */
   submit() {
-    if (this.organizationSettingsCompanyForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.organizationSettingsCompanyForm);
-      return;
+    if (this.organizationSettingsCompanyForm.valid) {
+      const companyName = this.organizationSettingsCompanyForm.get('companyName').value;
+      const companyName2 = this.organizationSettingsCompanyForm.get('companyName2').value;
+      const taxationID = this.organizationSettingsCompanyForm.get('taxationID').value;
+
+      this.updateCompanyProfile.emit({ ...this.currentCustomer, companyName, companyName2, taxationID });
     }
-    const companyName = this.organizationSettingsCompanyForm.get('companyName').value;
-    const companyName2 = this.organizationSettingsCompanyForm.get('companyName2').value;
-    const taxationID = this.organizationSettingsCompanyForm.get('taxationID').value;
-
-    this.updateCompanyProfile.emit({ ...this.currentCustomer, companyName, companyName2, taxationID });
-  }
-
-  get buttonDisabled() {
-    return this.organizationSettingsCompanyForm.invalid && this.submitted;
   }
 }

--- a/projects/organization-management/src/app/pages/organization-settings/organization-settings-page.component.html
+++ b/projects/organization-management/src/app/pages/organization-settings/organization-settings-page.component.html
@@ -40,7 +40,7 @@
 <div *ngIf="'services.OrderApprovalServiceDefinition.runnable' | ishServerSetting" class="row section">
   <div class="col-10 col-lg-8">
     <h3>{{ 'account.organization.org_settings.preferences.subtitle' | translate }}</h3>
-    <form class="form-horizontal" [formGroup]="budgetTypeForm">
+    <form class="form-horizontal" [formGroup]="budgetTypeForm" novalidate>
       <formly-form
         [form]="budgetTypeForm"
         [fields]="fields"

--- a/projects/organization-management/src/app/pages/organization-settings/organization-settings-page.component.ts
+++ b/projects/organization-management/src/app/pages/organization-settings/organization-settings-page.component.ts
@@ -9,7 +9,6 @@ import { Customer } from 'ish-core/models/customer/customer.model';
 import { PriceType } from 'ish-core/models/price/price.model';
 import { whenTruthy } from 'ish-core/utils/operators';
 import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 /**
  * The Organization Settings Page Component shows the company profile.
@@ -76,17 +75,15 @@ export class OrganizationSettingsPageComponent implements OnInit {
    * Submits form and throws update event when form is valid
    */
   submit() {
-    if (this.budgetTypeForm.invalid) {
-      markAsDirtyRecursive(this.budgetTypeForm);
-      return;
+    if (this.budgetTypeForm.valid) {
+      const budgetPriceType = this.budgetTypeForm.get('budgetPriceType').value;
+
+      this.accountFacade.updateCustomerProfile(
+        { ...this.customer, budgetPriceType },
+        { message: 'account.profile.update_company_profile.message' }
+      );
+
+      this.initialBudgetPriceType = this.budgetTypeForm.get('budgetPriceType').value;
     }
-    const budgetPriceType = this.budgetTypeForm.get('budgetPriceType').value;
-
-    this.accountFacade.updateCustomerProfile(
-      { ...this.customer, budgetPriceType },
-      { message: 'account.profile.update_company_profile.message' }
-    );
-
-    this.initialBudgetPriceType = this.budgetTypeForm.get('budgetPriceType').value;
   }
 }

--- a/projects/organization-management/src/app/pages/user-create/user-create-page.component.html
+++ b/projects/organization-management/src/app/pages/user-create/user-create-page.component.html
@@ -1,7 +1,14 @@
 <div class="row">
   <div class="col-md-12">
     <h1>{{ 'account.user.new.heading' | translate }}</h1>
-    <form [formGroup]="form" (ngSubmit)="submitForm()" class="form-horizontal" novalidate="novalidate">
+    <form
+      [formGroup]="form"
+      ishFormSubmit
+      #userForm="ngForm"
+      class="form-horizontal"
+      novalidate
+      (ngSubmit)="submitForm()"
+    >
       <ish-user-profile-form [form]="profile" [error]="userError$ | async" />
       <ish-user-roles-selection formControlName="roleIDs" />
       <ish-user-budget-form
@@ -10,7 +17,12 @@
       />
       <div class="row">
         <div class="offset-md-4 col-md-8">
-          <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="create-user-submit">
+          <button
+            type="submit"
+            class="btn btn-primary"
+            [disabled]="form.invalid && userForm.submitted"
+            data-testing-id="create-user-submit"
+          >
             {{ 'account.user.new.button.create.label' | translate }}
           </button>
           <a routerLink="../" class="btn btn-secondary" data-testing-id="create-user-cancel">{{

--- a/projects/organization-management/src/app/pages/user-create/user-create-page.component.spec.ts
+++ b/projects/organization-management/src/app/pages/user-create/user-create-page.component.spec.ts
@@ -1,11 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockPipe } from 'ng-mocks';
 import { instance, mock } from 'ts-mockito';
 
 import { ServerSettingPipe } from 'ish-core/pipes/server-setting.pipe';
-import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { UserProfileFormComponent } from '../../components/user-profile-form/user-profile-form.component';
 import { UserRolesSelectionComponent } from '../../components/user-roles-selection/user-roles-selection.component';
@@ -18,7 +17,6 @@ describe('User Create Page Component', () => {
   let fixture: ComponentFixture<UserCreatePageComponent>;
   let element: HTMLElement;
   let organizationManagementFacade: OrganizationManagementFacade;
-  let fb: FormBuilder;
 
   beforeEach(async () => {
     organizationManagementFacade = mock(OrganizationManagementFacade);
@@ -38,50 +36,11 @@ describe('User Create Page Component', () => {
     fixture = TestBed.createComponent(UserCreatePageComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;
-    fb = TestBed.inject(FormBuilder);
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
-  });
-
-  it('should submit a valid form when the user fills all required fields', () => {
-    fixture.detectChanges();
-
-    component.form = fb.group({
-      profile: fb.group({
-        firstName: ['Bernhard', [Validators.required]],
-        lastName: ['Boldner', [Validators.required]],
-        email: ['test@gmail.com', [Validators.required, SpecialValidators.email]],
-        active: [true],
-      }),
-      roleIDs: ['Buyer'],
-      userBudget: fb.group({
-        orderSpentLimitValue: ['70000'],
-        budgetValue: [10000],
-        budgetPeriod: ['monthly'],
-        currency: 'USD',
-      }),
-    });
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm();
-    expect(component.formDisabled).toBeFalse();
-  });
-
-  it('should disable submit button when the user submits an invalid form', () => {
-    fixture.detectChanges();
-
-    component.form = fb.group({
-      profile: fb.group({
-        firstName: ['', [Validators.required]],
-      }),
-    });
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm();
-    expect(component.formDisabled).toBeTrue();
   });
 });

--- a/projects/organization-management/src/app/pages/user-create/user-create-page.component.ts
+++ b/projects/organization-management/src/app/pages/user-create/user-create-page.component.ts
@@ -4,7 +4,6 @@ import { Observable } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
 import { B2bUser } from '../../models/b2b-user/b2b-user.model';
@@ -24,8 +23,6 @@ export class UserCreatePageComponent implements OnInit {
     userBudget: this.fb.group({}),
   });
 
-  private submitted = false;
-
   constructor(private fb: FormBuilder, private organizationManagementFacade: OrganizationManagementFacade) {}
 
   ngOnInit() {
@@ -42,45 +39,37 @@ export class UserCreatePageComponent implements OnInit {
   }
 
   submitForm() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      const formValue = this.form.value;
+
+      const user: B2bUser = {
+        title: formValue.profile.title,
+        firstName: formValue.profile.firstName,
+        lastName: formValue.profile.lastName,
+        email: formValue.profile.email,
+        active: formValue.profile.active,
+        phoneHome: formValue.profile.phoneHome,
+        birthday: formValue.profile.birthday === '' ? undefined : formValue.birthday,
+        businessPartnerNo: `U${uuid()}`,
+        roleIDs: formValue.roleIDs,
+        userBudget: formValue.userBudget.currency
+          ? {
+              budget: formValue.userBudget.budgetValue
+                ? { value: formValue.userBudget.budgetValue, currency: formValue.userBudget.currency, type: 'Money' }
+                : undefined,
+              budgetPeriod: formValue.userBudget.budgetPeriod,
+              orderSpentLimit: formValue.userBudget.orderSpentLimitValue
+                ? {
+                    value: formValue.userBudget.orderSpentLimitValue,
+                    currency: formValue.userBudget.currency,
+                    type: 'Money',
+                  }
+                : undefined,
+            }
+          : undefined,
+      };
+
+      this.organizationManagementFacade.addUser(user);
     }
-
-    const formValue = this.form.value;
-
-    const user: B2bUser = {
-      title: formValue.profile.title,
-      firstName: formValue.profile.firstName,
-      lastName: formValue.profile.lastName,
-      email: formValue.profile.email,
-      active: formValue.profile.active,
-      phoneHome: formValue.profile.phoneHome,
-      birthday: formValue.profile.birthday === '' ? undefined : formValue.birthday,
-      businessPartnerNo: `U${uuid()}`,
-      roleIDs: formValue.roleIDs,
-      userBudget: formValue.userBudget.currency
-        ? {
-            budget: formValue.userBudget.budgetValue
-              ? { value: formValue.userBudget.budgetValue, currency: formValue.userBudget.currency, type: 'Money' }
-              : undefined,
-            budgetPeriod: formValue.userBudget.budgetPeriod,
-            orderSpentLimit: formValue.userBudget.orderSpentLimitValue
-              ? {
-                  value: formValue.userBudget.orderSpentLimitValue,
-                  currency: formValue.userBudget.currency,
-                  type: 'Money',
-                }
-              : undefined,
-          }
-        : undefined,
-    };
-
-    this.organizationManagementFacade.addUser(user);
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/projects/organization-management/src/app/pages/user-edit-budget/user-edit-budget-page.component.html
+++ b/projects/organization-management/src/app/pages/user-edit-budget/user-edit-budget-page.component.html
@@ -6,15 +6,22 @@
   <form
     *ngIf="budgetForm && 'services.OrderApprovalServiceDefinition.runnable' | ishServerSetting"
     [formGroup]="budgetForm"
-    (ngSubmit)="submitForm()"
+    ishFormSubmit
+    #form="ngForm"
     class="form-horizontal"
-    novalidate="novalidate"
+    novalidate
+    (ngSubmit)="submitForm()"
   >
     <ish-user-budget-form [form]="budgetForm" [budget]="user.userBudget" />
 
     <div class="row">
       <div class="offset-md-4 col-md-8">
-        <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="edit-budget-submit">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          [disabled]="budgetForm.invalid && form.submitted"
+          data-testing-id="edit-budget-submit"
+        >
           {{ 'account.update.button.label' | translate }}
         </button>
         <a routerLink="../" class="btn btn-secondary" data-testing-id="edit-budget-cancel">{{

--- a/projects/organization-management/src/app/pages/user-edit-budget/user-edit-budget-page.component.spec.ts
+++ b/projects/organization-management/src/app/pages/user-edit-budget/user-edit-budget-page.component.spec.ts
@@ -55,13 +55,4 @@ describe('User Edit Budget Page Component', () => {
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
   });
-
-  it('should submit a valid form when the user fills all required fields', () => {
-    fixture.detectChanges();
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm();
-
-    expect(component.formDisabled).toBeFalse();
-  });
 });

--- a/projects/organization-management/src/app/pages/user-edit-budget/user-edit-budget-page.component.ts
+++ b/projects/organization-management/src/app/pages/user-edit-budget/user-edit-budget-page.component.ts
@@ -3,7 +3,6 @@ import { UntypedFormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
 import { B2bUser } from '../../models/b2b-user/b2b-user.model';
@@ -21,7 +20,6 @@ export class UserEditBudgetPageComponent implements OnInit {
   error$: Observable<HttpError>;
 
   budgetForm = new UntypedFormGroup({});
-  private submitted = false;
 
   ngOnInit() {
     this.loading$ = this.organizationManagementFacade.usersLoading$;
@@ -30,34 +28,26 @@ export class UserEditBudgetPageComponent implements OnInit {
   }
 
   submitForm() {
-    if (this.budgetForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.budgetForm);
-      return;
+    if (this.budgetForm.valid) {
+      const formValue = this.budgetForm.value;
+
+      const budget: UserBudget = formValue
+        ? {
+            budget: formValue.budgetValue
+              ? { value: formValue.budgetValue, currency: formValue.currency, type: 'Money' }
+              : undefined,
+            budgetPeriod: formValue.budgetPeriod,
+            orderSpentLimit: formValue.orderSpentLimitValue
+              ? {
+                  value: formValue.orderSpentLimitValue,
+                  currency: formValue.currency,
+                  type: 'Money',
+                }
+              : undefined,
+          }
+        : undefined;
+
+      this.organizationManagementFacade.setSelectedUserBudget(budget);
     }
-
-    const formValue = this.budgetForm.value;
-
-    const budget: UserBudget = formValue
-      ? {
-          budget: formValue.budgetValue
-            ? { value: formValue.budgetValue, currency: formValue.currency, type: 'Money' }
-            : undefined,
-          budgetPeriod: formValue.budgetPeriod,
-          orderSpentLimit: formValue.orderSpentLimitValue
-            ? {
-                value: formValue.orderSpentLimitValue,
-                currency: formValue.currency,
-                type: 'Money',
-              }
-            : undefined,
-        }
-      : undefined;
-
-    this.organizationManagementFacade.setSelectedUserBudget(budget);
-  }
-
-  get formDisabled() {
-    return this.budgetForm.invalid && this.submitted;
   }
 }

--- a/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.html
+++ b/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.html
@@ -1,10 +1,22 @@
 <div *ngIf="selectedUser$ | async as user">
   <h1>{{ 'account.user.update_profile.heading' | translate }} - {{ user.firstName }} {{ user.lastName }}</h1>
-  <form [formGroup]="profileForm" (ngSubmit)="submitForm(user)" class="form-horizontal" novalidate="novalidate">
+  <form
+    [formGroup]="profileForm"
+    ishFormSubmit
+    #form="ngForm"
+    (ngSubmit)="submitForm(user)"
+    class="form-horizontal"
+    novalidate
+  >
     <ish-user-profile-form [form]="profileForm" [user]="user" [error]="userError$ | async" />
     <div class="row">
       <div class="offset-md-4 col-md-8">
-        <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="edit-user-submit">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          [disabled]="profileForm.invalid && form.submitted"
+          data-testing-id="edit-user-submit"
+        >
           {{ 'account.update.button.label' | translate }}
         </button>
         <a routerLink="../" class="btn btn-secondary" data-testing-id="edit-user-cancel">{{

--- a/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.spec.ts
+++ b/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.spec.ts
@@ -63,12 +63,4 @@ describe('User Edit Profile Page Component', () => {
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
   });
-
-  it('should submit a valid form when the user fills all required fields', () => {
-    fixture.detectChanges();
-
-    expect(component.formDisabled).toBeFalse();
-    component.submitForm(user);
-    expect(component.formDisabled).toBeFalse();
-  });
 });

--- a/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.ts
+++ b/projects/organization-management/src/app/pages/user-edit-profile/user-edit-profile-page.component.ts
@@ -3,7 +3,6 @@ import { UntypedFormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
 import { B2bUser } from '../../models/b2b-user/b2b-user.model';
@@ -18,7 +17,6 @@ export class UserEditProfilePageComponent implements OnInit {
   userError$: Observable<HttpError>;
   selectedUser$: Observable<B2bUser>;
 
-  private submitted = false;
   profileForm = new UntypedFormGroup({});
 
   constructor(private organizationManagementFacade: OrganizationManagementFacade) {}
@@ -30,26 +28,18 @@ export class UserEditProfilePageComponent implements OnInit {
   }
 
   submitForm(b2bUser: B2bUser) {
-    if (this.profileForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.profileForm);
-      return;
+    if (this.profileForm.valid) {
+      const formValue = this.profileForm.value;
+
+      const user: B2bUser = {
+        ...b2bUser,
+        title: formValue.title,
+        firstName: formValue.firstName,
+        lastName: formValue.lastName,
+        active: formValue.active,
+        phoneHome: formValue.phoneHome,
+      };
+      this.organizationManagementFacade.updateUser(user);
     }
-
-    const formValue = this.profileForm.value;
-
-    const user: B2bUser = {
-      ...b2bUser,
-      title: formValue.title,
-      firstName: formValue.firstName,
-      lastName: formValue.lastName,
-      active: formValue.active,
-      phoneHome: formValue.phoneHome,
-    };
-    this.organizationManagementFacade.updateUser(user);
-  }
-
-  get formDisabled() {
-    return this.profileForm.invalid && this.submitted;
   }
 }

--- a/projects/organization-management/src/app/pages/user-edit-roles/user-edit-roles-page.component.html
+++ b/projects/organization-management/src/app/pages/user-edit-roles/user-edit-roles-page.component.html
@@ -3,7 +3,7 @@
 
   <ish-error-message [error]="error$ | async" />
 
-  <form *ngIf="form$ | async as form" [formGroup]="form" (ngSubmit)="submitForm()" class="form-horizontal">
+  <form *ngIf="form$ | async as form" [formGroup]="form" (ngSubmit)="submitForm()" class="form-horizontal" novalidate>
     <ish-user-roles-selection formControlName="roleIDs" [staticRoles]="staticRoles$ | async" />
 
     <div class="row">

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.html
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.html
@@ -7,13 +7,13 @@
       </button>
     </div>
 
-    <form [formGroup]="rejectForm" (ngSubmit)="submitForm()" class="clearfix">
+    <form [formGroup]="rejectForm" ishFormSubmit #form="ngForm" (ngSubmit)="submitForm()" class="clearfix" novalidate>
       <div class="modal-body">
         <formly-form [form]="rejectForm" [fields]="fields" />
       </div>
 
       <div class="modal-footer">
-        <button type="submit" class="btn btn-primary" [disabled]="formDisabled">
+        <button type="submit" class="btn btn-primary" [disabled]="rejectForm.invalid && form.submitted">
           {{ 'approval.rejectform.button.reject.label' | translate }}
         </button>
         <button type="button" class="btn btn-secondary" (click)="hide()">

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-reject-dialog/requisition-reject-dialog.component.ts
@@ -11,8 +11,6 @@ import { FormGroup } from '@angular/forms';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
-
 /**
  * The Wishlist Reject Approval Dialog shows the modal to reject a requisition.
  *
@@ -33,7 +31,6 @@ export class RequisitionRejectDialogComponent implements OnInit {
   @Output() submitRejectRequisition = new EventEmitter<string>();
 
   rejectForm = new FormGroup({});
-  private submitted = false;
   fields: FormlyFieldConfig[];
 
   /**
@@ -74,14 +71,10 @@ export class RequisitionRejectDialogComponent implements OnInit {
 
   /** Emits the reject comment data, when the form was valid. */
   submitForm() {
-    if (this.rejectForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.rejectForm);
-      return;
+    if (this.rejectForm.valid) {
+      this.submitRejectRequisition.emit(this.rejectForm.get('comment').value);
+      this.hide();
     }
-
-    this.submitRejectRequisition.emit(this.rejectForm.get('comment').value);
-    this.hide();
   }
 
   /** Opens the modal. */
@@ -92,13 +85,8 @@ export class RequisitionRejectDialogComponent implements OnInit {
 
   /** Close the modal. */
   hide() {
-    this.submitted = false;
     if (this.modal) {
       this.modal.close();
     }
-  }
-
-  get formDisabled() {
-    return this.rejectForm.invalid && this.submitted;
   }
 }

--- a/src/app/core/directives.module.ts
+++ b/src/app/core/directives.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 
 import { BrowserLazyViewDirective } from './directives/browser-lazy-view.directive';
 import { ClickOutsideDirective } from './directives/click-outside.directive';
+import { FormSubmitDirective } from './directives/form-submit.directive';
 import { IdentityProviderCapabilityDirective } from './directives/identity-provider-capability.directive';
 import { IntersectionObserverDirective } from './directives/intersection-observer.directive';
 import { LazyLoadingContentDirective } from './directives/lazy-loading-content.directive';
@@ -14,6 +15,7 @@ import { ServerHtmlDirective } from './directives/server-html.directive';
   declarations: [
     BrowserLazyViewDirective,
     ClickOutsideDirective,
+    FormSubmitDirective,
     IdentityProviderCapabilityDirective,
     IntersectionObserverDirective,
     LazyLoadingContentDirective,
@@ -25,6 +27,7 @@ import { ServerHtmlDirective } from './directives/server-html.directive';
   exports: [
     BrowserLazyViewDirective,
     ClickOutsideDirective,
+    FormSubmitDirective,
     IdentityProviderCapabilityDirective,
     IntersectionObserverDirective,
     LazyLoadingContentDirective,

--- a/src/app/core/directives/form-submit.directive.ts
+++ b/src/app/core/directives/form-submit.directive.ts
@@ -1,0 +1,20 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+/**
+ * This directive can be used to add functionality on form submit events.
+ * It has been used to focus the first invalid form element on submit.
+ */
+@Directive({
+  selector: '[ishFormSubmit]',
+})
+export class FormSubmitDirective {
+  constructor(private elementRef: ElementRef) {}
+
+  @HostListener('submit')
+  onFormSubmit() {
+    const invalidElements = this.elementRef.nativeElement.querySelectorAll('.ng-invalid');
+    if (invalidElements.length) {
+      invalidElements[0].focus();
+    }
+  }
+}

--- a/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.html
+++ b/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.html
@@ -1,16 +1,25 @@
 <p>{{ 'helpdesk.contactus.prolog' | translate }}</p>
-<p class="indicates-required"><span class="required">*</span>{{ 'helpdesk.contactus.indicates' | translate }}</p>
-<form class="form-horizontal" [formGroup]="contactForm" name="ContactUsForm" (ngSubmit)="submitForm()">
+<p class="indicates-required" aria-hidden="true">
+  <span class="required">*</span>{{ 'helpdesk.contactus.indicates' | translate }}
+</p>
+<form
+  [formGroup]="contactForm"
+  ishFormSubmit
+  #form="ngForm"
+  (ngSubmit)="submitForm()"
+  class="form-horizontal"
+  novalidate
+>
   <formly-form [form]="contactForm" [fields]="fields" [model]="model$ | async" />
 
   <div class="row form-group">
     <div class="offset-md-4 col-md-8">
       <input
         type="submit"
-        [disabled]="formDisabled"
-        data-testing-id="submitContact"
+        [disabled]="form.submitted && form.invalid"
         class="btn btn-primary"
         value="{{ 'helpdesk.contactus.submit' | translate }}"
+        data-testing-id="submitContact"
       />
     </div>
   </div>

--- a/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.spec.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.spec.ts
@@ -54,7 +54,6 @@ describe('Contact Form Component', () => {
     fixture.detectChanges();
     component.submitForm();
     verify(emitter.emit(anything())).never();
-    expect(component.submitted).toBeTrue();
   });
 
   it('should emit contact request when valid form is submitted', () => {

--- a/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.ts
@@ -6,7 +6,6 @@ import { map, shareReplay, startWith } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { Contact } from 'ish-core/models/contact/contact.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { ContactUsFacade } from '../../../facades/contact-us.facade';
 
@@ -24,9 +23,6 @@ import { ContactUsFacade } from '../../../facades/contact-us.facade';
 export class ContactFormComponent implements OnInit {
   /** The contact request to send. */
   @Output() request = new EventEmitter<Contact>();
-
-  // visible-for-testing
-  submitted = false;
 
   /** The form for customer message to the shop. */
   contactForm = new UntypedFormGroup({});
@@ -124,18 +120,10 @@ export class ContactFormComponent implements OnInit {
     ];
   }
 
-  /** emit contact request, when for is valid or mark form as dirty, when form is invalid */
+  /** emit contact request on submit */
   submitForm() {
     if (this.contactForm.valid) {
       this.request.emit(this.contactForm.value);
-    } else {
-      markAsDirtyRecursive(this.contactForm);
-      this.submitted = true;
     }
-  }
-
-  /** return boolean to set submit button enabled/disabled */
-  get formDisabled(): boolean {
-    return this.contactForm.invalid && this.submitted;
   }
 }

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
@@ -6,7 +6,7 @@
     </button>
   </div>
 
-  <form [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm()">
+  <form [formGroup]="orderTemplateForm" ishFormSubmit #form="ngForm" (ngSubmit)="submitOrderTemplateForm()" novalidate>
     <div class="modal-body">
       <formly-form [form]="orderTemplateForm" [fields]="fields" [model]="model" />
     </div>
@@ -15,7 +15,7 @@
       <button
         type="submit"
         class="btn btn-primary"
-        [disabled]="formDisabled"
+        [disabled]="orderTemplateForm.invalid && form.submitted"
         data-testing-id="order-template-dialog-submit"
       >
         {{ primaryButton | translate }}

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.ts
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.ts
@@ -13,7 +13,6 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { pick } from 'lodash-es';
 
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { OrderTemplate } from '../../models/order-template/order-template.model';
@@ -46,7 +45,6 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
   orderTemplateForm = new FormGroup({});
   model: Partial<OrderTemplate>;
   fields: FormlyFieldConfig[];
-  private submitted = false;
 
   /**
    *  A reference to the current modal.
@@ -96,18 +94,14 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
 
   /** Emits the order template data, when the form was valid. */
   submitOrderTemplateForm() {
-    if (this.orderTemplateForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.orderTemplateForm);
-      return;
+    if (this.orderTemplateForm.valid) {
+      this.submitOrderTemplate.emit({
+        id: !this.orderTemplate ? this.model.title : this.orderTemplateTitle,
+        title: this.model.title,
+      });
+
+      this.hide();
     }
-
-    this.submitOrderTemplate.emit({
-      id: !this.orderTemplate ? this.model.title : this.orderTemplateTitle,
-      title: this.model.title,
-    });
-
-    this.hide();
   }
 
   /** Opens the modal. */
@@ -119,13 +113,8 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
 
   /** Close the modal. */
   hide() {
-    this.submitted = false;
     if (this.modal) {
       this.modal.close();
     }
-  }
-
-  get formDisabled() {
-    return this.orderTemplateForm.invalid && this.submitted;
   }
 }

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -7,13 +7,13 @@
   </div>
 
   <ng-container *ngIf="showForm; else showSuccess">
-    <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+    <form [formGroup]="formGroup" ishFormSubmit #form="ngForm" (ngSubmit)="submitForm()" novalidate>
       <div class="modal-body">
         <ish-select-order-template-form [formGroup]="formGroup" [addMoveProduct]="addMoveProduct" />
       </div>
 
       <div class="modal-footer">
-        <button type="submit" class="btn btn-primary">
+        <button type="submit" [disabled]="formGroup.invalid && form.submitted" class="btn btn-primary">
           {{ submitButtonTranslationKey | translate }}
         </button>
         <button type="button" class="btn btn-secondary" (click)="hide()">

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
@@ -18,7 +18,6 @@ import { Observable, of } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
 
@@ -71,13 +70,9 @@ export class SelectOrderTemplateModalComponent implements OnInit {
     if (radioButtons?.orderTemplate && radioButtons.orderTemplate !== 'new') {
       if (this.formGroup.valid) {
         this.submitExisting(radioButtons.orderTemplate);
-      } else {
-        markAsDirtyRecursive(this.formGroup);
       }
     } else if (radioButtons.newOrderTemplate && this.formGroup.valid) {
       this.submitNew(radioButtons.newOrderTemplate);
-    } else {
-      markAsDirtyRecursive(this.formGroup);
     }
   }
 

--- a/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.html
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.html
@@ -11,7 +11,7 @@
   </div>
 
   <ng-container *ngIf="productNotification$ | async as productNotification; else createNotificationButton">
-    <form [formGroup]="productNotificationForm" (ngSubmit)="submitForm()">
+    <form [formGroup]="productNotificationForm" ishFormSubmit #form="ngForm" (ngSubmit)="submitForm()" novalidate>
       <div class="modal-body">
         <ish-product-image imageType="L" />
 
@@ -22,7 +22,12 @@
         />
       </div>
       <div class="modal-footer">
-        <button type="submit" class="btn btn-primary" data-testing-id="product-notification-edit-dialog-edit">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          [disabled]="productNotificationForm.invalid && form.submitted"
+          data-testing-id="product-notification-edit-dialog-edit"
+        >
           {{ 'product.notification.edit.form.update.button.label' | translate }}
         </button>
         <button type="button" class="btn btn-secondary" (click)="hide()">
@@ -33,7 +38,7 @@
   </ng-container>
 
   <ng-template #createNotificationButton>
-    <form [formGroup]="productNotificationForm" (ngSubmit)="submitForm()">
+    <form [formGroup]="productNotificationForm" ishFormSubmit (ngSubmit)="submitForm()" novalidate>
       <div class="modal-body">
         <ish-product-image imageType="L" />
 

--- a/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.spec.ts
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.spec.ts
@@ -1,12 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UntypedFormBuilder, Validators } from '@angular/forms';
+import { UntypedFormBuilder } from '@angular/forms';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
-import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { ProductNotificationsFacade } from '../../facades/product-notifications.facade';
 
@@ -56,18 +55,6 @@ describe('Product Notification Edit Dialog Component', () => {
   describe('form submit', () => {
     beforeEach(() => {
       fb = TestBed.inject(UntypedFormBuilder);
-    });
-
-    it('should submit a valid form when the user fills all required fields', () => {
-      component.productNotificationForm = fb.group({
-        alertType: ['price'],
-        email: ['jlink@test.intershop.de', [Validators.required, SpecialValidators.email]],
-        priceValue: [1000],
-      });
-
-      expect(component.formDisabled).toBeFalse();
-      component.submitForm();
-      expect(component.formDisabled).toBeFalse();
     });
 
     it('should emit delete product notification when alert type is delete', () => {

--- a/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.ts
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.ts
@@ -18,7 +18,6 @@ import { AppFacade } from 'ish-core/facades/app.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { whenTruthy } from 'ish-core/utils/operators';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { ProductNotificationsFacade } from '../../facades/product-notifications.facade';
 import { ProductNotification } from '../../models/product-notification/product-notification.model';
@@ -52,7 +51,6 @@ export class ProductNotificationEditDialogComponent implements OnInit {
   private currentCurrency: string;
 
   productNotificationForm = new UntypedFormGroup({});
-  private submitted = false;
 
   productNotification$: Observable<ProductNotification>;
 
@@ -103,17 +101,9 @@ export class ProductNotificationEditDialogComponent implements OnInit {
     this.modal = this.ngbModal.open(this.modalTemplate);
   }
 
-  get formDisabled() {
-    return this.productNotificationForm.invalid && this.submitted;
-  }
-
   // submit the form
   submitForm() {
-    if (this.productNotificationForm.invalid) {
-      markAsDirtyRecursive(this.productNotificationForm);
-      this.submitted = true;
-      return;
-    } else {
+    if (this.productNotificationForm.valid) {
       const sku = this.context.get('sku');
       const formValue = this.productNotificationForm.value;
       const productNotificationType = formValue.priceValue === undefined ? 'stock' : 'price';

--- a/src/app/extensions/punchout/pages/account-punchout-configuration/oci-configuration-form/oci-configuration-form.component.html
+++ b/src/app/extensions/punchout/pages/account-punchout-configuration/oci-configuration-form/oci-configuration-form.component.html
@@ -47,7 +47,7 @@
         {{ 'account.punchout.configuration.form.heading.format' | translate }}
       </div>
     </div>
-    <form [formGroup]="form" (ngSubmit)="submitForm()" class="pt-1">
+    <form [formGroup]="form" ishFormSubmit #configForm="ngForm" (ngSubmit)="submitForm()" class="pt-1" novalidate>
       <div class="list-body">
         <formly-form [model]="model$ | async" [fields]="fields$ | async" [form]="form" class="pt-1" />
       </div>
@@ -57,7 +57,7 @@
             <button
               type="submit"
               class="btn btn-primary"
-              [disabled]="formDisabled"
+              [disabled]="form.invalid && configForm.submitted"
               data-testing-id="update-oci-configuration"
             >
               {{ 'account.update.button.label' | translate }}

--- a/src/app/extensions/punchout/pages/account-punchout-configuration/oci-configuration-form/oci-configuration-form.component.ts
+++ b/src/app/extensions/punchout/pages/account-punchout-configuration/oci-configuration-form/oci-configuration-form.component.ts
@@ -7,7 +7,6 @@ import { Observable, filter, map, shareReplay, take } from 'rxjs';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { PunchoutFacade } from '../../../facades/punchout.facade';
@@ -20,7 +19,6 @@ import { OciConfigurationItem } from '../../../models/oci-configuration-item/oci
 })
 export class OciConfigurationFormComponent implements OnInit {
   form: FormGroup = new FormGroup({});
-  private submitted = false;
 
   configItems$: Observable<OciConfigurationItem[]>;
   error$: Observable<HttpError>;
@@ -156,15 +154,8 @@ export class OciConfigurationFormComponent implements OnInit {
   }
 
   submitForm() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      this.punchoutFacade.updateOciConfiguration(this.form.value.ociConfig);
     }
-    this.punchoutFacade.updateOciConfiguration(this.form.value.ociConfig);
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/src/app/extensions/punchout/pages/account-punchout-cxml-configuration/cxml-configuration-form/cxml-configuration-form.component.html
+++ b/src/app/extensions/punchout/pages/account-punchout-cxml-configuration/cxml-configuration-form/cxml-configuration-form.component.html
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <form [formGroup]="form" (ngSubmit)="submitForm()" class="pt-1">
+  <form [formGroup]="form" ishFormSubmit #configForm="ngForm" (ngSubmit)="submitForm()" class="pt-1" novalidate>
     <div class="list-body">
       <formly-form [form]="form" [fields]="fields" [model]="model" class="pt-1" />
     </div>
@@ -20,7 +20,7 @@
           <button
             type="submit"
             class="btn btn-primary"
-            [disabled]="formDisabled"
+            [disabled]="form.invalid && configForm.submitted"
             data-testing-id="update-cxml-configuration"
           >
             {{ 'account.update.button.label' | translate }}

--- a/src/app/extensions/punchout/pages/account-punchout-cxml-configuration/cxml-configuration-form/cxml-configuration-form.component.ts
+++ b/src/app/extensions/punchout/pages/account-punchout-cxml-configuration/cxml-configuration-form/cxml-configuration-form.component.ts
@@ -5,7 +5,6 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { Observable } from 'rxjs';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { PunchoutFacade } from '../../../facades/punchout.facade';
 import { CxmlConfiguration } from '../../../models/cxml-configuration/cxml-configuration.model';
@@ -22,7 +21,6 @@ export class CxmlConfigurationFormComponent implements OnDestroy, OnInit {
   model: { [key: string]: string };
   fields: FormlyFieldConfig[];
 
-  private submitted = false;
   cxmlConfigurationError$: Observable<HttpError>;
 
   constructor(private punchoutFacade: PunchoutFacade) {}
@@ -75,22 +73,14 @@ export class CxmlConfigurationFormComponent implements OnDestroy, OnInit {
   }
 
   submitForm() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      const updateData = Object.entries(this.form.value).map(([name, value]) => ({
+        name: name.replaceAll(':', '.'),
+        value: value ? value : null,
+      }));
+
+      this.updateConfiguration(updateData as CxmlConfiguration[]);
     }
-
-    const updateData = Object.entries(this.form.value).map(([name, value]) => ({
-      name: name.replaceAll(':', '.'),
-      value: value ? value : null,
-    }));
-
-    this.updateConfiguration(updateData as CxmlConfiguration[]);
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 
   private updateConfiguration(cxmlConfig: CxmlConfiguration[]) {

--- a/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.html
+++ b/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.html
@@ -1,8 +1,13 @@
-<form class="form-horizontal" [formGroup]="form" (ngSubmit)="submitForm()">
+<form class="form-horizontal" [formGroup]="form" ishFormSubmit #userForm="ngForm" (ngSubmit)="submitForm()" novalidate>
   <formly-form [form]="form" [fields]="fields" [model]="model" />
   <div class="row">
     <div class="offset-md-4 col-md-8">
-      <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="punchout-user-submit">
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="form.invalid && userForm.submitted"
+        data-testing-id="punchout-user-submit"
+      >
         {{ (punchoutUser ? 'account.update.button.label' : 'account.user.new.button.create.label') | translate }}
       </button>
       <a [routerLink]="['../']" [queryParams]="{ format: punchoutType }" class="btn btn-secondary">{{

--- a/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
+++ b/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 import { UntypedFormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { PunchoutType, PunchoutUser } from '../../models/punchout-user/punchout-user.model';
@@ -19,7 +18,6 @@ export class PunchoutUserFormComponent implements OnInit {
   @Input() punchoutType: PunchoutType;
   @Output() submitUser = new EventEmitter<PunchoutUser>();
 
-  private submitted = false;
   form = new UntypedFormGroup({});
   fields: FormlyFieldConfig[];
   model = {};
@@ -124,25 +122,16 @@ export class PunchoutUserFormComponent implements OnInit {
 
   /** emit punchout user, when form is valid - mark form as dirty, when form is invalid */
   submitForm() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      if (this.punchoutUser) {
+        this.submitUser.emit({
+          ...this.punchoutUser,
+          active: this.form.value.active,
+          password: this.form.value.password,
+        });
+      } else {
+        this.submitUser.emit({ ...this.form.value, punchoutType: this.punchoutType });
+      }
     }
-
-    if (this.punchoutUser) {
-      this.submitUser.emit({
-        ...this.punchoutUser,
-        active: this.form.value.active,
-        password: this.form.value.password,
-      });
-    } else {
-      this.submitUser.emit({ ...this.form.value, punchoutType: this.punchoutType });
-    }
-  }
-
-  /** return boolean to set submit button enabled/disabled */
-  get formDisabled(): boolean {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.html
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.html
@@ -1,42 +1,44 @@
 <ng-template #modal let-reviewModal>
-  <div class="modal-content">
-    <div class="modal-header">
-      <h2 class="modal-title">{{ 'product.reviews.create.dialog.heading' | translate }}</h2>
-      <button type="button" class="close" [title]="'dialog.close.text' | translate" (click)="hide()">
-        <span aria-hidden="true">&times;</span>
-      </button>
-    </div>
-
-    <div class="modal-body">
-      <ng-container *ishProductContextAccess="let product = product">
-        <div class="d-flex">
-          <ish-product-image imageType="S" [link]="true" />
-          <div>
-            <ish-product-name [link]="false" />
-            <ish-product-id />
-            <ish-product-variation-display />
-          </div>
+  <ng-container *ishProductContextAccess="let product = product">
+    <form
+      [formGroup]="form"
+      ishFormSubmit
+      #reviewForm="ngForm"
+      (ngSubmit)="submitForm(product.sku)"
+      class="form-horizontal"
+      data-testing-id="create-product-review-form"
+    >
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="modal-title">{{ 'product.reviews.create.dialog.heading' | translate }}</h2>
+          <button type="button" class="close" [title]="'dialog.close.text' | translate" (click)="hide()">
+            <span aria-hidden="true">&times;</span>
+          </button>
         </div>
 
-        <p>{{ 'product.reviews.create.dialog.description.text' | translate }}</p>
+        <div class="modal-body">
+          <div class="d-flex">
+            <ish-product-image imageType="S" [link]="true" />
+            <div>
+              <ish-product-name [link]="false" />
+              <ish-product-id />
+              <ish-product-variation-display />
+            </div>
+          </div>
 
-        <form
-          id="createProductReviewForm"
-          class="form-horizontal"
-          [formGroup]="form"
-          (ngSubmit)="submitForm(product.sku)"
-        >
+          <p>{{ 'product.reviews.create.dialog.description.text' | translate }}</p>
+
           <formly-form [form]="form" [fields]="fields" [model]="model$ | async" />
-        </form>
-      </ng-container>
-    </div>
-    <div class="modal-footer">
-      <button type="submit" form="createProductReviewForm" class="btn btn-primary" [disabled]="formDisabled">
-        {{ 'product.reviews.create.dialog.confirm.button.label' | translate }}
-      </button>
-      <button type="button" class="btn btn-secondary" (click)="hide()">
-        {{ 'product.reviews.create.dialog.cancel.button.label' | translate }}
-      </button>
-    </div>
-  </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-primary" [disabled]="form.invalid && reviewForm.submitted">
+            {{ 'product.reviews.create.dialog.confirm.button.label' | translate }}
+          </button>
+          <button type="button" class="btn btn-secondary" (click)="hide()">
+            {{ 'product.reviews.create.dialog.cancel.button.label' | translate }}
+          </button>
+        </div>
+      </div>
+    </form>
+  </ng-container>
 </ng-template>

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.spec.ts
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
@@ -34,8 +33,6 @@ describe('Product Review Create Dialog Component', () => {
     when(accountFacade.user$).thenReturn(of({ firstName: 'Patricia', lastName: 'Miller' } as User));
 
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
-      declarations: [ProductReviewCreateDialogComponent],
       providers: [
         { provide: AccountFacade, useFactory: () => instance(accountFacade) },
         { provide: ProductReviewsFacade, useFactory: () => instance(reviewsFacade) },

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
@@ -5,7 +5,6 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { Observable, map, tap } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { ProductReviewsFacade } from '../../facades/product-reviews.facade';
 import { ProductReview } from '../../models/product-reviews/product-review.model';
@@ -24,7 +23,6 @@ export class ProductReviewCreateDialogComponent implements OnInit {
   @ViewChild('modal') modalTemplate: TemplateRef<unknown>;
 
   form = new UntypedFormGroup({});
-  private submitted = false;
   fields: FormlyFieldConfig[];
   model$: Observable<Partial<ProductReview>>;
 
@@ -109,7 +107,6 @@ export class ProductReviewCreateDialogComponent implements OnInit {
   /** Opens the modal. */
   show() {
     this.form.reset();
-    this.submitted = false;
     this.modal = this.ngbModal.open(this.modalTemplate);
   }
 
@@ -122,17 +119,9 @@ export class ProductReviewCreateDialogComponent implements OnInit {
 
   /** Send the review to the server */
   submitForm(sku: string) {
-    if (this.form.invalid) {
-      markAsDirtyRecursive(this.form);
-      this.submitted = true;
-      return;
-    } else {
+    if (this.form.valid) {
       this.reviewFacade.createProductReview(sku, this.form.value);
       this.hide();
     }
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
@@ -7,7 +7,7 @@
   </div>
 
   <ng-container *ngIf="showForm; else showSuccess">
-    <form [formGroup]="formGroup" (ngSubmit)="submitForm()">
+    <form [formGroup]="formGroup" ishFormSubmit (ngSubmit)="submitForm()" novalidate>
       <div class="modal-body">
         <ish-select-wishlist-form [formGroup]="formGroup" [addMoveProduct]="addMoveProduct" />
       </div>

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.ts
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.ts
@@ -18,7 +18,6 @@ import { filter, map, take, withLatestFrom } from 'rxjs/operators';
 
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
 import { whenTruthy } from 'ish-core/utils/operators';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 import { WishlistsFacade } from '../../facades/wishlists.facade';
 
@@ -68,13 +67,9 @@ export class SelectWishlistModalComponent implements OnInit {
     if (radioButtons?.wishlist && radioButtons.wishlist !== 'new') {
       if (this.formGroup.valid) {
         this.submitExisting(radioButtons.wishlist);
-      } else {
-        markAsDirtyRecursive(this.formGroup);
       }
     } else if (radioButtons.newList && this.formGroup.valid) {
       this.submitNew(radioButtons.newList);
-    } else {
-      markAsDirtyRecursive(this.formGroup);
     }
   }
 

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
@@ -6,13 +6,18 @@
     </button>
   </div>
 
-  <form [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
+  <form [formGroup]="wishListForm" ishFormSubmit #form="ngForm" (ngSubmit)="submitWishlistForm()" novalidate>
     <div class="modal-body">
       <formly-form [form]="wishListForm" [fields]="fields" [model]="model" />
     </div>
 
     <div class="modal-footer">
-      <button type="submit" class="btn btn-primary" [disabled]="formDisabled" data-testing-id="wishlist-dialog-submit">
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="form.submitted && wishListForm.invalid"
+        data-testing-id="wishlist-dialog-submit"
+      >
         {{ primaryButton | translate }}
       </button>
       <button type="button" class="btn btn-secondary" (click)="hide()">

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.ts
@@ -13,7 +13,6 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { pick } from 'lodash-es';
 
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { Wishlist } from '../../models/wishlist/wishlist.model';
@@ -46,7 +45,6 @@ export class WishlistPreferencesDialogComponent implements OnInit {
   wishListForm = new FormGroup({});
   model: Partial<Wishlist> = { preferred: false };
   fields: FormlyFieldConfig[];
-  private submitted = false;
 
   /**
    *  A reference to the current modal.
@@ -109,19 +107,15 @@ export class WishlistPreferencesDialogComponent implements OnInit {
 
   /** Emits the wishlist data, when the form was valid. */
   submitWishlistForm() {
-    if (this.wishListForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.wishListForm);
-      return;
+    if (this.wishListForm.valid) {
+      this.submitWishlist.emit({
+        id: !this.wishlist ? this.model.title : this.wishlistTitle,
+        preferred: this.model.preferred,
+        title: this.model.title,
+        public: false,
+      });
+      this.hide();
     }
-
-    this.submitWishlist.emit({
-      id: !this.wishlist ? this.model.title : this.wishlistTitle,
-      preferred: this.model.preferred,
-      title: this.model.title,
-      public: false,
-    });
-    this.hide();
   }
 
   /** Opens the modal. */
@@ -137,13 +131,8 @@ export class WishlistPreferencesDialogComponent implements OnInit {
 
   /** Close the modal. */
   hide() {
-    this.submitted = false;
     if (this.modal) {
       this.modal.close();
     }
-  }
-
-  get formDisabled() {
-    return this.wishListForm.invalid && this.submitted;
   }
 }

--- a/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.html
@@ -6,7 +6,7 @@
     </button>
   </div>
 
-  <form [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
+  <form [formGroup]="wishListForm" ishFormSubmit #form="ngForm" (ngSubmit)="submitWishlistForm()" novalidate>
     <div class="modal-body">
       <p class="indicates-required">
         <span class="required">*</span> {{ 'account.required_field.message' | translate }}
@@ -26,7 +26,7 @@
       <button
         type="submit"
         class="btn btn-primary"
-        [disabled]="formDisabled"
+        [disabled]="form.submitted && wishListForm.invalid"
         data-testing-id="wishlist-share-dialog-submit"
       >
         {{ primaryButton | translate }}

--- a/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.ts
@@ -12,7 +12,6 @@ import { FormGroup } from '@angular/forms';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { WishlistSharing } from '../../models/wishlist-sharing/wishlist-sharing.model';
@@ -45,7 +44,6 @@ export class WishlistSharingDialogComponent implements OnInit {
 
   wishListForm = new FormGroup({});
   fields: FormlyFieldConfig[];
-  private submitted = false;
 
   /**
    *  A reference to the current modal.
@@ -99,18 +97,14 @@ export class WishlistSharingDialogComponent implements OnInit {
 
   /** Emits the wishlist sharing data, when the form was valid. */
   submitWishlistForm() {
-    if (this.wishListForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.wishListForm);
-      return;
+    if (this.wishListForm.valid) {
+      this.submitWishlistSharing.emit({
+        recipients: this.wishListForm.get('friendEmails').value,
+        message: this.wishListForm.get('personalMessage').value,
+      });
+
+      this.hide();
     }
-
-    this.submitWishlistSharing.emit({
-      recipients: this.wishListForm.get('friendEmails').value,
-      message: this.wishListForm.get('personalMessage').value,
-    });
-
-    this.hide();
   }
 
   /** Opens the modal. */
@@ -121,13 +115,8 @@ export class WishlistSharingDialogComponent implements OnInit {
 
   /** Close the modal. */
   hide() {
-    this.submitted = false;
     if (this.modal) {
       this.modal.close();
     }
-  }
-
-  get formDisabled() {
-    return this.wishListForm.invalid && this.submitted;
   }
 }

--- a/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.html
+++ b/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.html
@@ -6,7 +6,14 @@
 <div class="row">
   <div class="col-md-10 col-xl-8">
     <div class="section">
-      <form [formGroup]="form" (ngSubmit)="submit()" class="form-horizontal" novalidate="novalidate">
+      <form
+        [formGroup]="form"
+        ishFormSubmit
+        #emailForm="ngForm"
+        (ngSubmit)="submit()"
+        class="form-horizontal"
+        novalidate
+      >
         <div class="row form-group">
           <div class="col-md-4 col-form-label">{{ 'account.update_email.email.label' | translate }}</div>
           <div *ngIf="currentUser" class="col-md-8 col-form-label">{{ currentUser.email }}</div>
@@ -16,7 +23,7 @@
 
         <div class="row">
           <div class="offset-md-4 col-md-8">
-            <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">
+            <button type="submit" class="btn btn-primary" [disabled]="form.invalid && emailForm.submitted">
               {{ 'account.update.button.label' | translate }}
             </button>
             <a routerLink="/account/profile" class="btn btn-secondary">{{ 'account.cancel.link' | translate }}</a>

--- a/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.spec.ts
+++ b/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.spec.ts
@@ -64,12 +64,4 @@ describe('Account Profile Email Component', () => {
 
     verify(eventEmitter$.emit(anything())).never();
   });
-
-  it('should disable submit button when the user submits an invalid form', () => {
-    fixture.detectChanges();
-
-    expect(component.buttonDisabled).toBeFalse();
-    component.submit();
-    expect(component.buttonDisabled).toBeTrue();
-  });
 });

--- a/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
+++ b/src/app/pages/account-profile-email/account-profile-email/account-profile-email.component.ts
@@ -5,7 +5,6 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { Credentials } from 'ish-core/models/credentials/credentials.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 /**
@@ -26,8 +25,6 @@ export class AccountProfileEmailComponent implements OnInit {
   form = new FormGroup({});
   fields: FormlyFieldConfig[];
   model: Partial<User>;
-
-  private submitted = false;
 
   ngOnInit() {
     this.model = {};
@@ -92,21 +89,13 @@ export class AccountProfileEmailComponent implements OnInit {
    * Submits form and throws create event when form is valid
    */
   submit() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      const email = this.form.get('email').value;
+
+      this.updateEmail.emit({
+        user: { ...this.currentUser, email, login: undefined },
+        credentials: { login: this.currentUser.email, password: this.form.get('currentPassword').value },
+      });
     }
-
-    const email = this.form.get('email').value;
-
-    this.updateEmail.emit({
-      user: { ...this.currentUser, email, login: undefined },
-      credentials: { login: this.currentUser.email, password: this.form.get('currentPassword').value },
-    });
-  }
-
-  get buttonDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.html
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.html
@@ -8,15 +8,21 @@
     <div class="section">
       <form
         [formGroup]="accountProfilePasswordForm"
-        class="form-horizontal"
-        novalidate="novalidate"
+        ishFormSubmit
+        #form="ngForm"
         (ngSubmit)="submit()"
+        class="form-horizontal"
+        novalidate
       >
         <formly-form [form]="accountProfilePasswordForm" [fields]="fields" />
 
         <div class="row">
           <div class="offset-md-4 col-md-8">
-            <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">
+            <button
+              type="submit"
+              class="btn btn-primary"
+              [disabled]="accountProfilePasswordForm.invalid && form.submitted"
+            >
               {{ 'account.update.button.label' | translate }}
             </button>
             <a routerLink="/account/profile" class="btn btn-secondary">{{ 'account.cancel.link' | translate }}</a>

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.spec.ts
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.spec.ts
@@ -60,12 +60,4 @@ describe('Account Profile Password Component', () => {
 
     verify(eventEmitter$.emit(anything())).never();
   });
-
-  it('should disable submit button when the user submits an invalid form', () => {
-    fixture.detectChanges();
-
-    expect(component.buttonDisabled).toBeFalse();
-    component.submit();
-    expect(component.buttonDisabled).toBeTrue();
-  });
 });

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
@@ -12,7 +12,6 @@ import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 /**
@@ -31,7 +30,6 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
 
   accountProfilePasswordForm = new FormGroup({});
   fields: FormlyFieldConfig[];
-  private submitted = false;
 
   ngOnInit() {
     this.fields = [
@@ -107,19 +105,11 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
    * Submits form and throws create event when form is valid
    */
   submit() {
-    if (this.accountProfilePasswordForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.accountProfilePasswordForm);
-      return;
+    if (this.accountProfilePasswordForm.valid) {
+      this.updatePassword.emit({
+        password: this.accountProfilePasswordForm.get('password').value,
+        currentPassword: this.accountProfilePasswordForm.get('currentPassword').value,
+      });
     }
-
-    this.updatePassword.emit({
-      password: this.accountProfilePasswordForm.get('password').value,
-      currentPassword: this.accountProfilePasswordForm.get('currentPassword').value,
-    });
-  }
-
-  get buttonDisabled() {
-    return this.accountProfilePasswordForm.invalid && this.submitted;
   }
 }

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.html
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.html
@@ -12,9 +12,11 @@
       </p>
       <form
         [formGroup]="accountProfileUserForm"
+        ishFormSubmit
+        #form="ngForm"
         (ngSubmit)="submitForm()"
         class="form-horizontal"
-        novalidate="novalidate"
+        novalidate
       >
         <formly-form
           [form]="accountProfileUserForm"
@@ -23,7 +25,7 @@
         />
         <div class="row">
           <div class="offset-md-4 col-md-8">
-            <button type="submit" class="btn btn-primary" [disabled]="buttonDisabled">
+            <button type="submit" class="btn btn-primary" [disabled]="accountProfileUserForm.invalid && form.submitted">
               {{ 'account.update.button.label' | translate }}
             </button>
             <a routerLink="/account/profile" class="btn btn-secondary">{{ 'account.cancel.link' | translate }}</a>

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.spec.ts
@@ -129,16 +129,4 @@ describe('Account Profile User Component', () => {
 
     verify(eventEmitter$.emit(anything())).never();
   });
-
-  it('should disable submit button when the user submits an invalid form', () => {
-    component.currentUser = invalidUser;
-
-    fixture.detectChanges();
-
-    expect(component.buttonDisabled).toBeFalse();
-
-    component.submitForm();
-
-    expect(component.buttonDisabled).toBeTrue();
-  });
 });

--- a/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.ts
+++ b/src/app/pages/account-profile-user/account-profile-user/account-profile-user.component.ts
@@ -10,7 +10,6 @@ import { AppFacade } from 'ish-core/facades/app.facade';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { User } from 'ish-core/models/user/user.model';
 import { FieldLibrary } from 'ish-shared/formly/field-library/field-library';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 interface ComponentState {
   currentUser: User;
@@ -34,8 +33,6 @@ export class AccountProfileUserComponent extends RxState<ComponentState> impleme
   @Input() error: HttpError;
 
   @Output() updateUserProfile = new EventEmitter<User>();
-
-  private submitted = false;
 
   accountProfileUserForm = new FormGroup({});
 
@@ -91,21 +88,12 @@ export class AccountProfileUserComponent extends RxState<ComponentState> impleme
    * Submits form and throws update event when form is valid
    */
   submitForm() {
-    if (this.accountProfileUserForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.accountProfileUserForm);
-      return;
+    if (this.accountProfileUserForm.valid) {
+      if (this.accountProfileUserForm.get('newsletter')) {
+        const subscribedToNewsletter = this.accountProfileUserForm.get('newsletter').value;
+        this.accountFacade.updateNewsletterSubscription(subscribedToNewsletter);
+      }
+      this.updateUserProfile.emit({ ...this.get('currentUser'), ...this.accountProfileUserForm.value });
     }
-
-    if (this.accountProfileUserForm.get('newsletter')) {
-      const subscribedToNewsletter = this.accountProfileUserForm.get('newsletter').value;
-      this.accountFacade.updateNewsletterSubscription(subscribedToNewsletter);
-    }
-
-    this.updateUserProfile.emit({ ...this.get('currentUser'), ...this.accountProfileUserForm.value });
-  }
-
-  get buttonDisabled() {
-    return this.accountProfileUserForm.invalid && this.submitted;
   }
 }

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.html
@@ -55,16 +55,17 @@
         data-testing-id="create-address-form"
       >
         <form
-          #addressForm="ngForm"
           [formGroup]="form"
+          ishFormSubmit
+          #addressForm="ngForm"
           (ngSubmit)="submitAddressForm()"
           class="form-horizontal"
-          novalidate="novalidate"
+          novalidate
         >
           <ish-checkout-address-anonymous-form [parentForm]="form" />
           <div [ngClass]="{ 'row form-group': isShippingAddressFormExpanded }">
             <div [ngClass]="{ 'offset-md-4 col-md-8': isShippingAddressFormExpanded }">
-              <button class="btn btn-primary" type="submit" [disabled]="nextDisabled">
+              <button class="btn btn-primary" type="submit" [disabled]="form.invalid && addressForm.submitted">
                 {{ 'checkout.button.label' | translate }}
               </button>
               <button (click)="cancelAddressForm()" type="button" class="btn btn-secondary">

--- a/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
+++ b/src/app/pages/checkout-address/checkout-address-anonymous/checkout-address-anonymous.component.spec.ts
@@ -109,14 +109,6 @@ describe('Checkout Address Anonymous Component', () => {
     expect(element.querySelector('ish-error-message')).toBeTruthy();
   });
 
-  it('should set submitted flag if submit is clicked and form is not valid', async () => {
-    expect(component.submitted).toBeFalsy();
-    component.submitAddressForm();
-    await fixture.whenStable();
-
-    expect(component.submitted).toBeTruthy();
-  });
-
   it('should NOT create address for invalid form', () => {
     component.submitAddressForm();
     fixture.detectChanges();

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.html
@@ -100,9 +100,13 @@
 
     <div class="cost-summary">
       <ish-basket-cost-summary [totals]="basket.totals" />
-      <form [formGroup]="form" (ngSubmit)="submitOrder()">
+      <form [formGroup]="form" ishFormSubmit #tcForm="ngForm" (ngSubmit)="submitOrder()">
         <formly-form [form]="form" [model]="model" [fields]="fields" [options]="options" />
-        <button class="btn btn-lg btn-block btn-primary" type="submit" [disabled]="formDisabled || submitting">
+        <button
+          class="btn btn-lg btn-block btn-primary"
+          type="submit"
+          [disabled]="(form.invalid && tcForm.submitted) || multipleBuckets || submitting"
+        >
           <ng-container *ngIf="submitting">
             <fa-icon [icon]="['fas', 'spinner']" [spin]="true" class="pr-3" />
           </ng-container>

--- a/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
+++ b/src/app/pages/checkout-review/checkout-review/checkout-review.component.ts
@@ -13,7 +13,6 @@ import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 @Component({
   selector: 'ish-checkout-review',
@@ -32,7 +31,6 @@ export class CheckoutReviewComponent implements OnInit, OnChanges {
 
   model = { termsAndConditions: false };
 
-  private submitted = false;
   multipleBuckets = false;
 
   ngOnInit() {
@@ -49,12 +47,9 @@ export class CheckoutReviewComponent implements OnInit, OnChanges {
    * sends an event to submit order
    */
   submitOrder() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      this.createOrder.emit();
     }
-    this.createOrder.emit();
   }
 
   private setFields() {
@@ -77,9 +72,5 @@ export class CheckoutReviewComponent implements OnInit, OnChanges {
         },
       },
     ];
-  }
-
-  get formDisabled() {
-    return (this.form.invalid && this.submitted) || this.multipleBuckets;
   }
 }

--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.html
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.html
@@ -1,4 +1,11 @@
-<form name="LoginUserForm" [formGroup]="requestReminderForm" class="form-horizontal" (ngSubmit)="submitForm()">
+<form
+  [formGroup]="requestReminderForm"
+  ishFormSubmit
+  #form="ngForm"
+  (ngSubmit)="submitForm()"
+  class="form-horizontal"
+  novalidate
+>
   <formly-form [form]="requestReminderForm" [fields]="fields" />
 
   <div class="row form-group">
@@ -8,7 +15,7 @@
         value="PasswordReminder"
         name="passwordReminder"
         class="btn btn-primary"
-        [disabled]="buttonDisabled"
+        [disabled]="requestReminderForm.invalid && form.submitted"
       >
         {{ 'forgot_password.form.send.button.label' | translate }}
       </button>

--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
@@ -3,7 +3,6 @@ import { UntypedFormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
 import { PasswordReminder } from 'ish-core/models/password-reminder/password-reminder.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 /**
  * The Request Reminder Form Component displays a Forgot Password Request Reminder form and triggers the submit.
@@ -23,8 +22,6 @@ export class RequestReminderFormComponent implements OnInit {
    * Submit the form data to trigger the request for a password reminder.
    */
   @Output() submitPasswordReminder = new EventEmitter<PasswordReminder>();
-
-  private submitted = false;
 
   requestReminderForm = new UntypedFormGroup({});
   fields: FormlyFieldConfig[];
@@ -49,17 +46,9 @@ export class RequestReminderFormComponent implements OnInit {
     ];
   }
 
-  get buttonDisabled() {
-    return this.requestReminderForm.invalid && this.submitted;
-  }
-
   submitForm() {
-    if (this.requestReminderForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.requestReminderForm);
-      return;
+    if (this.requestReminderForm.valid) {
+      this.submitPasswordReminder.emit(this.requestReminderForm.value);
     }
-
-    this.submitPasswordReminder.emit(this.requestReminderForm.value);
   }
 }

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.html
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.html
@@ -1,8 +1,10 @@
 <form
   [formGroup]="updatePasswordForm"
+  ishFormSubmit
+  #form="ngForm"
   (ngSubmit)="submitPasswordForm()"
   class="form-horizontal"
-  novalidate="novalidate"
+  novalidate
 >
   <formly-form [form]="updatePasswordForm" [fields]="fields" />
   <div class="row">
@@ -12,7 +14,7 @@
         value="SubmitButton"
         name="SubmitButton"
         class="btn btn-primary"
-        [disabled]="buttonDisabled"
+        [disabled]="updatePasswordForm.invalid && form.submitted"
       >
         {{ 'account.change_password.button.label' | translate }}
       </button>

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.spec.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.spec.ts
@@ -53,12 +53,4 @@ describe('Update Password Form Component', () => {
 
     verify(eventEmitter$.emit(anything())).once();
   });
-
-  it('should disable submit button when the user submits an invalid form', () => {
-    fixture.detectChanges();
-
-    expect(component.buttonDisabled).toBeFalse();
-    component.submitPasswordForm();
-    expect(component.buttonDisabled).toBeTrue();
-  });
 });

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 /**
@@ -26,7 +25,6 @@ export class UpdatePasswordFormComponent implements OnInit {
 
   updatePasswordForm = new FormGroup({});
   fields: FormlyFieldConfig[];
-  private submitted = false;
 
   ngOnInit() {
     this.fields = [
@@ -76,18 +74,10 @@ export class UpdatePasswordFormComponent implements OnInit {
   }
 
   submitPasswordForm() {
-    if (this.updatePasswordForm.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.updatePasswordForm);
-      return;
+    if (this.updatePasswordForm.valid) {
+      this.submitPassword.emit({
+        password: this.updatePasswordForm.get('password').value,
+      });
     }
-
-    this.submitPassword.emit({
-      password: this.updatePasswordForm.get('password').value,
-    });
-  }
-
-  get buttonDisabled() {
-    return this.updatePasswordForm.invalid && this.submitted;
   }
 }

--- a/src/app/pages/registration/registration-page.component.html
+++ b/src/app/pages/registration/registration-page.component.html
@@ -1,7 +1,7 @@
 <ish-error-message [error]="error$ | async" />
 
 <div data-testing-id="account-create-full-page">
-  <form [formGroup]="form" (ngSubmit)="onCreate()">
+  <form [formGroup]="form" ishFormSubmit #registrationForm="ngForm" (ngSubmit)="onCreate()" novalidate>
     <formly-form [model]="model" [form]="form" [options]="options" [fields]="fields" />
     <div class="row">
       <div class="col-md-10 col-lg-8 col-xl-6">
@@ -9,7 +9,7 @@
           <div class="offset-md-4 col-md-8">
             <input
               type="submit"
-              [disabled]="submitDisabled"
+              [disabled]="form.invalid && registrationForm.submitted"
               class="btn btn-primary"
               value="{{ 'account.create.button.label' | translate }}"
             />

--- a/src/app/pages/registration/registration-page.component.ts
+++ b/src/app/pages/registration/registration-page.component.ts
@@ -38,8 +38,6 @@ export class RegistrationPageComponent implements OnInit {
     private featureEventService: FeatureEventService
   ) {}
 
-  private submitted = false;
-
   loading$: Observable<boolean>;
   private registrationConfig: RegistrationConfigType;
 
@@ -70,8 +68,8 @@ export class RegistrationPageComponent implements OnInit {
 
   onCreate() {
     if (this.form.invalid) {
+      // is still needed here
       markAsDirtyRecursive(this.form);
-      this.submitted = true;
       return;
     }
     // keep-localization-pattern: ^customer\..*\.error$
@@ -102,11 +100,6 @@ export class RegistrationPageComponent implements OnInit {
 
   private submitRegistrationForm() {
     this.registrationFormConfiguration.submitRegistrationForm(this.form, this.registrationConfig, this.model);
-  }
-
-  /** return boolean to set submit button enabled/disabled */
-  get submitDisabled(): boolean {
-    return this.form.invalid && this.submitted;
   }
 
   private clearCaptchaToken() {

--- a/src/app/shared/components/login/login-form/login-form.component.html
+++ b/src/app/shared/components/login/login-form/login-form.component.html
@@ -1,11 +1,17 @@
 <ish-error-message [error]="loginError$ | async" [toast]="false" />
 
-<form [formGroup]="form" class="form-horizontal" (ngSubmit)="loginUser()">
+<form [formGroup]="form" ishFormSubmit #loginForm="ngForm" (ngSubmit)="loginUser()" class="form-horizontal" novalidate>
   <formly-form [form]="form" [fields]="fields" />
 
   <div class="row form-group">
     <div [ngClass]="signInClass || 'offset-md-3 col-md-auto'">
-      <button type="submit" value="Login" name="login" class="btn btn-primary" [disabled]="buttonDisabled">
+      <button
+        type="submit"
+        value="Login"
+        name="login"
+        class="btn btn-primary"
+        [disabled]="form.invalid && loginForm.submitted"
+      >
         {{ 'account.signin.button.label' | translate }}
       </button>
     </div>

--- a/src/app/shared/components/login/login-form/login-form.component.ts
+++ b/src/app/shared/components/login/login-form/login-form.component.ts
@@ -7,7 +7,6 @@ import { USER_REGISTRATION_LOGIN_TYPE } from 'ish-core/configurations/injection-
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { InjectSingle } from 'ish-core/utils/injection';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 /**
  * The Login Form Page Container displays a login form using the {@link LoginFormComponent} and signs the user in
@@ -36,8 +35,6 @@ export class LoginFormComponent implements OnInit {
   loginError$: Observable<HttpError>;
 
   form = new UntypedFormGroup({});
-  private submitted = false;
-
   fields: FormlyFieldConfig[];
 
   constructor(
@@ -91,16 +88,8 @@ export class LoginFormComponent implements OnInit {
   }
 
   loginUser() {
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      this.accountFacade.loginUser(this.form.value);
     }
-
-    this.accountFacade.loginUser(this.form.value);
-  }
-
-  get buttonDisabled() {
-    return this.form.invalid && this.submitted;
   }
 }

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.html
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.html
@@ -1,9 +1,10 @@
 <form
   [formGroup]="form"
+  ishFormSubmit
   #addressForm="ngForm"
   (ngSubmit)="submitForm()"
   class="form-horizontal"
-  novalidate="novalidate"
+  novalidate
 >
   <p class="indicates-required"><span class="required">*</span>{{ 'account.required_field.message' | translate }}</p>
   <ish-formly-address-form
@@ -16,7 +17,7 @@
 
   <div class="row">
     <div class="offset-md-4 col-md-8 offset-lg-0 col-lg-12 offset-lg-4 col-xl-8">
-      <button [disabled]="formDisabled" type="submit" class="btn btn-primary">
+      <button type="submit" [disabled]="form.invalid && addressForm.submitted" class="btn btn-primary">
         {{ buttonLabel | translate }}
       </button>
       <button (click)="cancelForm()" type="reset" class="btn btn-secondary">

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.spec.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.spec.ts
@@ -72,17 +72,6 @@ describe('Formly Customer Address Form Component', () => {
     verify(emitter.emit()).once();
   });
 
-  it('should set submitted flag if submit is clicked and form is not valid', async () => {
-    component.form = new FormGroup({
-      control: new FormControl('', Validators.required),
-    });
-    expect(component.submitted).toBeFalsy();
-    component.submitForm();
-    await fixture.whenStable();
-
-    expect(component.submitted).toBeTruthy();
-  });
-
   it('should NOT throw submit event for invalid form', () => {
     component.form = new FormGroup({
       control: new FormControl('', Validators.required),

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
@@ -16,7 +16,6 @@ import { map, withLatestFrom } from 'rxjs/operators';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { FeatureToggleService } from 'ish-core/feature-toggle.module';
 import { Address } from 'ish-core/models/address/address.model';
-import { markAsDirtyRecursive } from 'ish-shared/forms/utils/form-utils';
 
 /**
  * The Customer Address Form Component renders an address form with apply/cancel buttons so that the user can create or edit an address.
@@ -50,8 +49,6 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges {
 
   extensionModel: { email: string };
 
-  // visible-for-testing
-  submitted = false;
   businessCustomer$: Observable<boolean>;
 
   @ViewChild('addressForm') addressForm: FormGroupDirective;
@@ -94,32 +91,22 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges {
     if (resetForm && this.form) {
       this.addressForm.resetForm();
       this.form.reset();
-      this.submitted = false;
     }
-  }
-
-  get formDisabled() {
-    return this.form.invalid && this.submitted;
   }
 
   submitForm() {
-    // if the form is invalid only mark all invalid fields
-    if (this.form.invalid) {
-      this.submitted = true;
-      markAsDirtyRecursive(this.form);
-      return;
+    if (this.form.valid) {
+      // build address from form data and send it to the parent
+      let formAddress: Address = this.form.value.address;
+      if (this.address) {
+        // update form values in the original address
+        formAddress = { ...this.address, mainDivisionCode: '', ...formAddress };
+      }
+      if (this.extension) {
+        formAddress = { ...formAddress, email: this.extensionForm.get('email')?.value };
+      }
+      this.save.emit(formAddress);
     }
-
-    // build address from form data and send it to the parent
-    let formAddress: Address = this.form.value.address;
-    if (this.address) {
-      // update form values in the original address
-      formAddress = { ...this.address, mainDivisionCode: '', ...formAddress };
-    }
-    if (this.extension) {
-      formAddress = { ...formAddress, email: this.extensionForm.get('email')?.value };
-    }
-    this.save.emit(formAddress);
   }
 
   cancelForm() {

--- a/src/app/shared/formly-address-forms/formly-address-forms.module.ts
+++ b/src/app/shared/formly-address-forms/formly-address-forms.module.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule } from '@ngx-formly/core';
 import { TranslateModule } from '@ngx-translate/core';
 
+import { DirectivesModule } from 'ish-core/directives.module';
 import { FormsSharedModule } from 'ish-shared/forms/forms.module';
 
 import { FormlyAddressExtensionFormComponent } from './components/formly-address-extension-form/formly-address-extension-form.component';
@@ -20,7 +21,7 @@ import { AddressFormGBConfiguration } from './configurations/gb/address-form-gb.
 import { AddressFormUSConfiguration } from './configurations/us/address-form-us.configuration';
 
 @NgModule({
-  imports: [CommonModule, FormlyModule, FormsSharedModule, ReactiveFormsModule, TranslateModule],
+  imports: [CommonModule, DirectivesModule, FormlyModule, FormsSharedModule, ReactiveFormsModule, TranslateModule],
   declarations: [FormlyAddressExtensionFormComponent, FormlyAddressFormComponent, FormlyCustomerAddressFormComponent],
   exports: [FormlyAddressExtensionFormComponent, FormlyAddressFormComponent, FormlyCustomerAddressFormComponent],
   providers: [


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
1. On form submit the invalid form fields are highlighted in case of validation errors, but the focus remains unchanged.
2. In many form components the method 'markAsDirtyRecursive' is used to mark all form fields as dirty after form submit to secure the untouched required form fields are shown as invalid. This is not necessary for formly forms. In these components there is often a variable (e.g. submitDisabled etc.) used to determine whether the user has already submitted the form in order to disable the submit button after form submit if the form is invalid. This variable is also unnecessary.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

1. The accessibility has been improved regarding the following guideline:  ([WCAG 3.3.1 - Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html))
A directive 'ishFormSubmit' has been introduced for form html elements to set the focus automatically on the first invalid form field after form submit.
2. The form components have been refactored. After form submit the 'markAsDirtyRecursive' method is not called any more for formly forms. The button is disabled by using the property 'submitted' from a corresponding FormGroupDirective defining a variable #form="ngForm" at the form html element.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#103801](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/103801)