### PR TITLE
docs: added hint to Content Security Policy into nginx guide; provide…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
             theme: b2c
       # ADDITIONAL_HEADERS: |
       #   headers:
-      #     - Content-Security-Policy: 'default-src develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self'';'
+      #     - Content-Security-Policy: 'default-src https://develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self''; script-src secure.pay1.de ''self''; frame-src secure.pay1.de;'
       #     - X-Frame-Options: 'SAMEORIGIN'
 
     # Logging to an External Device (see logging.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
             theme: b2c
       # ADDITIONAL_HEADERS: |
       #   headers:
-      #     - Content-Security-Policy: 'default-src https://develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self''; script-src secure.pay1.de ''self''; frame-src secure.pay1.de;'
+      #     - Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; style-src 'unsafe-inline' 'self'; font-src data: 'self'; script-src secure.pay1.de 'self'; frame-src secure.pay1.de;"
       #     - X-Frame-Options: 'SAMEORIGIN'
 
     # Logging to an External Device (see logging.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
             theme: b2c
       # ADDITIONAL_HEADERS: |
       #   headers:
+      #     - Content-Security-Policy: 'default-src develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self'';'
       #     - X-Frame-Options: 'SAMEORIGIN'
 
     # Logging to an External Device (see logging.md)

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -234,13 +234,20 @@ cache:
 
 Explanation of example security policy:
 
-- `default-src https://develop.icm.intershop.de 'self'`: This sets the default policy for fetching resources such as scripts, images, etc. It allows resources to be loaded only from `https://develop.icm.intershop.de` and the same origin (`'self'`).
-- `style-src 'unsafe-inline' 'self'`: This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`). Inline styles are used at some places in the PWA, and this directive permits them.
-- `font-src data: 'self'`: This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`). Due to the usage of “fontawesome”, it is required to define this extra policy to permit these fonts.
+- `default-src https://develop.icm.intershop.de 'self'`:
+  This sets the default policy for fetching resources such as scripts, images, etc.
+  It allows resources to be loaded only from `https://develop.icm.intershop.de` and the same origin (`'self'`).
+- `style-src 'unsafe-inline' 'self'`:
+  This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`).
+  Inline styles are used at some places in the PWA, and this directive permits them.
+- `font-src data: 'self'`:
+  This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`).
+  Due to the usage of “fontawesome”, it is required to define this extra policy to permit these fonts.
 
 > [!IMPORTANT]
 > The value `https://develop.icm.intershop.de` is used here as an example for the development configuration.
-> The value needs to point to the ICM server; it has to be set to the same value as the `ICM_BASE_URL`.
+> The value needs to point to the ICM server.
+> It has to be set to the same value as the `ICM_BASE_URL`.
 
 Since there are no other directives defined, the fallback (`default-src`) is used for all other resource types (frame, media, ...).
 
@@ -255,8 +262,10 @@ Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; s
 
 Explanation of the two additional CSP header policies:
 
-- `script-src secure.pay1.de 'self'` This allows scripts to be loaded only from `secure.pay1.de` and the same origin (`'self'`).
-- `frame-src secure.pay1.de`: This allows framing (embedding the site in an iFrame) only from `secure.pay1.de`.
+- `script-src secure.pay1.de 'self'`:
+  This allows scripts to be loaded only from `secure.pay1.de` and the same origin (`'self'`).
+- `frame-src secure.pay1.de`:
+  This allows framing (embedding the site in an iFrame) only from `secure.pay1.de`.
 
 In summary, this CSP header restricts the sources from which various types of content can be loaded, enhancing security by reducing the risk of cross-site scripting (XSS) and other attacks.
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -214,6 +214,11 @@ nginx:
 This simple example security policy does following:
 
 - `default-src https://develop.icm.intershop.de 'self'`: This sets the default policy for fetching resources such as scripts, images, etc. It allows resources to be loaded only from `https://develop.icm.intershop.de` and the same origin (`'self'`).
+  > [!IMPORTANT]
+  > The example value 'https://develop.icm.intershop.de' was used here for better readability.
+  > The value needs to be the ICM server and must not be hard coded.
+  > It has to be set to the same value as the ICM_BASE_URL.
+  > This can be done for instance within the Helm charts.
 - `style-src 'unsafe-inline' 'self'`: This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`). Inline styles are used at some places in the PWA and this directive permits them.
 - `font-src data: 'self'`: This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`). Due to the usage of “fontawesome” it is required to define this extra policy to permit these fonts.
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -178,7 +178,8 @@ If no environment variable is set, this feature is disabled.
 > [!IMPORTANT]
 > To configure additional headers, the [PWA Helm Chart](https://github.com/intershop/helm-charts/tree/main/charts/pwa) version 0.8.0 or above has to be used.
 
-For some security or functional reasons it is necessary to add additional headers to page responses.
+For some security or functional reasons, it is necessary to add additional headers to page responses.
+One such security reason may be a Content Security Policy directive.
 To make such headers configurable, the environment variable `ADDITIONAL_HEADERS` has been introduced.
 
 ```yaml

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -105,7 +105,7 @@ http://foo.com/en/sitemap_pwa.xml
 To make above sitemap index file available under your deployment, you need to add the environment variable `ICM_BASE_URL` to your NGINX container.
 Let `ICM_BASE_URL` point to your ICM backend installation, e.g., `https://develop.icm.intershop.de`.
 
-On a local development system you need to add it to [`docker-compose.yml`](../../docker-compose.yml), e.g.,
+On a local development system, you need to add it to [`docker-compose.yml`](../../docker-compose.yml), e.g.,
 
 ```yaml
 nginx:
@@ -113,7 +113,7 @@ nginx:
     ICM_BASE_URL: 'https://develop.icm.intershop.de'
 ```
 
-When the container is started it will process cache-ignore and multi-channel templates as well as sitemap proxy rules like this:
+When the container is started, it will process cache-ignore and multi-channel templates as well as sitemap proxy rules like this:
 
 ```yaml
 location /sitemap_ {
@@ -148,9 +148,9 @@ nginx:
 ### Override Identity Providers by Path
 
 The PWA can be configured with multiple identity providers.
-In some use cases a specific identity provider must be selected when a certain route is requested.
+In some use cases, a specific identity provider must be selected when a certain route is requested.
 For example, a punchout user should be logged in by the punchout identity provider requesting a punchout route.
-For all other possible routes the default identity provider must be selected.
+For all other possible routes, the default identity provider must be selected.
 This can be done by setting the environment variable `OVERRIDE_IDENTITY_PROVIDER`.
 
 ```yaml
@@ -180,7 +180,6 @@ If no environment variable is set, this feature is disabled.
 
 For some security or functional reasons, it is necessary to add additional headers to page responses.
 One such security reason may be a Content Security Policy directive.
-More on that in the next chapter.
 To make such headers configurable, the environment variable `ADDITIONAL_HEADERS` has been introduced.
 
 `docker-compose` example:
@@ -206,14 +205,13 @@ cache:
 
 Alternatively, the source can be supplied by setting `ADDITIONAL_HEADERS_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources/).
 
-For every entry NGINX will add this header to every possible response.
+For every entry, NGINX will add this header to every possible response.
 
 To make the additional headers available during build-time, the value for the environment variable `ADDITIONAL_HEADERS` can be put into the [additional-headers.yaml](../../nginx/additional-headers.yaml) file.
 
 #### Content Security Policy
 
-In order to add a Content Security Policy (CSP) to fulfill the requirements of PCI DSS 4.0 a header can be added to each response handled by nginx.
-A simple one may look like this.
+In order to add a Content Security Policy (CSP) to fulfill the requirements of PCI DSS 4.0, a header can be added to each response handled by NGINX.
 
 `docker-compose` example:
 
@@ -234,29 +232,31 @@ cache:
       - Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; style-src 'unsafe-inline' 'self'; font-src data: 'self';"
 ```
 
-This simple example security policy does following:
+Explanation of example security policy:
 
 - `default-src https://develop.icm.intershop.de 'self'`: This sets the default policy for fetching resources such as scripts, images, etc. It allows resources to be loaded only from `https://develop.icm.intershop.de` and the same origin (`'self'`).
-- `style-src 'unsafe-inline' 'self'`: This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`). Inline styles are used at some places in the PWA and this directive permits them.
-- `font-src data: 'self'`: This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`). Due to the usage of “fontawesome” it is required to define this extra policy to permit these fonts.
+- `style-src 'unsafe-inline' 'self'`: This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`). Inline styles are used at some places in the PWA, and this directive permits them.
+- `font-src data: 'self'`: This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`). Due to the usage of “fontawesome”, it is required to define this extra policy to permit these fonts.
 
 > [!IMPORTANT]
 > The value `https://develop.icm.intershop.de` is used here as an example for the development configuration.
-> The value needs to point to the ICM server, it has to be set to the same value as the `ICM_BASE_URL`.
+> The value needs to point to the ICM server; it has to be set to the same value as the `ICM_BASE_URL`.
 
-Since there are no other directives defined the fallback (`default-src`) is used for all other resource types (frame, media, ...).
+Since there are no other directives defined, the fallback (`default-src`) is used for all other resource types (frame, media, ...).
 
-Many payment integrations use iFrames and/or scripts from the payment provider, they have to be included into the CSP.
-Here a small sample how such a policy may look like for Payone:
+Many payment integrations use iFrames and/or scripts from the payment provider.
+They have to be included into the CSP.
+
+Example policy for Payone:
 
 ```
 Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; style-src 'unsafe-inline' 'self'; font-src data: 'self'; script-src secure.pay1.de 'self'; frame-src secure.pay1.de;"
 ```
 
-Here's a breakdown of what the two additional policies in this CSP header, added to the initial example, do:
+Explanation of the two additional CSP header policies:
 
-- `script-src secure.pay1.de 'self'` This allows scripts to be loaded only from `secure.pay1.de` and the same origin (`'self'`).
-- `frame-src secure.pay1.de`: This allows framing (embedding the site in an iframe) only from `secure.pay1.de`.
+- `script-src secure.pay1.de 'self'` This allows scripts to be loaded only from `secure.pay1.de` and the same origin (`'self'`).
+- `frame-src secure.pay1.de`: This allows framing (embedding the site in an iFrame) only from `secure.pay1.de`.
 
 In summary, this CSP header restricts the sources from which various types of content can be loaded, enhancing security by reducing the risk of cross-site scripting (XSS) and other attacks.
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -176,12 +176,14 @@ If no environment variable is set, this feature is disabled.
 ### Add Additional Headers
 
 > [!IMPORTANT]
-> To configure additional headers, the [PWA Helm Chart](https://github.com/intershop/helm-charts/tree/main/charts/pwa) version 0.8.0 or above has to be used.
+> To configure additional headers, the [PWA Helm Chart](https://github.com/intershop/helm-charts/tree/main/charts/pwa) version 0.9.3 or above has to be used.
 
 For some security or functional reasons, it is necessary to add additional headers to page responses.
 One such security reason may be a Content Security Policy directive.
 More on that in the next chapter.
 To make such headers configurable, the environment variable `ADDITIONAL_HEADERS` has been introduced.
+
+`docker-compose` example:
 
 ```yaml
 nginx:
@@ -190,6 +192,16 @@ nginx:
       headers:
         - header-a: 'value-a'
         - header-b: 'value-b'
+```
+
+[PWA Helm Cart](https://github.com/intershop/helm-charts/tree/main/charts/pwa) example:
+
+```yaml
+cache:
+  additionalHeaders: |
+    headers:
+      - header-a: 'value-a'
+      - header-b: 'value-b'
 ```
 
 Alternatively, the source can be supplied by setting `ADDITIONAL_HEADERS_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources/).
@@ -201,26 +213,36 @@ To make the additional headers available during build-time, the value for the en
 #### Content Security Policy
 
 In order to add a Content Security Policy (CSP) to fulfill the requirements of PCI DSS 4.0 a header can be added to each response handled by nginx.
-A simple one may look like this:
+A simple one may look like this.
+
+`docker-compose` example:
 
 ```yaml
 nginx:
   environment:
     ADDITIONAL_HEADERS: |
       headers:
-        - Content-Security-Policy: 'default-src https://develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self'';'
+        - Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; style-src 'unsafe-inline' 'self'; font-src data: 'self';"
+```
+
+[PWA Helm Cart](https://github.com/intershop/helm-charts/tree/main/charts/pwa) example:
+
+```yaml
+cache:
+  additionalHeaders: |
+    headers:
+      - Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; style-src 'unsafe-inline' 'self'; font-src data: 'self';"
 ```
 
 This simple example security policy does following:
 
 - `default-src https://develop.icm.intershop.de 'self'`: This sets the default policy for fetching resources such as scripts, images, etc. It allows resources to be loaded only from `https://develop.icm.intershop.de` and the same origin (`'self'`).
-  > [!IMPORTANT]
-  > The example value 'https://develop.icm.intershop.de' was used here for better readability.
-  > The value needs to be the ICM server and must not be hard coded.
-  > It has to be set to the same value as the ICM_BASE_URL.
-  > This can be done for instance within the Helm charts.
 - `style-src 'unsafe-inline' 'self'`: This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`). Inline styles are used at some places in the PWA and this directive permits them.
 - `font-src data: 'self'`: This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`). Due to the usage of “fontawesome” it is required to define this extra policy to permit these fonts.
+
+> [!IMPORTANT]
+> The value `https://develop.icm.intershop.de` is used here as an example for the development configuration.
+> The value needs to point to the ICM server, it has to be set to the same value as the `ICM_BASE_URL`.
 
 Since there are no other directives defined the fallback (`default-src`) is used for all other resource types (frame, media, ...).
 
@@ -228,7 +250,7 @@ Many payment integrations use iFrames and/or scripts from the payment provider, 
 Here a small sample how such a policy may look like for Payone:
 
 ```
-Content-Security-Policy: 'default-src https://develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self''; script-src secure.pay1.de ''self''; frame-src secure.pay1.de;'
+Content-Security-Policy: "default-src https://develop.icm.intershop.de 'self'; style-src 'unsafe-inline' 'self'; font-src data: 'self'; script-src secure.pay1.de 'self'; frame-src secure.pay1.de;"
 ```
 
 Here's a breakdown of what the two additional policies in this CSP header, added to the initial example, do:

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -180,6 +180,7 @@ If no environment variable is set, this feature is disabled.
 
 For some security or functional reasons, it is necessary to add additional headers to page responses.
 One such security reason may be a Content Security Policy directive.
+More on that in the next chapter.
 To make such headers configurable, the environment variable `ADDITIONAL_HEADERS` has been introduced.
 
 ```yaml
@@ -196,6 +197,41 @@ Alternatively, the source can be supplied by setting `ADDITIONAL_HEADERS_SOURCE`
 For every entry NGINX will add this header to every possible response.
 
 To make the additional headers available during build-time, the value for the environment variable `ADDITIONAL_HEADERS` can be put into the [additional-headers.yaml](../../nginx/additional-headers.yaml) file.
+
+#### Content Security Policy
+
+In order to add a Content Security Policy (CSP) to fulfill the requirements of PCI DSS 4.0 a header can be added to each response handled by nginx.
+A simple one may look like this:
+
+```yaml
+nginx:
+  environment:
+    ADDITIONAL_HEADERS: |
+      headers:
+        - Content-Security-Policy: 'default-src https://develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self'';'
+```
+
+This simple example security policy does following:
+
+- `default-src https://develop.icm.intershop.de 'self'`: This sets the default policy for fetching resources such as scripts, images, etc. It allows resources to be loaded only from `https://develop.icm.intershop.de` and the same origin (`'self'`).
+- `style-src 'unsafe-inline' 'self'`: This allows the use of inline styles (`'unsafe-inline'`) and styles from the same origin (`'self'`). Inline styles are used at some places in the PWA and this directive permits them.
+- `font-src data: 'self'`: This allows fonts to be loaded from data URIs (`data:`) and the same origin (`'self'`). Due to the usage of “fontawesome” it is required to define this extra policy to permit these fonts.
+
+Since there are no other directives defined the fallback (`default-src`) is used for all other resource types (frame, media, ...).
+
+Many payment integrations use iFrames and/or scripts from the payment provider, they have to be included into the CSP.
+Here a small sample how such a policy may look like for Payone:
+
+```
+Content-Security-Policy: 'default-src https://develop.icm.intershop.de ''self''; style-src ''unsafe-inline'' ''self''; font-src data: ''self''; script-src secure.pay1.de ''self''; frame-src secure.pay1.de;'
+```
+
+Here's a breakdown of what the two additional policies in this CSP header, added to the initial example, do:
+
+- `script-src secure.pay1.de 'self'` This allows scripts to be loaded only from `secure.pay1.de` and the same origin (`'self'`).
+- `frame-src secure.pay1.de`: This allows framing (embedding the site in an iframe) only from `secure.pay1.de`.
+
+In summary, this CSP header restricts the sources from which various types of content can be loaded, enhancing security by reducing the risk of cross-site scripting (XSS) and other attacks.
 
 ### Other
 


### PR DESCRIPTION
Extended guide for Building and Running NGINX Docker Image by section about configuring a Content Security Policy to meet requirements of PCI DSS 4.0. Also provided (commented out) sample Content Security Policy directive to the nginx configuration in the `docker-compose.yml`. 

Such a directive has to be provided in the helm charts (value of `additionalHeaders`) of the PWA for production use.

## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[x] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#104002](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104002)