### PR TITLE
chore: add eslint rule to secure button types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -941,7 +941,8 @@
       ],
       "rules": {
         "@angular-eslint/template/no-positive-tabindex": "error",
-        "@angular-eslint/template/prefer-self-closing-tags": "error"
+        "@angular-eslint/template/prefer-self-closing-tags": "error",
+        "@angular-eslint/template/button-has-type": "warn"
       }
     },
     {

--- a/src/app/extensions/compare/shared/product-add-to-compare/product-add-to-compare.component.html
+++ b/src/app/extensions/compare/shared/product-add-to-compare/product-add-to-compare.component.html
@@ -1,5 +1,6 @@
 <button
   *ngIf="(visible$ | async) && ('compare' | ishFeature)"
+  type="button"
   class="btn add-to-compare"
   [ngClass]="cssClass"
   [class.is-selected]="isInCompareList$ | async"

--- a/src/app/extensions/quoting/shared/basket-add-to-quote/basket-add-to-quote.component.html
+++ b/src/app/extensions/quoting/shared/basket-add-to-quote/basket-add-to-quote.component.html
@@ -11,10 +11,11 @@
 </ng-container>
 <ng-template #loginButton>
   <button
-    data-testing-id="create-quote-from-basket"
+    type="button"
     class="btn btn-secondary"
     [title]="'account.login.quotes.message' | translate"
     (click)="login()"
+    data-testing-id="create-quote-from-basket"
   >
     {{ 'shopping_cart.quote.create.button' | translate }}
   </button>

--- a/src/app/extensions/tacton/pages/configure/tacton-step-buttons/tacton-step-buttons.component.html
+++ b/src/app/extensions/tacton/pages/configure/tacton-step-buttons/tacton-step-buttons.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="stepConfig$ | async as config" class="d-flex flex-nowrap justify-content-between tacton-button-bar">
   <div class="d-inline-block mr-auto">
     <button
+      type="button"
       class="btn btn-secondary no-wrap text-nowrap"
       (click)="reset()"
       data-testing-id="reset-configuration-button"
@@ -10,6 +11,7 @@
   </div>
   <div *ngIf="config.previousStep" class="d-inline-block ml-2">
     <button
+      type="button"
       class="btn btn-secondary text-nowrap"
       (click)="changeStep(config.previousStep)"
       data-testing-id="previous-button"
@@ -18,12 +20,17 @@
     </button>
   </div>
   <div *ngIf="config.nextStep" class="d-inline-block ml-2">
-    <button class="btn btn-primary text-nowrap" (click)="changeStep(config.nextStep)" data-testing-id="next-button">
+    <button
+      type="button"
+      class="btn btn-primary text-nowrap"
+      (click)="changeStep(config.nextStep)"
+      data-testing-id="next-button"
+    >
       {{ 'tacton.step_buttons.next.label' | translate }}
     </button>
   </div>
   <div *ngIf="!config.nextStep" class="d-inline-block ml-2">
-    <button class="btn btn-primary text-nowrap" (click)="submit()" data-testing-id="submit-button">
+    <button type="submit" class="btn btn-primary text-nowrap" (click)="submit()" data-testing-id="submit-button">
       {{ 'tacton.step_buttons.submit.label' | translate }}
     </button>
   </div>

--- a/src/app/extensions/tacton/pages/configure/tacton-step-buttons/tacton-step-buttons.component.spec.ts
+++ b/src/app/extensions/tacton/pages/configure/tacton-step-buttons/tacton-step-buttons.component.spec.ts
@@ -44,6 +44,7 @@ describe('Tacton Step Buttons Component', () => {
       <div class="d-flex flex-nowrap justify-content-between tacton-button-bar">
         <div class="d-inline-block mr-auto">
           <button
+            type="button"
             data-testing-id="reset-configuration-button"
             class="btn btn-secondary no-wrap text-nowrap"
           >
@@ -51,12 +52,12 @@ describe('Tacton Step Buttons Component', () => {
           </button>
         </div>
         <div class="d-inline-block ml-2">
-          <button data-testing-id="previous-button" class="btn btn-secondary text-nowrap">
+          <button type="button" data-testing-id="previous-button" class="btn btn-secondary text-nowrap">
             tacton.step_buttons.previous.label
           </button>
         </div>
         <div class="d-inline-block ml-2">
-          <button data-testing-id="next-button" class="btn btn-primary text-nowrap">
+          <button type="button" data-testing-id="next-button" class="btn btn-primary text-nowrap">
             tacton.step_buttons.next.label
           </button>
         </div>

--- a/src/app/pages/account-order-history/account-order-history-page.component.html
+++ b/src/app/pages/account-order-history/account-order-history-page.component.html
@@ -21,7 +21,7 @@
 />
 
 <div *ngIf="moreOrdersAvailable$ | async" class="d-flex justify-content-center">
-  <button class="btn btn-secondary" (click)="loadMoreOrders()" [disabled]="ordersLoading$ | async">
+  <button type="button" class="btn btn-secondary" (click)="loadMoreOrders()" [disabled]="ordersLoading$ | async">
     {{ 'account.order.load_more' | translate }}
   </button>
 </div>

--- a/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.html
+++ b/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.html
@@ -15,6 +15,7 @@
     <li class="d-block text-center p-2">{{ 'shopping_cart.payment.or.text' | translate }}</li>
     <li *ngFor="let paymentMethod of paymentMethods" class="d-block">
       <button
+        type="button"
         (click)="fastCheckout(paymentMethod.id)"
         class="btn btn-lg btn-block btn-secondary"
         [disabled]="paymentMethod.isRestricted"

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
@@ -7,6 +7,7 @@
           <ng-container *ngIf="pagelet$ | async as pagelet">
             <div class="name">{{ pagelet.displayName ? pagelet.displayName : '(Language missing)' }}</div>
             <button
+              type="button"
               (click)="triggerAction(pagelet.id, 'pageletEdit')"
               class="btn"
               title="{{ 'designview.edit.link.title' | translate }}"
@@ -29,6 +30,7 @@
         <ng-template [ngSwitchCase]="'slot'">
           <div class="name">{{ pagelet.slot(this.slotId).displayName }}</div>
           <button
+            type="button"
             (click)="triggerAction(this.slotId, 'slotAdd')"
             class="btn"
             title="{{ 'designview.add.link.title' | translate }}"
@@ -40,6 +42,7 @@
         <ng-template [ngSwitchCase]="'include'">
           <div class="name">{{ include.displayName }}</div>
           <button
+            type="button"
             (click)="triggerAction(include.id, 'includeAdd')"
             class="btn"
             title="{{ 'designview.add.link.title' | translate }}"

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.spec.ts
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.spec.ts
@@ -73,7 +73,7 @@ describe('Content Design View Wrapper Component', () => {
       <div class="design-view-wrapper pagelet" ng-reflect-ng-class="pagelet">
         <div class="design-view-wrapper-actions">
           <div class="name">Pagelet Name xyz</div>
-          <button class="btn" title="designview.edit.link.title">
+          <button type="button" class="btn" title="designview.edit.link.title">
             <fa-icon ng-reflect-icon="fas,pencil-alt"></fa-icon>
           </button>
         </div>
@@ -100,7 +100,7 @@ describe('Content Design View Wrapper Component', () => {
       <div class="design-view-wrapper slot" ng-reflect-ng-class="slot">
         <div class="design-view-wrapper-actions">
           <div class="name">Slot Name xyz</div>
-          <button class="btn" title="designview.add.link.title">
+          <button type="button" class="btn" title="designview.add.link.title">
             <fa-icon ng-reflect-icon="fas,plus"></fa-icon>
           </button>
         </div>
@@ -120,7 +120,7 @@ describe('Content Design View Wrapper Component', () => {
       <div class="design-view-wrapper include" ng-reflect-ng-class="include">
         <div class="design-view-wrapper-actions">
           <div class="name">Include Name xyz</div>
-          <button class="btn" title="designview.add.link.title">
+          <button type="button" class="btn" title="designview.add.link.title">
             <fa-icon ng-reflect-icon="fas,plus"></fa-icon>
           </button>
         </div>

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.html
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.html
@@ -31,11 +31,12 @@
 <!-- Add a new Invoice to address -->
 <div class="row" *ngIf="(collapseChange | async) && (isLoggedIn$ | async)">
   <button
-    data-testing-id="create-invoice-address-link"
+    type="button"
     class="btn btn-link"
     (click)="showAddressForm()"
     [attr.aria-expanded]="(collapseChange | async) === false"
     aria-controls="invoice-address-panel"
+    data-testing-id="create-invoice-address-link"
   >
     {{ 'checkout.create_invoice_address.link' | translate }}
   </button>

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.html
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.html
@@ -66,11 +66,12 @@
 <!-- Add a new Shipping to address -->
 <div *ngIf="displayAddAddressLink$ | async" class="row">
   <button
-    data-testing-id="create-shipping-address-link"
+    type="button"
     class="btn btn-link"
     (click)="showAddressForm()"
     [attr.aria-expanded]="(collapseChange | async) === false"
     aria-controls="shipping-address-panel"
+    data-testing-id="create-shipping-address-link"
   >
     {{ 'checkout.create_shipping_address.link' | translate }}
   </button>

--- a/src/app/shared/components/common/in-place-edit/in-place-edit.component.html
+++ b/src/app/shared/components/common/in-place-edit/in-place-edit.component.html
@@ -12,18 +12,18 @@
     <button
       type="button"
       class="btn btn-link"
-      data-testing-id="confirm"
       [title]="'inplace_edit.save' | translate"
       (click)="confirm()"
+      data-testing-id="confirm"
     >
       <fa-icon [icon]="['fas', 'check']" />
     </button>
     <button
       type="button"
       class="btn btn-link"
-      data-testing-id="cancel"
       [title]="'inplace_edit.cancel' | translate"
       (click)="cancel()"
+      data-testing-id="cancel"
     >
       <fa-icon [icon]="['fas', 'times']" />
     </button>

--- a/src/app/shared/components/common/in-place-edit/in-place-edit.component.html
+++ b/src/app/shared/components/common/in-place-edit/in-place-edit.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="viewMode; else edit">
   <div class="d-flex flex-row align-items-baseline" [title]="'inplace_edit.click_to_edit' | translate">
     <ng-content select=".form-control-plaintext"></ng-content>
-    <button (click)="changeEditMode()" class="btn btn-link">
+    <button type="button" (click)="changeEditMode()" class="btn btn-link">
       <fa-icon class="pl-2 mr-auto btn-link" [icon]="['fas', 'pencil-alt']" />
     </button>
   </div>
@@ -10,6 +10,7 @@
   <div class="d-flex flex-row align-items-baseline">
     <ng-content select=".form-control"></ng-content>
     <button
+      type="button"
       class="btn btn-link"
       data-testing-id="confirm"
       [title]="'inplace_edit.save' | translate"
@@ -18,6 +19,7 @@
       <fa-icon [icon]="['fas', 'check']" />
     </button>
     <button
+      type="button"
       class="btn btn-link"
       data-testing-id="cancel"
       [title]="'inplace_edit.cancel' | translate"

--- a/src/app/shared/components/common/in-place-edit/in-place-edit.component.spec.ts
+++ b/src/app/shared/components/common/in-place-edit/in-place-edit.component.spec.ts
@@ -59,7 +59,7 @@ describe('In Place Edit Component', () => {
       <ish-in-place-edit
         ><div class="d-flex flex-row align-items-baseline" title="inplace_edit.click_to_edit">
           <p class="form-control-plaintext">VIEW</p>
-          <button class="btn btn-link">
+          <button type="button" class="btn btn-link">
             <fa-icon class="pl-2 mr-auto btn-link" ng-reflect-icon="fas,pencil-alt"></fa-icon>
           </button></div
       ></ish-in-place-edit>
@@ -74,12 +74,18 @@ describe('In Place Edit Component', () => {
       <ish-in-place-edit
         ><div class="d-flex flex-row align-items-baseline">
           <input class="form-control" /><button
+            type="button"
             data-testing-id="confirm"
             class="btn btn-link"
             title="inplace_edit.save"
           >
             <fa-icon ng-reflect-icon="fas,check"></fa-icon></button
-          ><button data-testing-id="cancel" class="btn btn-link" title="inplace_edit.cancel">
+          ><button
+            type="button"
+            data-testing-id="cancel"
+            class="btn btn-link"
+            title="inplace_edit.cancel"
+          >
             <fa-icon ng-reflect-icon="fas,times"></fa-icon>
           </button></div
       ></ish-in-place-edit>

--- a/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.html
+++ b/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.html
@@ -1,6 +1,7 @@
 <div ngbDropdown autoClose="outside">
   <button
     ngbDropdownToggle
+    type="button"
     class="form-control"
     role="button"
     id="dropdownMenuLink"

--- a/src/app/shared/components/line-item/line-item-list-element/line-item-list-element.component.html
+++ b/src/app/shared/components/line-item/line-item-list-element/line-item-list-element.component.html
@@ -88,11 +88,12 @@
         <ish-lazy-product-add-to-wishlist *ngIf="editable" [cssClass]="'btn-link btn-tool'" displayType="icon" />
         <button
           *ngIf="!pli.isFreeGift && editable"
+          type="button"
           class="btn-tool btn-link"
-          [attr.data-testing-id]="'remove-line-item'"
           [attr.data-id]="pli.id"
           title="{{ 'shopping_cart.remove.item.button.label' | translate }}"
           (click)="onDeleteItem(pli.id)"
+          [attr.data-testing-id]="'remove-line-item'"
         >
           <fa-icon [icon]="['fas', 'trash-alt']" />
         </button>

--- a/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.html
+++ b/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.html
@@ -13,9 +13,10 @@
         <button
           ngbDropdownItem
           *ngIf="!option.alternativeCombination || multipleOptions"
+          type="button"
           [value]="option.value"
-          [attr.data-testing-id]="group.id + '-' + option.value"
           (click)="optionChange(group.id, option.value)"
+          [attr.data-testing-id]="group.id + '-' + option.value"
         >
           <ng-container *ngTemplateOutlet="optionTemplate; context: { group, option }" />
         </button>

--- a/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.spec.ts
+++ b/src/app/shared/components/product/product-variation-select-enhanced/product-variation-select-enhanced.component.spec.ts
@@ -85,9 +85,9 @@ describe('Product Variation Select Enhanced Component', () => {
           <img class="image-swatch" alt="zzz" src="imageZ.png" /><span class="label selected">zzz </span>
         </button>
         <div ngbdropdownmenu="" class="variation-options" aria-labelledby="uuidswatchlabel">
-          <button ngbdropdownitem="" value="Y" data-testing-id="swatch-Y">
+          <button ngbdropdownitem="" type="button" value="Y" data-testing-id="swatch-Y">
             <img class="image-swatch" alt="yyy" src="imageY.png" /><span class="label">yyy </span></button
-          ><button ngbdropdownitem="" value="Z" data-testing-id="swatch-Z">
+          ><button ngbdropdownitem="" type="button" value="Z" data-testing-id="swatch-Z">
             <img class="image-swatch" alt="zzz" src="imageZ.png" /><span class="label selected"
               >zzz
             </span>

--- a/src/app/shell/header/language-switch/language-switch.component.html
+++ b/src/app/shell/header/language-switch/language-switch.component.html
@@ -20,7 +20,7 @@
       }}<span class="switch_arrow"></span
     ></span>
   </button>
-  <div ngbDropdownMenu class="language-switch-container dropdown-menu" style="left: 0 !important" role="menu">
+  <div ngbDropdownMenu class="language-switch-container dropdown-menu" role="menu">
     <div class="language-switch-menu-container">
       <ng-container *ngIf="availableLocales$ | async as availableLocales">
         <ul *ngIf="availableLocales.length">

--- a/src/app/shell/header/language-switch/language-switch.component.html
+++ b/src/app/shell/header/language-switch/language-switch.component.html
@@ -8,6 +8,7 @@
 >
   <button
     ngbDropdownToggle
+    type="button"
     class="language-switch-button btn btn-link"
     aria-expanded="false"
     aria-haspopup="menu"

--- a/src/styles/components/header/language-switch.scss
+++ b/src/styles/components/header/language-switch.scss
@@ -34,6 +34,7 @@
     }
 
     .language-switch-container {
+      left: 0 !important;
       z-index: 9999;
       padding: divide($space-default * 2, 3) $space-default;
       background: $color-inverse;


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[x] Other: <!--Please describe.-->add eslint rule @angular-eslint/template/button-has-type

## What Is the Current Behavior?
If buttons don't have a type property most browsers use the button type 'submit' as default. It may happen the button type is accidentally not set and a unintentional submit will be triggered.

Issue Number: Closes #

## What Is the New Behavior?
The eslint rule @angular-eslint/template/button-has-type is added as warning to avoid issues mentioned above. All missing types for buttons have been added.

## Does this PR Introduce a Breaking Change?

[X] No

## Other Information


[AB#104009](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104009)