### PR TITLE
refactor: access to the Payone language object

### DIFF
--- a/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.ts
+++ b/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.ts
@@ -124,7 +124,7 @@ export class PaymentPayoneCreditcardComponent implements OnChanges, OnDestroy, O
           // resolve Payone localization object from language (default: en -> Payone.ClientApi.Language.en)
           let langCode = this.getParamValue('languageCode', '');
 
-          // fallback to old parameter (have value like 'Payone.ClientApi.Language.en) and extract language code from it
+          // fallback to old parameter (have value like 'Payone.ClientApi.Language.en') and extract language code from it
           if (!langCode) {
             const lang = this.getParamValue('language', '');
             const langParts = lang.split('.');

--- a/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.ts
+++ b/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.ts
@@ -121,9 +121,17 @@ export class PaymentPayoneCreditcardComponent implements OnChanges, OnDestroy, O
         .load('https://secure.pay1.de/client-api/js/v1/payone_hosted_min.js')
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
-          // append localization language: Payone.ClientApi.Language.en, Language to display error-messages (default:Payone.ClientApi.Language.en)
-          // eslint-disable-next-line no-eval
-          config.language = eval(this.getParamValue('language', ''));
+          // resolve Payone localization object from language (default: en -> Payone.ClientApi.Language.en)
+          let langCode = this.getParamValue('languageCode', '');
+
+          // fallback to old parameter (have value like 'Payone.ClientApi.Language.en) and extract language code from it
+          if (!langCode) {
+            const lang = this.getParamValue('language', '');
+            const langParts = lang.split('.');
+            langCode = langParts.length > 1 ? langParts[langParts.length - 1] : 'en';
+          }
+
+          config.language = Payone.ClientApi.Language[langCode] || Payone.ClientApi.Language.en;
 
           // setup
           this.iframes = new Payone.ClientApi.HostedIFrames(config, request);


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The current implementation uses an `eval()` expression to resolve the Payone Client API object for localization. That's unsafe.

## What Is the New Behavior?
The Payone connector will be updated to provide a simplified access to this object in the Payone API using an attributed named `languageCode`. The fallback uses the old response attribute `language` and extracts the locale code from it without using `eval()` anymore. There are no visual changes. 

- prepare use of adapted API for hosted payment page configuration of Payone Hosted Payment Page (Client API)
- refactored fallback code in order to avoid usage of `eval()` to resolve Payone language object

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#104064](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104064)