### PR TITLE
feat: Sparque suggest focus handling, config

### DIFF
--- a/docs/guides/sparque-integration.md
+++ b/docs/guides/sparque-integration.md
@@ -19,22 +19,31 @@ Example for the specification of the sparque configuration in a docker compose f
 
 ```yaml
 # PWA container settings
-  pwa:
-    container_name: pwa
-    image: ${PWA_IMAGE}
-    environment:
-      ...
-      SPARQUE: '{"server_url": "<sparque connection url>", "wrapperAPI": "v2", "workspaceName": <name of the workspace>, "apiName": <used sparque api>, "channelId": <in sparque workspace configured channel>}'
+pwa:
+  environment:
+    SPARQUE: '{"serverUrl": "<sparque connection url>", "wrapperApi": "<wrapper api version>", "WorkspaceName": "<name of the workspace>", "ApiName": "<used sparque api>", "ChannelId": <in sparque workspace configured channel>}'
+```
+
+Example for the specification of the sparque configuration in an environment file:
+
+```typescript
+sparque: {
+  serverUrl: '<sparque connection url>',
+  wrapperApi: '<wrapper api version>',
+  WorkspaceName: '<name of the workspace>',
+  ApiName: '<used sparque api>',
+  ChannelId: '<in sparque workspace configured channel>',
+},
 ```
 
 > The specification of the sparque configuration data in the kubernetes deployment file uses the same key/value syntax.
 > The value of the SPARQUE key is a string that must be specified in JSON format. See the example above.
 
-## Affected Components
+## Suggest Components
 
 - [Search Box Component](../../src/app/core/standalone/component/suggest/search-box/search-box.component.ts): This component is responsible for providing autosuggestions for search queries. When a user starts typing in the search box, the component interacts with the Sparque AI search engine to fetch and display relevant keyword suggestions, products, catalogs and brands in real-time. This enhances the user experience by helping users quickly find what they are looking for and reducing the effort required to type full search queries.
 
-  > This component will also used for the Solr suggestion, in case Sparque is not configured.
+  > This component is used for the Solr suggestion too, in case Sparque is not configured.
 
   The Search Box Component consists of several components that work together to provide a seamless search experience:
 
@@ -42,10 +51,9 @@ Example for the specification of the sparque configuration in a docker compose f
   - **[ish-suggest-categories-tile](../../src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.ts)**: Displays the real-time suggested categories.
   - **[ish-suggest-products-tile](../../src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.ts)**: Shows relevant product suggestions based on the user's input.
   - **[ish-suggest-brands-tile](../../src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.ts)**: Provides brand suggestions related to the search terms.
-  - **[ish-suggest-search-terms-tile](../../src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.ts)**: Shows the search terms the user has already searched for in the past. The only the last 10 search terms are stored in the browser's local storage.
+  - **[ish-suggest-search-terms-tile](../../src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.ts)**: Shows the search terms the user has already searched for in the past. The last 10 search terms are stored in the browser's local storage.
 
-  The arrangement of these components is realized via the flex framework.
-  The number of objects to be displayed can be configured individually for each component.
+  The number of objects to be displayed can be configured individually for each component:
 
   ```ts
   @Input() maxAutoSuggests: number;

--- a/e2e/cypress/e2e/specs/filter/filter-search-results.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/filter/filter-search-results.b2c.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HomePage } from '../../pages/home.page';
 import { SearchResultPage } from '../../pages/shopping/search-result.page';
 
 const _ = {
-  suggestTerm: 'go',
+  suggestTerm: 'gop',
   searchTerm: 'gopro',
   suggestItemText: 'Gopro',
   results: 6,

--- a/e2e/cypress/e2e/specs/shopping/search-box.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/shopping/search-box.b2c.e2e-spec.ts
@@ -30,12 +30,15 @@ describe('Search Box', () => {
       page.header.searchBox.assertNoSuggestions();
 
       page.header.searchBox.type('e');
+      page.header.searchBox.assertNoSuggestions();
+
+      page.header.searchBox.type('n');
       page.header.searchBox.suggestions.should('contain', 'Kensington');
 
       page.header.searchBox.backspace();
       page.header.searchBox.assertNoSuggestions();
 
-      page.header.searchBox.type('ensington');
+      page.header.searchBox.type('nsington');
       page.header.searchBox.suggestions.should('contain', 'Kensington');
 
       page.header.searchBox.enter();
@@ -46,7 +49,7 @@ describe('Search Box', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should follow search when hitting enter with choosing suggestion with keyboard', () => {
     at(HomePage, page => {
-      page.header.searchBox.type('ke');
+      page.header.searchBox.type('ken');
       page.header.searchBox.suggestions.should('contain', 'Kensington');
 
       page.header.searchBox.tab().enter();
@@ -92,7 +95,7 @@ describe('Search Box', () => {
 
   it('should properly track displaying suggestion focus', () => {
     at(HomePage, page => {
-      page.header.searchBox.type('ke');
+      page.header.searchBox.type('ken');
       page.header.searchBox.suggestions.should('contain', 'Kensington');
 
       page.header.searchBox.esc();

--- a/e2e/cypress/e2e/specs/shopping/search-products.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/shopping/search-products.b2c.e2e-spec.ts
@@ -4,7 +4,7 @@ import { ProductDetailPage } from '../../pages/shopping/product-detail.page';
 import { SearchResultPage } from '../../pages/shopping/search-result.page';
 
 const _ = {
-  suggestTerm: 'ke',
+  suggestTerm: 'ken',
   suggestItemText: 'Kensington',
   searchTerm: 'Kensington K55786WW',
   product: '5800646',

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -258,7 +258,6 @@ export class ShoppingFacade {
     return searchTerm.pipe(
       debounceTime(400),
       filter(term => term.length > 2),
-      distinctUntilChanged(),
       tap(term => this.store.dispatch(suggestSearch({ searchTerm: term }))),
       switchMap(() => this.store.pipe(select(getSuggestSearchResults)))
     );

--- a/src/app/core/models/sparque/sparque-config.model.ts
+++ b/src/app/core/models/sparque/sparque-config.model.ts
@@ -3,9 +3,9 @@
  */
 export interface SparqueConfig {
   // base url of the sparque wrapper server
-  server_url: string;
+  serverUrl: string;
   // version of the sparque wrapper REST API
-  wrapperAPI: string;
+  wrapperApi: string;
   // sparque workspace name
   WorkspaceName: string;
   // sparque API name

--- a/src/app/core/services/sparque-api/sparque-api.service.spec.ts
+++ b/src/app/core/services/sparque-api/sparque-api.service.spec.ts
@@ -25,16 +25,16 @@ import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { SparqueApiService } from './sparque-api.service';
 
 const sparqueConfig = {
-  server_url: 'http://fancy:0815',
-  ApiName: 'dopeShit',
-  WorkspaceName: 'OttoKartoffel',
-  wrapperAPI: 'infinity',
+  serverUrl: 'http://fancy:0815',
+  wrapperApi: 'infinity',
+  ApiName: 'foo',
+  WorkspaceName: 'bar',
   ChannelId: 'aura',
 } as SparqueConfig;
 
 function getRestURL(endpoint: string): string {
-  return sparqueConfig.server_url
-    .concat('/api/', sparqueConfig.wrapperAPI)
+  return sparqueConfig.serverUrl
+    .concat('/api/', sparqueConfig.wrapperApi)
     .concat(endpoint)
     .concat('?ApiName=')
     .concat(sparqueConfig.ApiName)

--- a/src/app/core/services/sparque-api/sparque-api.service.ts
+++ b/src/app/core/services/sparque-api/sparque-api.service.ts
@@ -12,7 +12,7 @@ import { ApiTokenService } from 'ish-core/utils/api-token/api-token.service';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 // sparque config keys that should not be appended to the query params
-const SPARQUE_CONFIG_EXCLUDE_PARAMS = ['server_url', 'wrapperAPI'];
+const SPARQUE_CONFIG_EXCLUDE_PARAMS = ['serverUrl', 'wrapperApi'];
 
 /**
  * Service to interact with the Sparque API.
@@ -155,7 +155,7 @@ export class SparqueApiService extends ApiService {
       this.store.pipe(
         select(getSparqueConfig),
         whenTruthy(),
-        map(config => config.server_url.concat('/api/', config.wrapperAPI))
+        map(config => config.serverUrl.concat('/api/', config.wrapperApi))
       ),
       of(`/${path}`),
     ]).pipe(

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.html
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.html
@@ -11,7 +11,7 @@
     (focus)="handleFocus(true)"
     (keydown.enter)="submitSearch(searchInput.value)"
     aria-controls="search-suggest-layer"
-    [attr.aria-expanded]="(searchBoxResults$ | async) && hasMoreThanTwoCharacters && searchBoxFocus ? 'true' : 'false'"
+    [attr.aria-expanded]="(searchBoxResults$ | async) && hasMinimumCharCount && searchBoxFocus ? 'true' : 'false'"
   />
 
   <div *ngIf="searchSuggestError$ | async" class="search-suggest-container" aria-live="polite">
@@ -23,7 +23,7 @@
 
   <ng-container *ngIf="configuration?.autoSuggest && searchResults$ | async as results; else initialState">
     <div
-      *ngIf="(searchBoxResults$ | async) && hasMoreThanTwoCharacters; else noResults"
+      *ngIf="(searchBoxResults$ | async) && hasMinimumCharCount; else noResults"
       id="search-suggest-layer"
       class="search-suggest-container"
       aria-labelledby="header-search-input"
@@ -91,7 +91,7 @@
     </div>
     <ng-template #noResults>
       <div class="search-suggest-container" aria-live="polite">
-        <div *ngIf="hasMoreThanTwoCharacters" class="col-12">
+        <div *ngIf="hasMinimumCharCount" class="col-12">
           <div class="headline">{{ 'suggest.no_results.headline' | translate }}</div>
           <p>{{ 'suggest.no_results.text' | translate }}</p>
         </div>

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.html
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.html
@@ -90,7 +90,7 @@
       </div>
     </div>
     <ng-template #noResults>
-      <div class="search-suggest-container" aria-live="polite">
+      <div *ngIf="hasMinimumCharCount || hasSearchedTerms()" class="search-suggest-container" aria-live="polite">
         <div *ngIf="hasMinimumCharCount" class="col-12">
           <div class="headline">{{ 'suggest.no_results.headline' | translate }}</div>
           <p>{{ 'suggest.no_results.text' | translate }}</p>

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.html
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.html
@@ -9,7 +9,6 @@
     (input)="handleInput($event.target)"
     [value]="inputSearchTerms$ | async"
     (focus)="handleFocus(true)"
-    (keydown.esc)="resetInput()"
     (keydown.enter)="submitSearch(searchInput.value)"
     aria-controls="search-suggest-layer"
     [attr.aria-expanded]="(searchBoxResults$ | async) && hasMoreThanTwoCharacters && searchBoxFocus ? 'true' : 'false'"
@@ -129,6 +128,7 @@
       type="reset"
       name="reset"
       [title]="'search.searchbox.button.reset.title' | translate"
+      (focus)="handleFocus(true)"
       (click)="handleResetButton($event); setFocusOnSearchInput()"
     >
       <fa-icon [icon]="['fas', 'times']" />
@@ -140,8 +140,8 @@
       type="submit"
       name="search"
       [title]="'search.searchbox.button.title' | translate"
+      (focus)="handleFocus(true)"
       (click)="submitSearch(searchInput.value)"
-      (keydown.esc)="resetInput()"
     >
       <!-- search button with icon -->
       <ng-container *ngIf="!configuration?.buttonText; else textBlock">

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.html
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.html
@@ -6,11 +6,10 @@
     type="search"
     id="header-search-input"
     class="form-control searchTerm"
-    (input)="searchSuggest($event.target)"
+    (input)="handleInput($event.target)"
     [value]="inputSearchTerms$ | async"
-    (focus)="setFocus(true)"
-    (keydown)="setFocus(true)"
-    (keydown.esc)="reset()"
+    (focus)="handleFocus(true)"
+    (keydown.esc)="resetInput()"
     (keydown.enter)="submitSearch(searchInput.value)"
     aria-controls="search-suggest-layer"
     [attr.aria-expanded]="(searchBoxResults$ | async) && hasMoreThanTwoCharacters && searchBoxFocus ? 'true' : 'false'"
@@ -49,7 +48,7 @@
           <ish-suggest-categories-tile
             [categories]="results.categories"
             [inputTerms$]="inputSearchTerms$"
-            (routeChange)="reset()"
+            (routeChange)="resetInput()"
             [maxAutoSuggests]="3"
           />
         </div>
@@ -57,7 +56,7 @@
           <ish-suggest-brands-tile
             [brands]="results.brands"
             [inputTerms$]="inputSearchTerms$"
-            (routeChange)="reset()"
+            (routeChange)="resetInput()"
             [maxAutoSuggests]="3"
           />
         </div>
@@ -74,7 +73,7 @@
           [products]="results.products"
           [inputTerms$]="inputSearchTerms$"
           [deviceType]="deviceType"
-          (routeChange)="reset()"
+          (routeChange)="resetInput()"
           [maxAutoSuggests]="8"
         />
       </div>
@@ -130,9 +129,7 @@
       type="reset"
       name="reset"
       [title]="'search.searchbox.button.reset.title' | translate"
-      (focus)="setFocus(true)"
-      (click)="handleReset()"
-      (keydown.esc)="reset()"
+      (click)="handleResetButton($event); setFocusOnSearchInput()"
     >
       <fa-icon [icon]="['fas', 'times']" />
     </button>
@@ -143,9 +140,8 @@
       type="submit"
       name="search"
       [title]="'search.searchbox.button.title' | translate"
-      (keydown)="setFocus(true)"
       (click)="submitSearch(searchInput.value)"
-      (keydown.esc)="reset()"
+      (keydown.esc)="resetInput()"
     >
       <!-- search button with icon -->
       <ng-container *ngIf="!configuration?.buttonText; else textBlock">

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.html
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.html
@@ -8,9 +8,8 @@
     class="form-control searchTerm"
     (input)="searchSuggest($event.target)"
     [value]="inputSearchTerms$ | async"
-    (focus)="handleFocus()"
-    (blur)="handleBlur($event)"
-    (keydown)="handleFocus()"
+    (focus)="setFocus(true)"
+    (keydown)="setFocus(true)"
     (keydown.esc)="reset()"
     (keydown.enter)="submitSearch(searchInput.value)"
     aria-controls="search-suggest-layer"
@@ -131,9 +130,8 @@
       type="reset"
       name="reset"
       [title]="'search.searchbox.button.reset.title' | translate"
-      (focus)="handleFocus()"
+      (focus)="setFocus(true)"
       (click)="handleReset()"
-      (blur)="handleBlur($event)"
       (keydown.esc)="reset()"
     >
       <fa-icon [icon]="['fas', 'times']" />
@@ -145,9 +143,8 @@
       type="submit"
       name="search"
       [title]="'search.searchbox.button.title' | translate"
-      (keydown)="handleFocus()"
+      (keydown)="setFocus(true)"
       (click)="submitSearch(searchInput.value)"
-      (blur)="handleBlur($event)"
       (keydown.esc)="reset()"
     >
       <!-- search button with icon -->

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.spec.ts
@@ -90,7 +90,7 @@ describe('Search Box Component', () => {
       component.searchBoxFocus = false;
       fixture.detectChanges();
 
-      expect(element.querySelector('.search-suggest-container')).toBeTruthy();
+      expect(element.querySelector('.search-suggest-container')).toBeFalsy();
     });
 
     it('should show results when input is 3 or more characters', () => {

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.ts
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.ts
@@ -236,6 +236,9 @@ export class SearchBoxComponent implements OnInit, AfterViewInit, OnDestroy {
       return false;
     }
 
+    // add the suggested term to the input field
+    this.inputSearchTerms$.next(suggestedTerm);
+
     this.router.navigate(['/search', suggestedTerm]);
     this.blur();
     return false; // prevent form submission

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.ts
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.ts
@@ -151,20 +151,29 @@ export class SearchBoxComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
+  // reset input when ESC key is pressed and element is focused within the search box
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscape(event: KeyboardEvent) {
+    if (this.searchBox.nativeElement.contains(event.target)) {
+      event.preventDefault(); // Optional: Prevent default behavior
+      this.resetInput();
+    }
+  }
+
   // remove focus when clicking outside the search box
   @HostListener('document:click', ['$event.target'])
   onClick(targetElement: undefined): void {
-    this.checkIfOutside(targetElement);
+    this.blurIfOutside(targetElement);
   }
 
   // remove focus when focused outside the search box
   @HostListener('document:focusin', ['$event.target'])
   onFocusIn(targetElement: undefined): void {
-    this.checkIfOutside(targetElement);
+    this.blurIfOutside(targetElement);
   }
 
   // check if the target element is outside the search box
-  private checkIfOutside(targetElement: undefined): void {
+  private blurIfOutside(targetElement: undefined): void {
     const clickedOrFocusedInside = this.searchBox.nativeElement.contains(targetElement);
     if (!clickedOrFocusedInside) {
       this.blur();

--- a/src/app/core/standalone/component/suggest/search-box/search-box.component.ts
+++ b/src/app/core/standalone/component/suggest/search-box/search-box.component.ts
@@ -242,7 +242,7 @@ export class SearchBoxComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   // getter method to check if the input search term has more than 3 characters
-  get hasMoreThanTwoCharacters(): boolean {
+  get hasMinimumCharCount(): boolean {
     let term = '';
     this.inputSearchTerms$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(value => (term = value));
     return term.length > 2;

--- a/src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReplaySubject } from 'rxjs';
+
+import { SuggestBrandsTileComponent } from './suggest-brands-tile.component';
+
+describe('Suggest Brands Tile Component', () => {
+  let component: SuggestBrandsTileComponent;
+  let fixture: ComponentFixture<SuggestBrandsTileComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, SuggestBrandsTileComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SuggestBrandsTileComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.brands = [
+      { name: 'Branda', productCount: 10, imageUrl: 'urla' },
+      { name: 'Brandb', productCount: 20, imageUrl: 'urlb' },
+      { name: 'Brandc', productCount: 30, imageUrl: 'urlc' },
+    ];
+    component.maxAutoSuggests = 2;
+    component.inputTerms$ = new ReplaySubject<string>(1);
+    component.inputTerms$.next('brand');
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display the correct number of brand suggestions', () => {
+    fixture.detectChanges();
+    const brandElements = element.querySelectorAll('ul li');
+    expect(brandElements).toHaveLength(2);
+  });
+
+  it('should display brand names correctly', () => {
+    fixture.detectChanges();
+    const brandElements = element.querySelectorAll('ul li a');
+    expect(brandElements[0].textContent).toContain('Branda');
+  });
+});

--- a/src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.spec.ts
@@ -12,7 +12,7 @@ describe('Suggest Brands Tile Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SuggestBrandsTileComponent, TranslateModule.forRoot()],
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 

--- a/src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-brands-tile/suggest-brands-tile.component.spec.ts
@@ -47,5 +47,6 @@ describe('Suggest Brands Tile Component', () => {
     fixture.detectChanges();
     const brandElements = element.querySelectorAll('ul li a');
     expect(brandElements[0].textContent).toContain('Branda');
+    expect(brandElements[1].textContent).toContain('Brandb');
   });
 });

--- a/src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReplaySubject } from 'rxjs';
+import { instance, mock } from 'ts-mockito';
+
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+
+import { SuggestCategoriesTileComponent } from './suggest-categories-tile.component';
+
+describe('Suggest Categories Tile Component', () => {
+  let component: SuggestCategoriesTileComponent;
+  let fixture: ComponentFixture<SuggestCategoriesTileComponent>;
+  let element: HTMLElement;
+  const shoppingFacade = mock(ShoppingFacade);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, SuggestCategoriesTileComponent, TranslateModule.forRoot()],
+      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
+      declarations: [],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SuggestCategoriesTileComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.categories = [
+      {
+        uniqueId: 'catA',
+        name: 'Categorya',
+        images: [],
+        categoryRef: '',
+        categoryPath: [],
+        hasOnlineProducts: false,
+        description: '',
+        attributes: [],
+        completenessLevel: 0,
+      },
+      {
+        uniqueId: 'catB',
+        name: 'Categoryb',
+        images: [],
+        categoryRef: '',
+        categoryPath: [],
+        hasOnlineProducts: false,
+        description: '',
+        attributes: [],
+        completenessLevel: 0,
+      },
+    ];
+    component.maxAutoSuggests = 2;
+    component.inputTerms$ = new ReplaySubject<string>(1);
+    component.inputTerms$.next('cat');
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display the correct number of category suggestions', () => {
+    fixture.detectChanges();
+    expect(element.querySelectorAll('ul li')).toHaveLength(2);
+  });
+});

--- a/src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { ReplaySubject } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -16,7 +15,7 @@ describe('Suggest Categories Tile Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SuggestCategoriesTileComponent, TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot()],
       providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
       declarations: [],
     }).compileComponents();

--- a/src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-categories-tile/suggest-categories-tile.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { ReplaySubject } from 'rxjs';
-import { instance, mock } from 'ts-mockito';
+import { ReplaySubject, of } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
 
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 
 import { SuggestCategoriesTileComponent } from './suggest-categories-tile.component';
 
@@ -11,12 +13,17 @@ describe('Suggest Categories Tile Component', () => {
   let component: SuggestCategoriesTileComponent;
   let fixture: ComponentFixture<SuggestCategoriesTileComponent>;
   let element: HTMLElement;
+  let activatedRoute: ActivatedRoute;
   const shoppingFacade = mock(ShoppingFacade);
 
   beforeEach(async () => {
+    activatedRoute = mock(ActivatedRoute);
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
-      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
+      providers: [
+        { provide: ActivatedRoute, useFactory: () => instance(activatedRoute) },
+        { provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) },
+      ],
       declarations: [],
     }).compileComponents();
   });
@@ -30,7 +37,18 @@ describe('Suggest Categories Tile Component', () => {
       {
         uniqueId: 'catA',
         name: 'Categorya',
-        images: [],
+        images: [
+          {
+            effectiveUrl: 'http://domain.com/M/123.jpg',
+            name: 'front M',
+            primaryImage: true,
+            type: 'Image',
+            typeID: 'M',
+            viewID: 'front',
+            imageActualHeight: 270,
+            imageActualWidth: 270,
+          },
+        ],
         categoryRef: '',
         categoryPath: [],
         hasOnlineProducts: false,
@@ -41,7 +59,18 @@ describe('Suggest Categories Tile Component', () => {
       {
         uniqueId: 'catB',
         name: 'Categoryb',
-        images: [],
+        images: [
+          {
+            effectiveUrl: 'http://domain.com/M/456.jpg',
+            name: 'front M',
+            primaryImage: true,
+            type: 'Image',
+            typeID: 'M',
+            viewID: 'front',
+            imageActualHeight: 270,
+            imageActualWidth: 270,
+          },
+        ],
         categoryRef: '',
         categoryPath: [],
         hasOnlineProducts: false,
@@ -53,6 +82,9 @@ describe('Suggest Categories Tile Component', () => {
     component.maxAutoSuggests = 2;
     component.inputTerms$ = new ReplaySubject<string>(1);
     component.inputTerms$.next('cat');
+
+    when(shoppingFacade.category$('catA')).thenReturn(of({ uniqueId: 'catA', name: 'Categorya' } as CategoryView));
+    when(shoppingFacade.category$('catB')).thenReturn(of({ uniqueId: 'catB', name: 'Categoryb' } as CategoryView));
   });
 
   it('should be created', () => {
@@ -64,5 +96,19 @@ describe('Suggest Categories Tile Component', () => {
   it('should display the correct number of category suggestions', () => {
     fixture.detectChanges();
     expect(element.querySelectorAll('ul li')).toHaveLength(2);
+  });
+
+  it('should display category names correctly', () => {
+    fixture.detectChanges();
+    const categoryElements = element.querySelectorAll('ul li a');
+    expect(categoryElements[1].textContent).toContain('Categorya');
+    expect(categoryElements[3].textContent).toContain('Categoryb');
+  });
+
+  it('should display category images correctly', () => {
+    fixture.detectChanges();
+    const imgElements = element.querySelectorAll('ul li img');
+    expect(imgElements[0].getAttribute('src')).toBe('http://domain.com/M/123.jpg');
+    expect(imgElements[1].getAttribute('src')).toBe('http://domain.com/M/456.jpg');
   });
 });

--- a/src/app/core/standalone/component/suggest/suggest-keywords-tile/suggest-keywords-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-keywords-tile/suggest-keywords-tile.component.spec.ts
@@ -19,7 +19,7 @@ describe('Suggest Keywords Tile Component', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement;
 
-    component.keywords = ['test1', 'test2', 'test3'];
+    component.keywords = ['Test1', 'Test2', 'Test3'];
     component.maxAutoSuggests = 2;
   });
 
@@ -32,5 +32,12 @@ describe('Suggest Keywords Tile Component', () => {
   it('should display the correct number of suggestions', () => {
     fixture.detectChanges();
     expect(element.querySelectorAll('button')).toHaveLength(2);
+  });
+
+  it('should display keyword names correctly', () => {
+    fixture.detectChanges();
+    const keywordElements = element.querySelectorAll('ul li button');
+    expect(keywordElements[0].textContent).toContain('Test1');
+    expect(keywordElements[1].textContent).toContain('Test2');
   });
 });

--- a/src/app/core/standalone/component/suggest/suggest-keywords-tile/suggest-keywords-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-keywords-tile/suggest-keywords-tile.component.spec.ts
@@ -10,7 +10,7 @@ describe('Suggest Keywords Tile Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SuggestKeywordsTileComponent, TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot()],
     }).compileComponents();
   });
 

--- a/src/app/core/standalone/component/suggest/suggest-keywords-tile/suggest-keywords-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-keywords-tile/suggest-keywords-tile.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { SuggestKeywordsTileComponent } from './suggest-keywords-tile.component';
+
+describe('Suggest Keywords Tile Component', () => {
+  let component: SuggestKeywordsTileComponent;
+  let fixture: ComponentFixture<SuggestKeywordsTileComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SuggestKeywordsTileComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SuggestKeywordsTileComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.keywords = ['test1', 'test2', 'test3'];
+    component.maxAutoSuggests = 2;
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display the correct number of suggestions', () => {
+    fixture.detectChanges();
+    expect(element.querySelectorAll('button')).toHaveLength(2);
+  });
+});

--- a/src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.spec.ts
@@ -1,0 +1,81 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { SuggestProductsTileComponent } from './suggest-products-tile.component';
+
+describe('Suggest Products Tile Component', () => {
+  let component: SuggestProductsTileComponent;
+  let fixture: ComponentFixture<SuggestProductsTileComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, SuggestProductsTileComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SuggestProductsTileComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.maxAutoSuggests = 2;
+    component.deviceType = 'desktop';
+    component.products = [
+      {
+        name: 'Product 1',
+        shortDescription: 'Product 1 short desc',
+        longDescription: 'Product 1 long desc',
+        minOrderQuantity: 1,
+        maxOrderQuantity: 10,
+        stepQuantity: 1,
+        manufacturer: 'Manufacturer 1',
+        roundedAverageRating: 0,
+        numberOfReviews: 0,
+        readyForShipmentMax: 0,
+        readyForShipmentMin: 0,
+        packingUnit: 'piece',
+        type: 'Product',
+        available: true,
+        images: [
+          {
+            effectiveUrl: 'http://domain.com/M/3538322-4095.jpg',
+            name: 'front M',
+            primaryImage: true,
+            type: 'Image',
+            typeID: 'M',
+            viewID: 'front',
+            imageActualHeight: 270,
+            imageActualWidth: 270,
+          },
+        ],
+        attributes: [
+          {
+            name: 'primaryImageId',
+            value: 'M/3538322-4095.jpg',
+          },
+          {
+            name: 'supplier-sku',
+            value: '12345',
+          },
+        ],
+        sku: '3538322',
+        completenessLevel: 0,
+        failed: false,
+        promotionIds: [],
+      },
+    ];
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display the correct number of product suggestions', () => {
+    fixture.detectChanges();
+    expect(element.querySelectorAll('li')).toHaveLength(1);
+  });
+});

--- a/src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.spec.ts
@@ -11,7 +11,7 @@ describe('Suggest Products Tile Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SuggestProductsTileComponent, TranslateModule.forRoot()],
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 

--- a/src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-products-tile/suggest-products-tile.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { spy, when } from 'ts-mockito';
 
 import { SuggestProductsTileComponent } from './suggest-products-tile.component';
 
@@ -77,5 +78,26 @@ describe('Suggest Products Tile Component', () => {
   it('should display the correct number of product suggestions', () => {
     fixture.detectChanges();
     expect(element.querySelectorAll('li')).toHaveLength(1);
+  });
+
+  it('should display keyword names correctly', () => {
+    fixture.detectChanges();
+    const keywordElements = element.querySelectorAll('ul li a');
+    expect(keywordElements[1].textContent).toContain('Product 1');
+  });
+
+  it('should display the image', () => {
+    const componentSpy = spy(component);
+    when(componentSpy.getImageEffectiveUrl(component.products[0])).thenReturn('http://domain.com/M/3538322-4095.jpg');
+
+    fixture.detectChanges();
+    const imageElement = element.querySelector('img');
+    expect(imageElement.getAttribute('src')).toBe('http://domain.com/M/3538322-4095.jpg');
+  });
+
+  it('should display the image not available image', () => {
+    fixture.detectChanges();
+    const imageElement = element.querySelector('img');
+    expect(imageElement.getAttribute('src')).toBe('/assets/img/not-available.svg');
   });
 });

--- a/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.html
+++ b/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.html
@@ -1,4 +1,4 @@
-<div class="search-suggest-terms">
+<div class="search-suggest-recent-terms">
   <div class="headline">{{ 'suggest.recent_searched_terms.headline' | translate }}</div>
   <ul>
     <li *ngFor="let result of keywords | slice : 0 : maxRecentlySearchedWords">

--- a/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.spec.ts
@@ -18,7 +18,7 @@ describe('Suggest Search Terms Tile Component', () => {
     when(shoppingFacade.recentlySearchTerms$).thenReturn(recentlySearchTerms$);
 
     await TestBed.configureTestingModule({
-      imports: [SuggestSearchTermsTileComponent, TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot()],
       providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
     }).compileComponents();
   });

--- a/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.spec.ts
@@ -29,7 +29,7 @@ describe('Suggest Search Terms Tile Component', () => {
     element = fixture.nativeElement;
 
     component.maxRecentlySearchedWords = 2;
-    recentlySearchTerms$.next(['term1', 'term2', 'term3']);
+    recentlySearchTerms$.next(['Term1', 'Term2', 'Term3']);
   });
 
   it('should be created', () => {
@@ -41,5 +41,12 @@ describe('Suggest Search Terms Tile Component', () => {
   it('should display the correct number of saved terms', () => {
     fixture.detectChanges();
     expect(element.querySelectorAll('button')).toHaveLength(2);
+  });
+
+  it('should display saved term names correctly', () => {
+    fixture.detectChanges();
+    const savedTermElements = element.querySelectorAll('ul li button');
+    expect(savedTermElements[0].textContent).toContain('Term1');
+    expect(savedTermElements[1].textContent).toContain('Term2');
   });
 });

--- a/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.spec.ts
+++ b/src/app/core/standalone/component/suggest/suggest-search-terms-tile/suggest-search-terms-tile.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { BehaviorSubject } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
+
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+
+import { SuggestSearchTermsTileComponent } from './suggest-search-terms-tile.component';
+
+describe('Suggest Search Terms Tile Component', () => {
+  let component: SuggestSearchTermsTileComponent;
+  let fixture: ComponentFixture<SuggestSearchTermsTileComponent>;
+  let element: HTMLElement;
+  const shoppingFacade = mock(ShoppingFacade);
+  const recentlySearchTerms$ = new BehaviorSubject<string[]>([]);
+
+  beforeEach(async () => {
+    when(shoppingFacade.recentlySearchTerms$).thenReturn(recentlySearchTerms$);
+
+    await TestBed.configureTestingModule({
+      imports: [SuggestSearchTermsTileComponent, TranslateModule.forRoot()],
+      providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SuggestSearchTermsTileComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.maxRecentlySearchedWords = 2;
+    recentlySearchTerms$.next(['term1', 'term2', 'term3']);
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display the correct number of saved terms', () => {
+    fixture.detectChanges();
+    expect(element.querySelectorAll('button')).toHaveLength(2);
+  });
+});

--- a/src/environments/environment.b2b.ts
+++ b/src/environments/environment.b2b.ts
@@ -8,24 +8,6 @@ export const environment: Environment = {
 
   themeColor: '#688dc3',
 
-  /**
-   * To use the sparque api wrapper follow following steps:
-   * 1. download the sparque wrapper repository => git clone https://intershop-com@dev.azure.com/intershop-com/Products/_git/search-sparque-api-wrapper
-   * 2. build the docker image => docker build -t sparque_wrapper:local .
-   * 3. adapt the docker-compose.yml file:
-   *   - change the image in the dotnet section form eusparqueops/sparque-api-wrapper to sparque_wrapper:local
-   *   - add the team2 workspace and API(intershop-project-base-v2-team2|PWA) to the list for WORKSPACE_ENDPOINTSETS_WITHOUT_AUTH
-   *   - set CACHE_SHOULD_CACHE to false
-   * 4. start the docker-compose => docker-compose up -d
-   * 5. to check if the sparque wrapper is running correctly open the url http://localhost:5755/swagger/index.html
-  sparque: {
-    server_url: 'http://host.docker.internal:28090',
-    wrapperAPI: 'v2',
-    WorkspaceName: 'intershop-project-base-v2-team2',
-    ApiName: 'PWA',
-    ChannelId: 'ish',
-  },**/
-
   features: [
     ...ENVIRONMENT_DEFAULTS.features,
     'businessCustomerRegistration',

--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -218,8 +218,8 @@
             align-items: center;
 
             @media (min-width: $screen-md) {
-              flex: 0 1 22%;
               flex-direction: column;
+              width: calc((100% - 45px) / 4);
             }
 
             a {


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Feature
[x] Refactoring (no functional changes, no API changes)
[x] Documentation content changes

## What Is the Current Behavior?

## What Is the New Behavior?
* feat: add the suggested term value to the input field when selecting the term inside the suggest
* feat: update Sparque config naming, remove demo config from environment file
* doc: update Sparque documentation
* test: add Jest and update Cypress tests
* refactor: focus and tab handling to get it working on touch devices
* refactor: general ESC handling, better naming, expand when focus is on buttons too
* refactor: always check for changes in input field when searching and trigger (cached) suggest request
* refactor: better name for minimum characters count method
* fix: prevent empty suggest layer on mobile if there are neither results nor recent terms
* fix: use available width for products on desktop

## Does this PR Introduce a Breaking Change?
[x] No

## Other Information
