### PR TITLE
feat(accessibility): sticky header feature toggle

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -162,6 +162,7 @@ Of course, the ICM server must supply appropriate REST resources to leverage fun
 | rating                       | Display product ratings                                                                                                                         |
 | recently                     | Display recently viewed products (additional configuration via `dataRetention` configuration options)                                           |
 | saveLanguageSelection        | Save the user's language selection and restore it after PWA load                                                                                |
+| stickyHeader                 | Display sticky header                                                                                                                           |
 | storeLocator                 | Display physical stores and their addresses                                                                                                     |
 | **B2B Features**             |                                                                                                                                                 |
 | businessCustomerRegistration | Create business customers on registration                                                                                                       |

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -15,6 +15,8 @@ A directive `ishFormSubmit` has been introduced for form html elements.
 In case of validation errors the focus is set to the first invalid form field after submit.
 The logic to disable the submit buttons as long as the form is invalid has been simplified, the usage of the function `markAsDirtyRecursive` is no longer necessary for formly forms.
 
+The feature toggle `stickyHeader` has been added to enable or disable the sticky header.
+
 ## From 5.2 to 5.3
 
 The Intershop PWA 5.3.0 introduces a standard integration with Intershop Copilot for Buyers.

--- a/src/app/core/store/core/viewconf/viewconf.integration.spec.ts
+++ b/src/app/core/store/core/viewconf/viewconf.integration.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
 
+import { FeatureToggleService } from 'ish-core/feature-toggle.module';
 import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
 import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
 
@@ -11,8 +14,11 @@ import { getBreadcrumbData, getHeaderType, getWrapperClass } from './viewconf.se
 describe('Viewconf Integration', () => {
   let store$: StoreWithSnapshots;
   let router: Router;
+  const featureToggleServiceMock = mock(FeatureToggleService);
 
   beforeEach(() => {
+    when(featureToggleServiceMock.enabled$(anything())).thenReturn(of(true));
+
     TestBed.configureTestingModule({
       imports: [
         CoreStoreModule.forTesting(['router', 'viewconf'], [ViewconfEffects]),
@@ -29,7 +35,10 @@ describe('Viewconf Integration', () => {
           { path: '**', children: [] },
         ]),
       ],
-      providers: [provideStoreSnapshots()],
+      providers: [
+        { provide: FeatureToggleService, useFactory: () => instance(featureToggleServiceMock) },
+        provideStoreSnapshots(),
+      ],
     });
 
     store$ = TestBed.inject(StoreWithSnapshots);

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -33,6 +33,7 @@ export interface Environment {
     | 'rating'
     | 'recently'
     | 'saveLanguageSelection'
+    | 'stickyHeader'
     | 'storeLocator'
     /* B2B features */
     | 'businessCustomerRegistration'
@@ -49,11 +50,11 @@ export interface Environment {
     | 'legacyEncoding'
     /* Third-party Integrations */
     | 'addressDoctor'
-    | 'sentry'
-    | 'tracking'
-    | 'tacton'
-    | 'maps'
     | 'copilot'
+    | 'maps'
+    | 'sentry'
+    | 'tacton'
+    | 'tracking'
   )[];
 
   /* ADDITIONAL FEATURE CONFIGURATIONS */
@@ -165,6 +166,7 @@ export const ENVIRONMENT_DEFAULTS: Omit<Environment, 'icmChannel'> = {
     'rating',
     'recently',
     'saveLanguageSelection',
+    'stickyHeader',
     'storeLocator',
   ],
 


### PR DESCRIPTION
## PR Type

[X] Feature

## What Is the Current Behavior?

The sticky header is always active and could not be turned off.

## What Is the New Behavior?

The sticky header can be turned on and off via the feature toggle `stickyHeader`.
The sticky header is enabled by default.

## Does this PR Introduce a Breaking Change?

[X] No

## Other Information


[AB#104896](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104896)