### PR TITLE
docs: fix dead link detection

### DIFF
--- a/docs/check-dead-links.mjs
+++ b/docs/check-dead-links.mjs
@@ -10,11 +10,19 @@ async function mapSeries(iterable, action) {
   }
 }
 
+const axiosConfig = {
+  headers: {
+    'User-Agent':
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+  },
+};
+
 async function checkExternalLinkError(link) {
   console.log('check', link);
-  return axios.head(link).catch(() =>
+
+  return axios.head(link, axiosConfig).catch(() =>
     // retry with get
-    axios.get(link)
+    axios.get(link, axiosConfig)
   );
 }
 
@@ -90,12 +98,7 @@ const filtered = externalLinks
       !link.includes('support.intershop.') &&
       !link.includes('docs.intershop.') &&
       !link.includes('azurewebsites.net') &&
-      !link.includes('github.com') &&
-      !link.includes('angular.io') &&
-      !link.includes('angular.love') &&
-      !link.includes('optimizesmart.com') &&
-      !link.includes('gnu.org') &&
-      !link.includes('tacton.com')
+      !link.includes('github.com')
   );
 
 mapSeries(filtered, checkExternalLinkError).catch(error => {


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Some websites have to be manually excluded from the Docs > "Check Dead Links for Changed Files"-action because the requested website would throw a 403 status code, even if the website is reachable.

## What Is the New Behavior?

Adding a request header with a user-agent to the request makes the request look more like a real browser request, and is therefor less likely to be blocked. This also reduces the number of websites that have to be manually blocked.

The intershop and azure URLs are excluded because they are internal links.
The GitHub URLs are excluded because there are way too many in the files (~3500) and mostly just reference commits, 3rd party licenses and packages.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#104907](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104907)