### PR TITLE
feat: added `autocomplete` HTML attributes for registration form

### DIFF
--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -260,6 +260,7 @@ export class RegistrationFormConfigurationService {
             props: {
               label: 'account.register.email.label',
               required: true,
+              attributes: { autocomplete: 'email' },
             },
           },
           {
@@ -269,6 +270,7 @@ export class RegistrationFormConfigurationService {
               type: 'email',
               label: 'account.register.email_confirmation.label',
               required: true,
+              attributes: { autocomplete: 'email' },
             },
             validation: {
               messages: {

--- a/src/app/shared/formly/field-library/configurations/address-line-1.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/address-line-1.configuration.ts
@@ -16,6 +16,7 @@ export class AddressLine1Configuration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.street.label',
         required: true,
+        attributes: { autocomplete: 'address-line1' },
       },
       validation: {
         messages: {

--- a/src/app/shared/formly/field-library/configurations/address-line-2.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/address-line-2.configuration.ts
@@ -16,6 +16,7 @@ export class AddressLine2Configuration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.street2.label',
         required: false,
+        attributes: { autocomplete: 'address-line2' },
       },
     };
   }

--- a/src/app/shared/formly/field-library/configurations/city.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/city.configuration.ts
@@ -16,6 +16,7 @@ export class CityConfiguration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.city.label',
         required: true,
+        attributes: { autocomplete: 'address-level2' },
       },
       validation: {
         messages: {

--- a/src/app/shared/formly/field-library/configurations/company-name-1.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/company-name-1.configuration.ts
@@ -16,6 +16,7 @@ export class CompanyName1Configuration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.company_name.label',
         required: true,
+        attributes: { autocomplete: 'organization' },
       },
       validation: {
         messages: {

--- a/src/app/shared/formly/field-library/configurations/first-name.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/first-name.configuration.ts
@@ -18,6 +18,7 @@ export class FirstNameConfiguration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.firstname.label',
         required: true,
+        attributes: { autocomplete: 'given-name' },
       },
       validators: {
         validation: [SpecialValidators.noSpecialChars],

--- a/src/app/shared/formly/field-library/configurations/last-name.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/last-name.configuration.ts
@@ -18,6 +18,7 @@ export class LastNameConfiguration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.lastname.label',
         required: true,
+        attributes: { autocomplete: 'family-name' },
       },
       validators: {
         validation: [SpecialValidators.noSpecialChars],

--- a/src/app/shared/formly/field-library/configurations/phone-home.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/phone-home.configuration.ts
@@ -16,6 +16,7 @@ export class PhoneHomeConfiguration extends FieldLibraryConfiguration {
       props: {
         label: 'account.profile.phone.label',
         required: false,
+        attributes: { autocomplete: 'tel' },
       },
     };
   }

--- a/src/app/shared/formly/field-library/configurations/postal-code.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/postal-code.configuration.ts
@@ -16,6 +16,7 @@ export class PostalCodeConfiguration extends FieldLibraryConfiguration {
       props: {
         label: 'account.address.postalcode.label',
         required: true,
+        attributes: { autocomplete: 'postal-code' },
       },
       validation: {
         messages: {

--- a/src/app/shared/formly/field-library/configurations/title.configuration.ts
+++ b/src/app/shared/formly/field-library/configurations/title.configuration.ts
@@ -22,6 +22,7 @@ export class TitleConfiguration extends FieldLibraryConfiguration {
         label: 'account.address.title.label',
         placeholder: 'account.option.select.text',
         options: this.formsService.getSalutationOptions(),
+        attributes: { autocomplete: 'honorific-prefix' },
       },
     };
   }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Input fields in the registration form don't have `autocomplete`-HTML tags.

## What Is the New Behavior?

Input fields in the registration form now have `autocomplete`-HTML tags, so they can be more reliable automatically filled.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#104968](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104968)