### PR TITLE
feat: add support for Cybersource Microform v2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,6 +24,9 @@
 *.key
 *.lua
 *.xml
+*.bak
+*.rej
+*.orig
 .*ignore
 .husky
 .gitattributes
@@ -53,3 +56,5 @@ nginx.conf
 /charts/**/templates/*
 *~
 /src/environments/environment.development.ts
+.DS_Store
+Thumbs.db

--- a/docs/check-dead-links.mjs
+++ b/docs/check-dead-links.mjs
@@ -10,19 +10,30 @@ async function mapSeries(iterable, action) {
   }
 }
 
-const axiosConfig = {
+const linkCheck = axios.create({
   headers: {
     'User-Agent':
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
   },
-};
+});
+
+linkCheck.interceptors.response.use(
+  response => response,
+  error => {
+    // ignore 403 (authentication required)
+    if (error.response?.status === 403) {
+      return null;
+    }
+    return Promise.reject({ message: `Request failed with status code ${error.response?.status}` });
+  }
+);
 
 async function checkExternalLinkError(link) {
   console.log('check', link);
 
-  return axios.head(link, axiosConfig).catch(() =>
+  return linkCheck.head(link).catch(() =>
     // retry with get
-    axios.get(link, axiosConfig)
+    linkCheck.get(link)
   );
 }
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -17,6 +17,10 @@ The logic to disable the submit buttons as long as the form is invalid has been 
 
 The feature toggle `stickyHeader` has been added to enable or disable the sticky header.
 
+The signature of the `ScriptLoader`'s `load` function was changed slightly.
+The second parameter was changed from type `string` to `ScriptLoaderOption`.
+The new type allows to set all options supported by the loader.
+
 ## From 5.2 to 5.3
 
 The Intershop PWA 5.3.0 introduces a standard integration with Intershop Copilot for Buyers.

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -21,6 +21,10 @@ The signature of the `ScriptLoader`'s `load` function was changed slightly.
 The second parameter was changed from type `string` to `ScriptLoaderOption`.
 The new type allows to set all options supported by the loader.
 
+The Cybersource integration has been migrated to version 2 of the Microform API.
+In order to utilize this integration, it is necessary to have an ICM with a Cybersource Service Connector 2.
+Given that the support for [Microform v1 will come to an end on July 1, 2025](https://support.visaacceptance.com/knowledgebase/Knowledgearticle/?code=KA-07550), its support was terminated.
+
 ## From 5.2 to 5.3
 
 The Intershop PWA 5.3.0 introduces a standard integration with Intershop Copilot for Buyers.

--- a/src/app/core/utils/script-loader/script-loader.service.ts
+++ b/src/app/core/utils/script-loader/script-loader.service.ts
@@ -7,6 +7,21 @@ interface ScriptType {
   loaded: boolean;
 }
 
+interface ScriptLoaderOption {
+  /**
+   * optionally set a type if it is not a classic Javascript file, e.g. 'module'
+   */
+  type?: string;
+  /**
+   * integrity hash and crossOrigin to 'anonymous' (parameter 'crossorigin' ignored in that case)
+   */
+  integrity?: string;
+  /**
+   * optional value for crossOrigin attribute in script tag
+   */
+  crossorigin?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ScriptLoaderService {
   private registeredScripts: ScriptType[] = [];
@@ -21,10 +36,11 @@ export class ScriptLoaderService {
    * load a script, if it has not already been loaded
    *
    * @param url   script url, e.g. https://pptest.payengine.de/bridge/1.0/payengine.min.js
-   * @param type  optionally set a type if it is not a classic Javascript file, e.g. 'module'
+   * @param options  a set of optional parameters to configure script handling optionally set a type if it is not a classic Javascript file, e.g. 'module'
+   * @returns Observable<ScriptType>
    */
 
-  load(url: string, type?: string): Observable<ScriptType> {
+  load(url: string, options?: ScriptLoaderOption): Observable<ScriptType> {
     return new Observable<ScriptType>((observer: Observer<ScriptType>) => {
       let script = this.registeredScripts.find(s => s.src === url);
       if (!script) {
@@ -41,8 +57,17 @@ export class ScriptLoaderService {
         const scriptElement = this.renderer.createElement('script');
         scriptElement.src = url;
         scriptElement.async = true;
-        if (type) {
-          scriptElement.type = type;
+        if (options?.type) {
+          scriptElement.type = options.type;
+        }
+
+        if (options?.crossorigin) {
+          scriptElement.crossOrigin = options.crossorigin;
+        }
+
+        if (options?.integrity) {
+          scriptElement.integrity = options.integrity;
+          scriptElement.crossOrigin = 'anonymous'; // required to be 'anonymous' if integrity is given
         }
 
         scriptElement.onload = () => {

--- a/src/app/extensions/copilot/shared/copilot/copilot.component.ts
+++ b/src/app/extensions/copilot/shared/copilot/copilot.component.ts
@@ -59,7 +59,7 @@ export class CopilotComponent {
   private loadCopilot() {
     combineLatest([
       this.copilotFacade.copilotConfiguration$.pipe(
-        switchMap(config => this.scriptLoader.load(config.copilotUIFile, 'module').pipe(map(() => config)))
+        switchMap(config => this.scriptLoader.load(config.copilotUIFile, { type: 'module' }).pipe(map(() => config)))
       ),
       this.translateService.get([
         'copilot.disclaimer.buttonText',

--- a/src/app/pages/checkout-payment/payment-cybersource-creditcard/payment-cybersource-creditcard.component.spec.ts
+++ b/src/app/pages/checkout-payment/payment-cybersource-creditcard/payment-cybersource-creditcard.component.spec.ts
@@ -64,7 +64,18 @@ describe('Payment Cybersource Creditcard Component', () => {
     const emitter = spy(component.submitPayment);
 
     const payloadjson = {
-      data: { number: '4111 1111 1111 1111', type: '001', expirationMonth: '11', expirationYear: '2022' },
+      content: {
+        paymentInformation: {
+          card: {
+            number: {
+              maskedValue: '4111 1111 1111 1111',
+              detectedCardTypes: '001',
+            },
+            expirationMonth: { value: '08' },
+            expirationYear: { value: '2028' },
+          },
+        },
+      },
       iss: 'test',
       exp: '123423',
       iat: 'test',
@@ -72,10 +83,10 @@ describe('Payment Cybersource Creditcard Component', () => {
     };
     const payload = window.btoa(JSON.stringify(payloadjson));
 
-    component.cyberSourceCreditCardForm.controls.expirationMonth.setValue('11');
-    component.cyberSourceCreditCardForm.controls.expirationYear.setValue('2022');
-    component.expirationMonthVal = '11';
-    component.expirationYearVal = '2022';
+    component.cyberSourceCreditCardForm.controls.expirationMonth.setValue('08');
+    component.cyberSourceCreditCardForm.controls.expirationYear.setValue('2028');
+    component.expirationMonthVal = '08';
+    component.expirationYearVal = '2028';
     component.submitCallback(undefined, 'header.' + `${payload}` + '.signature');
 
     verify(emitter.emit(anything())).once();
@@ -86,7 +97,18 @@ describe('Payment Cybersource Creditcard Component', () => {
     const emitter = spy(component.submitPayment);
 
     const payloadjson = {
-      data: { number: '4111 1111 1111 1111', type: '001', expirationMonth: '11', expirationYear: '2022' },
+      content: {
+        paymentInformation: {
+          card: {
+            number: {
+              maskedValue: '4111 1111 1111 1111',
+              detectedCardTypes: '001',
+            },
+            expirationMonth: { value: '08' },
+            expirationYear: { value: '2023' },
+          },
+        },
+      },
       iss: 'test',
       exp: '123423',
       iat: 'test',
@@ -94,8 +116,8 @@ describe('Payment Cybersource Creditcard Component', () => {
     };
     const payload = window.btoa(JSON.stringify(payloadjson));
 
-    component.expirationMonthVal = '11';
-    component.expirationYearVal = '2022';
+    component.expirationMonthVal = '08';
+    component.expirationYearVal = '2023';
     component.submitCallback(undefined, 'header.' + `${payload}` + '.signature');
 
     verify(emitter.emit(anything())).never();


### PR DESCRIPTION
Upgrade Cybersource Credit Card integration to Microform v2. Microform v1 will reach end of life by July 1, 2025.

More details can be found in the pages of [Cybersource Support center](https://support.visaacceptance.com/knowledgebase/knowledgearticle/?code=KA-07550).

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

[x] Yes
[ ] No

The signature of the `ScriptLoader`'s `load`function was changed.
The used Microform v1 reaches end of life soon and was removed completely.

## Other Information

The integration requires the Cybersource Service connector 2 or higher for ICM.


[AB#104982](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/104982)