### PR TITLE
fix: missing translation on search result page

### DIFF
--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -8,7 +8,7 @@ import { REQUEST } from '@nguniversal/express-engine/tokens';
 import { TranslateService } from '@ngx-translate/core';
 import { isEqual } from 'lodash-es';
 import { Subject, combineLatest, merge, race } from 'rxjs';
-import { distinctUntilChanged, filter, map, switchMap, takeWhile, tap } from 'rxjs/operators';
+import { delay, distinctUntilChanged, filter, map, switchMap, takeWhile, tap } from 'rxjs/operators';
 
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 import { CategoryHelper } from 'ish-core/models/category/category.model';
@@ -163,6 +163,7 @@ export class SeoEffects {
   seoTitle$ = createEffect(
     () =>
       this.pageTitle$.pipe(
+        delay(0), // ensures asynchronous stream processing to prevent "missing translation" issues
         switchMap(title => combineLatest([this.translate.get(title), this.translate.get('seo.applicationName')])),
         map(([title, application]) => `${title} | ${application}`),
         tap(title => {
@@ -176,6 +177,7 @@ export class SeoEffects {
   seoDescription$ = createEffect(
     () =>
       this.pageDescription$.pipe(
+        delay(0), // ensures asynchronous stream processing to prevent "missing translation" issues
         switchMap(description => this.translate.get(description)),
         tap(description => {
           this.addOrModifyTag({ name: 'description', content: description });


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
The following errors are thrown in case the search result page is reloaded in a language other than the default language: 
- `missing translation in en_US: seo.applicationName`
- `missing translation in en_US: seo.defaults.description`

Furthermore, the text for these keys is not translated.

Steps to reproduce:
- start PWA with `ng s` or in Docker using `docker compose up --build`
- open the homepage with default language en_US
- search for something, e.g. *: error does not occur
- switch to French in the header using the language switch: error occurs
- reload page: error occurs
- switch to German and reload page: error occurs

Issue Number: Closes #

## What Is the New Behavior?
The `ERROR missing translation` does not occur and the localization keys are correctly translated.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No

## Other Information


[AB#105214](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/105214)