### PR TITLE
fix: products list carousel paging buttons not working after accessibility improvements

### DIFF
--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -2,7 +2,6 @@
   <ng-container *ngIf="products.length">
     <ng-container *ngIf="listStyle === 'carousel'; else plainList">
       <div class="product-list">
-        <div class="swiper-button-prev" tabindex="0" role="button"></div>
         <swiper [config]="swiperConfig">
           <ng-template *ngFor="let sku of products" swiperSlide let-data>
             <div [ngClass]="listItemCSSClass">
@@ -16,7 +15,6 @@
             </div>
           </ng-template>
         </swiper>
-        <div class="swiper-button-next" tabindex="0" role="button"></div>
       </div>
     </ng-container>
 

--- a/src/app/shared/components/product/products-list/products-list.component.spec.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.spec.ts
@@ -52,13 +52,7 @@ describe('Products List Component', () => {
     component.ngOnChanges();
     fixture.detectChanges();
 
-    expect(element).toMatchInlineSnapshot(`
-      <div class="product-list">
-        <div tabindex="0" role="button" class="swiper-button-prev"></div>
-        <swiper></swiper>
-        <div tabindex="0" role="button" class="swiper-button-next"></div>
-      </div>
-    `);
+    expect(element).toMatchInlineSnapshot(`<div class="product-list"><swiper></swiper></div>`);
   });
 
   it('should set displayType of product item to listItemStyle value', () => {

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -51,10 +51,7 @@ export class ProductsListComponent implements OnChanges {
     this.swiperConfig = {
       watchSlidesProgress: true,
       direction: 'horizontal',
-      navigation: {
-        nextEl: '.swiper-button-next',
-        prevEl: '.swiper-button-prev',
-      },
+      navigation: true,
       pagination: {
         clickable: true,
       },


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

The accessibility improvements introduced next and previous buttons for the swiper carousels that did not work.

## What Is the New Behavior?

Reverted the changes that did not improve the swiper carousel functionality

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
