### PR TITLE
fix: fixed positioning of the mini basket drop down to the bottom right

### DIFF
--- a/src/app/shell/header/mini-basket/mini-basket.component.html
+++ b/src/app/shell/header/mini-basket/mini-basket.component.html
@@ -5,6 +5,7 @@
   (isClickedOutside)="collapse()"
   ngbDropdown
   #miniBasketDropdown="ngbDropdown"
+  placement="bottom-right"
 >
   <button
     type="button"


### PR DESCRIPTION


## PR Type

[x] Bugfix

## What Is the Current Behavior?

Accessibility changes with the use of `ngbDropdown` for the mini basket changed the positioning on wider browser windows to `bottom-left`.

## What Is the New Behavior?

Fixed positioning of the mini basket drop down to `bottom-right`.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#105772](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/105772)