### PR TITLE
fix: hide account name in header on tablet view to prevent overlap with quickorder link

### DIFF
--- a/src/app/shell/header/login-status/login-status.component.ts
+++ b/src/app/shell/header/login-status/login-status.component.ts
@@ -24,7 +24,7 @@ export class LoginStatusComponent implements OnInit {
   getViewClasses(): string {
     switch (this.view) {
       case 'auto':
-        return 'd-none d-md-inline';
+        return 'd-none d-lg-inline';
       case 'full':
         return 'd-inline';
       case 'small':


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Because of the expanding search box for sparque, the quickorder link was moved to the top of the header next to the compare link. This causes an overlap of the quickorder link and the language switch button when the user is logged in on tablet view (992px-768px).

## What Is the New Behavior?

VD Decision: The name is hidden on tablet view, only the account icon is displayed. This prevents an overlap, no matter how long the name is.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
