### PR TITLE
feat: use search select box (ng-select) for more relevant places

### DIFF
--- a/src/app/extensions/store-locator/pages/store-locator/store-locator-page.component.ts
+++ b/src/app/extensions/store-locator/pages/store-locator/store-locator-page.component.ts
@@ -46,7 +46,7 @@ export class StoreLocatorPageComponent implements OnInit {
     return [
       {
         key: 'countryCode',
-        type: 'ish-select-field',
+        type: 'ish-search-select-field',
         wrappers: ['form-field-horizontal'],
         props: {
           required: false,

--- a/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
+++ b/src/app/pages/account-addresses/account-addresses/account-addresses.component.ts
@@ -98,7 +98,7 @@ export class AccountAddressesComponent implements OnInit {
     // Selectbox formly configurations
     this.selectInvoiceConfig = {
       key: 'preferredInvoiceAddressUrn',
-      type: 'ish-select-field',
+      type: 'ish-search-select-field',
       props: {
         fieldClass: 'w-100',
         options: addressesAndUser$.pipe(
@@ -119,7 +119,7 @@ export class AccountAddressesComponent implements OnInit {
 
     this.selectShippingConfig = {
       key: 'preferredShippingAddressUrn',
-      type: 'ish-select-field',
+      type: 'ish-search-select-field',
       props: {
         fieldClass: 'w-100',
         options: addressesAndUser$.pipe(

--- a/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-invoice-address-widget/basket-invoice-address-widget.component.ts
@@ -77,7 +77,7 @@ export class BasketInvoiceAddressWidgetComponent implements OnInit {
     this.fields = [
       {
         key: 'id',
-        type: 'ish-select-field',
+        type: 'ish-search-select-field',
         props: {
           fieldClass: 'col-12',
           options: FormsService.getAddressOptions(this.addresses$),

--- a/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
+++ b/src/app/shared/components/checkout/basket-shipping-address-widget/basket-shipping-address-widget.component.ts
@@ -92,7 +92,7 @@ export class BasketShippingAddressWidgetComponent implements OnInit {
     this.fields = [
       {
         key: 'id',
-        type: 'ish-select-field',
+        type: 'ish-search-select-field',
         props: {
           fieldClass: 'col-12',
           options: FormsService.getAddressOptions(this.addresses$),

--- a/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-address-form/formly-address-form.component.ts
@@ -107,7 +107,7 @@ export class FormlyAddressFormComponent implements OnInit, OnChanges {
           fieldGroup: [
             {
               key: 'countryCode',
-              type: 'ish-select-field',
+              type: 'ish-search-select-field',
               props: {
                 required: true,
                 label: 'account.address.country.label',

--- a/src/app/shared/formly-address-forms/configurations/default/address-form-default.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/default/address-form-default.configuration.ts
@@ -44,7 +44,7 @@ export class AddressFormDefaultConfiguration extends AddressFormConfiguration {
         'city',
         {
           key: 'mainDivisionCode',
-          type: 'ish-select-field',
+          type: 'ish-search-select-field',
           props: {
             required: true,
             label: 'account.default_address.state.label',

--- a/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
+++ b/src/app/shared/formly-address-forms/configurations/us/address-form-us.configuration.ts
@@ -54,7 +54,7 @@ export class AddressFormUSConfiguration extends AddressFormConfiguration {
         },
         {
           key: 'mainDivisionCode',
-          type: 'ish-select-field',
+          type: 'ish-search-select-field',
           props: {
             label: 'account.address.state.label',
             required: true,

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -3,7 +3,6 @@
 .main-container {
   position: relative;
   min-height: 200px;
-  overflow-y: auto;
   background: $color-inverse;
   outline: none; // remove focus outline from container when using "skip to main content link"
 }


### PR DESCRIPTION
## PR Type

[x] Feature

## What Is the Current Behavior?

Standard select boxes are used in all forms except for the basket cost center selection and the cost center manager selection.

## What Is the New Behavior?

The newly introduced searchable select box (ng-select, see #1785) is used for more places where more than 10 options might be presented.

Additional places:
* Country (Address, Store locator)
* State/Province (Address)
* Address selection (Checkout, My Account)

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information
