### PR TITLE
fix: item positioning in header navigation (design view)

### DIFF
--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
@@ -5,13 +5,15 @@
         <!-- pagelet -->
         <ng-template [ngSwitchCase]="'pagelet'">
           <ng-container *ngIf="pagelet$ | async as pagelet">
-            <div class="name">{{ pagelet.displayName ? pagelet.displayName : '(Language missing)' }}</div>
             <button
               type="button"
               (click)="triggerAction(pagelet.id, 'pageletEdit')"
               class="btn"
-              title="{{ 'designview.edit.link.title' | translate }}"
+              title="{{
+                ('designview.edit.link.title' | translate) + (pagelet.displayName ? ' ' + pagelet.displayName : '')
+              }}"
             >
+              {{ pagelet.displayName ? pagelet.displayName : '(Language missing)' }}
               <fa-icon [icon]="['fas', 'pencil-alt']" />
             </button>
             <!--

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
@@ -18,15 +18,22 @@ $design-view-color-include: #ce5399;
     justify-content: flex-end;
     color: $color-inverse;
 
-    .name {
-      padding: 0 $space-default;
-      white-space: nowrap;
-    }
-
     .btn {
+      display: flex;
+      gap: $space-default;
+      align-items: center;
+      padding: 0.375rem 0.75rem;
       margin-bottom: 0;
-      font-size: 20px;
+      font-family: $font-family-regular;
+      font-weight: normal;
       color: $color-inverse;
+      text-transform: none;
+      white-space: nowrap;
+
+      fa-icon {
+        font-size: 20px;
+        line-height: 1.5;
+      }
     }
   }
 

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
@@ -35,7 +35,7 @@ $design-view-color-include: #ce5399;
      * Highlight only the last .pagelet element in the hierarchy and highlight neither slot nor include.
      * The class .last-design-view-wrapper is applied in TypeScript because &.pagelet:not(:has(.design-view-wrapper))
      * does not work in Firefox yet. So it cannot be done in CSS only.
-    */
+     */
 
     &:hover {
       &::before {
@@ -92,4 +92,11 @@ $design-view-color-include: #ce5399;
       }
     }
   }
+}
+
+// Design View Wrapper storefront styling adaptions
+// to fix styling issues that result from the additional wrapper div elements
+:host-context(.main-navigation-list) :host {
+  display: inline-flex;
+  align-items: center;
 }

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.spec.ts
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.spec.ts
@@ -72,9 +72,8 @@ describe('Content Design View Wrapper Component', () => {
     expect(element).toMatchInlineSnapshot(`
       <div class="design-view-wrapper pagelet" ng-reflect-ng-class="pagelet">
         <div class="design-view-wrapper-actions">
-          <div class="name">Pagelet Name xyz</div>
-          <button type="button" class="btn" title="designview.edit.link.title">
-            <fa-icon ng-reflect-icon="fas,pencil-alt"></fa-icon>
+          <button type="button" class="btn" title="designview.edit.link.title Pagelet Name xyz">
+            Pagelet Name xyz <fa-icon ng-reflect-icon="fas,pencil-alt"></fa-icon>
           </button>
         </div>
       </div>

--- a/src/styles/components/header/main-navigation.scss
+++ b/src/styles/components/header/main-navigation.scss
@@ -119,7 +119,6 @@
 .main-navigation {
   z-index: 2;
   align-self: center;
-  height: $top-header-height;
   transition: height 500ms ease-in-out;
 
   ul li ul {
@@ -136,8 +135,6 @@
   }
 
   .main-navigation-list {
-    display: block;
-
     a {
       font-size: $font-size-navbar-item;
       color: $text-color-primary;
@@ -148,7 +145,6 @@
 
       &.dropdown {
         position: static;
-        float: left;
         padding: 0 10px;
 
         &.first {


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Feature

## What Is the Current Behavior?

When components are assigned to the header navigation include, they wrap instead of being positioned next to each other in the Design View. Moreover, the action bar (for editing) of some components cannot be reached.

## What Is the New Behavior?

Components added to the header navigation include are displayed in a row by default in the Design View, and the action bar of each component is reachable. Additionally, the whole action bar can be clicked to trigger the edit action.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

[AB#106245](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/106245)