### PR TITLE
fix: same approver name is displayed twice on requisition detail page

### DIFF
--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-summary/requisition-summary.component.html
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-summary/requisition-summary.component.html
@@ -26,7 +26,7 @@
         <!-- prettier-ignore -->
         <dt class="col-6 col-sm-4 col-md-3">{{ 'approval.detailspage.approver.label' | translate: { '0': customerApproverCount } }}</dt>
         <dd class="col-6 col-sm-8 col-md-9">
-          <ng-container *ngFor="let approver of requisition.approval?.approvers; let i = index"
+          <ng-container *ngFor="let approver of uniqueApprovers; let i = index"
             ><ng-container *ngIf="i > 0">, </ng-container>{{ approver.firstName }} {{ approver.lastName }}</ng-container
           >
         </dd>

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-summary/requisition-summary.component.spec.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-summary/requisition-summary.component.spec.ts
@@ -30,7 +30,7 @@ describe('Requisition Summary Component', () => {
       id: '4711',
       requisitionNo: '4712',
       approval: {
-        status: 'Approval Pending',
+        status: 'pending',
         statusCode: 'PENDING',
         customerApproval: {
           approvers: [
@@ -71,7 +71,40 @@ describe('Requisition Summary Component', () => {
         <span
           class="border border-secondary badge badge-secondary text-capitalize border-warning badge-warning"
         >
-          Approval Pending
+          pending
+        </span>
+      </dd>,
+      ]
+    `);
+  });
+
+  it('should display buyer view with a given rejected requisition', () => {
+    component.requisition = {
+      id: '4711_R',
+      requisitionNo: '4712_R',
+      approval: {
+        status: 'rejected',
+        statusCode: 'REJECTED',
+        approvers: [
+          { firstName: 'Bernhhard', lastName: 'Boldner', email: 'bboldner@test.intershop.de' },
+          { firstName: 'Bernhhard', lastName: 'Boldner', email: 'bboldner@test.intershop.de' },
+        ],
+      },
+    } as Requisition;
+
+    fixture.detectChanges();
+    expect(element.querySelectorAll('dd')).toMatchInlineSnapshot(`
+      NodeList [
+        <dd class="col-6 col-sm-8 col-md-9">4712_R</dd>,
+        <dd class="col-6 col-sm-8 col-md-9"></dd>,
+        <dd class="col-6 col-sm-8 col-md-9">Bernhhard Boldner</dd>,
+        <dd class="col-6 col-sm-8 col-md-9"></dd>,
+        <dd class="col-6 col-sm-8 col-md-9"></dd>,
+        <dd class="col-6 col-sm-8 col-md-9">
+        <span
+          class="border border-secondary badge badge-secondary text-capitalize border-danger badge-danger"
+        >
+          rejected
         </span>
       </dd>,
       ]
@@ -92,7 +125,7 @@ describe('Requisition Summary Component', () => {
         <span
           class="border border-secondary badge badge-secondary text-capitalize border-warning badge-warning"
         >
-          Approval Pending
+          pending
         </span>
       </dd>,
       ]

--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-summary/requisition-summary.component.ts
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-summary/requisition-summary.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 
 import { AttributeHelper } from 'ish-core/models/attribute/attribute.helper';
+import { BasketApprover } from 'ish-core/models/basket-approval/basket-approval.model';
 
 import { Requisition, RequisitionViewer } from '../../../models/requisition/requisition.model';
 
@@ -15,6 +16,7 @@ export class RequisitionSummaryComponent implements OnInit {
 
   costCenterName: string;
   customerApproverCount: number;
+  uniqueApprovers: BasketApprover[];
 
   ngOnInit() {
     this.costCenterName = AttributeHelper.getAttributeValueByAttributeName(
@@ -22,12 +24,26 @@ export class RequisitionSummaryComponent implements OnInit {
       'BusinessObjectAttributes#Order_CostCenter_Name'
     );
 
-    this.customerApproverCount = this.getCustomerApproverCount();
+    if (this.requisition) {
+      const rawApprovers =
+        this.requisition.approval.statusCode === 'PENDING'
+          ? this.requisition.approval.customerApproval.approvers || []
+          : this.requisition.approval.approvers || [];
+
+      this.uniqueApprovers = this.uniqueByEmail(rawApprovers);
+
+      this.customerApproverCount = this.uniqueApprovers.length || 1;
+    }
   }
 
-  private getCustomerApproverCount() {
-    return this.requisition?.approval?.statusCode === 'PENDING'
-      ? this.requisition?.approval?.customerApproval.approvers?.length || 1
-      : this.requisition?.approval?.approvers?.length || 1;
+  private uniqueByEmail(list: BasketApprover[]) {
+    const uniqueEmails = new Set<string>();
+    return list.filter(a => {
+      if (uniqueEmails.has(a.email)) {
+        return false;
+      }
+      uniqueEmails.add(a.email);
+      return true;
+    });
   }
 }


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

When the buyer and cost center manager are the same individual, the name appears twice in the approver field on the requisition detail page.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1664

## What Is the New Behavior?

The approver name is only showing once in this case.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#106591](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/106591)