### PR TITLE
fix (accessibility): display error icons on payment forms

### DIFF
--- a/src/styles/pages/payment/payment.scss
+++ b/src/styles/pages/payment/payment.scss
@@ -21,12 +21,6 @@
     }
   }
 
-  .has-feedback {
-    .form-control-feedback {
-      display: none;
-    }
-  }
-
   .iframe-container {
     height: 35px;
   }


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1791

## What Is the New Behavior?

Error and validity icons are now visible on test payment parameter forms for credit card (ISH Demo Credit Card)/direct debit (Direct Debit Transfer) form fields on checkout payment page.

Note: This fix changes only the appearance and accessibility of native payment forms. Payment forms of external payment providers won't show error icons, because it is not possible to adapt input fields in iframes.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

[AB#106835](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/106835)