### PR TITLE
Bugfix/search string containing special characters causes invalid canonical links

### DIFF
--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -198,11 +198,18 @@ export class SeoEffects {
   }
 
   private setCanonicalLink(url: string) {
-    // the canonical URL of a production system should always be with 'https:'
-    // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
-    const urlObject = new URL(url);
-    urlObject.protocol = 'https:';
-    const canonicalUrl = urlObject.toString();
+    //the canonical URL of a production system should always be with 'https:'
+    //even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
+    let editedUrl;
+    if (url.includes('/search/')) {
+      const [baseUrl, searchTerm] = url.split('/search/');
+
+      editedUrl = `${baseUrl.replace('http:', 'https:')}/search/${encodeURIComponent(decodeURIComponent(searchTerm))}`;
+    } else {
+      editedUrl = encodeURI(url.replace('http:', 'https:'));
+    }
+
+    const canonicalUrl = editedUrl;
 
     const canonicalLink = this.domService.getOrCreateElement('link[rel="canonical"]', 'link', this.doc.head);
 

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -200,7 +200,10 @@ export class SeoEffects {
   private setCanonicalLink(url: string) {
     // the canonical URL of a production system should always be with 'https:'
     // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
-    const canonicalUrl = encodeURI(url.replace('http:', 'https:'));
+    const decodedUrl = decodeURI(url);
+
+    const canonicalUrl = encodeURI(decodedUrl.replace('http:', 'https:'));
+
     const canonicalLink = this.domService.getOrCreateElement('link[rel="canonical"]', 'link', this.doc.head);
 
     this.domService.setAttribute(canonicalLink, 'rel', 'canonical');

--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -200,9 +200,9 @@ export class SeoEffects {
   private setCanonicalLink(url: string) {
     // the canonical URL of a production system should always be with 'https:'
     // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
-    const decodedUrl = decodeURI(url);
-
-    const canonicalUrl = encodeURI(decodedUrl.replace('http:', 'https:'));
+    const urlObject = new URL(url);
+    urlObject.protocol = 'https:';
+    const canonicalUrl = urlObject.toString();
 
     const canonicalLink = this.domService.getOrCreateElement('link[rel="canonical"]', 'link', this.doc.head);
 


### PR DESCRIPTION
## PR Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

When searching special characters in the search term would be automatically be encoded in the url an then later encoded again when creating the canonical link leading to it becoming invalid.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1711

## What Is the New Behavior?

When searching the url is is now decoded first before encoding it to avoid double encoding.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

AB#107040