### PR TITLE
fix: disable luarocks `lua-resty-redis-connector` installation

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,11 @@ kb_sync_latest_only
 
 # Migrations
 
+## From 7.0.0 to 7.1.0
+
+Because of installation problems with the used `luarocks` package manager we disabled the installation of the `lua-resty-redis-connector` that provides the functionality to connect to a shared Redis cache.
+Since this functionality can and was currently not yet used by any project, disabling it is not regarded to as a breaking change.
+
 ## From 6.0.0 to 7.0.0
 
 The Intershop PWA 7.0.0 release contains the **Sparque suggest** and **Sparque search** functionality to improve the product search in the PWA.

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -332,6 +332,10 @@ The value supplied must be in the `time` format that is supported by [NGINX prox
 
 ### Shared Redis Cache
 
+> [!IMPORTANT]
+> The Shared Redis Cache functionality can currently not be used because of a `luarocks` installation issue (see [#1825](https://github.com/intershop/intershop-pwa/pull/1825)).
+> In addition the current connection with username and password needs to be changed to a token to actually work.
+
 Each NGINX has its own cache, so in a deployment with multiple NGINX (for redundancy) the cache hit rate is significantly lower than it could be.
 With the shared Redis cache the different NGINX instances push the cache to a shared Redis service and retrieve it from there.
 This way each NGINX profits from already rendered SSR results and the overall performance of such a deployment increases.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,12 +12,12 @@ RUN wget -q https://nginx.org/download/nginx-1.21.4.tar.gz && tar -zxf nginx-1.2
 FROM openresty/openresty:1.21.4.3-1-jammy
 COPY --from=nginx:mainline /docker-entrypoint.sh /
 COPY --from=nginx:mainline /docker-entrypoint.d/*.sh /docker-entrypoint.d/
-COPY lua/*.lua /usr/local/openresty/lualib/
+# COPY lua/*.lua /usr/local/openresty/lualib/
 RUN ln -s /usr/local/openresty/nginx/conf/mime.types /etc/nginx/ \
-  && useradd -Ms /bin/false nginx \
-  && mkdir -p /etc/resolvconf/resolv.conf.d \
-  && echo "nameserver 8.8.8.8" >> /etc/resolvconf/resolv.conf.d/tail \
-  && luarocks install lua-resty-redis-connector
+  && useradd -Ms /bin/false nginx
+  # && mkdir -p /etc/resolvconf/resolv.conf.d \
+  # && echo "nameserver 8.8.8.8" >> /etc/resolvconf/resolv.conf.d/tail \
+  # && luarocks install lua-resty-redis-connector
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
 


### PR DESCRIPTION
## PR Type

[x] Build-related changes

## What Is the Current Behavior?

Currently the NGINX docker image builds fail because of failing downloads from luarocks (see https://github.com/luarocks/luarocks/issues/1797).
Since we are only downloading the `lua-resty-redis-connector` from luarocks this part can be disabled for now since the shared Redis cache integration is not actively used yet in any project.

## What Is the New Behavior?

Not installing the `lua-resty-redis-connector` from luarocks for now to prevent the install problems.

## Does this PR Introduce a Breaking Change?

[x] Yes

This change completely disables the possibility to connect to Redis for a shared NGINX pod cache.
Since this feature is not actively used yet in any project, disabling it should not be a problem for now.


## Other Information

[AB#107374](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107374)