### PR TITLE
fix: display captcha validation message (#1833)

### DIFF
--- a/src/app/extensions/captcha/shared/captcha-v2/captcha-v2.component.html
+++ b/src/app/extensions/captcha/shared/captcha-v2/captcha-v2.component.html
@@ -1,8 +1,6 @@
-<div *ngIf="captchaSiteKey$ | async as captchaSiteKey" class="row form-group">
-  <div [ngClass]="cssClass">
-    <div [ngClass]="{ 'has-error': hasError }">
-      <re-captcha [siteKey]="captchaSiteKey" (resolved)="resolved($event)" class="captcha" />
-      <small *ngIf="hasError" class="validation-message">{{ 'recaptcha.v2.incorrect.error' | translate }}</small>
-    </div>
-  </div>
-</div>
+<re-captcha
+  *ngIf="captchaSiteKey$ | async as captchaSiteKey"
+  [siteKey]="captchaSiteKey"
+  (resolved)="resolved($event)"
+  class="captcha"
+/>

--- a/src/app/extensions/captcha/shared/captcha-v2/captcha-v2.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v2/captcha-v2.component.ts
@@ -42,10 +42,6 @@ export class CaptchaV2Component implements OnInit {
   private get formControl(): AbstractControl {
     return this.parentForm?.get('captcha');
   }
-
-  get hasError(): boolean {
-    return this.formControl?.invalid && this?.formControl.dirty;
-  }
 }
 
 @NgModule({

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.html
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.html
@@ -1,12 +1,8 @@
-<div class="row">
-  <div class="offset-md-4 col-md-8">
-    <p
-      data-testing-id="recaptcha-v3-info"
-      class="validation-message"
-      [ishServerHtml]="
-        'recaptcha.v3.info_text'
-          | translate : { '0': 'https://policies.google.com/privacy', '1': 'https://policies.google.com/terms' }
-      "
-    ></p>
-  </div>
-</div>
+<p
+  data-testing-id="recaptcha-v3-info"
+  class="validation-message"
+  [ishServerHtml]="
+    'recaptcha.v3.info_text'
+      | translate : { '0': 'https://policies.google.com/privacy', '1': 'https://policies.google.com/terms' }
+  "
+></p>

--- a/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.spec.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.spec.ts
@@ -65,6 +65,7 @@ describe('Contact Form Component', () => {
     component.contactForm.get('order').setValue('456789');
     component.contactForm.get('subject').setValue('Return');
     component.contactForm.get('comment').setValue('want to return stuff');
+    component.contactForm.get('captcha').setValue(anything());
     component.submitForm();
     verify(emitter.emit(anything())).once();
   });

--- a/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-form/contact-form.component.ts
@@ -113,8 +113,16 @@ export class ContactFormComponent implements OnInit {
       },
       {
         type: 'ish-captcha-field',
+        key: 'captcha',
         props: {
           topic: 'contactUs',
+          required: true,
+          fieldClass: 'offset-md-4 col-md-8',
+        },
+        validation: {
+          messages: {
+            required: 'recaptcha.v2.incorrect.error',
+          },
         },
       },
     ];

--- a/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
+++ b/src/app/pages/forgot-password/request-reminder-form/request-reminder-form.component.ts
@@ -39,8 +39,16 @@ export class RequestReminderFormComponent implements OnInit {
       },
       {
         type: 'ish-captcha-field',
+        key: 'captcha',
         props: {
           topic: 'forgotPassword',
+          required: true,
+          fieldClass: 'offset-md-4 col-md-8',
+        },
+        validation: {
+          messages: {
+            required: 'recaptcha.v2.incorrect.error',
+          },
         },
       },
     ];

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.spec.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.spec.ts
@@ -94,6 +94,7 @@ describe('Registration Form Configuration Service', () => {
           [
             "termsAndConditions",
             "newsletterSubscription",
+            "captcha",
           ],
         ]
       `);
@@ -132,6 +133,7 @@ describe('Registration Form Configuration Service', () => {
             [
               "termsAndConditions",
               "newsletterSubscription",
+              "captcha",
             ],
           ]
         `);
@@ -160,6 +162,7 @@ describe('Registration Form Configuration Service', () => {
             [
               "termsAndConditions",
               "newsletterSubscription",
+              "captcha",
             ],
           ]
         `);

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -130,8 +130,16 @@ export class RegistrationFormConfigurationService {
           },
           {
             type: 'ish-captcha-field',
+            key: 'captcha',
             props: {
               topic: 'register',
+              required: true,
+              fieldClass: 'offset-md-4 col-md-8',
+            },
+            validation: {
+              messages: {
+                required: 'recaptcha.v2.incorrect.error',
+              },
             },
           },
         ],

--- a/src/app/shared/formly/types/types.module.ts
+++ b/src/app/shared/formly/types/types.module.ts
@@ -165,7 +165,11 @@ const fieldComponents = [
           component: CheckboxFieldComponent,
           wrappers: ['form-field-checkbox-horizontal'],
         },
-        { name: 'ish-captcha-field', component: CaptchaFieldComponent },
+        {
+          name: 'ish-captcha-field',
+          component: CaptchaFieldComponent,
+          wrappers: ['validation'],
+        },
         {
           name: 'ish-fieldset-field',
           component: FieldsetFieldComponent,

--- a/src/app/shared/formly/wrappers/validation-wrapper/validation-wrapper.component.html
+++ b/src/app/shared/formly/wrappers/validation-wrapper/validation-wrapper.component.html
@@ -1,4 +1,4 @@
-<div [class.has-error]="showError">
+<div *ngIf="field.type !== 'ish-captcha-field'; else captchaWrapper" [class.has-error]="showError">
   <ng-template #fieldComponent></ng-template>
   <ish-validation-icons
     *ngIf="showValidationIcons()"
@@ -13,3 +13,14 @@
     <ish-validation-message [field]="field" class="validation-message" />
   </ng-container>
 </div>
+<!-- wrapper for captcha deviates from the standard, has no label and doesn't need the validation icon -->
+<ng-template #captchaWrapper>
+  <div class="row form-group" [class.has-error]="showError">
+    <div [ngClass]="field.props?.fieldClass">
+      <ng-template #fieldComponent></ng-template>
+      <ng-container *ngIf="showError" class="invalid-feedback d-block">
+        <ish-validation-message [field]="field" class="validation-message" />
+      </ng-container>
+    </div>
+  </div>
+</ng-template>


### PR DESCRIPTION
## PR Type

[ x] Bugfix

## What Is the Current Behavior?

In the PWA, the ReCaptcha Check V2 implementation does not display the validation message "recaptcha.v2.incorrect.error" in the <small> tag if an attempt is made to skip the check, e.g. during registration. 

## What Is the New Behavior?

Forms that use the type _ish-captcha-field_ as field configuration now have the property _required_ and and the _validation_ wrapper. All validation messages are now displayed by the wrapper and no longer by the captcha component.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x ] No

## Other Information

#107447
[AB#107456](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107456)