### PR TITLE
fix: keep the focus after changing a payment method

### DIFF
--- a/src/app/pages/checkout-payment/checkout-payment-page.component.ts
+++ b/src/app/pages/checkout-payment/checkout-payment-page.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { isEqual } from 'lodash-es';
 import { Observable } from 'rxjs';
-import { filter, first, map, shareReplay, tap, withLatestFrom } from 'rxjs/operators';
+import { distinctUntilChanged, filter, first, map, shareReplay, tap, withLatestFrom } from 'rxjs/operators';
 
 import { CheckoutFacade } from 'ish-core/facades/checkout.facade';
 import { BasketView } from 'ish-core/models/basket/basket.model';
@@ -49,6 +50,7 @@ export class CheckoutPaymentPageComponent implements OnInit {
               basket.payment.paymentInstrument.id === pm.id)
         )
       ),
+      distinctUntilChanged(isEqual),
       shareReplay(1)
     );
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?
When a user selects or changes a payment method on the checkout payment page, the payment methods area reloads. This reload causes the user's focus (particularly for keyboard and screen reader users) to be lost and the focus returns to the top of the document, forcing the user to re-navigate the page to find their previous position.

Issue Number: Closes #1830 

## What Is the New Behavior?
The focus won't be changed if the user selects or change the payment method.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information
