### PR TITLE
fix(accessibility): tab focus outline for carousel (#1826, #1843)

### DIFF
--- a/src/styles/components/carousel/carousel.scss
+++ b/src/styles/components/carousel/carousel.scss
@@ -8,9 +8,13 @@
   }
 }
 
-.carousel,
-.carousel-inner {
-  outline: none;
+.carousel {
+  margin: -2px;
+
+  .carousel-inner {
+    // necessary to make the tab focus on the content inside the carousel visible
+    padding: 2px;
+  }
 }
 
 .carousel-indicators {

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -3,7 +3,6 @@
 .main-container {
   position: relative;
   min-height: 200px;
-  overflow-y: auto;
   background: $color-inverse;
   outline: none; // remove focus outline from container when using "skip to main content link"
 }


### PR DESCRIPTION
## PR Type

[x] Other: Accessibility Improvements

## What Is the Current Behavior?

The keyboard focus on the ngbCarousel (b2c homepage teaser carousel) is hidden via CSS.
The keyboard focus also is not visible on the image links inside the carousel slides.

Issue Number: Closes #1826

## What Is the New Behavior?

Changed the CSS so that the keyboard focus is visible of the ngbCarousel content inside the carousel.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#107649](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107649)