### PR TITLE
fix: link styling

### DIFF
--- a/projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.html
+++ b/projects/organization-management/src/app/components/user-roles-selection/user-roles-selection.component.html
@@ -26,19 +26,15 @@
             </ul>
             <p>
               <!-- Expand/Collapse user permissions -->
-              <button
-                type="button"
-                (click)="toggleExpanded(i)"
-                class="btn btn-link btn-link-action text-decoration-none"
-              >
+              <button type="button" (click)="toggleExpanded(i)" class="btn btn-link btn-link-with-icon btn-link-action">
                 <ng-container *ngIf="isExpanded[i]; else show_permissions_link">
-                  {{ 'account.user.details.profile.role.hide_permissions.link' | translate }}&nbsp;
-                  <fa-icon [icon]="['fas', 'angle-up']" />
+                  {{ 'account.user.details.profile.role.hide_permissions.link' | translate
+                  }}<fa-icon [icon]="['fas', 'angle-up']" />
                 </ng-container>
 
                 <ng-template #show_permissions_link>
-                  {{ 'account.user.details.profile.role.show_permissions.link' | translate }}&nbsp;
-                  <fa-icon [icon]="['fas', 'angle-down']" />
+                  {{ 'account.user.details.profile.role.show_permissions.link' | translate
+                  }}<fa-icon [icon]="['fas', 'angle-down']" />
                 </ng-template>
               </button>
             </p>

--- a/src/app/extensions/punchout/pages/account-punchout-configuration/oci-configuration-form/oci-configuration-form.component.html
+++ b/src/app/extensions/punchout/pages/account-punchout-configuration/oci-configuration-form/oci-configuration-form.component.html
@@ -15,7 +15,7 @@
         </ng-template>
         <button
           type="button"
-          class="btn btn-link header-note details-tooltip pl-1"
+          class="btn btn-link header-note details-tooltip"
           [ngbPopover]="OciConfigurationPlaceholder"
           placement="bottom"
           [title]="'account.punchout.configuration.form.tooltip.placeholder.icon' | translate"
@@ -34,7 +34,7 @@
         </ng-template>
         <button
           type="button"
-          class="btn btn-link header-note details-tooltip pl-1"
+          class="btn btn-link header-note details-tooltip"
           [ngbPopover]="OciConfigurationMapping"
           placement="bottom"
           [title]="'account.punchout.configuration.form.tooltip.mapping.icon' | translate"

--- a/src/app/extensions/quoting/shared/quoting-basket-line-items/quoting-basket-line-items.component.html
+++ b/src/app/extensions/quoting/shared/quoting-basket-line-items/quoting-basket-line-items.component.html
@@ -1,17 +1,16 @@
 <ng-container *ngFor="let item of lineItems$ | async; trackBy: trackByFn">
-  <div class="row" *ngIf="item[0] !== 'undefined'">
-    <h2 class="col-12">
+  <div class="d-flex align-items-center justify-content-between flex-wrap" *ngIf="item[0] !== 'undefined'">
+    <h2>
       {{ 'quote.basket_items.label' | translate : { '0': getName(item[0]) | async } }}
-      <button
-        type="button"
-        class="float-md-right pt-2 d-block d-md-inline header-note btn btn-link btn-link-action"
-        title="{{ 'quote.basket_items.remove.button.label' | translate }}"
-        (click)="onDeleteQuote(item[0])"
-      >
-        <fa-icon [icon]="['fas', 'trash-alt']" />
-        <span class="pl-1">{{ 'quote.basket_items.remove.button.label' | translate }}</span>
-      </button>
     </h2>
+    <button
+      type="button"
+      class="float-md-right px-2 mx-1 d-block d-md-inline btn btn-link btn-link-action"
+      title="{{ 'quote.basket_items.remove.button.label' | translate }}"
+      (click)="onDeleteQuote(item[0])"
+    >
+      {{ 'quote.basket_items.remove.button.label' | translate }}
+    </button>
   </div>
   <ish-line-item-list [lineItems]="item[1]" />
 </ng-container>

--- a/src/app/extensions/wishlists/pages/account-wishlist-detail/account-wishlist-detail-page.component.html
+++ b/src/app/extensions/wishlists/pages/account-wishlist-detail/account-wishlist-detail-page.component.html
@@ -45,7 +45,7 @@
       class="btn btn-link details-tooltip header-note mt-1"
       popoverTitle="{{ 'account.wishlists.heading.tooltip.headline' | translate }}"
     >
-      {{ 'account.wishlists.heading.tooltip.link' | translate }} <fa-icon [icon]="['fas', 'info-circle']" />
+      {{ 'account.wishlists.heading.tooltip.link' | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
     </button>
   </h1>
 

--- a/src/app/extensions/wishlists/pages/account-wishlist/account-wishlist-page.component.html
+++ b/src/app/extensions/wishlists/pages/account-wishlist/account-wishlist-page.component.html
@@ -12,8 +12,7 @@
         placement="bottom"
         popoverTitle="{{ 'account.wishlists.heading.tooltip.headline' | translate }}"
       >
-        {{ 'account.wishlists.heading.tooltip.link' | translate }}
-        <fa-icon [icon]="['fas', 'info-circle']" />
+        {{ 'account.wishlists.heading.tooltip.link' | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
       </button>
     </h1>
 

--- a/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.html
+++ b/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.html
@@ -9,18 +9,16 @@
     <div class="col-md-4 d-flex align-items-center">
       <button
         type="button"
-        class="btn btn-link pl-0 text-decoration-none"
+        class="btn btn-link btn-link-with-icon"
         (click)="expandForm()"
         [attr.aria-expanded]="!formIsCollapsed"
       >
         <ng-container *ngIf="formIsCollapsed; else hide_filters">
-          {{ 'account.order_history.filter.show' | translate }}&nbsp;
-          <fa-icon [icon]="['fas', 'angle-down']" />
+          {{ 'account.order_history.filter.show' | translate }}<fa-icon [icon]="['fas', 'angle-down']" />
         </ng-container>
 
         <ng-template #hide_filters>
-          {{ 'account.order_history.filter.hide' | translate }}&nbsp;
-          <fa-icon [icon]="['fas', 'angle-up']" />
+          {{ 'account.order_history.filter.hide' | translate }}<fa-icon [icon]="['fas', 'angle-up']" />
         </ng-template>
       </button>
     </div>

--- a/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.html
+++ b/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.html
@@ -9,8 +9,7 @@
       [ngbPopover]="ShippingMethodDescription"
       placement="top"
     >
-      {{ 'checkout.detail.text' | translate }}
-      <fa-icon [icon]="['fas', 'info-circle']" />
+      {{ 'checkout.detail.text' | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
     </button>
   </label>
 </div>

--- a/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
+++ b/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.html
@@ -74,8 +74,7 @@
       [popoverTitle]="surcharge.displayName"
       placement="top"
     >
-      {{ 'shopping_cart.detail.text' | translate }}
-      <fa-icon [icon]="['fas', 'info-circle']" />
+      {{ 'shopping_cart.detail.text' | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
     </button>
   </dt>
   <dd class="col-6">{{ surcharge.amount | ishPrice }}</dd>

--- a/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.spec.ts
+++ b/src/app/shared/components/basket/basket-cost-summary/basket-cost-summary.component.spec.ts
@@ -49,7 +49,7 @@ describe('Basket Cost Summary Component', () => {
     tick(500);
 
     expect(element.textContent.replace(/^\s*[\r\n]*/gm, '')).toMatchInlineSnapshot(
-      `"checkout.cart.subtotal.heading$141,796.98-$11.90checkout.order.shipping.labelproduct.price.na.text Battery Deposit Surcharge  shopping_cart.detail.text $595.00checkout.cart.payment_cost.label$3.57checkout.tax.TaxesLabel.TotalOrderVat$22,747.55checkout.order.total_cost.label$142,470.71"`
+      `"checkout.cart.subtotal.heading$141,796.98-$11.90checkout.order.shipping.labelproduct.price.na.text Battery Deposit Surcharge  shopping_cart.detail.text$595.00checkout.cart.payment_cost.label$3.57checkout.tax.TaxesLabel.TotalOrderVat$22,747.55checkout.order.total_cost.label$142,470.71"`
     );
   }));
 

--- a/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.html
+++ b/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.html
@@ -37,19 +37,19 @@
   <button
     *ngIf="isShowAllLinkVisible()"
     type="button"
-    class="btn btn-link btn-link-action cart-items-collapse-link"
+    class="btn btn-link btn-content-toggle cart-items-collapse-link"
     (click)="toggleCollapse()"
   >
-    {{ 'checkout.show_all.link' | translate : { '0': basket.lineItems.length } }}&nbsp;
-    <fa-icon [icon]="['fas', 'angle-right']" class="float-right" />
+    {{ 'checkout.show_all.link' | translate : { '0': basket.lineItems.length } }}
+    <fa-icon [icon]="['fas', 'angle-down']" class="float-right" />
   </button>
   <button
     *ngIf="isHideLinkVisible()"
     type="button"
-    class="btn btn-link btn-link-action cart-items-collapse-link"
+    class="btn btn-link btn-content-toggle cart-items-collapse-link"
     (click)="toggleCollapse()"
   >
-    {{ 'checkout.hide_all.link' | translate }}&nbsp;
+    {{ 'checkout.hide_all.link' | translate }}
     <fa-icon [icon]="['fas', 'angle-up']" class="float-right" />
   </button>
 </div>

--- a/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.spec.ts
+++ b/src/app/shared/components/basket/basket-items-summary/basket-items-summary.component.spec.ts
@@ -52,7 +52,7 @@ describe('Basket Items Summary Component', () => {
 
   it('should not show showAll/HideAll links if there are less items than in collapsedItemsCount specified', () => {
     fixture.detectChanges();
-    expect(element.querySelector('.fa-angle-right')).toBeFalsy();
+    expect(element.querySelector('.fa-angle-down')).toBeFalsy();
     expect(element.querySelector('.fa-angle-up')).toBeFalsy();
   });
 
@@ -61,7 +61,7 @@ describe('Basket Items Summary Component', () => {
     component.basket.lineItems.push(BasketMockData.getBasketItem());
     component.basket.lineItems.push(BasketMockData.getBasketItem());
     fixture.detectChanges();
-    expect(element.querySelector('fa-icon[ng-reflect-icon="fas,angle-right"]')).toBeTruthy();
+    expect(element.querySelector('fa-icon[ng-reflect-icon="fas,angle-down"]')).toBeTruthy();
     expect(element.querySelector('fa-icon[ng-reflect-icon="fas,angle-up"]')).toBeFalsy();
   });
 
@@ -71,7 +71,7 @@ describe('Basket Items Summary Component', () => {
     component.basket.lineItems.push(BasketMockData.getBasketItem());
     component.basket.lineItems.push(BasketMockData.getBasketItem());
     fixture.detectChanges();
-    expect(element.querySelector('fa-icon[ng-reflect-icon="fas,angle-right"]')).toBeFalsy();
+    expect(element.querySelector('fa-icon[ng-reflect-icon="fas,angle-down"]')).toBeFalsy();
     expect(element.querySelector('fa-icon[ng-reflect-icon="fas,angle-up"]')).toBeTruthy();
   });
 });

--- a/src/app/shared/components/basket/basket-promotion-code/basket-promotion-code.component.html
+++ b/src/app/shared/components/basket/basket-promotion-code/basket-promotion-code.component.html
@@ -2,14 +2,14 @@
   <button
     type="button"
     id="promotion-code-button"
-    class="btn btn-link btn-link-action promo-collapse-link"
+    class="btn btn-link btn-content-toggle p-0"
     (click)="isCollapsed = !isCollapsed"
     [attr.aria-expanded]="!isCollapsed"
     aria-controls="promo-code-input"
     data-testing-id="promo-collapse-link"
   >
-    {{ 'shopping_cart.promotional_code.heading' | translate }}
-    <fa-icon [icon]="['fas', isCollapsed ? 'angle-down' : 'angle-up']" class="float-right" />
+    {{ 'shopping_cart.promotional_code.heading' | translate
+    }}<fa-icon [icon]="['fas', isCollapsed ? 'angle-down' : 'angle-up']" class="float-right" />
   </button>
 
   <ish-error-message [error]="promotionError$ | async" [toast]="toast" />

--- a/src/app/shared/components/basket/clear-basket/clear-basket.component.html
+++ b/src/app/shared/components/basket/clear-basket/clear-basket.component.html
@@ -1,6 +1,6 @@
 <button
   type="button"
-  class="btn btn-link"
+  class="btn btn-link mr-0"
   [ngClass]="cssClass"
   data-testing-id="clearBasketButton"
   (click)="clearDialog.show()"

--- a/src/app/shared/components/filter/filter-collapsible/filter-collapsible.component.html
+++ b/src/app/shared/components/filter/filter-collapsible/filter-collapsible.component.html
@@ -2,15 +2,13 @@
   <button
     type="button"
     (click)="toggle()"
-    class="btn-filter-toggle"
+    class="btn btn-link btn-content-toggle p-0 mb-3"
     [attr.aria-expanded]="!isCollapsed"
     [attr.aria-controls]="filterElement.id"
     data-testing-id="filter-toggle-button"
   >
-    <h3>
-      {{ filterElement.name }}
-      <fa-icon [icon]="['fas', isCollapsed ? 'angle-down' : 'angle-up']" />
-    </h3>
+    <h3 class="m-0">{{ filterElement.name }}</h3>
+    <fa-icon [icon]="['fas', isCollapsed ? 'angle-down' : 'angle-up']" />
   </button>
 
   <ng-content></ng-content>

--- a/src/app/shared/components/filter/filter-collapsible/filter-collapsible.component.spec.ts
+++ b/src/app/shared/components/filter/filter-collapsible/filter-collapsible.component.spec.ts
@@ -42,11 +42,12 @@ describe('Filter Collapsible Component', () => {
         <button
           type="button"
           data-testing-id="filter-toggle-button"
-          class="btn-filter-toggle"
+          class="btn btn-link btn-content-toggle p-0 mb-3"
           aria-expanded="true"
           aria-controls="PriceFilterId"
         >
-          <h3>Price <fa-icon ng-reflect-icon="fas,angle-up"></fa-icon></h3>
+          <h3 class="m-0">Price</h3>
+          <fa-icon ng-reflect-icon="fas,angle-up"></fa-icon>
         </button>
       </div>
     `);
@@ -62,11 +63,12 @@ describe('Filter Collapsible Component', () => {
         <button
           type="button"
           data-testing-id="filter-toggle-button"
-          class="btn-filter-toggle"
+          class="btn btn-link btn-content-toggle p-0 mb-3"
           aria-expanded="false"
           aria-controls="PriceFilterId"
         >
-          <h3>Price <fa-icon ng-reflect-icon="fas,angle-down"></fa-icon></h3>
+          <h3 class="m-0">Price</h3>
+          <fa-icon ng-reflect-icon="fas,angle-down"></fa-icon>
         </button>
       </div>
     `);

--- a/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.html
+++ b/src/app/shared/components/filter/filter-dropdown/filter-dropdown.component.html
@@ -22,7 +22,7 @@
     >
       {{ facet.displayName }}
       <ng-container *ngIf="facet.count"> ({{ facet.count }})</ng-container>
-      <fa-icon *ngIf="facet.selected" [icon]="['fas', 'check']" class="icon-checked" />
+      <fa-icon *ngIf="facet.selected" [icon]="['fas', 'check']" class="icon-checked pl-1" />
     </button>
   </div>
 </div>

--- a/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.html
+++ b/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.html
@@ -1,9 +1,13 @@
 <div *ngIf="selected" class="row">
   <div class="col-md-10">
     <div *ngFor="let select of selected" class="filter-navigation-badges">
-      <button type="button" class="btn btn-link btn-link-action" (click)="apply(select.searchParameter)">
-        {{ select.filterName }}: {{ select.displayName }}
-        <fa-icon [icon]="['fas', 'times']" class="form-control-feedback" />
+      <button
+        type="button"
+        class="btn btn-link btn-link-action btn-link-with-icon"
+        (click)="apply(select.searchParameter)"
+      >
+        {{ select.filterName }}: {{ select.displayName
+        }}<fa-icon [icon]="['fas', 'times']" class="form-control-feedback" />
       </button>
     </div>
   </div>

--- a/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.spec.ts
+++ b/src/app/shared/components/filter/filter-navigation-badges/filter-navigation-badges.component.spec.ts
@@ -61,18 +61,18 @@ describe('Filter Navigation Badges Component', () => {
       <div class="row">
         <div class="col-md-10">
           <div class="filter-navigation-badges">
-            <button type="button" class="btn btn-link btn-link-action">
-              Color: blue <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon>
+            <button type="button" class="btn btn-link btn-link-action btn-link-with-icon">
+              Color: blue<fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon>
             </button>
           </div>
           <div class="filter-navigation-badges">
-            <button type="button" class="btn btn-link btn-link-action">
-              Color: black <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon>
+            <button type="button" class="btn btn-link btn-link-action btn-link-with-icon">
+              Color: black<fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon>
             </button>
           </div>
           <div class="filter-navigation-badges">
-            <button type="button" class="btn btn-link btn-link-action">
-              HDD: 456 <fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon>
+            <button type="button" class="btn btn-link btn-link-action btn-link-with-icon">
+              HDD: 456<fa-icon class="form-control-feedback" ng-reflect-icon="fas,times"></fa-icon>
             </button>
           </div>
         </div>

--- a/src/app/shared/components/line-item/line-item-list-element/line-item-list-element.component.html
+++ b/src/app/shared/components/line-item/line-item-list-element/line-item-list-element.component.html
@@ -67,8 +67,7 @@
               [popoverTitle]="surcharge.displayName"
               placement="top"
             >
-              {{ 'shopping_cart.detail.text' | translate }}
-              <fa-icon [icon]="['fas', 'info-circle']" />
+              {{ 'shopping_cart.detail.text' | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
             </button>
           </div>
         </ng-container>

--- a/src/app/shared/formly/components/field-tooltip/field-tooltip.component.html
+++ b/src/app/shared/formly/components/field-tooltip/field-tooltip.component.html
@@ -10,7 +10,6 @@
     class="btn btn-link details-tooltip"
     [ngClass]="tooltipInfo.class"
   >
-    {{ tooltipInfo.link | translate }}
-    <fa-icon [icon]="['fas', 'info-circle']" />
+    {{ tooltipInfo.link | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
   </button>
 </ng-container>

--- a/src/styles/global/buttons.scss
+++ b/src/styles/global/buttons.scss
@@ -149,6 +149,19 @@ button.btn-link {
   }
 }
 
+.details-tooltip,
+.btn-link-with-icon {
+  .ng-fa-icon {
+    padding-left: 6px;
+  }
+
+  @include hover-none-underline();
+}
+
+.btn-link-with-icon {
+  padding-left: 0;
+}
+
 // multiple buttons margin handling (use "button-group" in case the buttons are not direct siblings)
 .button-group .btn,
 .btn:not(:only-child):not(.btn-link) {
@@ -171,7 +184,7 @@ button.btn-link {
   }
 }
 
-// TODO: refactor button toggles with toggle icon (filter, promo, accordion) into a single class
+// toggle link with width 100%
 .btn-content-toggle {
   display: flex;
   align-items: center;

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -361,10 +361,6 @@ img.marketing {
   white-space: nowrap;
 }
 
-.details-tooltip {
-  text-decoration: none !important;
-}
-
 .download-link {
   display: inline-block;
   padding-left: $space-default * 0.5;

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -292,6 +292,7 @@ img {
   .nav-link:hover,
   .nav-link:focus {
     border-color: transparent;
+    box-shadow: 0 2px $CORPORATE-SECONDARY;
   }
 
   .nav-link.active,

--- a/src/styles/pages/category/filter-panel.scss
+++ b/src/styles/pages/category/filter-panel.scss
@@ -14,14 +14,6 @@
     margin-top: $space-default;
   }
 
-  .btn-filter-toggle {
-    width: 100%;
-    padding: 0;
-    text-align: left;
-    background-color: transparent;
-    border: 0;
-  }
-
   h3 {
     .ng-fa-icon {
       float: right;

--- a/src/styles/pages/checkout/shopping-cart.scss
+++ b/src/styles/pages/checkout/shopping-cart.scss
@@ -50,21 +50,8 @@
   }
 
   .cart-items-collapse-link {
+    padding: 0;
     margin-top: $space-default;
-  }
-
-  .cart-items-collapse-link,
-  .promo-collapse-link {
-    width: 100%;
-    color: $color-primary;
-    text-align: left;
-    text-decoration: none !important;
-
-    .ng-fa-icon {
-      position: relative;
-      top: 2px;
-      color: $text-color-corporate;
-    }
   }
 
   .promotion-details-and-remove-links {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Tabs do not underline when hovered.
The “Remove items” button for the quoting basket was part of the h2 and therefore not formatted correctly.
Buttons with text and an icon were not underlined and were separated by spaces.

Closes: #1790
## What Is the New Behavior?

Box-shadow below the tab when hovered similar to when active 
The position of the “Remove items” button has been corrected and aligned with the “Clear cart” button.
All buttons with text and an icon are now underlined when hovered and the text and icon are separated by a padding. The class "btn-link-with-icon" was added for this purpose.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#107785](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107785)