### PR TITLE
fix: checkout "add payment instrument" submit is called twice (#1850, #1852)

### DIFF
--- a/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
+++ b/src/app/pages/checkout-payment/checkout-payment/checkout-payment.component.html
@@ -180,7 +180,6 @@
                           [submitDisabled]="submitDisabled"
                           [activated]="formIsOpen(i)"
                           (cancelPayment)="closePaymentInstrumentForm()"
-                          (submitPayment)="submitParameterForm()"
                         />
                       </ng-template>
                     </ng-container>


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When adding a payment instrument via the payment instrument form on the checkout payment page, after submitting a valid form there is an error displayed, stating that the same payment instrument can't be added because it already exists. The payment method is still successfully created.
The behavior only appears on forms that use the <ish-payment-parameter-form> component.
This can visually confuse users, but especially users that rely on a screen reader, because the error message is read out as important information, making the user think that adding the payment method was not successful.

Issue Number: Closes #1850

## What Is the New Behavior?

Removed the redundant `(submitPayment)="submitParameterForm()"` on the `<ish-payment-parameter-form>`, since the function is already called in the form submit in the ts file.
Now, after submitting a valid payment instrument form, no error is displayed.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#107914](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107914)