### PR TITLE
feat(accessibility): wrap category navigation into `<nav>` element (#1834, #1853)

### DIFF
--- a/src/app/pages/category/category-categories/category-categories.component.html
+++ b/src/app/pages/category/category-categories/category-categories.component.html
@@ -12,7 +12,9 @@
     <div class="col-md-3">
       <ish-skip-content-link skipToElementId="nav-breadcrumbs" linkText="category.navigation.skip_content.link.text" />
       <div class="navigation-panel" [ngbCollapse]="isCollapsed">
-        <ish-category-navigation [uniqueId]="category.categoryPath[0]" />
+        <nav [attr.aria-label]="'category.navigation.aria_label' | translate">
+          <ish-category-navigation [uniqueId]="category.categoryPath[0]" />
+        </nav>
         <!-- DISABLED VIEW CONTEXT --
         <div class="marketing-area">
           <ish-content-viewcontext

--- a/src/app/pages/category/category-products/category-products.component.html
+++ b/src/app/pages/category/category-products/category-products.component.html
@@ -17,7 +17,9 @@
     <div class="col-md-3">
       <ish-skip-content-link skipToElementId="nav-breadcrumbs" linkText="common.skip_content.link.text.filter" />
       <div class="navigation-panel" [ngbCollapse]="isCollapsed">
-        <ish-category-navigation [uniqueId]="category.categoryPath[0]" />
+        <nav [attr.aria-label]="'category.navigation.aria_label' | translate">
+          <ish-category-navigation [uniqueId]="category.categoryPath[0]" />
+        </nav>
         <br />
         <ish-filter-navigation [showCategoryFilter]="false" />
       </div>

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -691,7 +691,7 @@
   "basket.validation.general.error": "Ihr Warenkorb ist nicht mehr gültig. Bitte korrigieren Sie die unten angegebenen Fehler.",
   "breadcrumbs.aria_label": "Breadcrumbs",
   "captcha.incorrect": "Die Sicherheitsprüfung ist fehlgeschlagen. Korrigieren Sie den unten angegebenen Fehler.",
-  "category.navigation.aria_label": "Kategorienavigation",
+  "category.navigation.aria_label": "Kategorie-Navigation",
   "category.navigation.skip_content.link.text": "Kategorie-Navigation überspringen",
   "checkout.account.confirm.button.label": "Bestätigen",
   "checkout.account.email.registered.heading": "Benutzerkonto",

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -691,6 +691,7 @@
   "basket.validation.general.error": "Ihr Warenkorb ist nicht mehr gültig. Bitte korrigieren Sie die unten angegebenen Fehler.",
   "breadcrumbs.aria_label": "Breadcrumbs",
   "captcha.incorrect": "Die Sicherheitsprüfung ist fehlgeschlagen. Korrigieren Sie den unten angegebenen Fehler.",
+  "category.navigation.aria_label": "Kategorienavigation",
   "category.navigation.skip_content.link.text": "Kategorie-Navigation überspringen",
   "checkout.account.confirm.button.label": "Bestätigen",
   "checkout.account.email.registered.heading": "Benutzerkonto",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -691,6 +691,7 @@
   "basket.validation.general.error": "Your shopping cart is not valid anymore. Please correct the errors indicated below.",
   "breadcrumbs.aria_label": "Breadcrumbs",
   "captcha.incorrect": "The security verification failed. Please correct the error indicated below.",
+  "category.navigation.aria_label": "Category navigation",
   "category.navigation.skip_content.link.text": "Skip category navigation",
   "checkout.account.confirm.button.label": "Confirm",
   "checkout.account.email.registered.heading": "Account",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -691,6 +691,7 @@
   "basket.validation.general.error": "Votre panier n’est plus valide. Veuillez corriger les erreurs indiquées ci-dessous.",
   "breadcrumbs.aria_label": "Breadcrumbs",
   "captcha.incorrect": "Échec de la vérification de sécurité. Veuillez corriger l’erreur indiquée ci-dessous.",
+  "category.navigation.aria_label": "Navigation par catégories",
   "category.navigation.skip_content.link.text": "Ignorer la navigation de catégorie",
   "checkout.account.confirm.button.label": "Confirmer",
   "checkout.account.email.registered.heading": "Compte",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -691,7 +691,7 @@
   "basket.validation.general.error": "Votre panier n’est plus valide. Veuillez corriger les erreurs indiquées ci-dessous.",
   "breadcrumbs.aria_label": "Breadcrumbs",
   "captcha.incorrect": "Échec de la vérification de sécurité. Veuillez corriger l’erreur indiquée ci-dessous.",
-  "category.navigation.aria_label": "Navigation par catégories",
+  "category.navigation.aria_label": "Navigation de catégorie",
   "category.navigation.skip_content.link.text": "Ignorer la navigation de catégorie",
   "checkout.account.confirm.button.label": "Confirmer",
   "checkout.account.email.registered.heading": "Compte",


### PR DESCRIPTION
## PR Type

[x] Other: Accessibility Improvements

## What Is the Current Behavior?

The category navigation is used to navigate between different pages on the website, but is not wrapped inside a `<nav>` landmark element.

Issue Number: Closes #1834

## What Is the New Behavior?

The category navigation is wrapped inside a `<nav>`-element to make it easier to find and identify this section as a navigation landmark for the website.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#107931](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107931)