### PR TITLE
test: enable `-u` parameter for tests with `@Component`/`@Input`/`@Output` decorators

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [['@babel/plugin-proposal-decorators', { legacy: true }]],
+};


### PR DESCRIPTION
>  [!IMPORTANT]
> #1859 adds the necessary dev-dependency for the plugin `@babel/plugin-proposal-decorators` that is a prerequisite for the `babel.config.js` that is added in #1857
>
> #1857 adds the `babel.config.js` to enable the `-u` parameter for tests with Angular `@Component`/`@Input`/`@Output` decorators

## PR Type

[x] Other: jest test fix

## What Is the Current Behavior?

- Jest tests fail to run with `-u` parameter (snapshot updates) if the test contains `@Component`/`@Input`/`@Output` decorators,
  -  e.g. `npx jest in-place-edit.component.spec.ts -u` if there is a changed snapshot in this test
  → Error: `"Support for the experimental syntax 'decorators' isn't currently enabled"`

## What Is the New Behavior?

- Tests with `@Component`/`@Input`/`@Output` decorators can now be executed with the `-u` parameter
- added necessary Babel plugin configuration ([`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators)) in the `babel.config.js` to support Angular decorators
- used configuration option `{ legacy: true }`:
  - necessary for Angular's TypeScript-based decorator compatibility, because Angular uses the older decorator syntax from early TC39 proposals, not the final ECMAScript standard

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#107966](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107966)