### PR TITLE
feat(accessibility): indicate which categories/filters are selected (#1832, #1858)

### DIFF
--- a/src/app/pages/category/category-navigation/category-navigation.component.html
+++ b/src/app/pages/category/category-navigation/category-navigation.component.html
@@ -6,6 +6,7 @@
           class="filter-item-name link-decoration-hover"
           [ngClass]="{ 'filter-selected': category.uniqueId === currentCategoryId }"
           [routerLink]="category.url"
+          [attr.aria-current]="category.uniqueId === currentCategoryId ? 'true' : undefined"
         >
           {{ category.name }}
         </a>

--- a/src/app/pages/category/category-navigation/category-navigation.component.spec.ts
+++ b/src/app/pages/category/category-navigation/category-navigation.component.spec.ts
@@ -61,6 +61,7 @@ describe('Category Navigation Component', () => {
         <a
         class="filter-item-name link-decoration-hover filter-selected"
         ng-reflect-router-link="/c/A/A.1"
+        aria-current="true"
         href="/c/A/A.1"
       >
         nA.1
@@ -83,6 +84,7 @@ describe('Category Navigation Component', () => {
         <a
         class="filter-item-name link-decoration-hover filter-selected"
         ng-reflect-router-link="/c/A/A.1"
+        aria-current="true"
         href="/c/A/A.1"
       >
         nA.1

--- a/src/app/shared/components/filter/filter-swatch-images/__snapshots__/filter-swatch-images.component.spec.ts.snap
+++ b/src/app/shared/components/filter/filter-swatch-images/__snapshots__/filter-swatch-images.component.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`Filter Swatch Images Component should be created 1`] = `
       class="filter-swatch btn btn-link btn-link-action"
       title="Red (5)"
       data-testing-id="filter-link-Red"
+      aria-current="true"
     >
       <span style="background-color: red"></span>
     </button>

--- a/src/app/shared/components/filter/filter-swatch-images/filter-swatch-images.component.html
+++ b/src/app/shared/components/filter/filter-swatch-images/filter-swatch-images.component.html
@@ -7,6 +7,7 @@
         [title]="facet.displayName + ' (' + facet.count + ')'"
         (click)="filter(facet)"
         [attr.data-testing-id]="'filter-link-' + (facet.displayName | ishSanitize)"
+        [attr.aria-current]="facet.selected ? 'true' : undefined"
       >
         <span
           [style.background-image]="getBackgroundImage(facet)"

--- a/src/app/shared/components/filter/filter-text/filter-text.component.html
+++ b/src/app/shared/components/filter/filter-text/filter-text.component.html
@@ -8,6 +8,7 @@
           class="btn btn-link btn-link-action link-decoration-hover"
           (click)="filter(facet)"
           [attr.data-testing-id]="'filter-link-' + (facet.name | ishSanitize)"
+          aria-current="true"
         >
           <span class="filter-item-name"> {{ facet.displayName }} </span>
           <span class="count"> ({{ facet.count }}) </span>

--- a/src/app/shared/components/filter/filter-text/filter-text.component.spec.ts
+++ b/src/app/shared/components/filter/filter-text/filter-text.component.spec.ts
@@ -49,6 +49,7 @@ describe('Filter Text Component', () => {
         <li class="filter-item filter-layer0 filter-selected">
           <button
             type="button"
+            aria-current="true"
             class="btn btn-link btn-link-action link-decoration-hover"
             data-testing-id="filter-link-LogitechName"
           >


### PR DESCRIPTION
## PR Type

[x] Other: Accessibility Improvements

## What Is the Current Behavior?

Assistive technology cannot detect which categories or filters are selected (category & product list pages).

Issue Number: Closes #1832

## What Is the New Behavior?

Active categories and filters are marked with `aria-current="true"`, so assistive technology can detect which categories/filters are currently selected.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#107979](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/107979)