### PR TITLE
fix: Order history filters open unintended

### DIFF
--- a/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.ts
+++ b/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.ts
@@ -15,7 +15,7 @@ import { UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbDateAdapter, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { Observable, distinctUntilChanged, map, shareReplay, takeUntil } from 'rxjs';
+import { Observable, distinctUntilChanged, map, shareReplay, take, takeUntil } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { OrderListQuery } from 'ish-core/models/order-list-query/order-list-query.model';
@@ -72,8 +72,9 @@ function selectArray(val: string | string[]): string[] {
 function removeEmpty<T extends Record<string, unknown>>(obj: T): T {
   return Object.keys(obj).reduce<Record<string, unknown>>((acc, key) => {
     if (Array.isArray(obj[key])) {
-      if ((obj[key] as unknown[]).length > 0) {
-        acc[key] = obj[key];
+      const filtered = (obj[key] as unknown[]).filter(v => v !== undefined && v !== '');
+      if (filtered.length > 0) {
+        acc[key] = filtered;
       }
     } else if (obj[key]) {
       acc[key] = obj[key];
@@ -126,6 +127,7 @@ function urlToQuery(params: UrlModel): Partial<OrderListQuery> {
   providers: [{ provide: NgbDateAdapter, useClass: OrderDateFilterAdapter }],
 })
 export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
+  private paramThreshold: number;
   @Input() fragmentOnRouting: string;
 
   form = new UntypedFormGroup({});
@@ -147,6 +149,11 @@ export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
       takeUntil(this.accountFacade.isLoggedIn$.pipe(whenFalsy())),
       shareReplay(1)
     );
+
+    this.isAdmin$
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(isAdmin => (this.paramThreshold = isAdmin ? 2 : 1));
+
     this.fields$ = this.isAdmin$.pipe(
       map(isAdmin => [
         {
@@ -213,14 +220,19 @@ export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
-      if (
-        Object.keys(params).length > 1 ||
-        (Object.keys(params).length === 1 && Object.keys(params)[0] !== 'orderNo')
-      ) {
+      const hasRelevantFilters =
+        !!params.sku || !!params.from || !!params.to || (!!params.buyer && params.buyer !== 'all');
+
+      const hasOnlyOrderNo =
+        Object.keys(params)[0] === 'orderNo' &&
+        Object.keys(params).length <= this.paramThreshold &&
+        params.buyer === 'all';
+
+      if (hasRelevantFilters || (Object.keys(params).length > this.paramThreshold && !hasOnlyOrderNo)) {
         this.formIsCollapsed = false;
       }
-      this.form.patchValue(urlToModel(params));
 
+      this.form.patchValue(urlToModel(params));
       this.model$ = this.getModel(params);
     });
   }

--- a/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.ts
+++ b/src/app/pages/account-order-history/account-order-filters/account-order-filters.component.ts
@@ -15,7 +15,7 @@ import { UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbDateAdapter, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { Observable, distinctUntilChanged, map, shareReplay, take, takeUntil } from 'rxjs';
+import { Observable, distinctUntilChanged, map, shareReplay, takeUntil } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { OrderListQuery } from 'ish-core/models/order-list-query/order-list-query.model';
@@ -72,9 +72,8 @@ function selectArray(val: string | string[]): string[] {
 function removeEmpty<T extends Record<string, unknown>>(obj: T): T {
   return Object.keys(obj).reduce<Record<string, unknown>>((acc, key) => {
     if (Array.isArray(obj[key])) {
-      const filtered = (obj[key] as unknown[]).filter(v => v !== undefined && v !== '');
-      if (filtered.length > 0) {
-        acc[key] = filtered;
+      if ((obj[key] as unknown[]).length > 0) {
+        acc[key] = obj[key];
       }
     } else if (obj[key]) {
       acc[key] = obj[key];
@@ -101,12 +100,12 @@ function modelToUrl(model: FormModel): UrlModel {
     from: model.date?.fromDate,
     to: model.date?.toDate,
     orderNo: model.orderNo?.split(',').map(s => s.trim()),
-    sku: model.sku?.split(',').map(s => s.trim()),
+    sku: model.sku ? model.sku.split(',').map(s => s.trim()) : undefined,
     state: model.state
       ?.split(',')
       .map(s => s.trim())
       .filter(x => !!x),
-    buyer: model.buyer,
+    buyer: model.buyer === 'all' || !model.buyer ? undefined : model.buyer,
   });
 }
 
@@ -127,7 +126,6 @@ function urlToQuery(params: UrlModel): Partial<OrderListQuery> {
   providers: [{ provide: NgbDateAdapter, useClass: OrderDateFilterAdapter }],
 })
 export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
-  private paramThreshold: number;
   @Input() fragmentOnRouting: string;
 
   form = new UntypedFormGroup({});
@@ -149,11 +147,6 @@ export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
       takeUntil(this.accountFacade.isLoggedIn$.pipe(whenFalsy())),
       shareReplay(1)
     );
-
-    this.isAdmin$
-      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
-      .subscribe(isAdmin => (this.paramThreshold = isAdmin ? 2 : 1));
-
     this.fields$ = this.isAdmin$.pipe(
       map(isAdmin => [
         {
@@ -220,19 +213,14 @@ export class AccountOrderFiltersComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
-      const hasRelevantFilters =
-        !!params.sku || !!params.from || !!params.to || (!!params.buyer && params.buyer !== 'all');
-
-      const hasOnlyOrderNo =
-        Object.keys(params)[0] === 'orderNo' &&
-        Object.keys(params).length <= this.paramThreshold &&
-        params.buyer === 'all';
-
-      if (hasRelevantFilters || (Object.keys(params).length > this.paramThreshold && !hasOnlyOrderNo)) {
+      if (
+        Object.keys(params).length > 1 ||
+        (Object.keys(params).length === 1 && Object.keys(params)[0] !== 'orderNo')
+      ) {
         this.formIsCollapsed = false;
       }
-
       this.form.patchValue(urlToModel(params));
+
       this.model$ = this.getModel(params);
     });
   }


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

Order search filters are opening automatically after triggering a search on order history page, even none filters are applied. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Problem:
After introducing the buyer filter, the logic for handling the expansion of the filter panel did not account for this additional filter. There are some parameters that are always being applied with a default value and that result in  unnecessary empty url search parameters.
  
## What Is the New Behavior?

Order history filters are now only opening automatically if the filter toggle link has been clicked or if the order search contains a filter other than the order number.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#108218](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/108218)