### PR TITLE
fix(accessibility): use skip content link component (#1824, #1838)

### DIFF
--- a/src/app/pages/account/account-page.component.html
+++ b/src/app/pages/account/account-page.component.html
@@ -1,7 +1,7 @@
 <div class="account-wrapper">
   <div class="row account-main">
     <div class="col-lg-3 account-nav-box">
-      <ish-skip-content-link skipToElementId="page-main-content" linkText="account.navigation.skip_content.link.text" />
+      <ish-skip-content-link skipToElementId="nav-breadcrumbs" linkText="account.navigation.skip_content.link.text" />
       <ish-account-navigation [deviceType]="deviceType$ | async" />
     </div>
     <div id="page-main-content" class="col-lg-9" tabindex="-1">


### PR DESCRIPTION
## PR Type

[x] Bugfix
[x] Other: Accessibility Improvement

## What Is the Current Behavior?

The target of the `<skip-content-link>` on the "My Account" navigation is set to the main content of the page, which causes unnecessary scrolling on longer pages, because the skip-link scrolls to the center of the target.

## What Is the New Behavior?

The `<skip-content-link>` on the "My Account" navigation focuses on the breadcrumbs to prevent unnecessary scrolling.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information

Related to #1824 and #1838

[AB#108360](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/108360)