### PR TITLE
fix: select the most recently created "New" quote request when adding a product

### DIFF
--- a/src/app/extensions/quoting/services/quoting/quoting.service.ts
+++ b/src/app/extensions/quoting/services/quoting/quoting.service.ts
@@ -1,8 +1,8 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { pick } from 'lodash-es';
-import { EMPTY, Observable, concat, defer, forkJoin, iif, of, throwError } from 'rxjs';
-import { concatMap, defaultIfEmpty, expand, filter, last, map, take } from 'rxjs/operators';
+import { Observable, concat, defer, forkJoin, iif, of, throwError } from 'rxjs';
+import { concatMap, defaultIfEmpty, last, map, take } from 'rxjs/operators';
 
 import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
@@ -11,13 +11,7 @@ import { QuoteRequestUpdate } from '../../models/quote-request-update/quote-requ
 import { QuotingHelper } from '../../models/quoting/quoting.helper';
 import { QuoteData } from '../../models/quoting/quoting.interface';
 import { QuotingMapper } from '../../models/quoting/quoting.mapper';
-import {
-  QuoteCompletenessLevel,
-  QuoteRequest,
-  QuoteStub,
-  QuoteStubFromAttributes,
-  QuotingEntity,
-} from '../../models/quoting/quoting.model';
+import { QuoteCompletenessLevel, QuoteRequest, QuoteStub, QuotingEntity } from '../../models/quoting/quoting.model';
 
 @Injectable({ providedIn: 'root' })
 export class QuotingService {
@@ -130,34 +124,25 @@ export class QuotingService {
       .pipe(map(link => this.quoteMapper.fromData(link, 'QuoteRequest')));
   }
 
-  private expansion(stubs: (QuoteStub | QuoteStubFromAttributes)[]) {
-    return stubs?.length
-      ? (stubs[0].completenessLevel === 'List'
-          ? of(stubs[0])
-          : this.getQuoteDetails(stubs[0].id, stubs[0].type, 'List')
-        ).pipe(
-          map(quoteRequest => ({
-            quoteRequest,
-            next: stubs.slice(1),
-          }))
-        )
-      : EMPTY;
-  }
-
   private getOrCreateActiveQuoteRequest() {
     return this.apiService
       .b2bUserEndpoint()
       .get('quoterequests', {
-        params: new HttpParams().set('attrs', 'submittedDate,editable'),
+        params: new HttpParams().set('attrs', 'submittedDate,creationDate'),
       })
       .pipe(
         unpackEnvelope<Link>(),
-        map(qrs => qrs.reverse()),
-        map(links => links.map(link => this.quoteMapper.fromData(link, 'QuoteRequest'))),
-        concatMap(stubs => this.expansion(stubs)),
-        expand(({ next }) => this.expansion(next)),
-        map(({ quoteRequest }) => quoteRequest),
-        filter(quoteRequest => QuotingHelper.state(quoteRequest) === 'New'),
+        map(links =>
+          links
+            // map Link data to QuoteRequest
+            .map(link => this.quoteMapper.fromData(link, 'QuoteRequest') as QuoteRequest)
+            // filter out submitted quote requests, keep only "New" ones
+            .filter(quoteRequest => !quoteRequest.submittedDate)
+            // sort by creationDate descending
+            .sort((qr1, qr2) => qr2.creationDate - qr1.creationDate)
+        ),
+        // take the most recent "New" quote request
+        map(quoteRequests => quoteRequests[0]),
         take(1),
         defaultIfEmpty(undefined as QuoteRequest)
       )


### PR DESCRIPTION
## PR Type

[x] Bugfix

## What Is the Current Behavior?

When adding a product to a quote request the current logic fetches all quote requests and then goes through the response list in reverse order until it finds the first quote request that has no submit date, meaning it is a "New" not yet submitted quote request. This quote request is used to add the product. Unfortunately the list returned from ICM is not sorted so the PWA does not always select the latest quote request that was created if there is more than one quote request.

## What Is the New Behavior?

The PWA now filters and sorts the list of returned quote requests so it will always select the newest unsubmitted quote request to add the product to, even if there is more than one quote request.

## Does this PR Introduce a Breaking Change?

[x] No

## Other Information


[AB#108745](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/108745)