### PR TITLE
feat: select a pagelet triggered by design view

### DIFF
--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -5,6 +5,7 @@ import { delay, switchMap, tap } from 'rxjs/operators';
 
 import { CallParameters } from 'ish-core/models/call-parameters/call-parameters.model';
 import { CategoryHelper } from 'ish-core/models/category/category.helper';
+import { getDesignViewSelectedPageletId } from 'ish-core/store/content/design-view';
 import { getContentInclude, loadContentInclude } from 'ish-core/store/content/includes';
 import { getCompleteContentPageTree, getContentPageTree, loadContentPageTree } from 'ish-core/store/content/page-tree';
 import { getContentPagelet } from 'ish-core/store/content/pagelets';
@@ -25,6 +26,7 @@ export class CMSFacade {
 
   contentPage$ = this.store.pipe(select(getSelectedContentPage));
   contentPageLoading$ = this.store.pipe(select(getContentPageLoading));
+  designViewSelectedPageletId$ = this.store.pipe(select(getDesignViewSelectedPageletId));
 
   contentInclude$(includeId$: Observable<string>) {
     return combineLatest([includeId$.pipe(whenTruthy()), this.store.pipe(select(getPGID))]).pipe(

--- a/src/app/core/store/content/content-store.module.ts
+++ b/src/app/core/store/content/content-store.module.ts
@@ -6,6 +6,7 @@ import { pick } from 'lodash-es';
 import { resetOnLogoutMeta } from 'ish-core/utils/meta-reducers';
 
 import { ContentState } from './content-store';
+import { designViewReducer } from './design-view/design-view.reducer';
 import { IncludesEffects } from './includes/includes.effects';
 import { includesReducer } from './includes/includes.reducer';
 import { PageTreeEffects } from './page-tree/page-tree.effects';
@@ -25,6 +26,7 @@ const contentReducers: ActionReducerMap<ContentState> = {
   viewcontexts: viewcontextsReducer,
   pagetree: pageTreeReducer,
   parameters: parametersReducer,
+  designView: designViewReducer,
 };
 
 const contentEffects = [IncludesEffects, PagesEffects, ViewcontextsEffects, PageTreeEffects, ParametersEffects];

--- a/src/app/core/store/content/content-store.ts
+++ b/src/app/core/store/content/content-store.ts
@@ -1,5 +1,6 @@
 import { createFeatureSelector } from '@ngrx/store';
 
+import { DesignViewState } from './design-view/design-view.reducer';
 import { IncludesState } from './includes/includes.reducer';
 import { PageTreeState } from './page-tree/page-tree.reducer';
 import { PageletsState } from './pagelets/pagelets.reducer';
@@ -14,6 +15,7 @@ export interface ContentState {
   viewcontexts: ViewcontextsState;
   pagetree: PageTreeState;
   parameters: ParametersState;
+  designView: DesignViewState;
 }
 
 export const getContentState = createFeatureSelector<ContentState>('content');

--- a/src/app/core/store/content/design-view/design-view.actions.ts
+++ b/src/app/core/store/content/design-view/design-view.actions.ts
@@ -1,0 +1,11 @@
+import { createActionGroup } from '@ngrx/store';
+
+import { payload } from 'ish-core/utils/ngrx-creators';
+
+// not-dead-code
+export const designViewActions = createActionGroup({
+  source: 'Design View',
+  events: {
+    'Select Pagelet': payload<{ pageletId: string }>(),
+  },
+});

--- a/src/app/core/store/content/design-view/design-view.reducer.ts
+++ b/src/app/core/store/content/design-view/design-view.reducer.ts
@@ -1,0 +1,23 @@
+import { createReducer, on } from '@ngrx/store';
+
+import { designViewActions } from './design-view.actions';
+
+export interface DesignViewState {
+  selectedPageletId: string;
+}
+
+const initialState: DesignViewState = {
+  selectedPageletId: undefined,
+};
+
+export const designViewReducer = createReducer(
+  initialState,
+
+  on(
+    designViewActions.selectPagelet,
+    (state, action): DesignViewState => ({
+      ...state,
+      selectedPageletId: action.payload.pageletId,
+    })
+  )
+);

--- a/src/app/core/store/content/design-view/design-view.selectors.spec.ts
+++ b/src/app/core/store/content/design-view/design-view.selectors.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ContentStoreModule } from 'ish-core/store/content/content-store.module';
+import { CoreStoreModule } from 'ish-core/store/core/core-store.module';
+import { StoreWithSnapshots, provideStoreSnapshots } from 'ish-core/utils/dev/ngrx-testing';
+
+import { designViewActions } from './design-view.actions';
+import { getDesignViewSelectedPageletId } from './design-view.selectors';
+
+describe('Design View Selectors', () => {
+  let store$: StoreWithSnapshots;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ContentStoreModule.forTesting('designView'), CoreStoreModule.forTesting()],
+      providers: [provideStoreSnapshots()],
+    });
+
+    store$ = TestBed.inject(StoreWithSnapshots);
+  });
+
+  describe('initial state', () => {
+    it('should not select a selectedPageletId in initial state', () => {
+      expect(getDesignViewSelectedPageletId(store$.state)).toBeUndefined();
+    });
+  });
+
+  describe('SelectedPageletId', () => {
+    it('should select a selectedPageletId after it was set', () => {
+      store$.dispatch(designViewActions.selectPagelet({ pageletId: 'dummy' }));
+
+      expect(getDesignViewSelectedPageletId(store$.state)).toBe('dummy');
+    });
+  });
+});

--- a/src/app/core/store/content/design-view/design-view.selectors.ts
+++ b/src/app/core/store/content/design-view/design-view.selectors.ts
@@ -1,0 +1,7 @@
+import { createSelector } from '@ngrx/store';
+
+import { getContentState } from 'ish-core/store/content/content-store';
+
+const getDesignViewState = createSelector(getContentState, state => state.designView);
+
+export const getDesignViewSelectedPageletId = createSelector(getDesignViewState, state => state.selectedPageletId);

--- a/src/app/core/store/content/design-view/index.ts
+++ b/src/app/core/store/content/design-view/index.ts
@@ -1,0 +1,3 @@
+// API to access ngrx pages state
+export * from './design-view.actions';
+export * from './design-view.selectors';

--- a/src/app/core/utils/design-view/design-view.service.ts
+++ b/src/app/core/utils/design-view/design-view.service.ts
@@ -3,27 +3,29 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { filter, first, fromEvent, map, switchMap, tap } from 'rxjs';
 
+import { designViewActions } from 'ish-core/store/content/design-view';
 import { getCurrentLocale } from 'ish-core/store/core/configuration';
 import { DomService } from 'ish-core/utils/dom/dom.service';
 import { whenTruthy } from 'ish-core/utils/operators';
 
-interface DesignViewMessage {
-  type:
-    | 'dv-clientAction'
-    | 'dv-clientNavigation'
-    | 'dv-clientReady'
-    | 'dv-clientRefresh'
-    | 'dv-clientLocale'
-    | 'dv-clientStable'
-    | 'dv-clientContentIds';
+interface DesignViewMessage<T = ToDVMessageType> {
+  type: T;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: any;
 }
 
+type FromDVMessageType = 'dv-clientRefresh' | 'dv-clientHighlightPagelet';
+
+type ToDVMessageType =
+  | 'dv-clientAction'
+  | 'dv-clientReady'
+  | 'dv-clientNavigation'
+  | 'dv-clientStable'
+  | 'dv-clientLocale'
+  | 'dv-clientContentIds';
+
 @Injectable({ providedIn: 'root' })
 export class DesignViewService {
-  private allowedHostMessageTypes = ['dv-clientRefresh'];
-
   constructor(
     private router: Router,
     private appRef: ApplicationRef,
@@ -78,7 +80,7 @@ export class DesignViewService {
   private listenToHostMessages() {
     fromEvent<MessageEvent>(window, 'message')
       .pipe(
-        filter(e => e.data.hasOwnProperty('type') && this.allowedHostMessageTypes.includes(e.data.type)),
+        filter(e => e.data.hasOwnProperty('type') && e.data.type.startsWith('dv-client')),
         map(message => message.data)
       )
       .subscribe(message => this.handleHostMessage(message));
@@ -134,11 +136,19 @@ export class DesignViewService {
    * Handle incoming message from the host window.
    * Invoked by the event listener in `listenToHostMessages()` when a new message arrives.
    */
-  private handleHostMessage(message: DesignViewMessage) {
+  private handleHostMessage(message: DesignViewMessage<FromDVMessageType>) {
     switch (message.type) {
       case 'dv-clientRefresh': {
         location.reload();
-        return;
+        break;
+      }
+      case 'dv-clientHighlightPagelet': {
+        this.store.dispatch(designViewActions.selectPagelet({ pageletId: message.payload.componentId }));
+        break;
+      }
+      default: {
+        // eslint-disable-next-line no-console
+        console.warn(`Design View Service received unknown message type: ${message.type}`, message);
       }
     }
   }

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="isDesignViewMode && type; else cmsOutlet">
-  <div class="design-view-wrapper" [ngClass]="type">
+  <div class="design-view-wrapper" [ngClass]="[type, (isPageletSelected$ | async) ? 'pagelet-selected' : '']">
     <div class="design-view-wrapper-actions">
       <ng-container [ngSwitch]="type">
         <!-- pagelet -->
@@ -13,7 +13,6 @@
                 ('designview.edit.link.title' | translate) + (pagelet.displayName ? ' ' + pagelet.displayName : '')
               }}"
             >
-              {{ pagelet.displayName ? pagelet.displayName : '(Language missing)' }}
               <fa-icon [icon]="['fas', 'pencil-alt']" />
             </button>
             <!--

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
 // DesignView colors
-$design-view-color-pagelet: #00b8d9;
+$design-view-color-pagelet: #399;
 $design-view-color-slot: #399;
 $design-view-color-include: #ce5399;
 
@@ -22,7 +22,7 @@ $design-view-color-include: #ce5399;
       display: flex;
       gap: $space-default;
       align-items: center;
-      padding: 0.375rem 0.75rem;
+      padding: 0 1rem;
       margin-bottom: 0;
       font-family: $font-family-regular;
       font-weight: normal;
@@ -60,6 +60,21 @@ $design-view-color-include: #ce5399;
 
       > .design-view-wrapper-actions {
         display: flex;
+      }
+    }
+
+    &.pagelet-selected {
+      &::before {
+        // create highlighted wrapping element which overlays the component
+        position: absolute;
+        top: 0;
+        z-index: 2;
+        display: block;
+        width: 100%;
+        height: 100%;
+        pointer-events: none; // important not to block mouse events on included components
+        content: '';
+        border: 2px solid $design-view-color-pagelet;
       }
     }
 

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.spec.ts
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.spec.ts
@@ -33,6 +33,7 @@ describe('Content Design View Wrapper Component', () => {
     when(cmsFacade.pagelet$(anything())).thenReturn(
       of({ id: 'xyz', displayName: 'Pagelet Name xyz' } as ContentPageletView)
     );
+    when(cmsFacade.designViewSelectedPageletId$).thenReturn(of('xyz'));
     when(previewService.isDesignViewMode).thenReturn(true);
 
     await TestBed.configureTestingModule({
@@ -70,10 +71,13 @@ describe('Content Design View Wrapper Component', () => {
 
     expect(component.type).toEqual('pagelet');
     expect(element).toMatchInlineSnapshot(`
-      <div class="design-view-wrapper pagelet" ng-reflect-ng-class="pagelet">
+      <div
+        class="design-view-wrapper pagelet pagelet-selected"
+        ng-reflect-ng-class="pagelet,pagelet-selected"
+      >
         <div class="design-view-wrapper-actions">
           <button type="button" class="btn" title="designview.edit.link.title Pagelet Name xyz">
-            Pagelet Name xyz <fa-icon ng-reflect-icon="fas,pencil-alt"></fa-icon>
+            <fa-icon ng-reflect-icon="fas,pencil-alt"></fa-icon>
           </button>
         </div>
       </div>
@@ -96,7 +100,7 @@ describe('Content Design View Wrapper Component', () => {
 
     expect(component.type).toEqual('slot');
     expect(element).toMatchInlineSnapshot(`
-      <div class="design-view-wrapper slot" ng-reflect-ng-class="slot">
+      <div class="design-view-wrapper slot" ng-reflect-ng-class="slot,">
         <div class="design-view-wrapper-actions">
           <div class="name">Slot Name xyz</div>
           <button type="button" class="btn" title="designview.add.link.title">
@@ -116,7 +120,7 @@ describe('Content Design View Wrapper Component', () => {
 
     expect(component.type).toEqual('include');
     expect(element).toMatchInlineSnapshot(`
-      <div class="design-view-wrapper include" ng-reflect-ng-class="include">
+      <div class="design-view-wrapper include" ng-reflect-ng-class="include,">
         <div class="design-view-wrapper-actions">
           <div class="name">Include Name xyz</div>
           <button type="button" class="btn" title="designview.add.link.title">

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.ts
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { CMSFacade } from 'ish-core/facades/cms.facade';
 import { ContentPageletEntryPointView, ContentPageletView } from 'ish-core/models/content-view/content-view.model';
@@ -26,6 +26,8 @@ export class ContentDesignViewWrapperComponent implements OnInit {
 
   isDesignViewMode = false; // temporary activation switch
 
+  isPageletSelected$: Observable<boolean>;
+
   constructor(
     private cmsFacade: CMSFacade,
     private previewService: PreviewService,
@@ -33,16 +35,20 @@ export class ContentDesignViewWrapperComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    this.isDesignViewMode = this.previewService.isDesignViewMode;
+
     if (this.pageletId) {
       this.type = 'pagelet';
       this.pagelet$ = this.cmsFacade.pagelet$(this.pageletId);
+
+      this.isPageletSelected$ = this.cmsFacade.designViewSelectedPageletId$.pipe(
+        map(id => (this.isDesignViewMode ? this.pageletId === id : false))
+      );
     } else if (this.slotId) {
       this.type = 'slot';
     } else if (this.include) {
       this.type = 'include';
     }
-
-    this.isDesignViewMode = this.previewService.isDesignViewMode;
   }
 
   triggerAction(id: string, action: string) {


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/intershop-pwa/blob/develop/CONTRIBUTING.md
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Visual changes have been approved by VD / IAD (if applicable)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes
[ ] Other: <!--Please describe.-->

## What Is the Current Behavior?

Selecting a leaf pagelet component in the design view page structure tree is not supported.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

If a user selects a leaf pagelet component in the design view it is highlighted in the pwa. After closing the page structure panel the pagelet component is not highlighted any more.

The interaction between the pwa and the design view is still incomplete, e.g. if the user starts to edit a pagelet component the previously selected component in the design view page structure tree as well as the selected component in the pwa remain selected.
This will be handled in another PR.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

## Other Information


[AB#108931](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/108931)