### PR TITLE
test: add tests for Sparque suggest products component

### DIFF
--- a/src/app/shared/components/search/suggest-categories/suggest-categories.component.spec.ts
+++ b/src/app/shared/components/search/suggest-categories/suggest-categories.component.spec.ts
@@ -15,8 +15,7 @@ describe('Suggest Categories Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
-      declarations: [MockComponent(SuggestCategoriesTileComponent), SuggestCategoriesComponent],
+      imports: [MockComponent(SuggestCategoriesTileComponent), SuggestCategoriesComponent, TranslateModule.forRoot()],
     }).compileComponents();
   });
 

--- a/src/app/shared/components/search/suggest-products-tile/suggest-products-tile.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products-tile/suggest-products-tile.component.spec.ts
@@ -23,8 +23,7 @@ describe('Suggest Products Tile Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [MockComponent(ProductImageComponent), SuggestProductsTileComponent],
+      imports: [MockComponent(ProductImageComponent), RouterTestingModule, SuggestProductsTileComponent],
       providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }],
     }).compileComponents();
 

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -1,15 +1,14 @@
-/* eslint-disable ish-custom-rules/no-intelligence-in-artifacts */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
-import { ReplaySubject } from 'rxjs';
+import { ReplaySubject, of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
-import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
-import { getServerConfig } from 'ish-core/store/core/server-config';
-import { getShoppingState } from 'ish-core/store/shopping/shopping-store';
-import { SuggestProductsTileComponent } from 'ish-shared/components/search/suggest-products-tile/suggest-products-tile.component';
+import { AppFacade } from 'ish-core/facades/app.facade';
+import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+import { CategoryView } from 'ish-core/models/category-view/category-view.model';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
 
 import { SuggestProductsComponent } from './suggest-products.component';
 
@@ -17,32 +16,26 @@ describe('Suggest Products Component', () => {
   let component: SuggestProductsComponent;
   let fixture: ComponentFixture<SuggestProductsComponent>;
   let element: HTMLElement;
-
-  let context: ProductContextFacade;
+  let appFacade: AppFacade;
+  let shoppingFacade: ShoppingFacade;
 
   beforeEach(async () => {
-    context = mock(ProductContextFacade);
-    when(context.set(anything)).thenReturn(undefined);
+    appFacade = mock(AppFacade);
+    when(appFacade.serverSetting$<number>(anything())).thenReturn(of(undefined as unknown as number));
+
+    shoppingFacade = mock(ShoppingFacade);
+    // return a minimal product view for any requested sku/level
+    when(shoppingFacade.product$(anything(), anything())).thenReturn(
+      of({ sku: 'any', name: 'Any Product', available: true, minOrderQuantity: 1 } as unknown as ProductView)
+    );
+    // category lookup can be undefined
+    when(shoppingFacade.category$(anything())).thenReturn(of(undefined as unknown as CategoryView));
+
     await TestBed.configureTestingModule({
-      imports: [MockComponent(SuggestProductsTileComponent), SuggestProductsComponent, TranslateModule.forRoot()],
+      imports: [RouterTestingModule, SuggestProductsComponent, TranslateModule.forRoot()],
       providers: [
-        { provide: ProductContextFacade, useFactory: () => instance(context) },
-        provideMockStore({
-          selectors: [
-            { selector: getServerConfig, value: '' },
-            {
-              selector: getShoppingState,
-              value: {
-                categories: {},
-                products: {
-                  failed: [],
-                  entities: {},
-                  defaultVariation: {},
-                },
-              },
-            },
-          ],
-        }),
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
+        { provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) },
       ],
     }).compileComponents();
   });
@@ -56,6 +49,7 @@ describe('Suggest Products Component', () => {
     component.maxAutoSuggests = 2;
     component.inputTerms$ = new ReplaySubject<string>(1);
     component.inputTerms$.next('cat');
+    component.deviceType = 'desktop';
   });
 
   it('should be created', () => {
@@ -64,15 +58,34 @@ describe('Suggest Products Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
-  it('should display the correct number of product suggestions', () => {
+  it('should display the correct number (maxAutoSuggests = 2) of product suggestions', () => {
     fixture.detectChanges();
+    // should contain custom elements for product tiles
+    expect(findAllCustomElements(element)).toContain('ish-suggest-products-tile');
     expect(element.querySelectorAll('ish-suggest-products-tile')).toHaveLength(2);
   });
 
-  it('should pass correct products to suggest-products-tile components', () => {
+  it('should limit displayed products to maxAutoSuggests', () => {
+    // set more products than maxAutoSuggests
+    component.products = ['12345', '67890', '98765', '43210'];
+    component.maxAutoSuggests = 3;
     fixture.detectChanges();
-    const tileComponents = element.querySelectorAll('ish-suggest-products-tile');
-    expect(tileComponents[0].getAttribute('ng-reflect-sku')).toBe('12345');
-    expect(tileComponents[1].getAttribute('ng-reflect-sku')).toBe('67890');
+
+    // should only show the first 3 despite having 4 products
+    expect(element.querySelectorAll('ish-suggest-products-tile')).toHaveLength(3);
+  });
+
+  it('should display headline text', () => {
+    fixture.detectChanges();
+    const headline = element.querySelector('.headline');
+    expect(headline).toBeTruthy();
+    expect(headline.textContent.trim()).toBe('suggest.products.headline');
+  });
+
+  it('should emit routeChange when handleInputFocus is called', () => {
+    // setup spy using ts-mockito
+    const emitSpy = jest.spyOn(component.routeChange, 'emit');
+    component.handleInputFocus();
+    expect(emitSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
+import { ReplaySubject } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+
+import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { getServerConfig } from 'ish-core/store/core/server-config';
+import { getShoppingState } from 'ish-core/store/shopping/shopping-store';
+import { SuggestProductsTileComponent } from 'ish-shared/components/search/suggest-products-tile/suggest-products-tile.component';
+
+import { SuggestProductsComponent } from './suggest-products.component';
+
+describe('Suggest Products Component', () => {
+  let component: SuggestProductsComponent;
+  let fixture: ComponentFixture<SuggestProductsComponent>;
+  let element: HTMLElement;
+
+  let context: ProductContextFacade;
+
+  beforeEach(async () => {
+    context = mock(ProductContextFacade);
+    when(context.set(anything)).thenReturn(undefined);
+    await TestBed.configureTestingModule({
+      imports: [MockComponent(SuggestProductsTileComponent), SuggestProductsComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: ProductContextFacade, useFactory: () => instance(context) },
+        provideMockStore({
+          selectors: [
+            { selector: getServerConfig, value: '' },
+            {
+              selector: getShoppingState,
+              value: {
+                categories: {},
+                products: {
+                  failed: [],
+                  entities: {},
+                  defaultVariation: {},
+                },
+              },
+            },
+          ],
+        }),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SuggestProductsComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+
+    component.products = ['12345', '67890'];
+    component.maxAutoSuggests = 2;
+    component.inputTerms$ = new ReplaySubject<string>(1);
+    component.inputTerms$.next('cat');
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should display the correct number of product suggestions', () => {
+    fixture.detectChanges();
+    expect(element.querySelectorAll('ish-suggest-products-tile')).toHaveLength(2);
+  });
+
+  it('should pass correct products to suggest-products-tile components', () => {
+    fixture.detectChanges();
+    const tileComponents = element.querySelectorAll('ish-suggest-products-tile');
+    expect(tileComponents[0].getAttribute('ng-reflect-sku')).toBe('12345');
+    expect(tileComponents[1].getAttribute('ng-reflect-sku')).toBe('67890');
+  });
+});

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ish-custom-rules/no-intelligence-in-artifacts */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateModule } from '@ngx-translate/core';

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -21,34 +21,11 @@ describe('Suggest Products Component', () => {
 
   beforeEach(async () => {
     appFacade = mock(AppFacade);
-    when(appFacade.serverSetting$<number>(anything())).thenReturn(of(10)); // using a reasonable default value
-
-    // factory function for creating properly typed mock ProductView objects
-    function createMockProductView(partial: Partial<ProductView> = {}): ProductView {
-      return {
-        sku: 'test',
-        name: 'Test Product',
-        shortDescription: '',
-        longDescription: '',
-        available: true,
-        minOrderQuantity: 1,
-        maxOrderQuantity: 100,
-        stepOrderQuantity: 1,
-        type: 'Product',
-        readyForShipmentMin: 0,
-        readyForShipmentMax: 0,
-        averageRating: 0,
-        ...partial,
-      } as ProductView;
-    }
-
     shoppingFacade = mock(ShoppingFacade);
-    // return a minimal product view for any requested sku/level
-    when(shoppingFacade.product$(anything(), anything())).thenReturn(
-      of(createMockProductView({ sku: 'any', name: 'Any Product' }))
-    );
-    // category lookup can be undefined
+
+    when(appFacade.serverSetting$<number>(anything())).thenReturn(of(10));
     when(shoppingFacade.category$(anything())).thenReturn(of({} as CategoryView));
+    when(shoppingFacade.product$(anything(), anything())).thenReturn(of({} as ProductView));
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, TranslateModule.forRoot()],

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -32,7 +32,7 @@ describe('Suggest Products Component', () => {
     when(shoppingFacade.category$(anything())).thenReturn(of(undefined as unknown as CategoryView));
 
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SuggestProductsComponent, TranslateModule.forRoot()],
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
       providers: [
         { provide: AppFacade, useFactory: () => instance(appFacade) },
         { provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) },

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { MockComponent } from 'ng-mocks';
 import { ReplaySubject, of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
@@ -10,7 +9,6 @@ import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
-import { SuggestProductsTileComponent } from 'ish-shared/components/search/suggest-products-tile/suggest-products-tile.component';
 
 import { SuggestProductsComponent } from './suggest-products.component';
 
@@ -30,12 +28,7 @@ describe('Suggest Products Component', () => {
     when(shoppingFacade.product$(anything(), anything())).thenReturn(of({} as ProductView));
 
     await TestBed.configureTestingModule({
-      imports: [
-        MockComponent(SuggestProductsTileComponent),
-        RouterTestingModule,
-        SuggestProductsComponent,
-        TranslateModule.forRoot(),
-      ],
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
       providers: [
         { provide: AppFacade, useFactory: () => instance(appFacade) },
         { provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) },

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -21,15 +21,34 @@ describe('Suggest Products Component', () => {
 
   beforeEach(async () => {
     appFacade = mock(AppFacade);
-    when(appFacade.serverSetting$<number>(anything())).thenReturn(of(undefined as unknown as number));
+    when(appFacade.serverSetting$<number>(anything())).thenReturn(of(10)); // using a reasonable default value
+
+    // factory function for creating properly typed mock ProductView objects
+    function createMockProductView(partial: Partial<ProductView> = {}): ProductView {
+      return {
+        sku: 'test',
+        name: 'Test Product',
+        shortDescription: '',
+        longDescription: '',
+        available: true,
+        minOrderQuantity: 1,
+        maxOrderQuantity: 100,
+        stepOrderQuantity: 1,
+        type: 'Product',
+        readyForShipmentMin: 0,
+        readyForShipmentMax: 0,
+        averageRating: 0,
+        ...partial,
+      } as ProductView;
+    }
 
     shoppingFacade = mock(ShoppingFacade);
     // return a minimal product view for any requested sku/level
     when(shoppingFacade.product$(anything(), anything())).thenReturn(
-      of({ sku: 'any', name: 'Any Product', available: true, minOrderQuantity: 1 } as unknown as ProductView)
+      of(createMockProductView({ sku: 'any', name: 'Any Product' }))
     );
     // category lookup can be undefined
-    when(shoppingFacade.category$(anything())).thenReturn(of(undefined as unknown as CategoryView));
+    when(shoppingFacade.category$(anything())).thenReturn(of({} as CategoryView));
 
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, TranslateModule.forRoot()],
@@ -58,6 +77,13 @@ describe('Suggest Products Component', () => {
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 
+  it('should display headline text', () => {
+    fixture.detectChanges();
+    const headline = element.querySelector('.headline');
+    expect(headline).toBeTruthy();
+    expect(headline.textContent.trim()).toBe('suggest.products.headline');
+  });
+
   it('should display the correct number (maxAutoSuggests = 2) of product suggestions', () => {
     fixture.detectChanges();
     // should contain custom elements for product tiles
@@ -75,17 +101,20 @@ describe('Suggest Products Component', () => {
     expect(element.querySelectorAll('ish-suggest-products-tile')).toHaveLength(3);
   });
 
-  it('should display headline text', () => {
+  it('should show fewer products when products array is smaller than maxAutoSuggests', () => {
+    component.products = ['12345'];
+    component.maxAutoSuggests = 5;
     fixture.detectChanges();
-    const headline = element.querySelector('.headline');
-    expect(headline).toBeTruthy();
-    expect(headline.textContent.trim()).toBe('suggest.products.headline');
+
+    expect(element.querySelectorAll('ish-suggest-products-tile')).toHaveLength(1);
   });
 
-  it('should emit routeChange when handleInputFocus is called', () => {
-    // setup spy using ts-mockito
-    const emitSpy = jest.spyOn(component.routeChange, 'emit');
-    component.handleInputFocus();
-    expect(emitSpy).toHaveBeenCalled();
+  it('should handle undefined maxAutoSuggests by showing all products', () => {
+    component.products = ['12345', '67890', '98765'];
+    component.maxAutoSuggests = undefined;
+    fixture.detectChanges();
+
+    // without maxAutoSuggests limit, all products should be displayed
+    expect(element.querySelectorAll('ish-suggest-products-tile')).toHaveLength(3);
   });
 });

--- a/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
+++ b/src/app/shared/components/search/suggest-products/suggest-products.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { ReplaySubject, of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
@@ -9,6 +10,7 @@ import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { CategoryView } from 'ish-core/models/category-view/category-view.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
+import { SuggestProductsTileComponent } from 'ish-shared/components/search/suggest-products-tile/suggest-products-tile.component';
 
 import { SuggestProductsComponent } from './suggest-products.component';
 
@@ -28,7 +30,12 @@ describe('Suggest Products Component', () => {
     when(shoppingFacade.product$(anything(), anything())).thenReturn(of({} as ProductView));
 
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, TranslateModule.forRoot()],
+      imports: [
+        MockComponent(SuggestProductsTileComponent),
+        RouterTestingModule,
+        SuggestProductsComponent,
+        TranslateModule.forRoot(),
+      ],
       providers: [
         { provide: AppFacade, useFactory: () => instance(appFacade) },
         { provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) },


### PR DESCRIPTION
### 🚀 Description

The Jest tests for the component suggest-products.component.html were missing and needed to be added. 

---

### PR Type

[x] Feature

---

### Breaking Changes

---

_If this PR contains a breaking change, please describe the impact and migration path for existing applications below._

[x] No

---

### Other Information

[AB#109373](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/109373)