### PR TITLE
fix: prevent unnecessary multiple dipatching of suggestions action

### DIFF
--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -257,8 +257,8 @@ export class ShoppingFacade {
 
   suggestResults$(searchTerm: Observable<string>) {
     return searchTerm.pipe(
-      debounceTime(400),
       distinctUntilChanged(),
+      debounceTime(400),
       filter(term => term.length > 2),
       tap(term => this.store.dispatch(suggestSearch({ searchTerm: term }))),
       switchMap(() => this.store.pipe(select(getSuggestSearchResults)))

--- a/src/app/core/facades/shopping.facade.ts
+++ b/src/app/core/facades/shopping.facade.ts
@@ -258,6 +258,7 @@ export class ShoppingFacade {
   suggestResults$(searchTerm: Observable<string>) {
     return searchTerm.pipe(
       debounceTime(400),
+      distinctUntilChanged(),
       filter(term => term.length > 2),
       tap(term => this.store.dispatch(suggestSearch({ searchTerm: term }))),
       switchMap(() => this.store.pipe(select(getSuggestSearchResults)))


### PR DESCRIPTION
### 🚀 Description

After dispatching a search request a suggestions request is unnecessarily executed a second time!

Fixes: #<issue-number>

<img width="1036" height="954" alt="image" src="https://github.com/user-attachments/assets/4e412847-d0fe-492a-beb8-f2162c5cc53b" />


_If this PR contains a breaking change, please describe the impact and migration path for existing applications below._

- [ ] Yes
- [x ] No

---

### Other Information


[AB#109518](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/109518)