### PR TITLE
feat: add account content includes

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -62,6 +62,11 @@ Intershop PWA 8.0.0 provides functionality to support recurring orders.
 To enable the recurring order support in the PWA, ICM 13.x with the Recurring Orders Extension 2.2.0 (`icm-as-customization-recurringorders:2.2.0`) is required.
 In addition, the "Recurring Orders" feature must be enabled in ICM (go to the channel > _Preferences > Recurring Orders_ and ensure the check box is _Enabled_).
 
+New content includes were added to the My Account area.
+They provide three general places to add content to all account pages and two specific places for the account overview page and two specific ones for the order history page.
+To use these content includes, an ICM with `icm-as-customization-headless:3.1.0.` or newer is needed.
+If the connected ICM does not provide the new content includes it is best to skip/revert these changes to avoid failing CMS REST requests, that will not lead to errors in the application but they will show in the browser console.
+
 ## From 7.0.0 to 7.1.0
 
 Due to installation issues with the used `luarocks` package manager, we have disabled the installation of the `lua-resty-redis-connector` that provides the functionality to connect to a shared Redis cache.

--- a/src/app/pages/account-order-history/account-order-history-page.component.html
+++ b/src/app/pages/account-order-history/account-order-history-page.component.html
@@ -1,5 +1,10 @@
 <a id="order-list-top" title="top"></a>
 <h1>{{ 'account.order_history.heading' | translate }}</h1>
+
+<div class="marketing-area">
+  <ish-content-include includeId="include.account.orders.content.top.pagelet2-Include" />
+</div>
+
 <ish-error-message [error]="ordersError$ | async" />
 <p class="section">{{ 'account.order.subtitle' | translate }}</p>
 
@@ -42,3 +47,7 @@
     'account.order.questions.note' | translate : { '0': 'page://page.helpdesk.pagelet2-Page', '1': 'route://contact' }
   "
 ></p>
+
+<div class="marketing-area">
+  <ish-content-include includeId="include.account.orders.content.bottom.pagelet2-Include" />
+</div>

--- a/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
+++ b/src/app/pages/account-order-history/account-order-history-page.component.spec.ts
@@ -6,6 +6,7 @@ import { instance, mock, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
 import { OrderListComponent } from 'ish-shared/components/order/order-list/order-list.component';
 
@@ -25,6 +26,7 @@ describe('Account Order History Page Component', () => {
     await TestBed.configureTestingModule({
       declarations: [
         AccountOrderHistoryPageComponent,
+        MockComponent(ContentIncludeComponent),
         MockComponent(ErrorMessageComponent),
         MockComponent(OrderListComponent),
         MockDirective(ServerHtmlDirective),

--- a/src/app/pages/account-overview/account-overview/account-overview.component.html
+++ b/src/app/pages/account-overview/account-overview/account-overview.component.html
@@ -10,6 +10,10 @@
   <p *ishHasNotRole="['APP_B2B_CXML_USER', 'APP_B2B_OCI_USER']">
     {{ 'account.overview.message_b2b.text' | translate }}
   </p>
+
+  <div class="marketing-area">
+    <ish-content-include includeId="include.account.overview.content.top.pagelet2-Include" />
+  </div>
 </ng-container>
 
 <ng-template #personalCustomerMessage>
@@ -19,6 +23,10 @@
   ></h1>
 
   <p>{{ 'account.overview.message.text' | translate }}</p>
+
+  <div class="marketing-area">
+    <ish-content-include includeId="include.account.overview.content.top.pagelet2-Include" />
+  </div>
 
   <div class="row account-dashboard">
     <div class="col-6 col-sm-4 col-md-3 dashboard-item">
@@ -86,6 +94,10 @@
     <ish-lazy-order-template-widget class="col-12 col-md-4" />
   </div>
 </ng-container>
+
+<div class="marketing-area">
+  <ish-content-include includeId="include.account.overview.content.bottom.pagelet2-Include" />
+</div>
 
 <p class="form-text">
   {{ 'account.overview.note.heading' | translate }}:

--- a/src/app/pages/account-overview/account-overview/account-overview.component.spec.ts
+++ b/src/app/pages/account-overview/account-overview/account-overview.component.spec.ts
@@ -13,6 +13,7 @@ import { User } from 'ish-core/models/user/user.model';
 import { HtmlEncodePipe } from 'ish-core/pipes/html-encode.pipe';
 import { ServerSettingPipe } from 'ish-core/pipes/server-setting.pipe';
 import { RoleToggleModule } from 'ish-core/role-toggle.module';
+import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
 import { OrderWidgetComponent } from 'ish-shared/components/order/order-widget/order-widget.component';
 
 import { LazyWishlistWidgetComponent } from '../../../extensions/wishlists/exports/lazy-wishlist-widget/lazy-wishlist-widget.component';
@@ -32,6 +33,7 @@ describe('Account Overview Component', () => {
     await TestBed.configureTestingModule({
       declarations: [
         AccountOverviewComponent,
+        MockComponent(ContentIncludeComponent),
         MockComponent(FaIconComponent),
         MockComponent(LazyBudgetWidgetComponent),
         MockComponent(LazyRequisitionWidgetComponent),

--- a/src/app/pages/account/account-page.component.html
+++ b/src/app/pages/account/account-page.component.html
@@ -1,11 +1,20 @@
+<div class="marketing-area">
+  <ish-content-include includeId="include.account.base.top.pagelet2-Include" />
+</div>
 <div class="account-wrapper">
   <div class="row account-main">
     <div class="col-lg-3 account-nav-box">
       <ish-skip-content-link skipToElementId="nav-breadcrumbs" linkText="account.navigation.skip_content.link.text" />
       <ish-account-navigation [deviceType]="deviceType$ | async" />
+      <div class="marketing-area">
+        <ish-content-include includeId="include.account.navigation.pagelet2-Include" />
+      </div>
     </div>
     <div id="page-main-content" class="col-lg-9" tabindex="-1">
       <ish-breadcrumb [account]="true" />
+      <div class="marketing-area">
+        <ish-content-include includeId="include.account.content.top.pagelet2-Include" />
+      </div>
       <router-outlet />
     </div>
   </div>

--- a/src/app/pages/account/account-page.component.spec.ts
+++ b/src/app/pages/account/account-page.component.spec.ts
@@ -4,6 +4,7 @@ import { MockComponent } from 'ng-mocks';
 import { instance, mock } from 'ts-mockito';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
+import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
 import { BreadcrumbComponent } from 'ish-shared/components/common/breadcrumb/breadcrumb.component';
 import { SkipContentLinkComponent } from 'ish-shared/components/common/skip-content-link/skip-content-link.component';
 
@@ -21,6 +22,7 @@ describe('Account Page Component', () => {
         AccountPageComponent,
         MockComponent(AccountNavigationComponent),
         MockComponent(BreadcrumbComponent),
+        MockComponent(ContentIncludeComponent),
         MockComponent(SkipContentLinkComponent),
       ],
       imports: [RouterTestingModule],


### PR DESCRIPTION
### 🚀 Description

New content includes for the My Account area.
* 3 general account includes
* 2 account overview includes
* 2 account order history includes

<img width="1920" height="1748" alt="image" src="https://github.com/user-attachments/assets/b7f97da8-2db7-45fb-8cc2-4ea80bbfefeb" />

<img width="1920" height="1265" alt="image" src="https://github.com/user-attachments/assets/5e0031ed-1b58-43c0-966f-18d88aa794ba" />

---

### Breaking Changes

Requires `icm-as-customization-headless:3.1.0` to get the used content includes in/from ICM.
If the used ICM does not provide the new content includes it is best to skip/revert these changes to avoid failing CMS REST requests. They will not lead to errors in the application but they will show in the browser console.

- [ ] Yes
- [x] No

---

### Other Information


[AB#110008](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/110008)