### PR TITLE
fix: allow the usage of common tracking parameters in search pages

### DIFF
--- a/src/app/core/store/shopping/product-listing/product-listing.effects.ts
+++ b/src/app/core/store/shopping/product-listing/product-listing.effects.ts
@@ -100,6 +100,11 @@ export class ProductListingEffects {
               !!params?.view ||
               !!params?.sorting ||
               !!params?.page ||
+              // allow common tracking parameters from google, matomo, meta
+              Object.keys(params || {}).some(
+                key => key.startsWith('utm_') || key.startsWith('mtm_') || key.endsWith('clid')
+              ) ||
+              // allow empty params
               Object.keys(params)?.length === 0
           ),
           map(params => {


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

Allow the usage of tracking parameters from google, matomo, facebook, instagram without breaking the search page.

- Related Ticket/Issue: Closes #1905

---

### 🔍 Detailed Changes

Until now, search result pages containing unknown query parameters resulted in an empty search page (no results page), because query params must be whitelisted in the `determineParams$` effect. However, some 3rd party tools (like matomo, google, instagram) require tracking parameters (like `?fbclid=xyz`). This PR allows those type of parameters.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#110673](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/110673)