### PR TITLE
fix: refresh payment buttons after basket recurrence changed

### DIFF
--- a/e2e/cypress/e2e/pages/checkout/cart.page.ts
+++ b/e2e/cypress/e2e/pages/checkout/cart.page.ts
@@ -97,6 +97,7 @@ export class CartPage {
 
   fillOutRecurringOrderForm(repetitions: string) {
     cy.get('[data-testing-id="enable-recurring-order"]').click();
+    waitLoadingEnd();
     cy.get('[data-testing-id="radio-order.recurrence.form.ending.repetitions.label"]').click();
     cy.get('[data-testing-id="repetitions"]').clear().type(repetitions);
   }

--- a/src/app/pages/basket/basket-order-recurrence-edit/basket-order-recurrence-edit.component.scss
+++ b/src/app/pages/basket/basket-order-recurrence-edit/basket-order-recurrence-edit.component.scss
@@ -2,7 +2,7 @@
 
 #order-recurrence {
   padding: ($space-default * 0.5) ($space-default * 1.5);
-  margin: ($space-default * 1) ($space-default * -1.5);
+  margin: ($space-default * 1) ($space-default * -1.5) ($space-default * 1.5);
   font-size: $font-size-corporate;
   background-color: $white;
 }

--- a/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.html
+++ b/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.html
@@ -13,16 +13,18 @@
   <!-- container for displaying of fast checkout payment methods -->
   <ng-container *ngIf="paymentMethods$ | async as paymentMethods">
     <ng-container *ngIf="paymentMethods.length">
-      <li class="d-block text-center p-2">{{ 'shopping_cart.payment.or.text' | translate }}</li>
+      <li class="d-block text-center pt-2">{{ 'shopping_cart.payment.or.text' | translate }}</li>
       <li *ngFor="let paymentMethod of paymentMethods" class="d-block">
-        <button
-          type="button"
-          (click)="fastCheckout(paymentMethod.id)"
-          class="btn btn-lg btn-block btn-secondary"
-          [disabled]="paymentMethod.isRestricted"
-        >
-          {{ paymentMethod.displayName }}
-        </button>
+        <div class="mt-2">
+          <button
+            type="button"
+            (click)="fastCheckout(paymentMethod.id)"
+            class="btn btn-lg btn-block btn-secondary"
+            [disabled]="paymentMethod.isRestricted"
+          >
+            {{ paymentMethod.displayName }}
+          </button>
+        </div>
         <!-- payment cost information -->
         <ish-basket-payment-cost-info
           [basket]="basket"

--- a/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.ts
+++ b/src/app/pages/basket/shopping-basket-payment/shopping-basket-payment.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 
@@ -13,7 +13,7 @@ import { PriceType } from 'ish-core/models/price/price.model';
   templateUrl: './shopping-basket-payment.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ShoppingBasketPaymentComponent implements OnInit {
+export class ShoppingBasketPaymentComponent implements OnInit, OnChanges {
   @Input({ required: true }) basket: BasketView;
 
   paymentMethods$: Observable<PaymentMethod[]>;
@@ -28,10 +28,20 @@ export class ShoppingBasketPaymentComponent implements OnInit {
 
   ngOnInit(): void {
     this.priceType$ = this.checkoutFacade.priceType$;
-    this.checkoutFacade.loadEligiblePaymentMethods();
+
     this.paymentMethods$ = this.checkoutFacade.eligibleFastCheckoutPaymentMethods$;
     // if page is shown after cancelled/faulty redirect determine error message variable
     this.redirectStatus = this.route.snapshot.queryParamMap.get('redirect');
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      changes.basket &&
+      (changes.basket.previousValue?.recurrence !== changes.basket.currentValue?.recurrence ||
+        !changes.basket.currentValue?.recurrence)
+    ) {
+      this.checkoutFacade.loadEligiblePaymentMethods();
+    }
   }
 
   fastCheckout(paymentId: string) {

--- a/src/app/pages/basket/shopping-basket/shopping-basket.component.html
+++ b/src/app/pages/basket/shopping-basket/shopping-basket.component.html
@@ -102,7 +102,7 @@
           <button
             *ishHasNotRole="['APP_B2B_CXML_USER', 'APP_B2B_OCI_USER']"
             type="submit"
-            class="btn btn-lg btn-block btn-primary"
+            class="btn btn-lg btn-block btn-primary mb-0"
             (click)="checkout()"
           >
             {{ 'shopping_cart.proceed_to_checkout.button.label' | translate }}


### PR DESCRIPTION

### 🚀 Description

If the user wants to order his basket more than once the eligible fast payment methods may not be available any more. So if the user changes the option from one time order to recurring order and vice versa it is necessary to re-fetch the eligible payment methods from server again.
This has not been done so far, find the issue in the related ticket

- Related Ticket/Issue: Closes #1932 

---



### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#110971](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/110971)