### PR TITLE
fix: prepend '#' to href for skip content link to avoid invalid link targets

### DIFF
--- a/src/app/shared/components/common/skip-content-link/skip-content-link.component.html
+++ b/src/app/shared/components/common/skip-content-link/skip-content-link.component.html
@@ -3,7 +3,7 @@
 <a
   #skipContentLink
   data-nosnippet
-  [href]="skipToElementId || generatedElementAfterListingId"
+  [href]="'#' + (skipToElementId || generatedElementAfterListingId)"
   class="d-none d-lg-block skip-content-link"
   >{{ linkText | translate }}</a
 >


### PR DESCRIPTION


<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

Fix invalid skip content link targets by ensuring they point to valid in-page anchors.

---

### 🔍 Detailed Changes

The skip content link components creates invalid link targets. For example, on product listing pages (e.g., [Data Projectors](https://intershoppwa.azurewebsites.net/conferencing/data-projectors-ctgpresentation-conferencing.data-projectors)):
`<a data-nosnippet="" class="d-none d-lg-block skip-content-link" href="nav-breadcrumbs">Skip filters</a>`

Some crawlers are finding and requesting these links (e.g., https://my-domain.com/nav-breadcrumbs) and receive a 404 Error.

This PR changes this behavior and creates a valid jump target to the referenced element by prepending the '#' instead.

[AB#111071](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111071)