### PR TITLE
test: fix flaky recurring order test

### DIFF
--- a/e2e/cypress/e2e/pages/checkout/cart.page.ts
+++ b/e2e/cypress/e2e/pages/checkout/cart.page.ts
@@ -100,6 +100,7 @@ export class CartPage {
     waitLoadingEnd();
     cy.get('[data-testing-id="radio-order.recurrence.form.ending.repetitions.label"]').click();
     cy.get('[data-testing-id="repetitions"]').clear().type(repetitions);
+    waitLoadingEnd();
   }
 
   lineItem(idx: number) {


### PR DESCRIPTION
### 🚀 Description

the order recurring e2e test often fails most probably because of time issues. 

- Related Ticket/Issue: Closes #<issue-number>

---

### 🔍 Detailed Changes

After updating the recurring properties during the test a waitLoadingEnd has been added to hopefully prevent failing the test because of time issues.

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#111132](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111132)