### PR TITLE
fix: prevent captcha timer from blocking app stability

### DIFF
--- a/src/app/core/facades/app.facade.ts
+++ b/src/app/core/facades/app.facade.ts
@@ -32,7 +32,7 @@ export class AppFacade {
   }
   icmBaseUrl: string;
 
-  wasAlreadyStable$ = this.appRef.isStable.pipe(whenTruthy(), take(1));
+  appBecameStable$ = this.appRef.isStable.pipe(whenTruthy(), take(1));
 
   headerType$ = this.store.pipe(select(getHeaderType));
   deviceType$ = this.store.pipe(select(getDeviceType));

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.spec.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.spec.ts
@@ -3,7 +3,8 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockDirective } from 'ng-mocks';
 import { RECAPTCHA_V3_SITE_KEY, RecaptchaV3Module } from 'ng-recaptcha';
-import { instance, mock } from 'ts-mockito';
+import { of } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { AppFacade } from 'ish-core/facades/app.facade';
@@ -15,14 +16,17 @@ describe('Captcha V3 Component', () => {
   let component: CaptchaV3Component;
   let fixture: ComponentFixture<CaptchaV3Component>;
   let element: HTMLElement;
+  let appFacade: AppFacade;
   const captchaSiteKey = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
 
   beforeEach(async () => {
+    appFacade = mock(AppFacade);
+    when(appFacade.appBecameStable$).thenReturn(of(true));
     await TestBed.configureTestingModule({
       declarations: [CaptchaV3Component, MockDirective(ServerHtmlDirective)],
       imports: [RecaptchaV3Module, TranslateModule.forRoot()],
       providers: [
-        { provide: AppFacade, useFactory: () => instance(mock(AppFacade)) },
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
         { provide: RECAPTCHA_V3_SITE_KEY, useValue: captchaSiteKey },
       ],
     }).compileComponents();

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { RECAPTCHA_V3_SITE_KEY, ReCaptchaV3Service, RecaptchaV3Module } from 'ng-recaptcha';
-import { combineLatest, timer } from 'rxjs';
+import { timer } from 'rxjs';
 import { filter, switchMap, take } from 'rxjs/operators';
 
 import { DirectivesModule } from 'ish-core/directives.module';
@@ -35,9 +35,9 @@ export class CaptchaV3Component implements OnInit {
   ngOnInit() {
     this.parentForm.get('captchaAction').setValidators([Validators.required]);
 
-    // as soon as the user starts editing the form request a captcha token every 2 minutes
+    // as soon as the app is getting stable the form requests a captcha token every 2 minutes
     if (!SSR) {
-      combineLatest([this.parentForm.statusChanges.pipe(take(1)), this.appFacade.wasAlreadyStable$])
+      this.appFacade.appBecameStable$
         .pipe(
           take(1),
           switchMap(() =>


### PR DESCRIPTION
### 🚀 Description

Pages such as registration or contact us with captcha components in forms never reach an internal angular stable status. 

---

### 🔍 Detailed Changes

Wait for app to be stable before starting captcha token refresh timer to allow ApplicationRef.isStable to become true on pages with captcha forms.

---

### 🔗 Other Information



[AB#111152](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111152)