### PR TITLE
fix: open quote dialog after login

### DIFF
--- a/src/app/extensions/quoting/shared/product-add-to-quote-dialog/product-add-to-quote-dialog.component.ts
+++ b/src/app/extensions/quoting/shared/product-add-to-quote-dialog/product-add-to-quote-dialog.component.ts
@@ -33,7 +33,11 @@ export class ProductAddToQuoteDialogComponent implements OnInit {
     this.state$ = this.context.select('state');
     this.error$ = this.context.select('error');
 
-    this.context.hold(this.router.events.pipe(filter(event => event instanceof NavigationEnd)), () => this.hide());
+    // prevent closing the dialog immediately after opening it
+    setTimeout(() => {
+      // close dialog if the user clicks a link within the dialog
+      this.context.hold(this.router.events.pipe(filter(event => event instanceof NavigationEnd)), () => this.hide());
+    }, 1000);
   }
 
   hide() {


### PR DESCRIPTION
### 🚀 Description

If an anonymous user wants to add a product to a quote he is required to login. Sometimes after the logging in the product-add-to-quote dialog opens up and closes automatically, before the user can see the content.

---

### 🔍 Detailed Changes

In the product-add-to-quote dialog there is a functionality to close the dialog after the user clicked a link and an RouterNavigationEvent is triggered. The PR prevents that this can happen directly after opening the dialog.


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#111171](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111171)