### PR TITLE
fix: wrong http parameter settings for basket recommendations (#111616)

### DIFF
--- a/src/app/core/services/sparque-api/sparque-api.service.ts
+++ b/src/app/core/services/sparque-api/sparque-api.service.ts
@@ -123,7 +123,7 @@ export class SparqueApiService {
       });
 
     params?.keys().forEach(key => {
-      if (key.includes('selectedFacets')) {
+      if (key.includes('selectedFacets') || key.includes('cartProductIds')) {
         params
           .get(key)
           ?.split(',')


### PR DESCRIPTION
Rest Call for basket recommendations contains wrong http parameter values for _cartProductIds_. Values of this http parameter is a comma separated list of ids. The SPARQUE Wrapper Rest API requires for each _cartProductId_ an own http parameter with key "_cartProductIds_" and value "id of one cart item".

**wrong behavior:**
<img width="1841" height="404" alt="image" src="https://github.com/user-attachments/assets/fdf7c247-24b7-4288-857c-1a6334ab07bc" />

**fixed behavior:**
<img width="1863" height="592" alt="image" src="https://github.com/user-attachments/assets/bfb1eacb-88d2-4dea-bb90-0c1919b8205e" />





[AB#111617](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111617)