### PR TITLE
fix: enable default sorting on product lists with Sparque config

### DIFF
--- a/src/app/core/services/sparque-products/sparque-products.service.ts
+++ b/src/app/core/services/sparque-products/sparque-products.service.ts
@@ -34,7 +34,7 @@ export class SparqueProductsService implements ProductsServiceInterface {
       .set('count', searchParams.amount.toString())
       .set('offset', searchParams.offset.toString())
       .set('facetOptionsCount', this.facetOptionsCount);
-    if (searchParams.sorting) {
+    if (searchParams.sorting && searchParams.sorting !== 'default') {
       params = params.set('sorting', searchParams.sorting);
     }
     if (!searchParams.searchParameter && searchParams.searchTerm) {
@@ -66,7 +66,7 @@ export class SparqueProductsService implements ProductsServiceInterface {
       .set('offset', offset.toString())
       .set('facetOptionsCount', this.facetOptionsCount)
       .set('keyword', searchParameter.searchTerm ? searchParameter.searchTerm[0] : '');
-    if (sortKey) {
+    if (sortKey && sortKey !== 'default') {
       params = params.set('sorting', sortKey);
     }
     params = params.append('selectedFacets', this.selectedFacets(omit(searchParameter, 'searchTerm')));


### PR DESCRIPTION
### 🚀 Description

Precondition: SPARQUE search is enabled.

When you change the sorting option on a search result page (e.g. "Name A-Z") and switch back to "Default sorting", the search result page does not show the products again but shows "No results found". 

---

### 🔍 Detailed Changes

<!-- Describe the changes in detail -->

---

### 📝 Notes

This issue is already [fixed in the SPARQUE navigation branch](https://github.com/intershop/intershop-pwa/pull/1888/commits/4f02ea6153bfd084de16e88646162109e97c5b59) but as long as this is not merged, we need to have this fixed in develop.

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#111659](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111659)