### PR TITLE
fix: prevent redundant spacing in category tree

### DIFF
--- a/src/app/pages/category/category-navigation/category-navigation.component.html
+++ b/src/app/pages/category/category-navigation/category-navigation.component.html
@@ -1,20 +1,22 @@
 <div *ngIf="currentCategoryId$ | async as currentCategoryId" class="non-parametric-panel">
-  <div class="filter-group">
-    <ul class="filter-list">
-      <li *ngFor="let category of navigationCategories$ | async" class="filter-item">
-        <a
-          class="filter-item-name link-decoration-hover"
-          [ngClass]="{ 'filter-selected': category.uniqueId === currentCategoryId }"
-          [routerLink]="category.url"
-          [attr.aria-current]="category.uniqueId === currentCategoryId ? 'true' : undefined"
-        >
-          {{ category.name }}
-        </a>
-        <ish-category-navigation
-          *ngIf="currentCategoryId.startsWith(category.uniqueId)"
-          [uniqueId]="category.uniqueId"
-        />
-      </li>
-    </ul>
-  </div>
+  <ng-container *ngIf="navigationCategories$ | async as navigationCategories">
+    <div *ngIf="navigationCategories.length" class="filter-group">
+      <ul class="filter-list">
+        <li *ngFor="let category of navigationCategories" class="filter-item">
+          <a
+            class="filter-item-name link-decoration-hover"
+            [ngClass]="{ 'filter-selected': category.uniqueId === currentCategoryId }"
+            [routerLink]="category.url"
+            [attr.aria-current]="category.uniqueId === currentCategoryId ? 'true' : undefined"
+          >
+            {{ category.name }}
+          </a>
+          <ish-category-navigation
+            *ngIf="currentCategoryId.startsWith(category.uniqueId)"
+            [uniqueId]="category.uniqueId"
+          />
+        </li>
+      </ul>
+    </div>
+  </ng-container>
 </div>


### PR DESCRIPTION
### 🚀 Description

The categories tree navigation in the leftpanel includes a redundant spacing below the active categorie even if there are no sub-categories available.

<img width="279" height="360" alt="image" src="https://github.com/user-attachments/assets/de552736-a17c-4ed6-b0ef-10fec1eed347" />

---

### 🔍 Detailed Changes

A check was added to prevent the display of empty HTML which creates the spacing.

---

### 📝 Notes

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->
