### PR TITLE
fix(order-templates): add/remove multiple products concurrently

### DIFF
--- a/src/app/extensions/order-templates/store/order-template/order-template.effects.spec.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.effects.spec.ts
@@ -409,6 +409,25 @@ describe('Order Template Effects', () => {
       expect(effects.addProductToOrderTemplate$).toBeObservable(expected$);
     });
 
+    it('should process multiple add requests sequentially', () => {
+      const firstResponse$ = cold('--a|', { a: orderTemplates[0] });
+      const secondResponse$ = cold('-a|', { a: orderTemplates[1] });
+      when(orderTemplateServiceMock.addProductToOrderTemplate(anyString(), anyString(), anyNumber())).thenReturn(
+        firstResponse$,
+        secondResponse$
+      );
+
+      const action1 = addProductToOrderTemplate(payload);
+      const action2 = addProductToOrderTemplate({ ...payload, sku: 'second-sku' });
+      const completion1 = addProductToOrderTemplateSuccess({ orderTemplate: orderTemplates[0] });
+      const completion2 = addProductToOrderTemplateSuccess({ orderTemplate: orderTemplates[1] });
+
+      actions$ = hot('-a-b----|', { a: action1, b: action2 });
+      const expected$ = cold('---c-d--|', { c: completion1, d: completion2 });
+
+      expect(effects.addProductToOrderTemplate$).toBeObservable(expected$);
+    });
+
     it('should map failed calls to actions of type AddProductToOrderTemplateFail', () => {
       const error = makeHttpError({ message: 'invalid' });
       when(orderTemplateServiceMock.addProductToOrderTemplate(anyString(), anyString(), anything())).thenReturn(
@@ -549,6 +568,27 @@ describe('Order Template Effects', () => {
       const expected$ = cold('-c-c-c', { c: completion });
       expect(effects.removeProductFromOrderTemplate$).toBeObservable(expected$);
     });
+    it('should process multiple remove requests sequentially', () => {
+      const orderTemplateAfterFirstRemoval: OrderTemplate = { ...orderTemplate, itemsCount: 1 };
+      const orderTemplateAfterSecondRemoval: OrderTemplate = { ...orderTemplate, itemsCount: 0 };
+      const firstResponse$ = cold('--a|', { a: orderTemplateAfterFirstRemoval });
+      const secondResponse$ = cold('-a|', { a: orderTemplateAfterSecondRemoval });
+      when(orderTemplateServiceMock.removeProductFromOrderTemplate(anyString(), anyString())).thenReturn(
+        firstResponse$,
+        secondResponse$
+      );
+
+      const action1 = removeItemFromOrderTemplate(payload);
+      const action2 = removeItemFromOrderTemplate({ ...payload, sku: 'another-sku' });
+      const completion1 = removeItemFromOrderTemplateSuccess({ orderTemplate: orderTemplateAfterFirstRemoval });
+      const completion2 = removeItemFromOrderTemplateSuccess({ orderTemplate: orderTemplateAfterSecondRemoval });
+
+      actions$ = hot('-a-b----|', { a: action1, b: action2 });
+      const expected$ = cold('---c-d--|', { c: completion1, d: completion2 });
+
+      expect(effects.removeProductFromOrderTemplate$).toBeObservable(expected$);
+    });
+
     it('should map failed calls to actions of type RemoveItemFromOrderTemplateFail', () => {
       const error = makeHttpError({ message: 'invalid' });
       when(orderTemplateServiceMock.removeProductFromOrderTemplate(anyString(), anyString())).thenReturn(

--- a/src/app/extensions/order-templates/store/order-template/order-template.effects.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.effects.ts
@@ -169,7 +169,7 @@ export class OrderTemplateEffects {
     this.actions$.pipe(
       ofType(addProductToOrderTemplate),
       mapToPayload(),
-      mergeMap(payload =>
+      concatMap(payload =>
         this.orderTemplateService
           .addProductToOrderTemplate(payload.orderTemplateId, payload.sku, payload.quantity)
           .pipe(
@@ -244,7 +244,7 @@ export class OrderTemplateEffects {
     this.actions$.pipe(
       ofType(removeItemFromOrderTemplate),
       mapToPayload(),
-      mergeMap(payload =>
+      concatMap(payload =>
         this.orderTemplateService.removeProductFromOrderTemplate(payload.orderTemplateId, payload.sku).pipe(
           map(orderTemplate => removeItemFromOrderTemplateSuccess({ orderTemplate })),
           mapErrorToAction(removeItemFromOrderTemplateFail)


### PR DESCRIPTION
**Description**

Fixes a race condition where concurrent Copilot requests to add/remove multiple products in an Order Template resulted in only one update being persisted.
Requests are now processed sequentially so all operations are applied.

**Related Ticket/Issue:** Closes #1946 

**Detailed Changes**

- Switched addProductToOrderTemplate$ and removeProductFromOrderTemplate$ effects from mergeMap to concatMap to serialize Order Template updates.
- Added unit tests covering multiple add/remove requests for a single Order Template (Copilot multi-product scenario).

**Notes**

- No breaking changes.
- No additional ICM version or migrations required.

**Open Tasks**

- [ ] Documentation and Localizations reviewed by the documentation team
- [ ] Visual changes approved by VD / IAD

[AB#111766](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111766)