### PR TITLE
fix: set autocomplete off in password fields for PCI DSS Compliance

### DIFF
--- a/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
+++ b/src/app/extensions/punchout/shared/punchout-user-form/punchout-user-form.component.ts
@@ -93,7 +93,6 @@ export class PunchoutUserFormComponent implements OnInit {
               label: this.punchoutUser
                 ? 'account.punchout.password.new.confirmation.label'
                 : 'account.punchout.password.confirmation.label',
-              attributes: { autocomplete: 'new-password' },
               hideRequiredMarker: true,
             },
             validation: {

--- a/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
+++ b/src/app/pages/account-profile-password/account-profile-password/account-profile-password.component.ts
@@ -73,7 +73,6 @@ export class AccountProfilePasswordComponent implements OnInit, OnChanges {
               required: true,
               hideRequiredMarker: true,
               label: 'account.update_password.newpassword_confirmation.label',
-              attributes: { autocomplete: 'new-password' },
             },
             validation: {
               messages: {

--- a/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
+++ b/src/app/pages/forgot-password/update-password-form/update-password-form.component.ts
@@ -59,7 +59,6 @@ export class UpdatePasswordFormComponent implements OnInit {
               required: true,
               hideRequiredMarker: true,
               label: 'account.register.password_confirmation.label',
-              attributes: { autocomplete: 'new-password' },
             },
             validation: {
               messages: {

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -327,7 +327,6 @@ export class RegistrationFormConfigurationService {
             props: {
               required: true,
               label: 'account.register.password_confirmation.label',
-              attributes: { autocomplete: 'new-password' },
             },
             validation: {
               messages: {

--- a/src/app/shared/formly/types/types.module.ts
+++ b/src/app/shared/formly/types/types.module.ts
@@ -127,7 +127,7 @@ const fieldComponents = [
           name: 'ish-password-field',
           extends: 'ish-password-novalidate-field',
           defaultOptions: {
-            props: { attributes: { autocomplete: 'new-password' } },
+            props: { attributes: { autocomplete: 'off' } },
             validators: {
               password: formlyValidation('password', SpecialValidators.password),
             },
@@ -143,7 +143,7 @@ const fieldComponents = [
           name: 'ish-password-novalidate-field',
           component: PasswordFieldComponent,
           defaultOptions: {
-            props: { attributes: { autocomplete: 'current-password' } },
+            props: { attributes: { autocomplete: 'off' } },
             validation: {
               messages: {
                 required: 'form.password.error.required',


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

**What has been changed?**
- Added autocomplete="off" to all password fields

**Why was it changed?**
- Having autocomplete="off" is a requirement for Payment Card Industry Data Security Standard (PCI DSS) and therefore PayOne Compliance. 
---

### 🔗 Other Information

autocomplete="off"  is widely ignored by major browsers, hence negative effects for users might be small:
https://caniuse.com/?search=input-autocomplete-off

Audit details (from Worldline):
<img width="979" height="912" alt="image" src="https://github.com/user-attachments/assets/17916cff-4468-4e93-aefd-b7a5f6b2f9ec" />



[AB#111781](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/111781)