### PR TITLE
feat: remove comments to show category top and bottom viewcontext

### DIFF
--- a/src/app/pages/category/category-categories/category-categories.component.html
+++ b/src/app/pages/category/category-categories/category-categories.component.html
@@ -45,7 +45,6 @@
       <ish-breadcrumb />
       <h1>{{ category.name }}</h1>
 
-      <!-- DISABLED VIEW CONTEXT --
       <div class="marketing-area">
         <ish-content-viewcontext
           *ngIf="category.categoryRef"
@@ -53,11 +52,9 @@
           [callParameters]="{ Category: category.categoryRef }"
         />
       </div>
-      -- DISABLED VIEW CONTEXT -->
 
       <ish-category-list [categories]="category.children" />
 
-      <!-- DISABLED VIEW CONTEXT --
       <div class="marketing-area">
         <ish-content-viewcontext
           *ngIf="category.categoryRef"
@@ -65,7 +62,6 @@
           [callParameters]="{ Category: category.categoryRef }"
         />
       </div>
-      -- DISABLED VIEW CONTEXT -->
     </div>
   </div>
   <!-- DISABLED VIEW CONTEXT --


### PR DESCRIPTION
### 🚀 Description

We need to show CMS maintained SEO text for catalogs. Currently, the following viewcontext are [commented out](https://github.com/intershop/intershop-pwa/pull/1650): 
`viewcontext.include.category.content.top` and `viewcontext.include.category.content.bottom` where the actual content needs to be rendered.

---

### 🔍 Detailed Changes

The comments are removed to show the CMS components.

---

### 📝 Notes

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team
- [ ] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#112002](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/112002)