### PR TITLE
fix: design view wrapper styling

### DIFF
--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.scss
@@ -5,6 +5,9 @@ $design-view-color-pagelet: #399;
 $design-view-color-slot: #399;
 $design-view-color-include: #ce5399;
 
+$design-view-color-pagelet-hover: #256f6f;
+$design-view-color-pagelet-active: #206060;
+
 .design-view-wrapper {
   position: relative;
 
@@ -29,6 +32,7 @@ $design-view-color-include: #ce5399;
       color: $color-inverse;
       text-transform: none;
       white-space: nowrap;
+      border: none;
 
       fa-icon {
         font-size: 20px;
@@ -60,6 +64,16 @@ $design-view-color-include: #ce5399;
 
       > .design-view-wrapper-actions {
         display: flex;
+
+        .btn {
+          &:hover {
+            background-color: $design-view-color-pagelet-hover;
+          }
+
+          &:active {
+            background-color: $design-view-color-pagelet-active;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
### 🚀 Description

Fix Design View wrapper styling on hover.

---

### 🔍 Detailed Changes

When viewing the PWA in Design View, a dashed border is used for the Wrapper when hovering over a component in the PWA, rather than a solid one.

Followup for: #1962 

---

### 📝 Notes

Preview in the IAP: https://iap-app-int.platform.intershop.de/preview?context=eyJkZXNpZ24tdmlldyI6Imh0dHBzOi8vaXNoaWFwaW50ZXJuYWwuYmxvYi5jb3JlLndpbmRvd3MubmV0L2lhcC1wdWJsaWMvaWFwLW1vZHVsZS1jbXMtZGVzaWduLXZpZXcvcHJldmlldy8xOTA4Ni9tYWluLmpzIiwiY21zIjoiaHR0cHM6Ly9pc2hpYXBpbnRlcm5hbC5ibG9iLmNvcmUud2luZG93cy5uZXQvaWFwLXB1YmxpYy9pYXAtYXBwLWNtcy9wcmV2aWV3LzE5MDg2L21haW4uanMifQ== (use the "PWA Design View Review (B2C)" PWA)

---

### ✅ Open Tasks

- [x] Visual changes approved by VD / IAD

---

### 🔗 Other Information



[AB#112153](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/112153)