### PR TITLE
fix: scroll positioning of the scroll directive

### DIFF
--- a/src/app/core/directives/scroll.directive.ts
+++ b/src/app/core/directives/scroll.directive.ts
@@ -72,13 +72,27 @@ export class ScrollDirective implements OnChanges {
       return;
     }
 
-    // calculate the offset from target to scrollContainer
-    let offset = target.offsetTop;
-    let tempTarget = target.offsetParent as HTMLElement;
-    while (!tempTarget.isSameNode(container) && !tempTarget.isSameNode(this.document.body)) {
-      offset += tempTarget.offsetTop;
-      tempTarget = tempTarget.offsetParent as HTMLElement;
+    let offset: number;
+
+    // for parent container, use simple offsetTop
+    if (this.scrollContainer === 'parent') {
+      // calculate the offset from target to scrollContainer
+      const targetRect = target.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      offset = targetRect.top - containerRect.top + container.scrollTop;
+    } else {
+      // for other containers, traverse the offsetParent chain
+      offset = target.offsetTop;
+      let tempTarget = target.offsetParent as HTMLElement;
+
+      // traverse up the DOM tree until we reach the container
+      while (tempTarget && !tempTarget.isSameNode(container) && !tempTarget.isSameNode(this.document.body)) {
+        offset += tempTarget.offsetTop;
+        tempTarget = tempTarget.offsetParent as HTMLElement;
+      }
     }
+
+    // apply spacing
     offset -= this.scrollSpacing;
     if (offset < 0) {
       offset = 0;


### PR DESCRIPTION
### 🚀 Description

After migrating from bootstrap 4 to 5 the calculation of the scroll target of the scroll directive was not correct any more. This led i.a. to issues in the store locator with the google maps integration.

- Related Ticket/Issue: Closes #<issue-number>

---

### 🔍 Detailed Changes

If the user clicked on a certain store in the map of the store finder, the selected store was often not visible in the list, because the scrolling didn't work as expected. This has been fixed by an improved scroll target calculation using the getBoundingClientRect() method.

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#112529](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/112529)