### PR TITLE
fix(accessibility): label - input association of ng-select

### DIFF
--- a/src/app/shared/formly/types/search-select-field/search-select-field.component.ts
+++ b/src/app/shared/formly/types/search-select-field/search-select-field.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, Renderer2, ViewChild } from '@angular/core';
+import { NgSelectComponent } from '@ng-select/ng-select';
 import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
@@ -12,10 +13,24 @@ import { SelectOption } from 'ish-core/models/select-option/select-option.model'
   templateUrl: './search-select-field.component.html',
   changeDetection: ChangeDetectionStrategy.Default,
 })
-export class SearchSelectFieldComponent extends FieldType<FieldTypeConfig> {
+export class SearchSelectFieldComponent extends FieldType<FieldTypeConfig> implements AfterViewInit {
+  @ViewChild(NgSelectComponent) ngSelect: NgSelectComponent;
+
   defaultOptions = {
     props: {
       options: [] as SelectOption[],
     },
   };
+
+  constructor(private renderer: Renderer2) {
+    super();
+  }
+
+  // set the id on the search input for accessibility reasons
+  ngAfterViewInit() {
+    const inputElement = this.ngSelect?.searchInput?.nativeElement;
+    if (inputElement) {
+      this.renderer.setAttribute(inputElement, 'id', this.id);
+    }
+  }
 }


### PR DESCRIPTION
### 🚀 Description

The formly element search-select-field causes the following accessibility issue: 'Form elements do not have associated labels'. 

- Related Ticket/Issue: Closes #1933

---

### 🔍 Detailed Changes

The formly element search-select-field that uses ng-select does not associate the label with the underlying input field.
This can be found e.g. on the cart page with a cost center selection.
This issue has been fixed by adding the id to the search input field.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#112850](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/112850)