### PR TITLE
fix: replace chmod 777 permissions with restrictive settings in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ LABEL displayVersion="${displayVersion}"
 ENV DISPLAY_VERSION=${displayVersion} NODE_PATH=/dist/node_modules PATH=$PATH:/dist/node_modules/.bin
 ENV LOG_ALL=on
 EXPOSE 4200 9113
-RUN mkdir /.pm2 && chmod 777 -Rf /.pm2 && touch /dist/ecosystem.yml && chmod 777 -f /dist/ecosystem.yml
+RUN mkdir /.pm2 && chown nobody:nobody /.pm2 && chmod 700 /.pm2 && \
+    touch /dist/ecosystem.yml && chown nobody:nobody /dist/ecosystem.yml && chmod 644 /dist/ecosystem.yml
 USER nobody
 HEALTHCHECK --interval=60s --timeout=20s --start-period=2s CMD node /dist/healthcheck.js
 ENTRYPOINT [ "/sbin/tini", "--", "sh", "/dist/entrypoint.sh" ]


### PR DESCRIPTION
### 🚀 Description

The Dockerfile used chmod 777 for the .pm2 directory and ecosystem.yml file, granting unrestricted read/write/execute access to all users. This was flagged as a security vulnerability by SonarQube scanning.

There are no functional changes - PM2 continues to run as `nobody` with full access to its files, but the security posture is improved.

---

### 🔍 Detailed Changes

Test the changes to verify file permissions inside the running container using `docker compose up --build`

- PWA Container builds successfully and PWA runs normally on http://localhost:4200
- PM2 starts without permission errors

Check inside the PWA Docker container:

- PM2 runs as `nobody` (check using `pm2 list` or `ps aux | grep pm2` )
- use `ls -la /.pm2` and `ls -la /dist/ecosystem.yml`, expected output: `drwx------` for .pm2 instead of `drwxrwxrwx` and `-rw-r--r--` for /dist/ecosystem.yml instead of `-rwxrwxrwx`
- No "EACCES" or "Permission denied" errors in logs

---

### 📝 Notes

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->
