### PR TITLE
fix: variations display on variation master page

### DIFF
--- a/e2e/cypress/e2e/specs/shopping/variation-handling.b2b.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/shopping/variation-handling.b2b.e2e-spec.ts
@@ -38,9 +38,7 @@ describe('Variation Handling B2B', () => {
       at(ProductDetailPage, page => page.gotoMasterProduct());
       at(ProductDetailPage, page => {
         page.sku.should('have.text', _.masterSKU);
-        // flaky test - has to be enabled again
-        // eslint-disable-next-line etc/no-commented-out-code
-        // page.variations.numberOfItems.should('equal', _.numberOfVariations);
+        page.variations.numberOfItems.should('equal', _.numberOfVariations);
       });
     });
   });
@@ -52,9 +50,7 @@ describe('Variation Handling B2B', () => {
       at(ProductDetailPage, page => {
         page.sku.should('have.text', _.masterSKU);
         page.infoNav('Details').should('be.visible');
-        // flaky test - has to be enabled again
-        // eslint-disable-next-line etc/no-commented-out-code
-        // page.variations.numberOfItems.should('equal', _.numberOfVariations);
+        page.variations.numberOfItems.should('equal', _.numberOfVariations);
       });
     });
   });

--- a/src/app/pages/product/product-master-variations/product-master-variations.component.ts
+++ b/src/app/pages/product/product-master-variations/product-master-variations.component.ts
@@ -2,10 +2,11 @@ import { ViewportScroller } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivationStart, NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { Observable, combineLatest } from 'rxjs';
-import { debounce, filter, map, takeUntil } from 'rxjs/operators';
+import { debounce, filter, map, startWith, takeUntil } from 'rxjs/operators';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductHelper } from 'ish-core/models/product/product.model';
+import { whenTruthy } from 'ish-core/utils/operators';
 
 @Component({
   selector: 'ish-product-master-variations',
@@ -25,8 +26,14 @@ export class ProductMasterVariationsComponent implements OnInit {
     this.categoryId$ = this.context.select('categoryId');
     this.hasVariations$ = combineLatest([
       this.context.select('product').pipe(map(product => ProductHelper.isMasterProduct(product))),
-      this.context.select('variations').pipe(map(variations => variations?.length > 0)),
-    ]).pipe(map(([isMaster, hasVariations]) => isMaster && hasVariations));
+      this.context.select('variations').pipe(
+        map(variations => variations?.length > 0),
+        whenTruthy()
+      ),
+    ]).pipe(
+      map(([isMaster, hasVariations]) => isMaster && hasVariations),
+      startWith(false)
+    );
 
     this.router.events
       .pipe(


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

If the user opens a link with a variation master page the variation filter and list is not shown. If the user navigates within the pwa to a variation master page the variation list is shown as expected.
This behavior broke our e2e tests regarding variation handling b2b.
 
---

### 🔍 Detailed Changes
The issue has been caused by timing problems on the initial page. Now the page will also react properly if the data are not immediately available.
The issue has been fixed and the e2e test are enabled again.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113059](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113059)