### PR TITLE
fix: redirect before checkout with a preferred payment instrument

### DIFF
--- a/src/app/pages/checkout-payment/checkout-payment-page.component.ts
+++ b/src/app/pages/checkout-payment/checkout-payment-page.component.ts
@@ -97,11 +97,7 @@ export class CheckoutPaymentPageComponent implements OnInit {
 
   private isPaymentRedirectRequired() {
     if (this.basketPayment) {
-      return (
-        this.basketPayment.capabilities?.includes('RedirectBeforeCheckout') &&
-        this.basketPayment.redirectUrl &&
-        this.basketPayment.redirectRequired
-      );
+      return this.basketPayment.capabilities?.includes('RedirectBeforeCheckout') && this.basketPayment.redirectRequired;
     }
   }
 }


### PR DESCRIPTION
### 🚀 Description

If a user wants to pay with a preferred payment instrument (like a credit card) that requires a redirect before checkout for authorization he cannot continue the checkout on checkout payment page.
There is no error message to show the reason. 
Find more information and the steps to repeat here: 

- Related Ticket/Issue: Closes #494

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113140](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113140)