### PR TITLE
fix: popover placement on mobile

### DIFF
--- a/projects/organization-management/src/app/components/budget-info/budget-info.component.html
+++ b/projects/organization-management/src/app/components/budget-info/budget-info.component.html
@@ -12,6 +12,7 @@
   type="button"
   class="btn btn-link budget-info"
   [ngbPopover]="BudgetPriceTypeInfo"
+  placement="auto"
   data-testing-id="budgetPriceTypeInfoTestingID"
   [title]="'account.organization.budget_price_type.icon' | translate"
 >

--- a/src/app/extensions/wishlists/pages/account-wishlist-detail/account-wishlist-detail-page.component.html
+++ b/src/app/extensions/wishlists/pages/account-wishlist-detail/account-wishlist-detail-page.component.html
@@ -41,7 +41,7 @@
     <button
       type="button"
       [ngbPopover]="WishlistDescription"
-      placement="bottom"
+      placement="bottom-start"
       class="btn btn-link details-tooltip header-note mt-1"
       popoverTitle="{{ 'account.wishlists.heading.tooltip.headline' | translate }}"
     >

--- a/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.html
+++ b/src/app/pages/checkout-shipping/formly/shipping-radio-wrapper/shipping-radio-wrapper.component.html
@@ -7,7 +7,7 @@
       type="button"
       class="btn btn-link details-tooltip"
       [ngbPopover]="ShippingMethodDescription"
-      placement="top"
+      placement="top-start"
     >
       {{ 'checkout.detail.text' | translate }}<fa-icon [icon]="['fas', 'info-circle']" />
     </button>

--- a/src/app/shell/header/mini-basket/mini-basket.component.html
+++ b/src/app/shell/header/mini-basket/mini-basket.component.html
@@ -42,7 +42,7 @@
       class="item-count-container position-relative sticky-header-icon"
       [autoClose]="'outside'"
       [ngbPopover]="'shopping_cart.ministatus.empty_cart.text' | translate"
-      placement="bottom"
+      placement="bottom-end"
       triggers="manual"
       #p="ngbPopover"
       (click)="p.open()"


### PR DESCRIPTION
### 🚀 Description

On mobile devices the popover widgets are sometimes not completely to be seen, because the placement is not correct.
This has been fixed on several pages:
- wishlist detail page (how do wishlists work?)
- checkout shipping page (shipping method descriptions)
- empty mini basket
- budget info, e.g. on cost center management page

---

### 🔍 Detailed Changes

<img width="683" height="783" alt="image" src="https://github.com/user-attachments/assets/445f5b16-6c05-4200-96bb-d70d31937468" />


---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113161](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113161)