### PR TITLE
fix: display of the language switcher on mobile

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -55,6 +55,9 @@ The `logoutUserSuccess` action is now designated as API-specific and should only
 For resetting user-related state without API calls (e.g., forced logout or session cleanup), use the new `resetUserData` action instead.
 This ensures clearer separation between API events and state management.
 
+The language switch component has been moved from the mobile user information dropdown to the main header navigation for better accessibility and user experience.
+Accordingly, the language switch accordion view and its associated component input variable have been removed.
+
 ## From 9.0.0 to 9.1.0
 
 Catalogs (root-level categories in ICM terminology) with _Show In Menu_ being disabled are now hidden from the main header navigation.

--- a/src/app/shell/header/header-default/__snapshots__/header-default.component.spec.ts.snap
+++ b/src/app/shell/header/header-default/__snapshots__/header-default.component.spec.ts.snap
@@ -17,8 +17,11 @@ exports[`Header Default Component should render normal header adequately for des
       tabindex="-1"
       aria-label="search.searchbox.button.sticky_header.aria_label"
     ></a>
-    <div class="language-switch-container d-none d-md-block">
-      <ish-language-switch data-testing-id="language-switch-desktop"></ish-language-switch>
+    <div class="language-switch-container">
+      <ish-language-switch
+        data-testing-id="language-switch-desktop"
+        ng-reflect-device-type="desktop"
+      ></ish-language-switch>
     </div>
     <ish-mini-basket
       data-testing-id="mini-basket-desktop"
@@ -97,8 +100,11 @@ exports[`Header Default Component should render normal header adequately for mob
         ng-reflect-device-type="mobile"
       ></ish-search-box>
     </div>
-    <div class="language-switch-container d-none d-md-block">
-      <ish-language-switch data-testing-id="language-switch-desktop"></ish-language-switch>
+    <div class="language-switch-container">
+      <ish-language-switch
+        data-testing-id="language-switch-desktop"
+        ng-reflect-device-type="mobile"
+      ></ish-language-switch>
     </div>
     <ish-login-status view="small" ng-reflect-view="small"></ish-login-status
     ><ish-mini-basket
@@ -166,8 +172,11 @@ exports[`Header Default Component should render normal header adequately for tab
       tabindex="-1"
       aria-label="search.searchbox.button.sticky_header.aria_label"
     ></a>
-    <div class="language-switch-container d-none d-md-block">
-      <ish-language-switch data-testing-id="language-switch-desktop"></ish-language-switch>
+    <div class="language-switch-container">
+      <ish-language-switch
+        data-testing-id="language-switch-desktop"
+        ng-reflect-device-type="tablet"
+      ></ish-language-switch>
     </div>
     <ish-mini-basket
       data-testing-id="mini-basket-desktop"
@@ -234,7 +243,7 @@ exports[`Header Default Component should render sticky header adequately for des
       aria-label="search.searchbox.button.sticky_header.aria_label"
       ><fa-icon class="header-icon" ng-reflect-icon="fas,search"></fa-icon
     ></a>
-    <div class="language-switch-container d-none d-md-block"></div>
+    <div class="language-switch-container"></div>
     <ish-login-status view="small" ng-reflect-view="small"></ish-login-status
     ><ish-mini-basket
       data-testing-id="mini-basket-desktop"
@@ -307,7 +316,7 @@ exports[`Header Default Component should render sticky header adequately for mob
         ng-reflect-device-type="mobile"
       ></ish-search-box>
     </div>
-    <div class="language-switch-container d-none d-md-block"></div>
+    <div class="language-switch-container"></div>
     <ish-login-status view="small" ng-reflect-view="small"></ish-login-status
     ><ish-mini-basket
       data-testing-id="mini-basket-desktop"
@@ -367,7 +376,7 @@ exports[`Header Default Component should render sticky header adequately for tab
       aria-label="search.searchbox.button.sticky_header.aria_label"
       ><fa-icon class="header-icon" ng-reflect-icon="fas,search"></fa-icon
     ></a>
-    <div class="language-switch-container d-none d-md-block"></div>
+    <div class="language-switch-container"></div>
     <ish-login-status view="small" ng-reflect-view="small"></ish-login-status
     ><ish-mini-basket
       data-testing-id="mini-basket-desktop"

--- a/src/app/shell/header/header-default/header-default.component.html
+++ b/src/app/shell/header/header-default/header-default.component.html
@@ -64,8 +64,8 @@
       </div>
     </ng-template>
 
-    <div class="language-switch-container d-none d-md-block">
-      <ish-language-switch *ngIf="!isSticky" data-testing-id="language-switch-desktop" />
+    <div class="language-switch-container">
+      <ish-language-switch *ngIf="!isSticky" [deviceType]="deviceType" data-testing-id="language-switch-desktop" />
     </div>
     <ish-login-status *ngIf="isSticky || deviceType === 'mobile'" view="small" />
 

--- a/src/app/shell/header/language-switch/language-switch.component.html
+++ b/src/app/shell/header/language-switch/language-switch.component.html
@@ -2,7 +2,6 @@
 <div
   *ngIf="locale$ | async as locale"
   class="language-switch"
-  [ngClass]="view"
   ngbDropdown
   placement="{{ placement === 'up' ? 'top-right' : 'bottom-right' }}"
 >
@@ -13,9 +12,12 @@
     aria-haspopup="menu"
     [attr.aria-label]="('language_switch.label' | translate) + ('locale.' + locale + '.long' | translate)"
   >
-    <fa-icon [icon]="['fas', 'globe-americas']" class="header-icon" />
+    <span class="sticky-header-icon">
+      <fa-icon [icon]="['fas', 'globe-americas']" class="header-icon mb-1" />
+    </span>
     <span class="language-switch-current-selection d-inline"
-      >{{ 'locale.' + locale + '.long' | translate }}<span class="switch_arrow"></span
+      >{{ 'locale.' + locale + (deviceType === 'mobile' ? '.short' : '.long') | translate
+      }}<span class="switch_arrow"></span
     ></span>
   </button>
   <div ngbDropdownMenu class="language-switch-container dropdown-menu" role="menu" style="left: 0 !important">

--- a/src/app/shell/header/language-switch/language-switch.component.ts
+++ b/src/app/shell/header/language-switch/language-switch.component.ts
@@ -4,15 +4,19 @@ import { Observable } from 'rxjs';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { FeatureToggleService } from 'ish-core/feature-toggle.module';
+import { DeviceType } from 'ish-core/models/viewtype/viewtype.types';
 import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 
+/**
+ * The Language Switch Component shows a dropdown allowing to switch the current language/locale.
+ */
 @Component({
   selector: 'ish-language-switch',
   templateUrl: './language-switch.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LanguageSwitchComponent implements OnInit {
-  @Input() view: '' | 'accordion' = '';
+  @Input() deviceType: DeviceType = 'desktop';
   /**
    * determines position of dropbox
    */

--- a/src/app/shell/header/user-information-mobile/user-information-mobile.component.html
+++ b/src/app/shell/header/user-information-mobile/user-information-mobile.component.html
@@ -10,5 +10,4 @@
   <div *ishFeature="'wishlists'" class="user-info-box-item">
     <ish-lazy-wishlists-link view="full" />
   </div>
-  <div class="user-info-box-item"><ish-language-switch view="accordion" placement="up" /></div>
 </div>

--- a/src/app/shell/header/user-information-mobile/user-information-mobile.component.spec.ts
+++ b/src/app/shell/header/user-information-mobile/user-information-mobile.component.spec.ts
@@ -4,7 +4,6 @@ import { MockComponent } from 'ng-mocks';
 
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { findAllCustomElements } from 'ish-core/utils/dev/html-query-utils';
-import { LanguageSwitchComponent } from 'ish-shell/header/language-switch/language-switch.component';
 import { LoginStatusComponent } from 'ish-shell/header/login-status/login-status.component';
 
 import { LazyProductCompareStatusComponent } from '../../../extensions/compare/exports/lazy-product-compare-status/lazy-product-compare-status.component';
@@ -22,7 +21,6 @@ describe('User Information Mobile Component', () => {
     await TestBed.configureTestingModule({
       imports: [FeatureToggleModule.forTesting('compare', 'quickorder', 'wishlists'), TranslateModule.forRoot()],
       declarations: [
-        MockComponent(LanguageSwitchComponent),
         MockComponent(LazyProductCompareStatusComponent),
         MockComponent(LazyQuickorderLinkComponent),
         MockComponent(LazyWishlistsLinkComponent),
@@ -54,7 +52,6 @@ describe('User Information Mobile Component', () => {
         "ish-lazy-product-compare-status",
         "ish-lazy-quickorder-link",
         "ish-lazy-wishlists-link",
-        "ish-language-switch",
       ]
     `);
   });

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -1121,7 +1121,7 @@
   "locale.de_DE.long": "Deutsch",
   "locale.de_DE.short": "de",
   "locale.en_US.long": "English (US)",
-  "locale.en_US.short": "en-US",
+  "locale.en_US.short": "en",
   "locale.fr_FR.long": "Français",
   "locale.fr_FR.short": "fr",
   "modal.heading.remove.order.template": "Produkt aus Bestellvorlage entfernen",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -1121,7 +1121,7 @@
   "locale.de_DE.long": "Deutsch",
   "locale.de_DE.short": "de",
   "locale.en_US.long": "English (US)",
-  "locale.en_US.short": "en-US",
+  "locale.en_US.short": "en",
   "locale.fr_FR.long": "Français",
   "locale.fr_FR.short": "fr",
   "modal.heading.remove.order.template": "Remove product from order template",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -1121,7 +1121,7 @@
   "locale.de_DE.long": "Deutsch",
   "locale.de_DE.short": "de",
   "locale.en_US.long": "English (US)",
-  "locale.en_US.short": "en-US",
+  "locale.en_US.short": "en",
   "locale.fr_FR.long": "Français",
   "locale.fr_FR.short": "fr",
   "modal.heading.remove.order.template": "Supprimer le produit du modèle de commande",

--- a/src/styles/components/header/language-switch.scss
+++ b/src/styles/components/header/language-switch.scss
@@ -1,84 +1,52 @@
 .language-switch {
-  margin-left: ($space-default * 2);
   font-family: $font-family-bold;
   font-size: $font-size-sm;
 
   .dropdown-menu {
     position: absolute;
-    min-width: 50px;
   }
 
   .language-switch-button {
-    //mobile
-    padding: 0;
-    margin: 13px 0 $space-default -1px;
+    padding: 0 3px;
+    margin: 13px 6px $space-default 0;
     font-family: $font-family-bold;
     font-size: 12px;
     text-transform: uppercase;
     cursor: pointer;
-  }
 
-  //language selector not as accordion
-  &:not(.accordion) {
-    .language-switch-button {
+    @media (min-width: $screen-sm-min) {
       display: block;
       padding: ($space-default * 0.5) $space-default 9px ($space-default * 0.5);
       margin: 2px 0 0;
       color: $text-color-quinary !important;
     }
-
-    .language-switch-menu-container {
-      padding: 15px;
-      margin: -15px;
-    }
-
-    .language-switch-container {
-      left: 0 !important;
-      z-index: 9999;
-      padding: divide($space-default * 2, 3) $space-default;
-      background: $color-inverse;
-      box-shadow: 0 4px 3px 0 rgb(0 0 0 / 0.2);
-
-      ul {
-        padding-left: 0;
-        margin-bottom: 0;
-        list-style: none;
-
-        li {
-          font-family: $font-family-regular;
-          font-size: $font-size-corporate;
-          line-height: ($line-height-base * 1.5);
-
-          a:hover {
-            color: $CORPORATE-SECONDARY;
-          }
-        }
-      }
-    }
   }
 
-  //language selector as accordion
-  &.accordion {
-    margin-left: 0;
+  .language-switch-menu-container {
+    padding: 15px;
+    margin: -15px;
+  }
 
-    .language-switch-container {
-      position: relative;
-      top: 0 !important;
-      left: 0 !important;
-      width: 100%;
-      padding-top: 0;
-      margin-top: 0;
+  .language-switch-container {
+    left: 0 !important;
+    z-index: 9999;
+    padding: divide($space-default * 2, 3) $space-default;
+    background: $color-inverse;
+    box-shadow: 0 4px 3px 0 rgb(0 0 0 / 0.2);
 
-      ul {
-        list-style: none;
-      }
+    ul {
+      padding-left: 0;
+      margin-bottom: 0;
+      list-style: none;
 
       li {
-        line-height: 25px;
-      }
+        font-family: $font-family-regular;
+        font-size: $font-size-corporate;
+        line-height: ($line-height-base * 1.5);
 
-      a {
-        font-size: 12px;
+        a:hover {
+          color: $CORPORATE-SECONDARY;
+        }
       }
     }
   }

--- a/src/styles/components/header/search-container.scss
+++ b/src/styles/components/header/search-container.scss
@@ -338,6 +338,7 @@
     &.header-search-container {
       @include media-breakpoint-down(md) {
         top: $header-height-mobile;
+        z-index: 9000;
         width: 100%;
         padding: 0;
       }

--- a/src/styles/components/header/user-information-mobile.scss
+++ b/src/styles/components/header/user-information-mobile.scss
@@ -20,18 +20,4 @@
     color: $text-color-tertiary;
     text-transform: uppercase;
   }
-
-  .language-switch.accordion .language-switch-container {
-    left: 30px !important;
-    padding-bottom: 0;
-
-    ul {
-      padding: divide($space-default * 2, 3);
-      margin-bottom: 0;
-
-      li a {
-        font-family: $font-family-bold;
-      }
-    }
-  }
 }


### PR DESCRIPTION
### 🚀 Description

The appearance of the language switcher in the mobile view is broken. 
The language switch has been moved to the main header navigation for better accessibility and user experience and the styling issues have been fixed.

---

### 🔍 Detailed Changes

Before the fix: 

<img width="412" height="622" alt="image" src="https://github.com/user-attachments/assets/67635abc-f5e7-4832-a004-476ec50f315f" />

After the fix:

<img width="397" height="469" alt="image" src="https://github.com/user-attachments/assets/6db54d9d-c699-4d0d-847d-0eae460825d6" />

---

### 📝 Notes

The input component variables of the 'language-switch.component.ts' have been changed: The input variable 'view' has been removed and the input variable 'deviceType' has been added.

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [x] Documentation and Localizations reviewed by the documentation team
- [x] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113258](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113258)