### PR TITLE
fix: use current locale in static filter navigation image URLs

### DIFF
--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.spec.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 
-import { getICMStaticURL } from 'ish-core/store/core/configuration';
+import { getCurrentLocale, getICMStaticURL } from 'ish-core/store/core/configuration';
 
 import { FilterNavigationData } from './filter-navigation.interface';
 import { FilterNavigationMapper } from './filter-navigation.mapper';
@@ -16,6 +16,7 @@ describe('Filter Navigation Mapper', () => {
         provideMockStore({
           selectors: [
             { selector: getICMStaticURL, value: 'http://www.example.org/INTERSHOP/static/WFS/Test-Channel-Site/rest' },
+            { selector: getCurrentLocale, value: 'de_DE' },
           ],
         }),
       ],
@@ -82,7 +83,7 @@ describe('Filter Navigation Mapper', () => {
       } as FilterNavigationData;
 
       // Override the private currentLocale property to undefined
-      (mapper as unknown as { currentLocale: string | undefined }).currentLocale = undefined;
+      (mapper as unknown as { currentLocale: string }).currentLocale = undefined;
 
       const model = mapper.fromData(data);
       expect(model.filter[0].facets[0].mappedValue).toBe(
@@ -106,12 +107,9 @@ describe('Filter Navigation Mapper', () => {
         ],
       } as FilterNavigationData;
 
-      // Override the private currentLocale property to 'en_US'
-      (mapper as unknown as { currentLocale: string | 'en_US' }).currentLocale = 'en_US';
-
       const model = mapper.fromData(data);
       expect(model.filter[0].facets[0].mappedValue).toBe(
-        'url(http://www.example.org/INTERSHOP/static/WFS/Test-Channel-Site/rest/image-unit/en_US/subfolder/image.jpg)'
+        'url(http://www.example.org/INTERSHOP/static/WFS/Test-Channel-Site/rest/image-unit/de_DE/subfolder/image.jpg)'
       );
     });
   });

--- a/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
+++ b/src/app/core/models/filter-navigation/filter-navigation.mapper.ts
@@ -12,10 +12,10 @@ import { FilterNavigation } from './filter-navigation.model';
 @Injectable({ providedIn: 'root' })
 export class FilterNavigationMapper {
   private icmStaticURL: string;
-  private currentLocale: string;
+  private currentLocale = '-';
   constructor(store: Store) {
     store.pipe(select(getICMStaticURL)).subscribe(url => (this.icmStaticURL = url));
-    store.pipe(select(getCurrentLocale)).subscribe(locale => (this.currentLocale = locale));
+    store.pipe(select(getCurrentLocale)).subscribe(locale => (this.currentLocale = locale || '-'));
   }
 
   fromData(data: FilterNavigationData): FilterNavigation {


### PR DESCRIPTION
### 🚀 Description

Filter navigation values that use an filter image mapping will use the current locale in the static image URL instead of always using the default locale '-' 

### 🚀 Details

When the search index configuration for filter image mapping uses localized images in filter value mappings, these images are not displayed in swatch components because the mapper was hardcoded to use '-' as the default locale value. This fix updates the mapper to use the current locale, enabling proper display of localized images. When no localized image is available, ICM's locale fallback mechanism will serve the image from the default (lead) locale.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113527](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113527)