### PR TITLE
fix: authorization-toggle directive after logout

### DIFF
--- a/src/app/core/utils/authorization-toggle/authorization-toggle.service.ts
+++ b/src/app/core/utils/authorization-toggle/authorization-toggle.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, skipWhile } from 'rxjs/operators';
 
 import { getUserPermissions } from 'ish-core/store/customer/authorization';
-import { whenTruthy } from 'ish-core/utils/operators';
 
 export function checkPermission(userPermissions: string[], permission: string | string[]): boolean {
   if (permission === 'always') {
@@ -14,7 +13,7 @@ export function checkPermission(userPermissions: string[], permission: string | 
   } else {
     // eslint-disable-next-line no-param-reassign
     permission = typeof permission === 'string' ? [permission] : typeof permission === 'undefined' ? [] : permission;
-    return permission.some(id => userPermissions.includes(id));
+    return permission.some(id => userPermissions?.includes(id));
   }
 }
 
@@ -32,9 +31,10 @@ export class AuthorizationToggleService {
       return of(checkPermission([], permission));
     }
     return this.permissions$.pipe(
-      // wait for permissions to be loaded
-      whenTruthy(),
-      map(permissions => checkPermission(permissions, permission))
+      // ignore initial undefined values
+      skipWhile(permissions => permissions === undefined),
+      // react on logout properly
+      map(permissions => (permissions ? checkPermission(permissions, permission) : false))
     );
   }
 }


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

A visual component might only be displayed if the user has a certain permission using the `ishIsAuthorizedTo` directive.
After logout the component visibility is currently not updated, e.i. the component is still visible after logout.


---

### 🔍 Detailed Changes

This issue has been fixed. 

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113622](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113622)

[AB#113705](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113705)