### PR TITLE
fix: remove additional encoding for canonical links to prevent double encoding

### DIFF
--- a/src/app/extensions/seo/store/seo/seo.effects.ts
+++ b/src/app/extensions/seo/store/seo/seo.effects.ts
@@ -67,10 +67,10 @@ export class SeoEffects {
         switchMap(() =>
           race([
             // PRODUCT PAGE
-            this.productPage$.pipe(map(product => this.baseURL + generateProductUrl(product).substring(1))),
+            this.productPage$.pipe(map(product => encodeURI(this.baseURL + generateProductUrl(product).substring(1)))),
             // CATEGORY / FAMILY PAGE
             this.categoryPage$.pipe(
-              map((category: CategoryView) => this.baseURL + generateCategoryUrl(category).substring(1))
+              map((category: CategoryView) => encodeURI(this.baseURL + generateCategoryUrl(category).substring(1)))
             ),
             // DEFAULT
             this.appRef.isStable.pipe(
@@ -207,9 +207,9 @@ export class SeoEffects {
   private setCanonicalLink(url: string) {
     // the canonical URL of a production system should always be with 'https:'
     // even though the PWA SSR container itself is usually not deployed in an SSL environment so the URLs need manual adaption
-    const canonicalUrl = encodeURI(url.replace('http:', 'https:'));
-    const canonicalLink = this.domService.getOrCreateElement('link[rel="canonical"]', 'link', this.doc.head);
+    const canonicalUrl = url.replace('http:', 'https:');
 
+    const canonicalLink = this.domService.getOrCreateElement('link[rel="canonical"]', 'link', this.doc.head);
     this.domService.setAttribute(canonicalLink, 'rel', 'canonical');
     this.domService.setAttribute(canonicalLink, 'href', canonicalUrl);
 


### PR DESCRIPTION
### 🚀 Description

This pull request makes a minor change to the `setCanonicalLink` method in `seo.effects.ts` to improve how canonical URLs are handled. The change removes the use of `encodeURI` when setting the canonical URL, which helps avoid unnecessary encoding and potential issues with special characters in URLs.

- Canonical URL handling:
  * Updated the `setCanonicalLink` method to remove `encodeURI`. This ensures the URL is not double-encoded and remains in a valid format.

The canonical link URL does not need to be encoded a second time since the incoming URL should already be encoded

The removed double encoding resolves issues with recursive searches of wrong encoded search terms that originally only had a white space, e.g. 

from: https://intershoppwa.azurewebsites.net/search/notebook%20black

to: https://intershoppwa.azurewebsites.net/search/notebook%252525252525252520black

- Related Ticket/Issue: Closes #1711

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#113688](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113688)


[AB#113756](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113756)