### PR TITLE
feat: use SPARQUE wrapper API 4

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -64,6 +64,9 @@ Accordingly, the language switch accordion view and its associated component inp
 The `CACHE_CLEARER` environment variable behavior changed from opt-in to opt-out.
 Set `CACHE_CLEARER` to `off` to disable this feature.
 
+The SPARQUE services use API version 4 now for all REST calls.
+Find the corresponding migration notes in the [SPARQUE API Wrapper Migration Guide](https://docs.sparque.ai/wrapper/migration_guides/migration_guide_wrapper_1x9x0.html).
+
 ## From 9.0.0 to 9.1.0
 
 Catalogs (root-level categories in ICM terminology) with _Show In Menu_ being disabled are now hidden from the main header navigation.

--- a/docs/guides/sparque-ai.md
+++ b/docs/guides/sparque-ai.md
@@ -81,8 +81,8 @@ environment:
 ### Configuration Parameters Explained
 
 - **serverUrl**: The URL of the SPARQUE server that the PWA will connect to.
-  - PROD: https://api.search.sparque.ai
-  - Early adopters can use our UAT: https://uat.api.search.sparque.ai (New API releases are available here approximately one week earlier.)
+  - PROD: `https://api.search.sparque.ai`
+  - Early adopters can use our UAT: `https://uat.api.search.sparque.ai` (New API releases are available here approximately one week earlier.)
 - **workspaceName**: The name of the workspace configured in SPARQUE Desk.
 - **apiName**: The name of the API to be used for SPARQUE requests. If your project is based on the ISH project template, use `PWA`. Otherwise, use the name defined in SPARQUE Desk.
 - **config**: Optional parameter specifying the SPARQUE REST configuration (defaults to `default` if not provided).
@@ -117,12 +117,12 @@ It is possible to specify the request API version to be used for each individual
 To change to another API version, the affected get method API parameter has to be adapted.
 If a version other than the recommended PWA version is used, the interfaces and mapper used for the request may have to be adapted.
 
-The following example shows the provided `SparqueSuggestionsService` which uses the v2 API version in the `searchSuggestions` method:
+The following example shows the provided `SparqueSuggestionsService` which uses the v4 API version in the `searchSuggestions` method:
 
 ```ts
 export class SparqueSuggestionsService implements SuggestionsServiceInterface {
   // API version for SPARQUE API.
-  private readonly apiVersion = 'v2';
+  private readonly apiVersion = 'v4';
   ...
   searchSuggestions(
     searchTerm: string
@@ -206,7 +206,7 @@ suggestSearch$ =
       this.actions$.pipe(
         ofType(suggestSearch),
         mapToPayloadProperty('searchTerm'),
-        concatMap(searchTerm =>
+        switchMap(searchTerm =>
           this.suggestionsServiceProvider
             .get()
             .searchSuggestions(searchTerm)
@@ -249,8 +249,6 @@ The number of objects to be displayed can be configured individually for each co
 ```ts
 @Input() maxAutoSuggests: number;
 ```
-
-The default settings are 5 elements for keywords and recent search terms, 3 elements each for categories and brands, and 8 elements for products.
 
 ### Recent Search Terms
 

--- a/src/app/core/services/sparque-api/sparque-api.service.ts
+++ b/src/app/core/services/sparque-api/sparque-api.service.ts
@@ -228,7 +228,7 @@ export class SparqueApiService {
    * Automatically handles authentication, parameter mapping, and error handling.
    *
    * @param path        The API endpoint path (relative or absolute URL)
-   * @param apiVersion  The SPARQUE API version to use (e.g., 'v2')
+   * @param apiVersion  The SPARQUE API version to use (e.g., 'v4')
    * @param options     Optional HTTP request configuration
    * @returns           Observable containing the API response
    */

--- a/src/app/core/services/sparque-products/sparque-products.service.spec.ts
+++ b/src/app/core/services/sparque-products/sparque-products.service.spec.ts
@@ -12,7 +12,7 @@ describe('Sparque Products Service', () => {
   let sparqueApiService: SparqueApiService;
   let sparqueProductsService: SparqueProductsService;
   let sparqueSearchMapper: SparqueSearchMapper;
-  const apiVersion = 'v2';
+  const apiVersion = 'v4';
 
   beforeEach(() => {
     sparqueApiService = mock(SparqueApiService);

--- a/src/app/core/services/sparque-products/sparque-products.service.ts
+++ b/src/app/core/services/sparque-products/sparque-products.service.ts
@@ -17,7 +17,7 @@ import { URLFormParams } from 'ish-core/utils/url-form-params';
 @Injectable({ providedIn: 'root' })
 export class SparqueProductsService implements ProductsServiceInterface {
   // API version for Sparque API.
-  private readonly apiVersion = 'v2';
+  private readonly apiVersion = 'v4';
   // Maximum number of facet options to request from the Sparque API.
   private readonly facetOptionsCount = '10';
 

--- a/src/app/core/services/sparque-recommendations/sparque-recommendations.service.spec.ts
+++ b/src/app/core/services/sparque-recommendations/sparque-recommendations.service.spec.ts
@@ -26,10 +26,16 @@ describe('Sparque Recommendations Service', () => {
   ];
 
   const mockRecommendationsResponse = { products: mockSparqueProducts };
+  const apiVersion = 'v4';
 
   beforeEach(() => {
     sparqueApiServiceMock = mock(SparqueApiService);
     sparqueProductMapperMock = mock(SparqueProductMapper);
+
+    when(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).thenReturn(
+      of(mockRecommendationsResponse)
+    );
+    when(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).thenReturn(mockProducts);
 
     TestBed.configureTestingModule({
       providers: [
@@ -52,9 +58,6 @@ describe('Sparque Recommendations Service', () => {
         maxCount: 5,
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of(mockRecommendationsResponse));
-      when(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).thenReturn(mockProducts);
-
       service.getRecommendations(recommendationsContext).subscribe(result => {
         expect(result).toEqual({
           recommendations: {
@@ -63,7 +66,7 @@ describe('Sparque Recommendations Service', () => {
           },
           products: mockProducts,
         });
-        verify(sparqueApiServiceMock.get('recommendations', 'v3', anything())).once();
+        verify(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).once();
         verify(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).once();
         done();
       });
@@ -78,9 +81,6 @@ describe('Sparque Recommendations Service', () => {
         maxCount: 3,
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of(mockRecommendationsResponse));
-      when(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).thenReturn(mockProducts);
-
       service.getRecommendations(recommendationsContext).subscribe(result => {
         expect(result).toEqual({
           recommendations: {
@@ -89,7 +89,7 @@ describe('Sparque Recommendations Service', () => {
           },
           products: mockProducts,
         });
-        verify(sparqueApiServiceMock.get('recommendations', 'v3', anything())).once();
+        verify(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).once();
         verify(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).once();
         done();
       });
@@ -101,7 +101,7 @@ describe('Sparque Recommendations Service', () => {
         maxCount: 5,
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of({}));
+      when(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).thenReturn(of({}));
       when(sparqueProductMapperMock.fromListData(anything(), anything())).thenReturn([]);
 
       service.getRecommendations(recommendationsContext).subscribe(result => {
@@ -121,9 +121,6 @@ describe('Sparque Recommendations Service', () => {
         strategy: 'trending',
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of(mockRecommendationsResponse));
-      when(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).thenReturn(mockProducts);
-
       service.getRecommendations(recommendationsContext).subscribe(result => {
         expect(result).toEqual({
           recommendations: {
@@ -132,7 +129,7 @@ describe('Sparque Recommendations Service', () => {
           },
           products: mockProducts,
         });
-        verify(sparqueApiServiceMock.get('recommendations', 'v3', anything())).once();
+        verify(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).once();
         verify(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).once();
         done();
       });
@@ -145,7 +142,7 @@ describe('Sparque Recommendations Service', () => {
       };
 
       const apiError = new Error('API Error');
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(throwError(() => apiError));
+      when(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).thenReturn(throwError(() => apiError));
 
       service.getRecommendations(recommendationsContext).subscribe({
         next: () => fail('should have thrown an error'),
@@ -163,9 +160,6 @@ describe('Sparque Recommendations Service', () => {
         maxCount: 2,
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of(mockRecommendationsResponse));
-      when(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).thenReturn(mockProducts);
-
       service.getRecommendations(recommendationsContext).subscribe(result => {
         expect(result).toEqual({
           recommendations: {
@@ -174,7 +168,7 @@ describe('Sparque Recommendations Service', () => {
           },
           products: mockProducts,
         });
-        verify(sparqueApiServiceMock.get('recommendations', 'v3', anything())).once();
+        verify(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).once();
         done();
       });
     });
@@ -185,9 +179,6 @@ describe('Sparque Recommendations Service', () => {
         maxCount: 4,
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of(mockRecommendationsResponse));
-      when(sparqueProductMapperMock.fromListData(mockSparqueProducts, anything())).thenReturn(mockProducts);
-
       service.getRecommendations(recommendationsContext).subscribe(result => {
         expect(result).toEqual({
           recommendations: {
@@ -196,7 +187,7 @@ describe('Sparque Recommendations Service', () => {
           },
           products: mockProducts,
         });
-        verify(sparqueApiServiceMock.get('recommendations', 'v3', anything())).once();
+        verify(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).once();
         done();
       });
     });
@@ -207,7 +198,9 @@ describe('Sparque Recommendations Service', () => {
         maxCount: 5,
       };
 
-      when(sparqueApiServiceMock.get('recommendations', 'v3', anything())).thenReturn(of({ products: undefined }));
+      when(sparqueApiServiceMock.get('recommendations', apiVersion, anything())).thenReturn(
+        of({ products: undefined })
+      );
       when(sparqueProductMapperMock.fromListData(anything(), anything())).thenReturn([]);
 
       service.getRecommendations(recommendationsContext).subscribe(result => {

--- a/src/app/core/services/sparque-recommendations/sparque-recommendations.service.ts
+++ b/src/app/core/services/sparque-recommendations/sparque-recommendations.service.ts
@@ -22,7 +22,7 @@ import { SparqueApiService } from 'ish-core/services/sparque-api/sparque-api.ser
 @Injectable({ providedIn: 'root' })
 export class SparqueRecommendationsService implements RecommendationsServiceInterface {
   // API version for Sparque API.
-  private readonly apiVersion = 'v3';
+  private readonly apiVersion = 'v4';
 
   constructor(private sparqueApiService: SparqueApiService, private sparqueProductMapper: SparqueProductMapper) {}
 

--- a/src/app/core/services/sparque-suggestions/sparque-suggestions.service.spec.ts
+++ b/src/app/core/services/sparque-suggestions/sparque-suggestions.service.spec.ts
@@ -12,7 +12,7 @@ describe('Sparque Suggestions Service', () => {
   let sparqueSuggestionsService: SparqueSuggestionsService;
   const sparqueApiService = mock(SparqueApiService);
   const sparqueSuggestionsMapper = mock(SparqueSuggestionsMapper);
-  const apiVersion = 'v2';
+  const apiVersion = 'v4';
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/src/app/core/services/sparque-suggestions/sparque-suggestions.service.ts
+++ b/src/app/core/services/sparque-suggestions/sparque-suggestions.service.ts
@@ -17,7 +17,7 @@ import { SparqueApiService } from 'ish-core/services/sparque-api/sparque-api.ser
 @Injectable({ providedIn: 'root' })
 export class SparqueSuggestionsService implements SuggestionsServiceInterface {
   // API version for Sparque API.
-  private readonly apiVersion = 'v2';
+  private readonly apiVersion = 'v4';
   // Maximum number of suggestions to request from the Sparque API.
   private readonly maxNumberOfRequestedSuggestions = '8';
 


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

An outdated version of the SPARQUE Wrapper REST API has been used in the SPARQUE services of the PWA.
Now the latest version v4 is used in all services.
Find migration notes in the [SPARQUE wrapper API migration guide](https://docs.sparque.ai/wrapper/migration_guides/migration_guide_wrapper_1x9x0.html).

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->
