### PR TITLE
fix: retry fetching eligible shipping methods on bucket not found error

### DIFF
--- a/src/app/core/services/basket/basket.service.spec.ts
+++ b/src/app/core/services/basket/basket.service.spec.ts
@@ -222,6 +222,30 @@ describe('Basket Service', () => {
     });
   });
 
+  it("should retry with fresh basket data when bucket not found error occurs in 'getBasketEligibleShippingMethods'", done => {
+    const bucketNotFoundError = makeHttpError({
+      errors: [{ code: 'basket.shipping_bucket.not_found.error', message: 'Bucket not found' }],
+    });
+
+    const basketWithNewBucketMockData = {
+      data: {
+        ...basketMockData.data,
+        buckets: ['newBucket123'],
+      },
+    } as BasketData;
+
+    when(apiService.get('eligible-shipping-methods', anything())).thenReturn(throwError(() => bucketNotFoundError));
+    when(apiService.get('', anything())).thenReturn(of(basketWithNewBucketMockData));
+    when(apiService.get('buckets/newBucket123/eligible-shipping-methods', anything())).thenReturn(of({ data: [] }));
+
+    basketService.getBasketEligibleShippingMethods().subscribe(() => {
+      verify(apiService.get('eligible-shipping-methods', anything())).once();
+      verify(apiService.get('', anything())).once(); // getBasket() retry call
+      verify(apiService.get('buckets/newBucket123/eligible-shipping-methods', anything())).once();
+      done();
+    });
+  });
+
   it("should submit a basket for approval when 'submitBasket' is called", done => {
     when(orderService.createOrder(anything(), anything())).thenReturn(
       throwError(() => makeHttpError({ message: 'invalid', status: 422 }))

--- a/src/app/core/services/basket/basket.service.ts
+++ b/src/app/core/services/basket/basket.service.ts
@@ -18,6 +18,7 @@ import { BasketBaseData, BasketData } from 'ish-core/models/basket/basket.interf
 import { BasketMapper } from 'ish-core/models/basket/basket.mapper';
 import { Basket } from 'ish-core/models/basket/basket.model';
 import { CustomFieldData } from 'ish-core/models/custom-field/custom-field.interface';
+import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { Recurrence } from 'ish-core/models/recurrence/recurrence.model';
 import { ShippingMethodData } from 'ish-core/models/shipping-method/shipping-method.interface';
 import { ShippingMethodMapper } from 'ish-core/models/shipping-method/shipping-method.mapper';
@@ -357,25 +358,39 @@ export class BasketService {
    * @returns         The eligible shipping methods.
    */
   getBasketEligibleShippingMethods(bucketId?: string): Observable<ShippingMethod[]> {
-    return bucketId
-      ? this.apiService
-          .currentBasketEndpoint()
-          .get(`buckets/${this.apiService.encodeResourceId(bucketId)}/eligible-shipping-methods`, {
-            headers: this.basketHeaders,
-          })
-          .pipe(
-            unpackEnvelope<ShippingMethodData>('data'),
-            map(data => data.map(ShippingMethodMapper.fromData))
-          )
-      : this.apiService
-          .currentBasketEndpoint()
-          .get('eligible-shipping-methods', {
-            headers: this.basketHeaders,
-          })
-          .pipe(
-            unpackEnvelope<ShippingMethodData>('data'),
-            map(data => data.map(ShippingMethodMapper.fromData))
+    const getShippingMethods = (currentBucketId?: string) =>
+      currentBucketId
+        ? this.apiService
+            .currentBasketEndpoint()
+            .get(`buckets/${this.apiService.encodeResourceId(currentBucketId)}/eligible-shipping-methods`, {
+              headers: this.basketHeaders,
+            })
+            .pipe(
+              unpackEnvelope<ShippingMethodData>('data'),
+              map(data => data.map(ShippingMethodMapper.fromData))
+            )
+        : this.apiService
+            .currentBasketEndpoint()
+            .get('eligible-shipping-methods', {
+              headers: this.basketHeaders,
+            })
+            .pipe(
+              unpackEnvelope<ShippingMethodData>('data'),
+              map(data => data.map(ShippingMethodMapper.fromData))
+            );
+
+    return getShippingMethods(bucketId).pipe(
+      catchError((error: HttpError) => {
+        if (error.errors?.some(err => err.code === 'basket.shipping_bucket.not_found.error')) {
+          // Reload basket and retry shipping methods call with updated bucket ID
+          return this.getBasket().pipe(
+            switchMap(basket => getShippingMethods(basket.bucketId)),
+            catchError(() => throwError(() => error))
           );
+        }
+        return throwError(() => error);
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
### 🚀 Description

On the **PWA Shipping page** an error can occur when the **same basket is modified in parallel** by two clients (e.g. user is logged in on two devices).
The PWA stores basket data internally after loading it via `GET /baskets/<id>`. The basket contains **Shipping Bucket IDs**.  
When the user opens the Shipping page, the PWA requests eligible shipping methods for each bucket via:
`GET /baskets/<id>/buckets/<bucket-id>/eligible-shipping-methods`
If, between the last basket load and this request, another client changes the basket (e.g.adds/removes items), the bucket structure may be recalculated by backend, which can result in **changed bucket IDs**.
The first PWA instance still uses the previously cached bucket IDs and sends the request with a now **invalid bucket-id**, leading to an error (bucket not found)

---

### 🔍 Detailed Changes

Added retry logic to getBasketEligibleShippingMethods to handle stale bucket ID errors. When the server returns a `basket.shipping_bucket.not_found.error`, the service now automatically reloads the basket to get the updated bucket ID and retries the shipping methods request.

---

### 📝 Notes

Replaced by #2007 

---

### 🔗 Other Information




[AB#113737](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113737)

[AB#113765](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113765)