### PR TITLE
fix: fetch shipping methods directly from basket

### DIFF
--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -277,9 +277,7 @@ describe('Basket Effects', () => {
 
   describe('loadBasketEligibleShippingMethods$', () => {
     beforeEach(() => {
-      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
-        of([BasketMockData.getShippingMethod()])
-      );
+      when(basketServiceMock.getBasketEligibleShippingMethods()).thenReturn(of([BasketMockData.getShippingMethod()]));
 
       store.dispatch(
         loadBasketSuccess({
@@ -296,7 +294,7 @@ describe('Basket Effects', () => {
       actions$ = of(action);
 
       effects.loadBasketEligibleShippingMethods$.subscribe(() => {
-        verify(basketServiceMock.getBasketEligibleShippingMethods(undefined)).once();
+        verify(basketServiceMock.getBasketEligibleShippingMethods()).once();
         done();
       });
     });
@@ -313,7 +311,7 @@ describe('Basket Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketEligibleShippingMethodsFail', () => {
-      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
+      when(basketServiceMock.getBasketEligibleShippingMethods()).thenReturn(
         throwError(() => makeHttpError({ message: 'invalid' }))
       );
       const action = loadBasketEligibleShippingMethods();

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -166,9 +166,8 @@ export class BasketEffects {
   loadBasketEligibleShippingMethods$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadBasketEligibleShippingMethods),
-      concatLatestFrom(() => this.store.pipe(select(getCurrentBasket))),
-      concatMap(([, basket]) =>
-        this.basketService.getBasketEligibleShippingMethods(basket.bucketId).pipe(
+      concatMap(() =>
+        this.basketService.getBasketEligibleShippingMethods().pipe(
           map(result => loadBasketEligibleShippingMethodsSuccess({ shippingMethods: result })),
           mapErrorToAction(loadBasketEligibleShippingMethodsFail)
         )


### PR DESCRIPTION
### 🚀 Description

On the **PWA Shipping page** an error can occur when the **same basket is modified in parallel** by two clients (e.g. user is logged in on two devices).
The PWA stores basket data internally after loading it via `GET /baskets/<id>`. The basket contains **Shipping Bucket IDs**.  
When the user opens the Shipping page, the PWA requests eligible shipping methods for each bucket via:
`GET /baskets/<id>/buckets/<bucket-id>/eligible-shipping-methods`
If, between the last basket load and this request, another client changes the basket (e.g.adds/removes items), the bucket structure may be recalculated by backend, which can result in **changed bucket IDs**.
The first PWA instance still uses the previously cached bucket IDs and sends the request with a now **invalid bucket-id**, leading to an error (bucket not found)

---

### 🔍 Detailed Changes

The effect has been updated to fetch eligible shipping methods directly from the basket endpoint, rather than from the basket buckets.

---

### 📝 Notes

An alternative approach is: #2006 where the eligible shipping methods continue to be fetched from the bucket. If there is a bucket ID mismatch, the basket is reloaded to retrieve updated bucket IDs.

---

### 🔗 Other Information



[AB#113764](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/113764)