### PR TITLE
chore: update vscode settings regarding the typescript version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
 
   "git.rebaseWhenSync": true,
   "git.autoStash": true,
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "workbench.iconTheme": "vscode-icons",
 
   // stylelint
@@ -50,5 +50,7 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "prettier.requireConfig": true,
-  "github.copilot.enable": true
+  "github.copilot.enable": {
+    "*": true
+  }
 }


### PR DESCRIPTION


<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

Update vscode settings to use the workspace typescript version (5.4). Otherwise there will be typescript errors regarding strict checks in typescript files in vscode.

<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

---

### 🔍 Detailed Changes

The property 'typescript.tsdk' in the vscode/settings.json was outdated and didn't work any more.
Now the property ''js/ts.tsdk.path" is used instead.
Additionally, the property "github.copilot.enable" value was update to use an object instead of a boolean.

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#115766](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/115766)