### PR TITLE
perf: add Resource Set ID to CMS View Context REST calls

### DIFF
--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -213,7 +213,7 @@ The resource set ID can be overridden at the individual view context inclusion b
 If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, you can also change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` usage.
 
 > [!NOTE]
-> Using view context REST requests with the added resource set ID requires ICM 12.1.0.
+> Using view context REST requests with the added resource set ID requires ICM 12.1.0 or later.
 
 ## Design View
 

--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -12,6 +12,7 @@ kb_sync_latest_only
 - [Navigation Components](#navigation-components)
 - [Account Content Pages](#account-content-pages)
 - [View Contexts](#view-contexts)
+  - [View Contexts requests with Resource Set ID](#view-contexts-requests-with-resource-set-id)
 - [Design View](#design-view)
 - [Integration with an External CMS](#integration-with-an-external-cms)
 
@@ -180,6 +181,39 @@ Be aware that enabling view contexts requires adapting some Jest component tests
 > [!NOTE]
 > The default view contexts are examples for demonstration purposes that could be used in the same way in a customer project.
 > It is advised, however, to evaluate which view contexts are indeed needed in the project and to activate those accordingly, or to create the ones that meet the project requirements even better.
+
+### View Contexts requests with Resource Set ID
+
+The REST requests to ICM to get CMS View Context data are more performant if a resource set ID is provided.
+
+Without resource set ID, less performant due to expensive Cartridge lookups:
+
+```
+/cms/viewcontexts/viewcontext.include.product.base.top/entrypoint?Product=201807181
+```
+
+With resource set ID, more performant when view context model Cartridge is provided:
+
+```
+/cms/viewcontexts/viewcontext.include.product.base.top@app_sf_base_cm/entrypoint?Product=201807181
+```
+
+With PWA 11.0.0 the Intershop PWA automatically adds the resource set ID to the View Context REST requests via configured `defaultResourceSetId` defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts).
+The default resource set ID is configured to the standard ICM Cartridge name that contains the defining view context models - `app_sf_base_cm`.
+The resource set ID can be overridden at the individual view context inclusion by providing the `resourceSetId` input parameter at the `ish-content-viewcontext` component.
+
+```html
+<ish-content-viewcontext
+  viewContextId="viewcontext.include.product.base.top"
+  [callParameters]="{ Product: product.sku }"
+  resourceSetId="custom_cartridge_name"
+/>
+```
+
+If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, it is also possible to change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` use.
+
+> [!NOTE]
+> Making View Context REST requests with the added resource set ID requires ICM 12.1.0.
 
 ## Design View
 

--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -213,7 +213,7 @@ The resource set ID can be overridden at the individual view context inclusion b
 If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, you can also change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` usage.
 
 > [!NOTE]
-> Making view context REST requests with the added resource set ID requires ICM 12.1.0.
+> Using view context REST requests with the added resource set ID requires ICM 12.1.0.
 
 ## Design View
 

--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -199,7 +199,7 @@ With resource set ID, the request is more performant when the view context model
 ```
 
 With PWA 11.0.0, the Intershop PWA automatically adds the resource set ID to view context REST requests via configured `defaultResourceSetId` defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts).
-The default resource set ID is configured to the standard ICM cartridge name that contains the defining view context models: `app_sf_base_cm`.
+The default resource set ID is configured to match the name of the standard ICM cartridge that contains the view context model definitions: `app_sf_base_cm`.
 The resource set ID can be overridden at the individual view context inclusion by providing the `resourceSetId` input parameter at the `ish-content-viewcontext` component.
 
 ```html

--- a/docs/concepts/cms-integration.md
+++ b/docs/concepts/cms-integration.md
@@ -12,7 +12,7 @@ kb_sync_latest_only
 - [Navigation Components](#navigation-components)
 - [Account Content Pages](#account-content-pages)
 - [View Contexts](#view-contexts)
-  - [View Contexts requests with Resource Set ID](#view-contexts-requests-with-resource-set-id)
+  - [View Context Requests with Resource Set ID](#view-context-requests-with-resource-set-id)
 - [Design View](#design-view)
 - [Integration with an External CMS](#integration-with-an-external-cms)
 
@@ -182,24 +182,24 @@ Be aware that enabling view contexts requires adapting some Jest component tests
 > The default view contexts are examples for demonstration purposes that could be used in the same way in a customer project.
 > It is advised, however, to evaluate which view contexts are indeed needed in the project and to activate those accordingly, or to create the ones that meet the project requirements even better.
 
-### View Contexts requests with Resource Set ID
+### View Context Requests with Resource Set ID
 
-The REST requests to ICM to get CMS View Context data are more performant if a resource set ID is provided.
+The REST requests to ICM to get CMS view context data are more performant if a resource set ID is provided.
 
-Without resource set ID, less performant due to expensive Cartridge lookups:
+Without resource set ID, the request is less performant due to expensive cartridge lookups:
 
 ```
 /cms/viewcontexts/viewcontext.include.product.base.top/entrypoint?Product=201807181
 ```
 
-With resource set ID, more performant when view context model Cartridge is provided:
+With resource set ID, the request is more performant when the view context model cartridge is provided:
 
 ```
 /cms/viewcontexts/viewcontext.include.product.base.top@app_sf_base_cm/entrypoint?Product=201807181
 ```
 
-With PWA 11.0.0 the Intershop PWA automatically adds the resource set ID to the View Context REST requests via configured `defaultResourceSetId` defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts).
-The default resource set ID is configured to the standard ICM Cartridge name that contains the defining view context models - `app_sf_base_cm`.
+With PWA 11.0.0, the Intershop PWA automatically adds the resource set ID to view context REST requests via configured `defaultResourceSetId` defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts).
+The default resource set ID is configured to the standard ICM cartridge name that contains the defining view context models: `app_sf_base_cm`.
 The resource set ID can be overridden at the individual view context inclusion by providing the `resourceSetId` input parameter at the `ish-content-viewcontext` component.
 
 ```html
@@ -210,10 +210,10 @@ The resource set ID can be overridden at the individual view context inclusion b
 />
 ```
 
-If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, it is also possible to change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` use.
+If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, you can also change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` usage.
 
 > [!NOTE]
-> Making View Context REST requests with the added resource set ID requires ICM 12.1.0.
+> Making view context REST requests with the added resource set ID requires ICM 12.1.0.
 
 ## Design View
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -9,10 +9,10 @@ kb_sync_latest_only
 
 ## From 10.1.0 to 11.0.0
 
-**CMS View Contexts REST requests with Resource Set ID**
+**CMS view context REST requests with resource set ID**
 
-The REST requests to get CMS View Context data now append the resource set ID (the defining view context models cartridge name) by default to improve performance.
-A default resource set ID - `app_sf_base_cm` - is defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts) and can be overridden at the individual view context inclusion if necessary.
+The REST requests to get CMS view context data now append the resource set ID (the defining view context model's cartridge name) by default to improve performance.
+A default resource set ID, `app_sf_base_cm`, is defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts) and can be overridden at the individual view context inclusion if necessary.
 
 ```html
 <ish-content-viewcontext
@@ -22,12 +22,12 @@ A default resource set ID - `app_sf_base_cm` - is defined at the [`CMSService`](
 />
 ```
 
-In migration projects nothing needs to be done if the default resource set ID is sufficient.
-If the default resource set ID is not sufficient, the `resourceSetId` input parameter needs to be added to all `ish-content-viewcontext` uses in the project that require a different resource set ID.
-If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, it is also possible to change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` use.
+In migration projects, nothing needs to be done if the default resource set ID is sufficient.
+If the default resource set ID is not sufficient, the `resourceSetId` input parameter needs to be added to all `ish-content-viewcontext` usages in the project that require a different resource set ID.
+If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, you can also change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` usage.
 
 > [!NOTE]
-> Making View Context REST requests with the added resource set ID requires ICM 12.1.0.
+> Making view context REST requests with the added resource set ID requires ICM 12.1.0.
 
 ## From 9.1.0 to 10.0.0
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -27,7 +27,7 @@ If the default resource set ID is not sufficient, the `resourceSetId` input para
 If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, you can also change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` usage.
 
 > [!NOTE]
-> Making view context REST requests with the added resource set ID requires ICM 12.1.0.
+> Using view context REST requests with the added resource set ID requires ICM 12.1.0.
 
 ## From 9.1.0 to 10.0.0
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,28 @@ kb_sync_latest_only
 
 # Migrations
 
+## From 10.1.0 to 11.0.0
+
+**CMS View Contexts REST requests with Resource Set ID**
+
+The REST requests to get CMS View Context data now append the resource set ID (the defining view context models cartridge name) by default to improve performance.
+A default resource set ID - `app_sf_base_cm` - is defined at the [`CMSService`](../../src/app/core/services/cms/cms.service.ts) and can be overridden at the individual view context inclusion if necessary.
+
+```html
+<ish-content-viewcontext
+  viewContextId="viewcontext.include.product.base.top"
+  [callParameters]="{ Product: product.sku }"
+  resourceSetId="custom_cartridge_name"
+/>
+```
+
+In migration projects nothing needs to be done if the default resource set ID is sufficient.
+If the default resource set ID is not sufficient, the `resourceSetId` input parameter needs to be added to all `ish-content-viewcontext` uses in the project that require a different resource set ID.
+If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, it is also possible to change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` use.
+
+> [!NOTE]
+> Making View Context REST requests with the added resource set ID requires ICM 12.1.0.
+
 ## From 9.1.0 to 10.0.0
 
 **Node.js update**

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -27,7 +27,7 @@ If the default resource set ID is not sufficient, the `resourceSetId` input para
 If `app_sf_base_cm` is not the correct resource set ID for the view contexts used in the project, you can also change the `defaultResourceSetId` at the `CMSService` to avoid adding the `resourceSetId` input parameter to every `ish-content-viewcontext` usage.
 
 > [!NOTE]
-> Using view context REST requests with the added resource set ID requires ICM 12.1.0.
+> Using view context REST requests with the added resource set ID requires ICM 12.1.0 or later.
 
 ## From 9.1.0 to 10.0.0
 

--- a/src/app/core/facades/cms.facade.ts
+++ b/src/app/core/facades/cms.facade.ts
@@ -46,8 +46,8 @@ export class CMSFacade {
     return this.store.pipe(select(getContentPagelet(id)));
   }
 
-  viewContext$(viewContextId: string, callParameters: CallParameters) {
-    this.store.dispatch(loadViewContextEntrypoint({ viewContextId, callParameters }));
+  viewContext$(viewContextId: string, callParameters: CallParameters, resourceSetId?: string) {
+    this.store.dispatch(loadViewContextEntrypoint({ viewContextId, callParameters, resourceSetId }));
     return this.store.pipe(select(getViewContext(viewContextId, callParameters)));
   }
 

--- a/src/app/core/services/cms/cms.service.spec.ts
+++ b/src/app/core/services/cms/cms.service.spec.ts
@@ -4,6 +4,7 @@ import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { ContentPageTreeData } from 'ish-core/models/content-page-tree/content-page-tree.interface';
 import { ContentPageletEntryPointMapper } from 'ish-core/models/content-pagelet-entry-point/content-pagelet-entry-point.mapper';
+import { ContentPageletEntryPoint } from 'ish-core/models/content-pagelet-entry-point/content-pagelet-entry-point.model';
 import { ApiService, AvailableOptions } from 'ish-core/services/api/api.service';
 
 import { CMSService } from './cms.service';
@@ -104,6 +105,63 @@ describe('Cms Service', () => {
       });
 
       verify(apiService.get(anything())).never();
+    });
+  });
+  describe('getViewContextContent', () => {
+    beforeEach(() => {
+      when(cpepMapper.fromData(anything())).thenReturn([{ id: 'vc-ep' } as ContentPageletEntryPoint, []]);
+    });
+
+    it('should use default resourceSetId when none is provided', done => {
+      when(apiService.get(anything(), anything())).thenReturn(of({}));
+
+      cmsService.getViewContextContent('vc.test', { Product: 'SKU' }).subscribe({
+        next: () => {
+          const [url] = capture(apiService.get).last();
+          expect(url).toEqual('cms/viewcontexts/vc.test@app_sf_base_cm/entrypoint');
+        },
+        error: fail,
+        complete: done,
+      });
+    });
+
+    it('should use custom resourceSetId when provided', done => {
+      when(apiService.get(anything(), anything())).thenReturn(of({}));
+
+      cmsService.getViewContextContent('vc.test', { Product: 'SKU' }, 'custom_cartridge').subscribe({
+        next: () => {
+          const [url] = capture(apiService.get).last();
+          expect(url).toEqual('cms/viewcontexts/vc.test@custom_cartridge/entrypoint');
+        },
+        error: fail,
+        complete: done,
+      });
+    });
+
+    it('should pass call parameters as HTTP params', done => {
+      when(apiService.get(anything(), anything())).thenReturn(of({}));
+
+      cmsService.getViewContextContent('vc.test', { Product: 'SKU', Category: 'CAT' }).subscribe({
+        next: () => {
+          const options: AvailableOptions = capture(apiService.get).last()[1];
+          expect(options.params.toString()).toContain('Product=SKU');
+          expect(options.params.toString()).toContain('Category=CAT');
+        },
+        error: fail,
+        complete: done,
+      });
+    });
+
+    it('should throw error when viewContextId is not given', done => {
+      cmsService.getViewContextContent(undefined, {}).subscribe({
+        next: fail,
+        error: err => {
+          expect(err.message).toContain('getViewContextContent() called without a viewContextId');
+          done();
+        },
+      });
+
+      verify(apiService.get(anything(), anything())).never();
     });
   });
 });

--- a/src/app/core/services/cms/cms.service.ts
+++ b/src/app/core/services/cms/cms.service.ts
@@ -26,7 +26,7 @@ export class CMSService {
   ) {}
 
   /** Configure the default `resource set id` - the cartridge id - for view context requests */
-  defaultResourceSetId = 'app_sf_base_cm';
+  private defaultResourceSetId = 'app_sf_base_cm';
 
   /**
    * Get the content for the given Content Include ID.

--- a/src/app/core/services/cms/cms.service.ts
+++ b/src/app/core/services/cms/cms.service.ts
@@ -25,6 +25,9 @@ export class CMSService {
     private contentPageTreeMapper: ContentPageTreeMapper
   ) {}
 
+  /** Configure the default `resource set id` - the cartridge id - for view context requests */
+  defaultResourceSetId = 'app_sf_base_cm';
+
   /**
    * Get the content for the given Content Include ID.
    *
@@ -100,11 +103,13 @@ export class CMSService {
    *
    * @param viewContextId  The view context ID.
    * @param callParameters The call parameters to give the current context.
+   * @param resourceSetId  The resource set ID (cartridge) of the view context model. If not given, the `defaultResourceSetId` is used.
    * @returns              The view contexts entrypoint content data.
    */
   getViewContextContent(
     viewContextId: string,
-    callParameters: CallParameters
+    callParameters: CallParameters,
+    resourceSetId?: string
   ): Observable<{ entrypoint: ContentPageletEntryPoint; pagelets: ContentPagelet[] }> {
     if (!viewContextId) {
       return throwError(() => new Error('getViewContextContent() called without a viewContextId'));
@@ -117,7 +122,9 @@ export class CMSService {
 
     return this.apiService
       .get<ContentPageletEntryPointData>(
-        `cms/viewcontexts/${this.apiService.encodeResourceId(viewContextId)}/entrypoint`,
+        `cms/viewcontexts/${this.apiService.encodeResourceId(viewContextId)}@${
+          resourceSetId || this.defaultResourceSetId
+        }/entrypoint`,
         {
           sendPGID: true,
           params,

--- a/src/app/core/store/content/viewcontexts/viewcontexts.actions.ts
+++ b/src/app/core/store/content/viewcontexts/viewcontexts.actions.ts
@@ -7,7 +7,7 @@ import { httpError, payload } from 'ish-core/utils/ngrx-creators';
 
 export const loadViewContextEntrypoint = createAction(
   '[Content View Context] Load Entrypoint',
-  payload<{ viewContextId: string; callParameters: CallParameters }>()
+  payload<{ viewContextId: string; callParameters: CallParameters; resourceSetId?: string }>()
 );
 
 export const loadViewContextEntrypointFail = createAction(

--- a/src/app/core/store/content/viewcontexts/viewcontexts.effects.spec.ts
+++ b/src/app/core/store/content/viewcontexts/viewcontexts.effects.spec.ts
@@ -32,7 +32,7 @@ describe('Viewcontexts Effects', () => {
 
   describe('loadViewContextEntrypoint$', () => {
     it('should dispatch success actions when encountering loadViewcontexts', () => {
-      when(cmsServiceMock.getViewContextContent(anything(), anything())).thenReturn(
+      when(cmsServiceMock.getViewContextContent(anything(), anything(), anything())).thenReturn(
         of({ entrypoint: { id: 'test' } as ContentPageletEntryPoint, pagelets: [] })
       );
 
@@ -43,6 +43,53 @@ describe('Viewcontexts Effects', () => {
         }),
       });
       const expected$ = cold('-c-c-c', {
+        c: loadViewContextEntrypointSuccess({
+          entrypoint: { id: 'test' } as ContentPageletEntryPoint,
+          pagelets: [],
+          viewContextId: 'test',
+          callParameters: {},
+        }),
+      });
+
+      expect(effects.loadViewContextEntrypoint$).toBeObservable(expected$);
+    });
+
+    it('should pass resourceSetId to cmsService when provided', () => {
+      when(cmsServiceMock.getViewContextContent(anything(), anything(), anything())).thenReturn(
+        of({ entrypoint: { id: 'test' } as ContentPageletEntryPoint, pagelets: [] })
+      );
+
+      actions$ = hot('-a', {
+        a: loadViewContextEntrypoint({
+          viewContextId: 'test',
+          callParameters: { Product: 'SKU' },
+          resourceSetId: 'custom_cartridge',
+        }),
+      });
+      const expected$ = cold('-c', {
+        c: loadViewContextEntrypointSuccess({
+          entrypoint: { id: 'test' } as ContentPageletEntryPoint,
+          pagelets: [],
+          viewContextId: 'test',
+          callParameters: { Product: 'SKU' },
+        }),
+      });
+
+      expect(effects.loadViewContextEntrypoint$).toBeObservable(expected$);
+    });
+
+    it('should pass undefined resourceSetId to cmsService when not provided', () => {
+      when(cmsServiceMock.getViewContextContent(anything(), anything(), anything())).thenReturn(
+        of({ entrypoint: { id: 'test' } as ContentPageletEntryPoint, pagelets: [] })
+      );
+
+      actions$ = hot('-a', {
+        a: loadViewContextEntrypoint({
+          viewContextId: 'test',
+          callParameters: {},
+        }),
+      });
+      const expected$ = cold('-c', {
         c: loadViewContextEntrypointSuccess({
           entrypoint: { id: 'test' } as ContentPageletEntryPoint,
           pagelets: [],

--- a/src/app/core/store/content/viewcontexts/viewcontexts.effects.ts
+++ b/src/app/core/store/content/viewcontexts/viewcontexts.effects.ts
@@ -19,8 +19,8 @@ export class ViewcontextsEffects {
     this.actions$.pipe(
       ofType(loadViewContextEntrypoint),
       mapToPayload(),
-      mergeMap(({ viewContextId, callParameters }) =>
-        this.cmsService.getViewContextContent(viewContextId, callParameters).pipe(
+      mergeMap(({ viewContextId, callParameters, resourceSetId }) =>
+        this.cmsService.getViewContextContent(viewContextId, callParameters, resourceSetId).pipe(
           map(({ entrypoint, pagelets }) =>
             loadViewContextEntrypointSuccess({ entrypoint, pagelets, viewContextId, callParameters })
           ),

--- a/src/app/shared/cms/components/content-viewcontext/content-viewcontext.component.spec.ts
+++ b/src/app/shared/cms/components/content-viewcontext/content-viewcontext.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { CMSFacade } from 'ish-core/facades/cms.facade';
 import {
@@ -51,5 +51,24 @@ describe('Content Viewcontext Component', () => {
     expect(element).toBeTruthy();
     expect(() => component.ngOnChanges()).not.toThrow();
     expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should pass resourceSetId to cmsFacade when provided', () => {
+    when(cmsFacade.viewContext$(anything(), anything(), anything())).thenReturn(of(entrypoint));
+    component.resourceSetId = 'custom_cartridge';
+    component.ngOnChanges();
+
+    verify(cmsFacade.viewContext$(anything(), anything(), anything())).once();
+    const [, , resourceSetId] = capture(cmsFacade.viewContext$).last();
+    expect(resourceSetId).toEqual('custom_cartridge');
+  });
+
+  it('should pass undefined resourceSetId to cmsFacade when not provided', () => {
+    when(cmsFacade.viewContext$(anything(), anything(), anything())).thenReturn(of(entrypoint));
+    component.ngOnChanges();
+
+    verify(cmsFacade.viewContext$(anything(), anything(), anything())).once();
+    const [, , resourceSetId] = capture(cmsFacade.viewContext$).last();
+    expect(resourceSetId).toBeUndefined();
   });
 });

--- a/src/app/shared/cms/components/content-viewcontext/content-viewcontext.component.ts
+++ b/src/app/shared/cms/components/content-viewcontext/content-viewcontext.component.ts
@@ -22,22 +22,25 @@ import { ContentPageletEntryPointView } from 'ish-core/models/content-view/conte
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ContentViewcontextComponent implements OnChanges {
-  /**
-   * The ID of the View Context whose content is to be rendered.
-   */
+  /** The ID of the View Context whose content is to be rendered. */
   @Input({ required: true }) viewContextId: string;
 
-  /**
-   * The call parameter object to provide the context, e.g. { Product: product.sku, Category: category.categoryRef }.
-   */
+  /** The call parameter object to provide the context, e.g. { Product: product.sku, Category: category.categoryRef }. */
   @Input({ required: true }) callParameters: CallParameters;
+
+  /** Optionally provide the resource set ID (cartridge) of the view context model. If not given, the `defaultResourceSetId` is used. */
+  @Input() resourceSetId: string;
 
   viewContextEntrypoint$: Observable<ContentPageletEntryPointView>;
 
   constructor(private cmsFacade: CMSFacade, private hostElement: ElementRef) {}
 
   ngOnChanges() {
-    this.viewContextEntrypoint$ = this.cmsFacade.viewContext$(this.viewContextId, this.callParameters);
+    this.viewContextEntrypoint$ = this.cmsFacade.viewContext$(
+      this.viewContextId,
+      this.callParameters,
+      this.resourceSetId
+    );
 
     // the 'callparametersstring' attribute is needed for the Design View - do not remove this code
     this.hostElement.nativeElement.setAttribute(


### PR DESCRIPTION
### 🚀 Description

This PR improves CMS View Context REST call performance by appending a resource set ID (cartridge name of the view context model) to the view context ID by default, while allowing overrides per `ish-content-viewcontext`  usage.

---


### 📝 Notes

* requires ICM 12.1.0
* view contexts are still disabled by default in the Intershop PWA source code (see [View Contexts](https://github.com/intershop/intershop-pwa/blob/develop/docs/concepts/cms-integration.md#view-contexts) for more information).


---

### ✅ Open Tasks

- [x] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#115783](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/115783)