### PR TITLE
fix: prevent mixing of curl output and server logs in SSR tests

### DIFF
--- a/e2e/test-ssr.sh
+++ b/e2e/test-ssr.sh
@@ -10,7 +10,7 @@ ssrTest() {
   echo "\n\nTEST $NUM: searching '$GREP' in '$URL'"
   timeout 5m sh -c "[ ! -z \"\$(wget -O - -q -t 0 --waitretry 5 $URL | grep \"$GREP\")\" ]"
   res=$?
-  [ "$res" -ne "0" ] && curl -v "$URL"
+  [ "$res" -ne "0" ] && { output=$(curl -v --no-progress-meter "$URL" 2>&1 || curl -v -sS "$URL" 2>&1); printf "%s\n\n" "$output"; }
   [ "$res" -eq "0" ] && echo "TEST $NUM: SUCCESS" || echo "\n\nTEST $NUM: searching '$GREP' in '$URL': FAILURE\n"
   [ "$res" -ne "0" ] && exit 1
 }


### PR DESCRIPTION
### 🚀 Description

Fixes an issue in `e2e/test-ssr.sh` where curl's verbose output was interleaved with server logs when tests fail. 

[Example](https://github.com/intershop/intershop-pwa/actions/runs/24332842914/job/71043538123?pr=2019)
`"productNotifications":{"productNotifications":{"ids":[],"entities":{},"loading":false}},"rating":{"productReviews":{"ids":[],"entities":{},"loading":false}},"recently":{}}}</script></body></html>[2026-04-13 08:20:33.518 +0000] ERROR: RES {"log.logger":"Server","trace":{"id":"724ad223-aef0-415c-b816-3b2209e9662b"},"url":{"original":"/computers/notebooks-and-pcs/notebooks-ctgComputers.1835.151","path":"/","domain":"localhost:4200"},"http":{"response":{"status_code":500}}}`

---

### 🔍 Detailed Changes
- capture curl output to a variable before printing
- `--no-progress-meter` flag to suppress progress meter
- print captured output atomically using `printf` to minimize race conditions

---

### 📝 Notes

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#115942](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/115942)