### PR TITLE
chore: remove nginx mkcert auto-generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,6 @@ services:
       # LOGLEVEL: 'info' # info (all), warn (4xx+5xx), error (5xx) - default: error
       # LOGFORMAT: 'text' # text, json - default: json (ECS-compatible)
       # SSL: 1
-      # SSL_MKCERT_OFF: 1
       # SSR: 0
       # DEBUG: 1
       # PROMETHEUS: 1
@@ -99,22 +98,10 @@ services:
       #     - X-Frame-Options: 'SAMEORIGIN'
       # REDIS_URI: redis://redis:6379
 
-    # Provide own SSL certificate files with SSL and SSL_MKCERT_OFF (see nginx-startup.md)
+    # Provide own SSL certificate files with SSL enabled (see nginx-startup.md)
     # volumes:
     #   - <LOCAL_PATH>/fullchain.pem:/var/nginx/certs/cert.pem
     #   - <LOCAL_PATH>/privkey.pem:/var/nginx/certs/key.pem
-
-    # Uncomment this if you want the containers CA to be available on your local machine
-    # 1.) provide below adjusted volume mapping
-    # 2.) download and install mkcert -> https://github.com/FiloSottile/mkcert
-    # 3.) `export CAROOT=/home/your-user/ca-dir`
-    # 4.) `mkcert -install`
-    #
-    # For more details have a look at https://github.com/FiloSottile/mkcert#installing-the-ca-on-other-systems
-    #
-    # hostname: 'your-local-host-name-with-fqdn'
-    # volumes:
-    #  - /home/your-user/ca-dir:/root/.local/share/mkcert
 
   # <CDN-Example>
   # - add 127.0.0.1 mypwa.net to your hosts file and

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -33,6 +33,11 @@ If `app_sf_base_cm` is not the correct resource set ID for the view contexts use
 
 The `OVERRIDE_IDENTITY_PROVIDERS` matching pattern configuration has been enhanced to not only support exact matches with `MULTI_CHANNEL` matching patterns; it can now also be configured as a RegEx that matches several `MULTI_CHANNEL` matching patterns.
 
+**Removed automatic SSL certificate generation in NGINX container**
+
+The automatic SSL certificate generation feature (development-only) using [mkcert](https://github.com/FiloSottile/mkcert) has been removed from the NGINX container.
+See the updated [NGINX Startup Guide](./nginx-startup.md#https-or-ssl) for detailed instructions on how to configure SSL development deployments.
+
 ## From 9.1.0 to 10.0.0
 
 **Node.js update**

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -50,20 +50,11 @@ For further information, please refer to [the official OpenResty Docker image pa
 
 ### HTTPS or SSL
 
-You can switch on HTTPS for the NGINX container to execute a production-like setup locally, or for demo purposes by changing `ENV SSL=0` to `ENV SSL=1` and adjusting the port mapping in `docker-compose.yml`.
-No need to supply a certificate and a key.
-They are automatically generated inside the running container with [mkcert](https://github.com/FiloSottile/mkcert).
-The certificate is self-signed and will not work in your browser.
-You have to confirm the security exception.
-As developer convenience, you can volume mount an internal folder to your host system to effectively trust the generated certificate.
-Please check the NGINX logs for the following output.
+You can switch on HTTPS for the NGINX container to execute a production-like setup locally, or for demo purposes by overriding the image default `SSL=off` with `SSL=on` in _docker-compose.yml_ and adjusting the port mapping accordingly.
 
-```
-You can now export the local CA by adjusting your docker-compose.yml /home/your-user/ca-dir:/root/.local/share/mkcert/rootCA.pem
-```
-
-If you want to run your NGINX container with HTTPS but want to use your own certificates, e.g., the same certificates that are used for a local ICM deployment for the Hybrid Approach, you can enable `SSL` but need to disable mkcert with `SSL_MKCERT_OFF`.
-Besides this, you map the certificate files you want to use in the NGINX container.
+To use HTTPS, provide your own SSL certificates by volume mounting them into the NGINX container.
+For local development, you can generate locally trusted development certificates using [mkcert](https://github.com/FiloSottile/mkcert), or self-signed certificates using OpenSSL on your host machine.
+For the Hybrid Approach with a local ICM deployment, use the same certificates as your ICM instance.
 
 ```yaml
 nginx:
@@ -72,12 +63,16 @@ nginx:
       - '443:443'
     environment:
       ...
-      SSL: 1
-      SSL_MKCERT_OFF: 1
+      SSL: 'on'
     volumes:
       - <LOCAL_PATH>/fullchain.pem:/var/nginx/certs/cert.pem
       - <LOCAL_PATH>/privkey.pem:/var/nginx/certs/key.pem
 ```
+
+The certificate files must be mapped to:
+
+- _/var/nginx/certs/cert.pem_ - The certificate file
+- _/var/nginx/certs/key.pem_ - The private key file
 
 ### Basic Auth
 
@@ -109,7 +104,7 @@ For more information on the multi-site syntax, see [Multi-Site Configurations](.
 
 The configuration can be supplied by setting the environment variable `MULTI_CHANNEL`.
 Alternatively, the source can be supplied by setting `MULTI_CHANNEL_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources/).
-If no environment variables for multi-channel configuration are provided, the configuration will fall back to the content of [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), which can also be customized.
+If no environment variables for multi-channel configuration are provided, the configuration will fall back to the content of [_nginx/multi-channel.yaml_](../../nginx/multi-channel.yaml), which can also be customized.
 
 > [!WARNING]
 > Multi-channel configuration with context paths does not work in conjunction with [service workers](../concepts/progressive-web-app.md#service-worker).
@@ -127,7 +122,7 @@ As with multi-site handling, the configuration can be supplied by setting the en
 Alternatively, the source can be supplied by setting `CACHING_IGNORE_PARAMS_SOURCE` in any [supported format by gomplate](https://docs.gomplate.ca/datasources/).
 Be aware that the supplied list of parameters must be declared under a `params` property.
 
-If no environment variables for ignoring parameters are provided, the configuration will fall back to the content of [`nginx/caching-ignore-params.yaml`](../../nginx/caching-ignore-params.yaml), which can also be customized.
+If no environment variables for ignoring parameters are provided, the configuration will fall back to the content of [_nginx/caching-ignore-params.yaml_](../../nginx/caching-ignore-params.yaml), which can also be customized.
 
 ### Access ICM Sitemap
 
@@ -138,9 +133,9 @@ http://foo.com/en/sitemap_pwa.xml
 ```
 
 To make above sitemap index file available under your deployment, add the environment variable `ICM_BASE_URL` to your NGINX container.
-Let `ICM_BASE_URL` point to your ICM backend installation, e.g., `https://develop.icm.intershop.de`.
+Let `ICM_BASE_URL` point to your ICM backend installation, e.g., _https://develop.icm.intershop.de_.
 
-On a local development system, add it to [`docker-compose.yml`](../../docker-compose.yml), e.g.,
+On a local development system, add it to [_docker-compose.yml_](../../docker-compose.yml), e.g.,
 
 ```yaml
 nginx:
@@ -244,7 +239,7 @@ Alternatively, the source can be supplied by setting `ADDITIONAL_HEADERS_SOURCE`
 
 For every entry, NGINX will add this header to every possible response.
 
-To make the additional headers available during build-time, the value for the environment variable `ADDITIONAL_HEADERS` can be put into the [additional-headers.yaml](../../nginx/additional-headers.yaml) file.
+To make the additional headers available during build-time, the value for the environment variable `ADDITIONAL_HEADERS` can be put into the [_additional-headers.yaml_](../../nginx/additional-headers.yaml) file.
 
 #### Content Security Policy
 
@@ -400,7 +395,7 @@ docker run --rm -it bitnami/redis redis-cli -u <REDIS_URI> flushdb
 
 #### Redis for Development
 
-For development environments, a local Redis can be started with the example `docker-compose.yml` configuration.
+For development environments, a local Redis can be started with the example _docker-compose.yml_ configuration.
 
 ```yaml
 redis:
@@ -441,7 +436,7 @@ The two NGINX modules
 - `ngx_http_brotli_filter_module.so` – for compressing responses on-the-fly
 - `ngx_http_brotli_static_module.so` - for serving pre-compressed files
 
-are built in the [`Dockerfile`](../../nginx/Dockerfile) using an NGINX archive in a version which matches the openresty Docker image version and are referenced in [`nginx.conf.tmpl`](../../nginx/nginx.conf.tmpl).
+are built in the [`Dockerfile`](../../nginx/Dockerfile) using an NGINX archive in a version which matches the openresty Docker image version and are referenced in [_nginx.conf.tmpl_](../../nginx/nginx.conf.tmpl).
 The archive needs to be used because it includes the `configure` command.
 The `./configure` [arguments](https://github.com/google/ngx_brotli?tab=readme-ov-file#dynamically-loaded) are taken from the current openresty configuration using `nginx -V` (`--add-module` arguments are excluded), see [ngx_brotli
 ](https://github.com/google/ngx_brotli?tab=readme-ov-file#dynamically-loaded).

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -22,7 +22,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils libnss3-tools \
+  && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 COPY nginx.conf.tmpl /etc/nginx/nginx.conf.tmpl
@@ -39,8 +39,6 @@ RUN chmod 700 /cache_clearer.sh
 
 COPY --from=hairyhenderson/gomplate:v4.3.3 /gomplate /gomplate
 RUN chmod 700 /gomplate
-ADD https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 /usr/bin/mkcert
-RUN chmod 700 /usr/bin/mkcert
 COPY --from=nginx/nginx-prometheus-exporter:1.4.2 /usr/bin/nginx-prometheus-exporter /nginx-prometheus-exporter
 COPY --from=buildstep /app/nginx-1.27.1/objs/ngx_http_brotli_static_module.so /etc/nginx/modules/
 COPY --from=buildstep /app/nginx-1.27.1/objs/ngx_http_brotli_filter_module.so /etc/nginx/modules/

--- a/nginx/docker-entrypoint.d/20-ssl.sh
+++ b/nginx/docker-entrypoint.d/20-ssl.sh
@@ -2,10 +2,20 @@
 
 set -e
 
-if env | grep -iqE "^SSL=(on|1|true|yes)$" && [ -z "$SSL_MKCERT_OFF" ]
+if env | grep -iqE "^SSL=(on|1|true|yes)$"
 then
   mkdir -p /var/nginx/certs
-  mkcert -install
-  mkcert -key-file /var/nginx/certs/key.pem -cert-file /var/nginx/certs/cert.pem "$(hostname)"
-  printf 'You can now export the local CA by adjusting your docker-compose.yml /home/your-user/ca-dir:%s\n' "$(mkcert -CAROOT)/rootCA.pem"
+
+  cert_file='/var/nginx/certs/cert.pem'
+  key_file='/var/nginx/certs/key.pem'
+
+  if [ ! -r "$cert_file" ] || [ ! -r "$key_file" ]
+  then
+    echo "ERROR: SSL is enabled, but the required certificate files are missing or not readable." >&2
+    echo "Expected readable files:" >&2
+    echo "  - $cert_file" >&2
+    echo "  - $key_file" >&2
+    echo "Mount the certificate and key into /var/nginx/certs before starting NGINX." >&2
+    exit 1
+  fi
 fi

--- a/nginx/docker-entrypoint.d/spec/20-ssl_spec.sh
+++ b/nginx/docker-entrypoint.d/spec/20-ssl_spec.sh
@@ -11,34 +11,4 @@ Describe "SSL script behavior"
       The status should be success
     End
   End
-
-  Describe 'With SSL switched on'
-    Parameters:value "on" "1" "true" "yes"
-    Mock mkcert
-      case $1 in
-        '-CAROOT')
-          echo "/root/.local/share/mkcert"
-          ;;
-        '-install')
-          echo "Installed CA"
-          ;;
-        '-key-file')
-          echo "Generated cert and key"
-          ;;
-        *)
-          echo "mkcert is called"
-          ;;
-      esac
-    End
-
-    It 'Should succesfully act on SSL= ($1)'
-      BeforeRun "export SSL=$1"
-      When run script 20-ssl.sh
-      The status should be success
-      The path '/var/nginx/certs' should be exist
-      The line 1 of output should eq 'Installed CA'
-      The line 2 of output should eq 'Generated cert and key'
-      The line 3 of output should eq 'You can now export the local CA by adjusting your docker-compose.yml /home/your-user/ca-dir:/root/.local/share/mkcert/rootCA.pem'
-    End
-  End
 End


### PR DESCRIPTION
### 🚀 Description

The automatic SSL certificate generation feature (development-only) using mkcert has been removed from the NGINX container for security reasons.
See the updated [NGINX Startup Guide](https://github.com/intershop/intershop-pwa/blob/develop/docs/guides/nginx-startup.md#https-or-ssl) for detailed instructions how to use HTTPS on a local machine.

---

### 🔍 Detailed Changes

---

### 📝 Notes

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116009](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116009)
[AB#113375](https://dev.azure.com/intershop-com/Products/_workitems/edit/113375)