### PR TITLE
fix: shipping method display on checkout shipping page

### DIFF
--- a/src/app/core/store/customer/basket/basket.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket.effects.spec.ts
@@ -276,7 +276,9 @@ describe('Basket Effects', () => {
 
   describe('loadBasketEligibleShippingMethods$', () => {
     beforeEach(() => {
-      when(basketServiceMock.getBasketEligibleShippingMethods()).thenReturn(of([BasketMockData.getShippingMethod()]));
+      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
+        of([BasketMockData.getShippingMethod()])
+      );
 
       store.dispatch(
         loadBasketSuccess({
@@ -293,7 +295,7 @@ describe('Basket Effects', () => {
       actions$ = of(action);
 
       effects.loadBasketEligibleShippingMethods$.subscribe(() => {
-        verify(basketServiceMock.getBasketEligibleShippingMethods()).once();
+        verify(basketServiceMock.getBasketEligibleShippingMethods(undefined)).once();
         done();
       });
     });
@@ -310,7 +312,7 @@ describe('Basket Effects', () => {
     });
 
     it('should map invalid request to action of type LoadBasketEligibleShippingMethodsFail', () => {
-      when(basketServiceMock.getBasketEligibleShippingMethods()).thenReturn(
+      when(basketServiceMock.getBasketEligibleShippingMethods(anything())).thenReturn(
         throwError(() => makeHttpError({ message: 'invalid' }))
       );
       const action = loadBasketEligibleShippingMethods();

--- a/src/app/core/store/customer/basket/basket.effects.ts
+++ b/src/app/core/store/customer/basket/basket.effects.ts
@@ -167,8 +167,9 @@ export class BasketEffects {
   loadBasketEligibleShippingMethods$ = createEffect(() =>
     this.actions$.pipe(
       ofType(loadBasketEligibleShippingMethods),
-      concatMap(() =>
-        this.basketService.getBasketEligibleShippingMethods().pipe(
+      concatLatestFrom(() => this.store.pipe(select(getCurrentBasket))),
+      concatMap(([, basket]) =>
+        this.basketService.getBasketEligibleShippingMethods(basket.bucketId).pipe(
           map(result => loadBasketEligibleShippingMethodsSuccess({ shippingMethods: result })),
           mapErrorToAction(loadBasketEligibleShippingMethodsFail)
         )

--- a/src/app/pages/checkout-shipping/formly/shipping-info/shipping-info.component.html
+++ b/src/app/pages/checkout-shipping/formly/shipping-info/shipping-info.component.html
@@ -2,7 +2,7 @@
 (shippingMethod.shippingCosts) {
 <strong>{{ shippingMethod.shippingCosts | ishPrice }}&nbsp;</strong>
 } @if (shippingMethod.shippingTimeMin && shippingMethod.shippingTimeMax) {
-<span class="form-text form-text-inline d-block">
+<span class="form-text form-text-inline">
   {{ 'checkout.shipping.delivery_time.description' | translate }}
   @if (shippingMethod.shippingTimeMin === 0 && shippingMethod.shippingTimeMax === 1) {
   <span>


### PR DESCRIPTION
### 🚀 Description

On checkout shipping page the eligible shipping methods are shown incompletely. Prices and arrival days are missing. 

### 🔍 Detailed Changes

This issue is due to the changes in #2007. 
The basket/id/eligible-shipping-methods call doesn't return the whole shipping method data like prices, so the information is missing on the page.
These changes have been reverted until a better solution has been found for the invalid bucket id issue and the basket bucket call is used again to fetch the eligible shipping methods.
Additionally a styling issue has been fixed to have all shipping method info on one line.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116130](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116130)