### PR TITLE
docs: add CSR mode related docu enhancements

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -294,10 +294,8 @@ To add languages other than English, German, or French:
 3. (optional) Add the new language switch translation keys to the existing locale files, for example to `de_DE.json`:
 
    ```json
-   {
-     "locale.nl_NL.long": "Niederländisch",
-     "locale.nl_NL.short": "nl"
-   }
+   "locale.nl_NL.long": "Niederländisch",
+   "locale.nl_NL.short": "nl",
    ```
 
 4. (optional) Add the locale-specific currency override to the environment files under `src/environments`, e.g.,
@@ -345,7 +343,7 @@ To add languages other than English, German, or French:
 If the feature toggle `saveLanguageSelection` is enabled, the selected language is saved as a browser cookie and restored after the PWA has loaded.
 
 > [!NOTE]
-> If SSR is disabled in NGINX (CSR mode) and the language is not part of the multi-site channel configuration, this feature toggle is not supported.
+> If SSR is disabled in nginx (resulting in client-side rendering (CSR) mode) and the language is not part of the URL configured in the multi-site configuration, the `saveLanguageSelection` feature toggle is not supported.
 
 ## Further References
 

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -25,8 +25,10 @@ kb_sync_latest_only
   - [Configuring Features](#configuring-features)
   - [Programmatically Switching Features](#programmatically-switching-features)
   - [Unit Testing with Feature Toggles](#unit-testing-with-feature-toggles)
-- [Setting Default Locale](#setting-default-locale)
-- [Extend Locales](#extend-locales)
+- [Locale Configuration](#locale-configuration)
+  - [Setting Default Locale](#setting-default-locale)
+  - [Extend Locales](#extend-locales)
+  - [Language Cookie](#language-cookie)
 - [Further References](#further-references)
 
 In a complex application like the Intershop Progressive Web App, there are multiple ways and kinds of configuration.
@@ -263,7 +265,9 @@ Switching features in tests can be triggered by calling [`FeatureToggleModule.sw
 
 [feature-toggle-module]: ../../src/app/core/feature-toggle.module.ts
 
-## Setting Default Locale
+## Locale Configuration
+
+### Setting Default Locale
 
 The default locale is set by providing `LOCALE_ID` in the [`InternationalizationModule`](../../src/app/core/internationalization.module.ts) using BCP 47 format, e.g., `'de-DE'`:
 
@@ -277,31 +281,32 @@ To set the default locale dynamically, use the URL parameter `lang` when rewriti
 The `fallbackLocales` property in the Angular CLI environment files defines the available translations when there is no connection to the server.
 These locales correspond to the local translation files shipped with the application (e.g., `src/assets/i18n/en_US.json`) and ensure the translation functionality works even if the ICM REST API is unavailable.
 
-## Extend Locales
+### Extend Locales
 
-To add other languages except English, German, or French:
+To add languages other than English, German, or French:
 
 1. Add the locale to the ICM channel configuration.
 
-2. Create a new json mapping file with all translations, e.g., `src/assets/i18n/nl_NL.json`.
+2. Create a new JSON mapping file with all translations, e.g., `src/assets/i18n/nl_NL.json`.
 
 <!-- spell-checker: words Niederländisch -->
 
-3. (optional) Add the new language switch translation keys to other locales:
-   _example de_DE.json_:
+3. (optional) Add the new language switch translation keys to the existing locale files, for example to `de_DE.json`:
 
-   ```
+   ```json
+   {
      "locale.nl_NL.long": "Niederländisch",
-     "locale.nl_NL.short": "nl",
+     "locale.nl_NL.short": "nl"
+   }
    ```
 
-4. (optional) Add the locale-specific currency filter to the environments under `src/environments`, e.g.,
+4. (optional) Add the locale-specific currency override to the environment files under `src/environments`, e.g.,
 
    ```typescript
-    localeCurrencyOverride: {
-      ...
-      nl_NL: 'EUR',
-    },
+   localeCurrencyOverride: {
+     ...
+     nl_NL: 'EUR',
+   },
    ```
 
 5. Import the Angular locale data in the [`InternationalizationModule`](../../src/app/core/internationalization.module.ts):
@@ -310,32 +315,37 @@ To add other languages except English, German, or French:
    import localeNl from '@angular/common/locales/nl';
    ```
 
-6. Register the locale using `registerLocaleData` in the constructor:
+6. Register the locale data in the module constructor using `registerLocaleData`:
 
    ```typescript
    registerLocaleData(localeNl);
    ```
 
-7. Add new json mapping file import to `LOCAL_TRANSLATIONS` injection token in the [`InternationalizationModule`](../../src/app/core/internationalization.module.ts) provider:
+7. Add the new locale to the `LOCAL_TRANSLATIONS` provider in the [`InternationalizationModule`](../../src/app/core/internationalization.module.ts):
 
    ```typescript
-    providers: [
-      {
-        provide: LOCAL_TRANSLATIONS,
-        useValue: {
-          useFactory: (lang: string) => {
-            switch (lang) {
-              // other added json-mapping-file imports with translations
-              ...
-              case: nl_NL {
-                return import('../../assets/i18n/nl_NL.json');
-              }
-            }
-          },
-        },
-      }
-   ]
+   providers: [
+     {
+       provide: LOCAL_TRANSLATIONS,
+       useValue: {
+         useFactory: (lang: string) => {
+           switch (lang) {
+             // other locale JSON imports
+             case 'nl_NL':
+               return import('../../assets/i18n/nl_NL.json');
+           }
+         },
+       },
+     },
+   ];
    ```
+
+### Language Cookie
+
+If the feature toggle `saveLanguageSelection` is enabled, the selected language is saved as a browser cookie and restored after the PWA has loaded.
+
+> [!NOTE]
+> If SSR is disabled in NGINX (CSR mode) and the language is not part of the multi-site channel configuration, this feature toggle is not supported.
 
 ## Further References
 

--- a/docs/concepts/pwa-building-blocks.md
+++ b/docs/concepts/pwa-building-blocks.md
@@ -10,7 +10,7 @@ kb_sync_latest_only
 - [Intershop Commerce Management (ICM)](#intershop-commerce-management-icm)
 - [PWA - Server-Side Rendering (SSR)](#pwa---server-side-rendering-ssr)
 - [PWA - Nginx](#pwa---nginx)
-  - [CSR Mode with Nginx](#csr-mode-with-nginx)
+  - [CSR Mode with nginx](#csr-mode-with-nginx)
 - [Browser](#browser)
 - [Default Production Deployment](#default-production-deployment)
 - [Deployment Without Nginx](#deployment-without-nginx)
@@ -49,12 +49,13 @@ Nginx enables the following features to be used in an Intershop PWA deployment:
 - Customizable compression for downstream services.
 - Device type detection to ensure a correct pre-render, adapted to the incoming user agent.
 
-### CSR Mode with Nginx
+### CSR Mode with nginx
 
 It is also possible to run the nginx container without SSR for browser requests by disabling SSR in the nginx configuration (see [Building and Running nginx Docker Image](../guides/nginx-startup.md)).
 In this client-side rendering (CSR) mode, nginx still acts as reverse proxy, but the initial page is no longer pre-rendered by Angular SSR.
 
-**Pros**: Lower operational complexity and no SSR rendering overhead on the server side.<br>
+**Pros**: Lower operational complexity and no SSR rendering overhead on the server side.
+
 **Cons**: No pre-rendered HTML, weaker SEO, slower first meaningful content for users, and some SSR-based configuration scenarios are not available.
 
 For a public production PWA deployment, CSR mode is generally not recommended.

--- a/docs/concepts/pwa-building-blocks.md
+++ b/docs/concepts/pwa-building-blocks.md
@@ -10,6 +10,7 @@ kb_sync_latest_only
 - [Intershop Commerce Management (ICM)](#intershop-commerce-management-icm)
 - [PWA - Server-Side Rendering (SSR)](#pwa---server-side-rendering-ssr)
 - [PWA - Nginx](#pwa---nginx)
+  - [CSR Mode with Nginx](#csr-mode-with-nginx)
 - [Browser](#browser)
 - [Default Production Deployment](#default-production-deployment)
 - [Deployment Without Nginx](#deployment-without-nginx)
@@ -47,6 +48,17 @@ Nginx enables the following features to be used in an Intershop PWA deployment:
 - Handling of multiple channels via URL parameters in conjunction with SSR (see [Multi-Site Handling](multi-site-handling.md)).
 - Customizable compression for downstream services.
 - Device type detection to ensure a correct pre-render, adapted to the incoming user agent.
+
+### CSR Mode with Nginx
+
+It is also possible to run the nginx container without SSR for browser requests by disabling SSR in the nginx configuration (see [Building and Running nginx Docker Image](../guides/nginx-startup.md)).
+In this client-side rendering (CSR) mode, nginx still acts as reverse proxy, but the initial page is no longer pre-rendered by Angular SSR.
+
+**Pros**: Lower operational complexity and no SSR rendering overhead on the server side.<br>
+**Cons**: No pre-rendered HTML, weaker SEO, slower first meaningful content for users, and some SSR-based configuration scenarios are not available.
+
+For a public production PWA deployment, CSR mode is generally not recommended.
+The default deployment with SSR should be preferred unless you have a very specific non-SEO or internal-only use case.
 
 For an overview of the ever-growing list of third party integrations relating to nginx and deployment in general, see [Third-party Integrations](../README.md#third-party-integrations).
 

--- a/docs/guides/nginx-startup.md
+++ b/docs/guides/nginx-startup.md
@@ -305,7 +305,7 @@ In summary, this CSP header restricts the sources from which various types of co
 
 Built-in features can be enabled and disabled:
 
-- `SSR=off` effectively disables SSR rendering for browsers (default `on`)
+- `SSR=off` effectively disables SSR rendering for browsers (default `on`). For a short explanation of CSR mode with nginx and its trade-offs, see [Building Blocks of the Intershop PWA Public Deployment](../concepts/pwa-building-blocks.md#csr-mode-with-nginx).
 - `CACHE=off` disables caching (default `on`)
 - `COMPRESSION=off` disables compression (default `on`)
 - `DEVICE_DETECTION=off` disables user-agent detection (default `on`)


### PR DESCRIPTION
### 🚀 Description

It is basically possible to configure the PWA to run in CSR mode (with nginx but without SSR).

This PR adds some documentation and explanations regarding CSR. 
It also states out the the feature toggle `saveLanguageSelection` is not support in this mode.


### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116141](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116141)