### PR TITLE
fix: rephrased misleading cxml user credentials description (#2055)

### DIFF
--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -415,7 +415,7 @@
   "account.punchout.cxml.configuration.link": "Konfiguration",
   "account.punchout.cxml.configuration.no_configuration": "Derzeit ist keine Konfiguration angelegt.",
   "account.punchout.cxml.configuration.save_success.message": "Die cXML-Punchout-Konfiguration wurde gespeichert.",
-  "account.punchout.cxml.info.url.helptext": "Bitte verwenden Sie die folgende URL für die Punchout-Konfiguration in Ihrem cXML-Procurement-System. Die Anmeldedaten des cXML-Benutzers müssen im Abschnitt „Sender“ angegeben werden: der Benutzername als „Identity“ und das Passwort als „SharedSecret“.",
+  "account.punchout.cxml.info.url.helptext": "Bitte verwenden Sie die folgende URL für die Punchout-Konfiguration in Ihrem cXML-Procurement-System. Die Anmeldedaten des cXML-Benutzers müssen im Abschnitt „Sender“ angegeben werden: der Benutzername als „Identity“ und das Kennwort als „SharedSecret“.",
   "account.punchout.cxml.toggle.helptext_close.title": "Hilfetext ausblenden",
   "account.punchout.cxml.toggle.helptext_open.title": "Hilfetext anzeigen",
   "account.punchout.heading": "Punchout",

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -415,7 +415,7 @@
   "account.punchout.cxml.configuration.link": "Konfiguration",
   "account.punchout.cxml.configuration.no_configuration": "Derzeit ist keine Konfiguration angelegt.",
   "account.punchout.cxml.configuration.save_success.message": "Die cXML-Punchout-Konfiguration wurde gespeichert.",
-  "account.punchout.cxml.info.url.helptext": "Bitte verwenden Sie die folgende URL für die Punchout-Konfiguration in Ihrem cXML-Procurement-System. Verwenden Sie für die Absender-Anmeldeinformationen den Benutzernamen als „Identity“ und das Kennwort als „SharedSecret“.",
+  "account.punchout.cxml.info.url.helptext": "Bitte verwenden Sie die folgende URL für die Punchout-Konfiguration in Ihrem cXML-Procurement-System. Die Anmeldedaten des cXML-Benutzers müssen im Abschnitt „Sender“ angegeben werden: der Benutzername als „Identity“ und das Passwort als „SharedSecret“.",
   "account.punchout.cxml.toggle.helptext_close.title": "Hilfetext ausblenden",
   "account.punchout.cxml.toggle.helptext_open.title": "Hilfetext anzeigen",
   "account.punchout.heading": "Punchout",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -415,7 +415,7 @@
   "account.punchout.cxml.configuration.link": "Configuration",
   "account.punchout.cxml.configuration.no_configuration": "No configuration has been created at this time.",
   "account.punchout.cxml.configuration.save_success.message": "The cXML Punchout configuration has been saved.",
-  "account.punchout.cxml.info.url.helptext": "Please use the following URL for the Punchout configuration in your cXML procurement system. For the sender credentials use the username as \"Identity\" and the password as \"SharedSecret\".",
+  "account.punchout.cxml.info.url.helptext": "Please use the following URL for the Punchout configuration in your cXML procurement system. The cXML user’s login credentials must be specified in the \"sender\" section: the username as \"Identity\" and the password as \"SharedSecret\".",
   "account.punchout.cxml.toggle.helptext_close.title": "Hide help text",
   "account.punchout.cxml.toggle.helptext_open.title": "Show help text",
   "account.punchout.heading": "Punchout",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -415,7 +415,7 @@
   "account.punchout.cxml.configuration.link": "Configuration",
   "account.punchout.cxml.configuration.no_configuration": "No configuration has been created at this time.",
   "account.punchout.cxml.configuration.save_success.message": "The cXML Punchout configuration has been saved.",
-  "account.punchout.cxml.info.url.helptext": "Please use the following URL for the Punchout configuration in your cXML procurement system. The cXML user’s login credentials must be specified in the \"sender\" section: the username as \"Identity\" and the password as \"SharedSecret\".",
+  "account.punchout.cxml.info.url.helptext": "Please use the following URL for the Punchout configuration in your cXML procurement system. The cXML user’s login credentials must be specified in the \"Sender\" section: the username as \"Identity\" and the password as \"SharedSecret\".",
   "account.punchout.cxml.toggle.helptext_close.title": "Hide help text",
   "account.punchout.cxml.toggle.helptext_open.title": "Show help text",
   "account.punchout.heading": "Punchout",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -415,7 +415,7 @@
   "account.punchout.cxml.configuration.link": "Configuration",
   "account.punchout.cxml.configuration.no_configuration": "Aucune configuration n’est disponible pour le moment.",
   "account.punchout.cxml.configuration.save_success.message": "La configuration de cXML Punchout a été sauvegardée.",
-  "account.punchout.cxml.info.url.helptext": "Veuillez utiliser l’URL suivante pour la configuration de Punchout dans votre système d’approvisionnement cXML. Les identifiants de connexion de l’utilisateur cXML doivent être indiqués dans la section « sender » : le nom d’utilisateur sous « Identity » et le mot de passe sous « SharedSecret ».",
+  "account.punchout.cxml.info.url.helptext": "Veuillez utiliser l’URL suivante pour la configuration de Punchout dans votre système d’approvisionnement cXML. Les identifiants de connexion de l’utilisateur cXML doivent être indiqués dans la section « Sender » : le nom d’utilisateur sous « Identity » et le mot de passe sous « SharedSecret ».",
   "account.punchout.cxml.toggle.helptext_close.title": "Masquer le texte d’aide",
   "account.punchout.cxml.toggle.helptext_open.title": "Afficher le texte d’aide",
   "account.punchout.heading": "Punchout",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -415,7 +415,7 @@
   "account.punchout.cxml.configuration.link": "Configuration",
   "account.punchout.cxml.configuration.no_configuration": "Aucune configuration n’est disponible pour le moment.",
   "account.punchout.cxml.configuration.save_success.message": "La configuration de cXML Punchout a été sauvegardée.",
-  "account.punchout.cxml.info.url.helptext": "Veuillez utiliser l’URL suivante pour la configuration de Punchout dans votre système d’approvisionnement cXML. Pour les données d’identification de l’expéditeur, utilisez le nom d’utilisateur comme « Identity » et le mot de passe comme « SharedSecret ».",
+  "account.punchout.cxml.info.url.helptext": "Veuillez utiliser l’URL suivante pour la configuration de Punchout dans votre système d’approvisionnement cXML. Les identifiants de connexion de l’utilisateur cXML doivent être indiqués dans la section « sender » : le nom d’utilisateur sous « Identity » et le mot de passe sous « SharedSecret ».",
   "account.punchout.cxml.toggle.helptext_close.title": "Masquer le texte d’aide",
   "account.punchout.cxml.toggle.helptext_open.title": "Afficher le texte d’aide",
   "account.punchout.heading": "Punchout",


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

Changed help text for cXML Punchout that is displayed. There was a customer who wasn't sure where to put the credentials. More details in related ticket description.

- Related Ticket/Issue: Closes #2055

---

### 🔍 Detailed Changes

<!-- Describe the changes in detail -->

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116214](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116214)