### PR TITLE
build: stabilize NGINX Docker build against Ubuntu apt-get failures

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -38,6 +38,11 @@ The `OVERRIDE_IDENTITY_PROVIDERS` matching pattern configuration has been enhanc
 The automatic SSL certificate generation feature (development-only) using [mkcert](https://github.com/FiloSottile/mkcert) has been removed from the NGINX container.
 See the updated [NGINX Startup Guide](./nginx-startup.md#https-or-ssl) for detailed instructions on how to configure SSL development deployments.
 
+**NGINX Docker build uses Ubuntu mirror**
+
+The NGINX Docker build now defaults to `azure.archive.ubuntu.com` for apt packages to improve build reliability on Azure and GitHub Actions.
+If this mirror is unreachable, pass `--build-arg UBUNTU_MIRROR=` to the pipeline to fall back to the default Ubuntu repositories.
+
 ## From 9.1.0 to 10.0.0
 
 **Node.js update**

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,23 @@
+# Use the Azure-hosted Ubuntu mirror by default to avoid transient failures on
+# archive.ubuntu.com / security.ubuntu.com during CI/CD pipeline builds.
+# azure.archive.ubuntu.com is co-located with Azure and GitHub Actions infrastructure.
+# To use a different mirror:  --build-arg UBUNTU_MIRROR=http://your-mirror/ubuntu/
+# To disable and use the original Ubuntu repos: --build-arg UBUNTU_MIRROR=
+ARG UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
+
 FROM openresty/openresty:1.29.2.3-2-jammy AS buildstep
-RUN apt-get update \
+ARG UBUNTU_MIRROR
+RUN if [ -n "$UBUNTU_MIRROR" ]; then \
+    if [ -f /etc/apt/sources.list ]; then \
+      sed -i "s|http://archive.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list && \
+      sed -i "s|http://security.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list; \
+    fi && \
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+      sed -i "s|http://archive.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list.d/ubuntu.sources && \
+      sed -i "s|http://security.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list.d/ubuntu.sources; \
+    fi; \
+  fi && \
+  apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y libpcre3 libpcre3-dev zlib1g zlib1g-dev openssl libssl-dev wget git gcc make
 
 WORKDIR /app
@@ -16,6 +34,21 @@ RUN wget -q https://nginx.org/download/nginx-1.29.2.tar.gz \
   && make modules
 
 FROM openresty/openresty:1.29.2.3-2-jammy
+ARG UBUNTU_MIRROR
+RUN if [ -n "$UBUNTU_MIRROR" ]; then \
+    if [ -f /etc/apt/sources.list ]; then \
+      sed -i "s|http://archive.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list && \
+      sed -i "s|http://security.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list; \
+    fi && \
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+      sed -i "s|http://archive.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list.d/ubuntu.sources && \
+      sed -i "s|http://security.ubuntu.com/ubuntu/|${UBUNTU_MIRROR}|g" /etc/apt/sources.list.d/ubuntu.sources; \
+    fi; \
+  fi && \
+  apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=nginx:mainline /docker-entrypoint.sh /
 COPY --from=nginx:mainline /docker-entrypoint.d/*.sh /docker-entrypoint.d/
 COPY lua/*.lua /usr/local/openresty/lualib/
@@ -26,11 +59,6 @@ RUN ln -s /usr/local/openresty/nginx/conf/mime.types /etc/nginx/ \
   && luarocks install lua-resty-redis-connector
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
-
-RUN apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y apache2-utils \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
 COPY nginx.conf.tmpl /etc/nginx/nginx.conf.tmpl
 COPY features /etc/nginx/features/
 COPY loglevel /etc/nginx/loglevel/


### PR DESCRIPTION
### 🚀 Description

The NGINX Docker build defaults to `azure.archive.ubuntu.com` for apt packages to improve build reliability on Azure and GitHub Actions. If this mirror is unreachable, pass `--build-arg UBUNTU_MIRROR=` to the pipeline to fall back to the default Ubuntu repositories

---

### 🔍 Detailed Changes

**opt-out** approach is used where the Azure mirror is enabled by default: 
- opt-out mirror: `UBUNTU_MIRROR` defaults to `http://azure.archive.ubuntu.com/ubuntu/` in the Dockerfile unless explicitly disabled: `--build-arg UBUNTU_MIRROR=`
- opt-in mirror: `UBUNTU_MIRROR` is empty by default and uses `archive.ubuntu.com` normally and only switches to the mirror if a build arg is explicitly passed: `--build-arg UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/`

It works immediately without pipeline changes. 

---

### 📝 Notes

**Tests**
- normal build works: `docker compose up --build`
- should fail: `docker build --build-arg UBUNTU_MIRROR=http://invalid.example.com/ubuntu/ nginx/`
- should use `archive.ubuntu.com` and `security.ubuntu.com`: 
  `docker build --build-arg UBUNTU_MIRROR= --target buildstep -t mirror-test nginx/`
  `docker run --rm mirror-test cat /etc/apt/sources.list` 
- should use `azure.archive.ubuntu.com`:
  `docker build --target buildstep -t mirror-test-default nginx/`
  `docker run --rm mirror-test-default cat /etc/apt/sources.list`

---

### ✅ Open Tasks

- [ ] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116299](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116299)
[AB#116089](https://dev.azure.com/intershop-com/Products/_workitems/edit/116089)