### PR TITLE
feat: hide language switch for single locale configurations

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -141,6 +141,11 @@ Two new adapters have been added - `PaypalGooglePayAdapter` and `PaypalApplePayA
 This functionality requires the **Intershop PPCP Connector version 3.1.0** or higher (ICM 14.2.2+, Google Pay JS API 2.0, Apple Pay JS API 4).
 For details, see the [PayPal Integration Guide](./paypal.md).
 
+**Language switch component**
+
+The behavior of the language switch component was changed.
+It will no longer render if only one language is configured in ICM and therefore no language switch options would be available.
+
 ## From 9.1.0 to 10.0.0
 
 **Node.js update**

--- a/src/app/core/facades/app.facade.ts
+++ b/src/app/core/facades/app.facade.ts
@@ -17,7 +17,11 @@ import {
 } from 'ish-core/store/core/configuration';
 import { businessError, getGeneralError, getGeneralErrorType } from 'ish-core/store/core/error';
 import { selectPath } from 'ish-core/store/core/router';
-import { getExtraConfigParameter, getServerConfigParameter } from 'ish-core/store/core/server-config';
+import {
+  getExtraConfigParameter,
+  getServerConfigParameter,
+  isServerConfigurationLoaded,
+} from 'ish-core/store/core/server-config';
 import { getBreadcrumbData, getHeaderType, getWrapperClass, isStickyHeader } from 'ish-core/store/core/viewconf';
 import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { getAllCountries, loadCountries } from 'ish-core/store/general/countries';
@@ -46,6 +50,7 @@ export class AppFacade {
   currentLocale$ = this.store.pipe(select(getCurrentLocale));
   availableLocales$ = this.store.pipe(select(getAvailableLocales));
   currentCurrency$ = this.store.pipe(select(getCurrentCurrency));
+  serverConfigurationLoaded$ = this.store.pipe(select(isServerConfigurationLoaded));
 
   generalError$ = this.store.pipe(select(getGeneralError));
   generalErrorType$ = this.store.pipe(select(getGeneralErrorType));

--- a/src/app/shell/header/language-switch/language-switch.component.html
+++ b/src/app/shell/header/language-switch/language-switch.component.html
@@ -1,42 +1,38 @@
 <!-- keep-localization-pattern: ^locale\..*\.(long|short)$ -->
-@if (locale$ | async; as locale) {
+@if (languageSwitchData$ | async; as data) {
   <div class="language-switch" ngbDropdown placement="{{ placement === 'up' ? 'top-right' : 'bottom-right' }}">
     <button
       aria-haspopup="menu"
       class="language-switch-button btn btn-link"
       ngbDropdownToggle
       type="button"
-      [attr.aria-label]="('language_switch.label' | translate) + ('locale.' + locale + '.long' | translate)"
+      [attr.aria-label]="('language_switch.label' | translate) + ('locale.' + data.locale + '.long' | translate)"
     >
       <span class="sticky-header-icon">
         <i class="bi bi-globe-americas header-icon mb-1"></i>
       </span>
       <span class="language-switch-current-selection d-inline"
-        >{{ 'locale.' + locale + (deviceType === 'mobile' ? '.short' : '.long') | translate
+        >{{ 'locale.' + data.locale + (deviceType === 'mobile' ? '.short' : '.long') | translate
         }}<span class="switch_arrow"></span
       ></span>
     </button>
     <div class="language-switch-container dropdown-menu" ngbDropdownMenu role="menu" style="left: 0 !important">
       <div class="language-switch-menu-container">
-        @if (availableLocales$ | async; as availableLocales) {
-          @if (availableLocales.length) {
-            <ul>
-              @for (l of availableLocales; track l) {
-                @if (l !== locale) {
-                  <li>
-                    <a
-                      [href]="location | ishMakeHref: { lang: l } | async"
-                      [lang]="'locale.' + l + '.short' | translate"
-                      (click)="setLocaleCookie(l)"
-                    >
-                      {{ 'locale.' + l + '.long' | translate }}
-                    </a>
-                  </li>
-                }
-              }
-            </ul>
+        <ul>
+          @for (l of data.availableLocales; track l) {
+            @if (l !== data.locale) {
+              <li>
+                <a
+                  [href]="location | ishMakeHref: { lang: l } | async"
+                  [lang]="'locale.' + l + '.short' | translate"
+                  (click)="setLocaleCookie(l)"
+                >
+                  {{ 'locale.' + l + '.long' | translate }}
+                </a>
+              </li>
+            }
           }
-        }
+        </ul>
       </div>
     </div>
   </div>

--- a/src/app/shell/header/language-switch/language-switch.component.html
+++ b/src/app/shell/header/language-switch/language-switch.component.html
@@ -19,15 +19,15 @@
     <div class="language-switch-container dropdown-menu" ngbDropdownMenu role="menu" style="left: 0 !important">
       <div class="language-switch-menu-container">
         <ul>
-          @for (l of data.availableLocales; track l) {
-            @if (l !== data.locale) {
+          @for (loc of data.availableLocales; track loc) {
+            @if (loc !== data.locale) {
               <li>
                 <a
-                  [href]="location | ishMakeHref: { lang: l } | async"
-                  [lang]="'locale.' + l + '.short' | translate"
-                  (click)="setLocaleCookie(l)"
+                  [href]="location | ishMakeHref: { lang: loc } | async"
+                  [lang]="'locale.' + loc + '.short' | translate"
+                  (click)="setLocaleCookie(loc)"
                 >
-                  {{ 'locale.' + l + '.long' | translate }}
+                  {{ 'locale.' + loc + '.long' | translate }}
                 </a>
               </li>
             }

--- a/src/app/shell/header/language-switch/language-switch.component.spec.ts
+++ b/src/app/shell/header/language-switch/language-switch.component.spec.ts
@@ -24,6 +24,9 @@ describe('Language Switch Component', () => {
 
   beforeEach(async () => {
     appFacade = mock(AppFacade);
+    when(appFacade.serverConfigurationLoaded$).thenReturn(of(true));
+    when(appFacade.availableLocales$).thenReturn(of(['en_US']));
+    when(appFacade.currentLocale$).thenReturn(of('en_US'));
 
     await TestBed.configureTestingModule({
       declarations: [LanguageSwitchComponent, MockPipe(MakeHrefPipe, (_, urlParams) => of(urlParams.lang))],
@@ -73,5 +76,24 @@ describe('Language Switch Component', () => {
     expect(element.querySelector('.language-switch-current-selection').textContent).toMatchInlineSnapshot(
       `"locale.de_DE.long"`
     );
+  });
+
+  it('should not render the language switch when only one locale is available', () => {
+    when(appFacade.availableLocales$).thenReturn(of(['en_US']));
+    when(appFacade.currentLocale$).thenReturn(of('en_US'));
+
+    fixture.detectChanges();
+
+    expect(element.querySelector('.language-switch')).toBeFalsy();
+  });
+
+  it('should not render the language switch when server configuration is not yet loaded', () => {
+    when(appFacade.serverConfigurationLoaded$).thenReturn(of(false));
+    when(appFacade.availableLocales$).thenReturn(of(locales));
+    when(appFacade.currentLocale$).thenReturn(of(locales[0]));
+
+    fixture.detectChanges();
+
+    expect(element.querySelector('.language-switch')).toBeFalsy();
   });
 });

--- a/src/app/shell/header/language-switch/language-switch.component.ts
+++ b/src/app/shell/header/language-switch/language-switch.component.ts
@@ -23,8 +23,6 @@ export class LanguageSwitchComponent implements OnInit {
    */
   @Input() placement: '' | 'up' = '';
 
-  locale$: Observable<string>;
-  availableLocales$: Observable<string[]>;
   languageSwitchData$: Observable<{ locale: string; availableLocales: string[] }>;
 
   constructor(
@@ -35,11 +33,9 @@ export class LanguageSwitchComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.locale$ = this.appFacade.currentLocale$;
-    this.availableLocales$ = this.appFacade.availableLocales$;
     this.languageSwitchData$ = combineLatest([
-      this.locale$,
-      this.availableLocales$,
+      this.appFacade.currentLocale$,
+      this.appFacade.availableLocales$,
       this.appFacade.serverConfigurationLoaded$,
     ]).pipe(
       filter(

--- a/src/app/shell/header/language-switch/language-switch.component.ts
+++ b/src/app/shell/header/language-switch/language-switch.component.ts
@@ -1,6 +1,7 @@
 import { LocationStrategy } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { FeatureToggleService } from 'ish-core/feature-toggle.module';
@@ -24,6 +25,7 @@ export class LanguageSwitchComponent implements OnInit {
 
   locale$: Observable<string>;
   availableLocales$: Observable<string[]>;
+  languageSwitchData$: Observable<{ locale: string; availableLocales: string[] }>;
 
   constructor(
     private appFacade: AppFacade,
@@ -35,6 +37,17 @@ export class LanguageSwitchComponent implements OnInit {
   ngOnInit() {
     this.locale$ = this.appFacade.currentLocale$;
     this.availableLocales$ = this.appFacade.availableLocales$;
+    this.languageSwitchData$ = combineLatest([
+      this.locale$,
+      this.availableLocales$,
+      this.appFacade.serverConfigurationLoaded$,
+    ]).pipe(
+      filter(
+        ([locale, availableLocales, serverConfigLoaded]) =>
+          serverConfigLoaded && !!locale && availableLocales?.length > 1
+      ),
+      map(([locale, availableLocales]) => ({ locale, availableLocales }))
+    );
   }
 
   setLocaleCookie(locale: string) {


### PR DESCRIPTION
### 🚀 Description

The language switch component is hidden if only one language is available. So it now only renders when multiple locales are available from the ICM server. 

---

### 🔍 Detailed Changes

---

### 📝 Notes

Fix flicker on page load:
- Previously, the component displayed all `fallbackLocales` (configured in environment) at page load before the server configuration loaded. When the server only returned one locale and the code checks to hide the language switch - the language switch was shown for a very short period of time and then it was hidden. 
- Now it waits for `serverConfigurationLoaded$` before rendering to ensure only ICM-provided locales are shown.

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116650](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116650)