### PR TITLE
feat: migration to Swiper 12

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -6,6 +6,5 @@
   "GHSA-x288-3778-4hhx": "Ignored since there probably won't be a fix for Angular 18",
   "GHSA-g93w-mfhg-p222": "Ignored since there probably won't be a fix for Angular 18",
   "GHSA-45q2-gjvg-7973": "Ignored since there probably won't be a fix for Angular 18",
-  "GHSA-rfh7-fxqc-q52v": "Ignored since there probably won't be a fix for Angular 18",
-  "GHSA-hmx5-qpq5-p643": "Ignored until we migrate the integration to the current swiper version"
+  "GHSA-rfh7-fxqc-q52v": "Ignored since there probably won't be a fix for Angular 18"
 }

--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -207,7 +207,6 @@ subfolder
 subfolders
 substate
 substates
-swiper
 switchmap
 systempage
 tabindex

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -19,6 +19,13 @@ This upgrade spans multiple major versions and includes several breaking changes
 
 For further details, see the official Swiper migration guides for [v9](https://swiperjs.com/migration-guide-v9), [v10](https://swiperjs.com/migration-guide-v10), and [v11](https://swiperjs.com/migration-guide-v11).
 
+**Lazy loading with `DeferredItemComponent`**
+
+The new `DeferredItemComponent` supports `IntersectionObserver`-based lazy loading.
+It defers the rendering of projected content until the element becomes visible in the viewport.
+It is used for Swiper carousel slides but also applies to any other lazy loading scenario.
+Use `ish-deferred-item` with `ishLazyLoadingContent` for lazy loading.
+
 ## From 11.0.0 to 11.1.0
 
 **New footer styling**

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -7,6 +7,18 @@ kb_sync_latest_only
 
 # Migrations
 
+## From 11.1.0 to 12.0.0
+
+**Swiper 12 upgrade**
+
+Swiper has been upgraded from version 8 to 12.
+This upgrade spans multiple major versions and includes several breaking changes:
+
+- Removal of Swiper Angular components (now using Swiper's [JavaScript API](https://swiperjs.com/swiper-api))
+- Changed module import path
+
+For further details, see the official Swiper migration guides for [v9](https://swiperjs.com/migration-guide-v9), [v10](https://swiperjs.com/migration-guide-v10), and [v11](https://swiperjs.com/migration-guide-v11).
+
 ## From 11.0.0 to 11.1.0
 
 **New footer styling**

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,16 +8,7 @@ const { pathsToModuleNameMapper } = require('ts-jest');
 
 const tsConfig = require('comment-json').parse(fs.readFileSync('./tsconfig.json', { encoding: 'utf-8' }));
 
-const esModules = [
-  'lodash-es/.*',
-  'swiper',
-  'ssr-window',
-  'dom7',
-  'uuid',
-  'rxjs',
-  '@angular/common/locales/.*\\.js$',
-  '.*\\.mjs$',
-];
+const esModules = ['lodash-es/.*', 'uuid', 'rxjs', '@angular/common/locales/.*\\.js$', '.*\\.mjs$'];
 
 export default {
   globals: {
@@ -32,7 +23,6 @@ export default {
   modulePaths: [tsConfig.compilerOptions.baseUrl],
   moduleNameMapper: {
     ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, { prefix: '<rootDir>' }),
-    '^swiper_angular$': '<rootDir>/node_modules/swiper/angular/fesm2015/swiper_angular.mjs',
   },
   snapshotSerializers: [
     './src/jest-serializer/AngularHTMLSerializer.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "pm2": "^7.0.1",
         "prom-client": "^15.1.3",
         "rxjs": "~7.8.2",
-        "swiper": "^8.4.7",
+        "swiper": "^12.1.4",
         "tslib": "^2.8.1",
         "typeface-roboto": "^1.1.13",
         "typeface-roboto-condensed": "^1.1.13",
@@ -14031,15 +14031,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom7": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
-      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
-      "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^4.0.0"
-      }
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -24760,12 +24751,6 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
-      "license": "MIT"
-    },
     "node_modules/ssri": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
@@ -25623,25 +25608,20 @@
       "dev": true
     },
     "node_modules/swiper": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
-      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
+      "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "dom7": "^4.0.4",
-        "ssr-window": "^4.0.2"
-      },
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "pm2": "^7.0.1",
     "prom-client": "^15.1.3",
     "rxjs": "~7.8.2",
-    "swiper": "^8.4.7",
+    "swiper": "^12.1.4",
     "tslib": "^2.8.1",
     "typeface-roboto": "^1.1.13",
     "typeface-roboto-condensed": "^1.1.13",

--- a/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.html
+++ b/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.html
@@ -1,19 +1,17 @@
-<ng-container *ishBrowserLazyView>
-  @if (recentlyProducts$ | async; as products) {
-    @if (products.length) {
-      <div class="product-list-container" data-testing-id="recently-viewed">
-        <h2>{{ 'recentlyViewed.component.heading' | translate }}</h2>
-        <ish-skip-content-link skipToElementId="pdp-view-all-link" />
-        <ish-products-list listItemStyle="tile" listStyle="carousel" [productSKUs]="products" />
-        <a
-          class="view-all"
-          data-testing-id="view-all"
-          id="pdp-view-all-link"
-          [attr.aria-label]="'common.view_all.link.label' | translate"
-          [routerLink]="['/recently']"
-          >{{ 'common.view_all.link' | translate }}</a
-        >
-      </div>
-    }
+@if (recentlyProducts$ | async; as products) {
+  @if (products.length) {
+    <div class="product-list-container" data-testing-id="recently-viewed">
+      <h2>{{ 'recentlyViewed.component.heading' | translate }}</h2>
+      <ish-skip-content-link skipToElementId="pdp-view-all-link" />
+      <ish-products-list listItemStyle="tile" listStyle="carousel" [productSKUs]="products" />
+      <a
+        class="view-all"
+        data-testing-id="view-all"
+        id="pdp-view-all-link"
+        [attr.aria-label]="'common.view_all.link.label' | translate"
+        [routerLink]="['/recently']"
+        >{{ 'common.view_all.link' | translate }}</a
+      >
+    </div>
   }
-</ng-container>
+}

--- a/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.spec.ts
+++ b/src/app/extensions/recently/shared/recently-viewed/recently-viewed.component.spec.ts
@@ -2,11 +2,10 @@ import { Location } from '@angular/common';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { RouterModule, provideRouter } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { MockComponent, MockDirective, MockPipe, ngMocks } from 'ng-mocks';
+import { MockComponent, MockPipe } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
-import { BrowserLazyViewDirective } from 'ish-core/directives/browser-lazy-view.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { findAllDataTestingIDs } from 'ish-core/utils/dev/html-query-utils';
 import { SkipContentLinkComponent } from 'ish-shared/components/common/skip-content-link/skip-content-link.component';
@@ -33,7 +32,6 @@ describe('Recently Viewed Component', () => {
       declarations: [
         MockComponent(ProductsListComponent),
         MockComponent(SkipContentLinkComponent),
-        MockDirective(BrowserLazyViewDirective),
         MockPipe(TranslatePipe),
         RecentlyViewedComponent,
       ],
@@ -51,9 +49,6 @@ describe('Recently Viewed Component', () => {
     element = fixture.nativeElement;
 
     location = TestBed.inject(Location);
-
-    const directive = ngMocks.findInstance(BrowserLazyViewDirective);
-    ngMocks.render(directive, directive);
   });
 
   it('should be created', () => {

--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -18,20 +18,28 @@
     @if (getImageViewIDs$('L') | async; as largeImages) {
       <div class="col-12 col-lg-9 product-detail-img clearfix">
         <div class="product-image-container">
-          <swiper #carousel [navigation]="true">
-            @for (imageView of largeImages; track imageView; let i = $index) {
-              <ng-template swiperSlide>
-                <div tabindex="0" (click)="openZoomModal(i)" (keydown.enter)="openZoomModal(i)">
-                  <ish-product-image
-                    imageType="L"
-                    [imageView]="imageView"
-                    [loading]="i === 0 ? 'eager' : 'lazy'"
-                    [ngClass]="{ 'product-image-zoom': zoomImageIds$ | async }"
-                  />
+          <div #swiper class="swiper">
+            <div class="swiper-button-prev"></div>
+            <div class="swiper-wrapper">
+              @for (imageView of largeImages; track imageView; let i = $index) {
+                <div class="swiper-slide">
+                  <div
+                    [tabindex]="isActiveSlide(i) ? 0 : -1"
+                    (click)="openZoomModal(i)"
+                    (keydown.enter)="openZoomModal(i)"
+                  >
+                    <ish-product-image
+                      imageType="L"
+                      [imageView]="imageView"
+                      [loading]="i === 0 ? 'eager' : 'lazy'"
+                      [ngClass]="{ 'product-image-zoom': zoomImageIds$ | async }"
+                    />
+                  </div>
                 </div>
-              </ng-template>
-            }
-          </swiper>
+              }
+            </div>
+            <div class="swiper-button-next"></div>
+          </div>
           <ish-product-label />
         </div>
       </div>

--- a/src/app/pages/product/product-images/product-images.component.spec.ts
+++ b/src/app/pages/product/product-images/product-images.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
-import { SwiperComponent } from 'swiper/angular';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
@@ -70,7 +69,7 @@ describe('Product Images Component', () => {
     );
     await TestBed.configureTestingModule({
       imports: [MockComponent(ProductImageComponent)],
-      declarations: [MockComponent(ProductLabelComponent), MockComponent(SwiperComponent), ProductImagesComponent],
+      declarations: [MockComponent(ProductLabelComponent), ProductImagesComponent],
       providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }],
     }).compileComponents();
   });
@@ -89,7 +88,7 @@ describe('Product Images Component', () => {
 
   it('should render carousel on component', () => {
     fixture.detectChanges();
-    expect(element.getElementsByTagName('ish-product-image')).toHaveLength(2);
+    expect(element.getElementsByTagName('ish-product-image')).toHaveLength(4);
   });
 
   it('should render thumbnails on component', () => {
@@ -116,6 +115,6 @@ describe('Product Images Component', () => {
     );
 
     fixture.detectChanges();
-    expect(element.getElementsByTagName('ish-product-image')).toHaveLength(1);
+    expect(element.getElementsByTagName('ish-product-image')).toHaveLength(2);
   });
 });

--- a/src/app/pages/product/product-images/product-images.component.ts
+++ b/src/app/pages/product/product-images/product-images.component.ts
@@ -1,16 +1,22 @@
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 import { distinctUntilKeyChanged, map, shareReplay, tap } from 'rxjs/operators';
-import SwiperCore, { Navigation, A11y } from 'swiper';
-import { SwiperComponent } from 'swiper/angular';
+import Swiper from 'swiper';
+import { A11y, Navigation } from 'swiper/modules';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { ProductHelper } from 'ish-core/models/product/product.model';
 import { whenTruthy } from 'ish-core/utils/operators';
 import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
-
-SwiperCore.use([Navigation, A11y]);
 
 /**
  * The Product Images Component
@@ -28,21 +34,41 @@ SwiperCore.use([Navigation, A11y]);
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { ngSkipHydration: 'true' },
 })
-export class ProductImagesComponent implements OnInit {
-  @ViewChild('carousel') carousel: SwiperComponent;
+export class ProductImagesComponent implements OnInit, OnDestroy {
+  private swiper: Swiper;
+
+  @ViewChild('swiper') set swiperRef(ref: ElementRef) {
+    if (ref && !this.swiper && !SSR) {
+      const swiperEl = ref.nativeElement;
+      this.swiper = new Swiper(swiperEl, {
+        modules: [A11y, Navigation],
+        navigation: {
+          nextEl: swiperEl.querySelector('.swiper-button-next'),
+          prevEl: swiperEl.querySelector('.swiper-button-prev'),
+        },
+        on: {
+          slideChange: () => this.cdRef.markForCheck(),
+        },
+      });
+    }
+  }
+
   @ViewChild('zoomDialog') zoomDialog: ModalDialogComponent<unknown>;
 
   product$: Observable<ProductView>;
   zoomImageIds$: Observable<string[]>;
 
-  constructor(private context: ProductContextFacade) {}
+  constructor(
+    private context: ProductContextFacade,
+    private cdRef: ChangeDetectorRef
+  ) {}
 
   ngOnInit() {
     this.product$ = this.context.select('product').pipe(
       whenTruthy(),
       distinctUntilKeyChanged('sku'),
       tap(() => {
-        if (this.carousel?.swiperRef?.activeIndex) {
+        if (this.swiper?.activeIndex) {
           this.setActiveSlide(0);
         }
       }),
@@ -64,7 +90,7 @@ export class ProductImagesComponent implements OnInit {
    * @param slideIndex The slide index to set the active slide
    */
   setActiveSlide(slideIndex: number) {
-    this.carousel?.swiperRef?.slideTo(slideIndex);
+    this.swiper?.slideTo(slideIndex);
   }
 
   /**
@@ -74,7 +100,7 @@ export class ProductImagesComponent implements OnInit {
    * @returns True if the given slide index is the active slide, false otherwise
    */
   isActiveSlide(slideIndex: number): boolean {
-    return this.carousel?.swiperRef?.activeIndex === slideIndex;
+    return (this.swiper?.activeIndex ?? 0) === slideIndex;
   }
 
   getZoomImageAnchorId(i: number) {
@@ -87,5 +113,9 @@ export class ProductImagesComponent implements OnInit {
       this.zoomDialog.scrollToAnchor(this.getZoomImageAnchorId(i));
     }
     return false;
+  }
+
+  ngOnDestroy(): void {
+    this.swiper?.destroy();
   }
 }

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
@@ -8,9 +8,13 @@
           <div class="swiper-wrapper">
             @for (sku$ of productSKUs; track sku$) {
               <div class="swiper-slide">
-                @if (sku$ | async; as sku) {
-                  <ish-product-item ishProductContext [sku]="sku" />
-                }
+                <ish-deferred-item>
+                  <ng-template ishLazyLoadingContent>
+                    @if (sku$ | async; as sku) {
+                      <ish-product-item ishProductContext [sku]="sku" />
+                    }
+                  </ng-template>
+                </ish-deferred-item>
               </div>
             }
           </div>

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.html
@@ -3,15 +3,20 @@
     <div class="product-list-container">
       <h2>{{ productLinkTitle }}</h2>
       <div class="product-list">
-        <swiper [config]="swiperConfig">
-          @for (sku$ of productSKUs; track sku$) {
-            <ng-template let-data swiperSlide>
-              @if (lazyFetch(data.isVisible, sku$) | async; as sku) {
-                <ish-product-item ishProductContext [sku]="sku" />
-              }
-            </ng-template>
-          }
-        </swiper>
+        <div #swiper class="swiper">
+          <div class="swiper-button-prev"></div>
+          <div class="swiper-wrapper">
+            @for (sku$ of productSKUs; track sku$) {
+              <div class="swiper-slide">
+                @if (sku$ | async; as sku) {
+                  <ish-product-item ishProductContext [sku]="sku" />
+                }
+              </div>
+            }
+          </div>
+          <div class="swiper-button-next"></div>
+          <div class="swiper-pagination"></div>
+        </div>
       </div>
     </div>
   }

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
@@ -1,14 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockComponent, MockDirective } from 'ng-mocks';
+import { MockComponent, MockDirective, MockInstance } from 'ng-mocks';
 import { forkJoin, of, switchMap } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { BrowserLazyViewDirective } from 'ish-core/directives/browser-lazy-view.directive';
+import { LazyLoadingContentDirective } from 'ish-core/directives/lazy-loading-content.directive';
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductInventory } from 'ish-core/models/product-inventory/product-inventory.model';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { DeferredItemComponent } from 'ish-shared/components/common/deferred-item/deferred-item.component';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductLinksCarouselComponent } from './product-links-carousel.component';
@@ -19,13 +21,17 @@ describe('Product Links Carousel Component', () => {
   let element: HTMLElement;
   let shoppingFacade: ShoppingFacade;
 
+  MockInstance.scope();
+
   beforeEach(async () => {
     shoppingFacade = mock(ShoppingFacade);
 
     await TestBed.configureTestingModule({
       declarations: [
+        MockComponent(DeferredItemComponent),
         MockComponent(ProductItemComponent),
         MockDirective(BrowserLazyViewDirective),
+        MockDirective(LazyLoadingContentDirective),
         MockDirective(ProductContextDirective),
         ProductLinksCarouselComponent,
       ],

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.spec.ts
@@ -1,13 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { forkJoin, of, switchMap } from 'rxjs';
-import { SwiperComponent } from 'swiper/angular';
 import { anything, instance, mock, when } from 'ts-mockito';
 
+import { BrowserLazyViewDirective } from 'ish-core/directives/browser-lazy-view.directive';
+import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductInventory } from 'ish-core/models/product-inventory/product-inventory.model';
 import { ProductLinks } from 'ish-core/models/product-links/product-links.model';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductLinksCarouselComponent } from './product-links-carousel.component';
 
@@ -21,7 +23,12 @@ describe('Product Links Carousel Component', () => {
     shoppingFacade = mock(ShoppingFacade);
 
     await TestBed.configureTestingModule({
-      declarations: [MockComponent(SwiperComponent), ProductLinksCarouselComponent],
+      declarations: [
+        MockComponent(ProductItemComponent),
+        MockDirective(BrowserLazyViewDirective),
+        MockDirective(ProductContextDirective),
+        ProductLinksCarouselComponent,
+      ],
       providers: [{ provide: ShoppingFacade, useFactory: () => instance(shoppingFacade) }],
     }).compileComponents();
   });
@@ -39,7 +46,7 @@ describe('Product Links Carousel Component', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
     expect(() => fixture.detectChanges()).not.toThrow();
-    expect(element.querySelector('swiper')).toBeTruthy();
+    expect(element.querySelector('.swiper')).toBeTruthy();
   });
 
   it('should render all product slides if stocks filtering is off', done => {

--- a/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
+++ b/src/app/pages/product/product-links-carousel/product-links-carousel.component.ts
@@ -1,8 +1,10 @@
-import { ChangeDetectionStrategy, Component, Inject, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Inject, Input, OnDestroy, ViewChild } from '@angular/core';
 import { RxState } from '@rx-angular/state';
-import { EMPTY, Observable, combineLatest, of } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
-import SwiperCore, { Navigation, Pagination, SwiperOptions, A11y } from 'swiper';
+import Swiper from 'swiper';
+import { A11y, Navigation, Pagination } from 'swiper/modules';
+import { SwiperOptions } from 'swiper/types';
 
 import { LARGE_BREAKPOINT_WIDTH, MEDIUM_BREAKPOINT_WIDTH } from 'ish-core/configurations/injection-keys';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
@@ -10,8 +12,6 @@ import { ProductLinks } from 'ish-core/models/product-links/product-links.model'
 import { ProductCompletenessLevel } from 'ish-core/models/product/product.model';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { whenTruthy } from 'ish-core/utils/operators';
-
-SwiperCore.use([Navigation, Pagination, A11y]);
 
 /**
  * The Product Link Carousel Component
@@ -28,7 +28,7 @@ SwiperCore.use([Navigation, Pagination, A11y]);
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [RxState],
 })
-export class ProductLinksCarouselComponent {
+export class ProductLinksCarouselComponent implements OnDestroy {
   /**
    * list of products which are assigned to the specific product link type
    */
@@ -48,16 +48,34 @@ export class ProductLinksCarouselComponent {
 
   productSKUs$ = this.state.select('products$');
 
-  /**
-   * track already fetched SKUs
-   */
-  private fetchedSKUs = new Set<Observable<string>>();
+  private swiper: Swiper;
+  private swiperInitialized = false;
 
-  /**
-   * configuration of swiper carousel
-   * https://swiperjs.com/swiper-api
-   */
-  swiperConfig: SwiperOptions;
+  @ViewChild('swiper') set swiperRef(ref: ElementRef) {
+    if (ref && !this.swiperInitialized && !SSR) {
+      this.swiperInitialized = true;
+      const swiperEl = ref.nativeElement;
+      this.swiper = new Swiper(swiperEl, {
+        modules: [A11y, Navigation, Pagination],
+        ...this.swiperConfig,
+        navigation: {
+          nextEl: swiperEl.querySelector('.swiper-button-next'),
+          prevEl: swiperEl.querySelector('.swiper-button-prev'),
+        },
+        pagination: {
+          el: swiperEl.querySelector('.swiper-pagination'),
+          clickable: true,
+        },
+      });
+    }
+  }
+
+  // configuration of swiper carousel: https://swiperjs.com/swiper-api
+  private swiperConfig: SwiperOptions = {
+    watchSlidesProgress: true,
+    direction: 'horizontal',
+    breakpoints: {},
+  };
 
   constructor(
     @Inject(LARGE_BREAKPOINT_WIDTH) largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
@@ -75,26 +93,18 @@ export class ProductLinksCarouselComponent {
       displayOnlyAvailableProducts: false,
     }));
 
-    this.swiperConfig = {
-      watchSlidesProgress: true,
-      direction: 'horizontal',
-      navigation: true,
-      pagination: {
-        clickable: true,
+    this.swiperConfig.breakpoints = {
+      0: {
+        slidesPerView: 2,
+        slidesPerGroup: 2,
       },
-      breakpoints: {
-        0: {
-          slidesPerView: 2,
-          slidesPerGroup: 2,
-        },
-        [mediumBreakpointWidth]: {
-          slidesPerView: 3,
-          slidesPerGroup: 3,
-        },
-        [largeBreakpointWidth]: {
-          slidesPerView: 4,
-          slidesPerGroup: 4,
-        },
+      [mediumBreakpointWidth]: {
+        slidesPerView: 3,
+        slidesPerGroup: 3,
+      },
+      [largeBreakpointWidth]: {
+        slidesPerView: 4,
+        slidesPerGroup: 4,
       },
     };
 
@@ -132,13 +142,7 @@ export class ProductLinksCarouselComponent {
     this.state.connect('products$', filteredProducts$);
   }
 
-  lazyFetch(fetch: boolean, sku$: Observable<string>): Observable<string> {
-    if (fetch) {
-      this.fetchedSKUs.add(sku$);
-    }
-    if (this.fetchedSKUs.has(sku$)) {
-      return sku$;
-    }
-    return EMPTY;
+  ngOnDestroy(): void {
+    this.swiper?.destroy();
   }
 }

--- a/src/app/shared/components/common/deferred-item/deferred-item.component.html
+++ b/src/app/shared/components/common/deferred-item/deferred-item.component.html
@@ -1,0 +1,7 @@
+<div ishIntersectionObserver [ngClass]="cssClass" (visibilityChange)="onVisibilityChange($any($event))">
+  @if (visible$ | async; as visible) {
+    @if (visible && lazyContent) {
+      <ng-template [ngTemplateOutlet]="lazyContent.templateRef" />
+    }
+  }
+</div>

--- a/src/app/shared/components/common/deferred-item/deferred-item.component.spec.ts
+++ b/src/app/shared/components/common/deferred-item/deferred-item.component.spec.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockDirective } from 'ng-mocks';
+
+import { IntersectionObserverDirective } from 'ish-core/directives/intersection-observer.directive';
+import { LazyLoadingContentDirective } from 'ish-core/directives/lazy-loading-content.directive';
+
+import { DeferredItemComponent } from './deferred-item.component';
+
+@Component({
+  template: `
+    <ish-deferred-item [cssClass]="cssClass">
+      <ng-template ishLazyLoadingContent>
+        <span class="lazy-content">content</span>
+      </ng-template>
+    </ish-deferred-item>
+  `,
+})
+class TestHostComponent {
+  cssClass: string | undefined;
+}
+
+describe('Deferred Item Component', () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        DeferredItemComponent,
+        LazyLoadingContentDirective,
+        MockDirective(IntersectionObserverDirective),
+        TestHostComponent,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+    expect(element).toBeTruthy();
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should not render lazy content before becoming visible', () => {
+    expect(element.querySelector('.lazy-content')).toBeFalsy();
+  });
+
+  it('should render lazy content after becoming visible', () => {
+    const deferredItem = fixture.debugElement.children[0].componentInstance as DeferredItemComponent;
+    deferredItem.onVisibilityChange('Visible');
+    fixture.detectChanges();
+
+    expect(element.querySelector('.lazy-content')).toBeTruthy();
+  });
+
+  it('should keep content rendered once visible even when scrolled out of viewport', () => {
+    const deferredItem = fixture.debugElement.children[0].componentInstance as DeferredItemComponent;
+    deferredItem.onVisibilityChange('Visible');
+    fixture.detectChanges();
+    deferredItem.onVisibilityChange('NotVisible');
+    fixture.detectChanges();
+
+    expect(element.querySelector('.lazy-content')).toBeTruthy();
+  });
+
+  it('should apply cssClass to the wrapper element', () => {
+    component.cssClass = 'col-6';
+    fixture.detectChanges();
+
+    expect(element.querySelector('.col-6')).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/common/deferred-item/deferred-item.component.ts
+++ b/src/app/shared/components/common/deferred-item/deferred-item.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, ContentChild, Input, OnInit } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import { IntersectionStatus } from 'ish-core/directives/intersection-observer-util';
+import { LazyLoadingContentDirective } from 'ish-core/directives/lazy-loading-content.directive';
+
+/**
+ * The Deferred Item Component
+ *
+ * Defers rendering of projected content until the element becomes visible in the viewport using IntersectionObserver.
+ * Once rendered, the content remains in the DOM even when scrolled out of view.
+ *
+ * @example
+ * <ish-deferred-item [cssClass]="'col-6'">
+ *   <ng-template ishLazyLoadingContent>
+ *     <!-- content to be lazily loaded -->
+ *   </ng-template>
+ * </ish-deferred-item>
+ */
+@Component({
+  selector: 'ish-deferred-item',
+  templateUrl: './deferred-item.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DeferredItemComponent implements OnInit {
+  @ContentChild(LazyLoadingContentDirective) lazyContent: LazyLoadingContentDirective;
+  @Input() cssClass: string;
+
+  visible$ = new BehaviorSubject<boolean>(false);
+
+  ngOnInit() {
+    // In Cypress, skip lazy loading to avoid intersection observer timing issues with Swiper
+    if (!SSR && typeof window !== 'undefined' && (window as { Cypress?: unknown }).Cypress) {
+      this.visible$.next(true);
+    }
+  }
+
+  onVisibilityChange(event: IntersectionStatus) {
+    if (event === 'Visible') {
+      this.visible$.next(true);
+    }
+  }
+}

--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -7,14 +7,16 @@
           <div class="swiper-wrapper">
             @for (sku of products; track $index) {
               <div class="swiper-slide">
-                <div [ngClass]="listItemCSSClass">
-                  <ish-product-item
-                    ishProductContext
-                    [configuration]="listItemConfiguration"
-                    [displayType]="listItemStyle"
-                    [sku]="sku"
-                  />
-                </div>
+                <ish-deferred-item [cssClass]="listItemCSSClass">
+                  <ng-template ishLazyLoadingContent>
+                    <ish-product-item
+                      ishProductContext
+                      [configuration]="listItemConfiguration"
+                      [displayType]="listItemStyle"
+                      [sku]="sku"
+                    />
+                  </ng-template>
+                </ish-deferred-item>
               </div>
             }
           </div>

--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -2,22 +2,25 @@
   @if (products.length) {
     @if (listStyle === 'carousel') {
       <div class="product-list">
-        <swiper [config]="swiperConfig">
-          @for (sku of products; track $index) {
-            <ng-template let-data swiperSlide>
-              <div [ngClass]="listItemCSSClass">
-                @if (lazyFetch(data.isVisible, sku)) {
+        <div #swiper class="swiper">
+          <div class="swiper-button-prev"></div>
+          <div class="swiper-wrapper">
+            @for (sku of products; track $index) {
+              <div class="swiper-slide">
+                <div [ngClass]="listItemCSSClass">
                   <ish-product-item
                     ishProductContext
                     [configuration]="listItemConfiguration"
                     [displayType]="listItemStyle"
                     [sku]="sku"
                   />
-                }
+                </div>
               </div>
-            </ng-template>
-          }
-        </swiper>
+            }
+          </div>
+          <div class="swiper-button-next"></div>
+          <div class="swiper-pagination"></div>
+        </div>
       </div>
     } @else {
       <div class="product-list row">

--- a/src/app/shared/components/product/products-list/products-list.component.spec.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.spec.ts
@@ -2,9 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
-import { SwiperComponent } from 'swiper/angular';
 import { instance, mock, when } from 'ts-mockito';
 
+import { BrowserLazyViewDirective } from 'ish-core/directives/browser-lazy-view.directive';
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
@@ -23,7 +23,7 @@ describe('Products List Component', () => {
     await TestBed.configureTestingModule({
       declarations: [
         MockComponent(ProductItemComponent),
-        MockComponent(SwiperComponent),
+        MockDirective(BrowserLazyViewDirective),
         MockDirective(ProductContextDirective),
         ProductsListComponent,
       ],
@@ -52,7 +52,8 @@ describe('Products List Component', () => {
     component.ngOnChanges();
     fixture.detectChanges();
 
-    expect(element).toMatchInlineSnapshot(`<div class="product-list"><swiper></swiper></div>`);
+    expect(element.querySelector('.swiper')).toBeTruthy();
+    expect(element.querySelectorAll('.swiper-slide')).toHaveLength(2);
   });
 
   it('should set displayType of product item to listItemStyle value', () => {

--- a/src/app/shared/components/product/products-list/products-list.component.spec.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.spec.ts
@@ -1,12 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { MockComponent, MockDirective } from 'ng-mocks';
+import { MockComponent, MockDirective, MockInstance } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
 import { BrowserLazyViewDirective } from 'ish-core/directives/browser-lazy-view.directive';
+import { LazyLoadingContentDirective } from 'ish-core/directives/lazy-loading-content.directive';
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
+import { DeferredItemComponent } from 'ish-shared/components/common/deferred-item/deferred-item.component';
 import { ProductItemComponent } from 'ish-shared/components/product/product-item/product-item.component';
 
 import { ProductsListComponent } from './products-list.component';
@@ -17,13 +19,17 @@ describe('Products List Component', () => {
   let element: HTMLElement;
   let shoppingFacade: ShoppingFacade;
 
+  MockInstance.scope();
+
   beforeEach(async () => {
     shoppingFacade = mock(ShoppingFacade);
 
     await TestBed.configureTestingModule({
       declarations: [
+        MockComponent(DeferredItemComponent),
         MockComponent(ProductItemComponent),
         MockDirective(BrowserLazyViewDirective),
+        MockDirective(LazyLoadingContentDirective),
         MockDirective(ProductContextDirective),
         ProductsListComponent,
       ],

--- a/src/app/shared/components/product/products-list/products-list.component.ts
+++ b/src/app/shared/components/product/products-list/products-list.component.ts
@@ -1,8 +1,19 @@
-import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Inject,
+  Input,
+  OnChanges,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
 import { isEqual } from 'lodash-es';
 import { Observable, combineLatest, of } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-import SwiperCore, { Navigation, Pagination, SwiperOptions, A11y } from 'swiper';
+import Swiper from 'swiper';
+import { A11y, Navigation, Pagination } from 'swiper/modules';
+import { SwiperOptions } from 'swiper/types';
 
 import {
   LARGE_BREAKPOINT_WIDTH,
@@ -14,14 +25,12 @@ import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { InjectSingle } from 'ish-core/utils/injection';
 import { ProductItemDisplayType } from 'ish-shared/components/product/product-item/product-item.component';
 
-SwiperCore.use([Pagination, Navigation, A11y]);
-
 @Component({
   selector: 'ish-products-list',
   templateUrl: './products-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProductsListComponent implements OnChanges {
+export class ProductsListComponent implements OnChanges, OnDestroy {
   @Input({ required: true }) productSKUs: string[];
   @Input() listStyle: string;
   @Input() slideItems: number;
@@ -31,34 +40,41 @@ export class ProductsListComponent implements OnChanges {
 
   productSKUs$: Observable<string[]>;
 
-  /**
-   * track already fetched SKUs
-   */
-  private fetchedSKUs = new Set<string>();
+  private swiper: Swiper;
+  private swiperInitialized = false;
 
-  /**
-   * configuration of swiper carousel
-   * https://swiperjs.com/swiper-api
-   */
-  swiperConfig: SwiperOptions;
+  @ViewChild('swiper') set swiperRef(ref: ElementRef) {
+    if (ref && !this.swiperInitialized && !SSR) {
+      this.swiperInitialized = true;
+      const swiperEl = ref.nativeElement;
+      this.swiper = new Swiper(swiperEl, {
+        modules: [A11y, Navigation, Pagination],
+        ...this.swiperConfig,
+        navigation: {
+          nextEl: swiperEl.querySelector('.swiper-button-next'),
+          prevEl: swiperEl.querySelector('.swiper-button-prev'),
+        },
+        pagination: {
+          el: swiperEl.querySelector('.swiper-pagination'),
+          clickable: true,
+        },
+      });
+    }
+  }
+
+  // configuration of swiper carousel: https://swiperjs.com/swiper-api
+  private swiperConfig: SwiperOptions = {
+    watchSlidesProgress: true,
+    direction: 'horizontal',
+    breakpoints: {},
+  };
 
   constructor(
     @Inject(SMALL_BREAKPOINT_WIDTH) private smallBreakpointWidth: InjectSingle<typeof SMALL_BREAKPOINT_WIDTH>,
     @Inject(MEDIUM_BREAKPOINT_WIDTH) private mediumBreakpointWidth: InjectSingle<typeof MEDIUM_BREAKPOINT_WIDTH>,
     @Inject(LARGE_BREAKPOINT_WIDTH) private largeBreakpointWidth: InjectSingle<typeof LARGE_BREAKPOINT_WIDTH>,
     private shoppingFacade: ShoppingFacade
-  ) {
-    this.swiperConfig = {
-      watchSlidesProgress: true,
-      direction: 'horizontal',
-      navigation: true,
-      pagination: {
-        clickable: true,
-      },
-      observer: true,
-      observeParents: true,
-    };
-  }
+  ) {}
 
   ngOnChanges(): void {
     this.configureSlides(this.slideItems);
@@ -68,13 +84,13 @@ export class ProductsListComponent implements OnChanges {
       distinctUntilChanged<[string[], string[]]>(isEqual),
       map(([skus, failed]) => skus.filter(x => !failed.includes(x)))
     );
+
+    // update swiper when slides change
+    this.swiper?.update();
   }
 
-  lazyFetch(fetch: boolean, sku: string): boolean {
-    if (fetch) {
-      this.fetchedSKUs.add(sku);
-    }
-    return this.fetchedSKUs.has(sku);
+  ngOnDestroy(): void {
+    this.swiper?.destroy();
   }
 
   /**

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -12,7 +12,6 @@ import {
 } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { InfiniteScrollDirective } from 'ngx-infinite-scroll';
-import { SwiperModule } from 'swiper/angular';
 
 import { AuthorizationToggleModule } from 'ish-core/authorization-toggle.module';
 import { DirectivesModule } from 'ish-core/directives.module';
@@ -196,7 +195,6 @@ const importExportModules = [
   RecentlyExportsModule,
   RoleToggleModule,
   RouterModule,
-  SwiperModule,
   TranslateModule,
   WishlistsExportsModule,
 ];

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -90,6 +90,7 @@ import { BasketShippingAddressWidgetComponent } from './components/checkout/bask
 import { AccordionItemComponent } from './components/common/accordion-item/accordion-item.component';
 import { AccordionComponent } from './components/common/accordion/accordion.component';
 import { BreadcrumbComponent } from './components/common/breadcrumb/breadcrumb.component';
+import { DeferredItemComponent } from './components/common/deferred-item/deferred-item.component';
 import { ErrorMessageComponent } from './components/common/error-message/error-message.component';
 import { InPlaceEditComponent } from './components/common/in-place-edit/in-place-edit.component';
 import { InfoBoxComponent } from './components/common/info-box/info-box.component';
@@ -287,6 +288,7 @@ const exportedComponents = [
   InfoBoxComponent,
   InfoMessageComponent,
   InPlaceEditComponent,
+  DeferredItemComponent,
   LineItemListComponent,
   LoadingComponent,
   LoginFormComponent,

--- a/src/styles/global/print.scss
+++ b/src/styles/global/print.scss
@@ -58,10 +58,10 @@
 
   .swiper-slide {
     display: none;
-  }
 
-  .swiper-slide-active {
-    display: inline-block !important;
+    &.swiper-slide-active {
+      display: inline-block !important;
+    }
   }
 
   .budget-bar-used {

--- a/src/styles/global/swiper.scss
+++ b/src/styles/global/swiper.scss
@@ -1,27 +1,19 @@
 .swiper {
-  padding-bottom: 20px;
+  padding-bottom: $space-default * 2;
 
   .swiper-pagination {
-    bottom: 0;
+    bottom: divide($space-default, -3);
+  }
 
-    .swiper-pagination-bullet-active {
-      background: $bg-color-corporate;
-    }
+  .swiper-pagination-bullet {
+    position: relative;
+    width: 24px;
+    height: 24px;
+    margin: 0 !important;
+    background: transparent;
+    opacity: 1;
 
-    .swiper-pagination-bullet {
-      &:only-child {
-        visibility: hidden;
-      }
-
-      position: relative;
-      width: 24px;
-      height: 24px;
-      margin: 0;
-      background: transparent;
-      opacity: 1;
-    }
-
-    .swiper-pagination-bullet::before {
+    &::before {
       position: absolute;
       top: 50%;
       left: 50%;
@@ -34,50 +26,64 @@
       transform: translate(-50%, -50%);
     }
 
-    .swiper-pagination-bullet-active::before {
+    &:only-child {
+      visibility: hidden;
+    }
+  }
+
+  .swiper-pagination-bullet-active {
+    &::before {
       background-color: $CORPORATE-PRIMARY;
     }
   }
-}
 
-.swiper-slide {
-  padding-right: $space-default;
-  padding-left: $space-default;
-}
-
-.swiper-button-next,
-.swiper-button-prev {
-  position: absolute;
-  top: 0;
-  z-index: 10;
-  width: $carousel-control-icon-width;
-  height: 100%;
-  cursor: pointer;
-  background: no-repeat 50% / 100% 100%;
-  opacity: 0.5;
-
-  &:hover {
-    opacity: 1;
+  .swiper-slide {
+    padding-right: $space-default;
+    padding-left: $space-default;
   }
 
-  &.swiper-button-disabled {
-    opacity: 0;
+  &.swiper-watch-progress {
+    // a11y: hide non visible slides to prevent tabbing into them
+    // only applies to carousels with watchSlidesProgress: true
+    .swiper-slide {
+      &:not(.swiper-slide-visible) {
+        visibility: hidden;
+      }
+    }
   }
-}
 
-.swiper-button-next {
-  right: 0;
-  background-image: escape-svg($carousel-control-next-icon-bg);
+  .swiper-button-next,
+  .swiper-button-prev {
+    position: absolute;
+    top: 0;
+    z-index: 10;
+    width: $carousel-control-icon-width;
+    height: 100%;
+    color: transparent;
+    cursor: pointer;
+    background: no-repeat 50% / 100% 100%;
+    opacity: 0.5;
 
-  &::after {
-    content: '';
+    &::after {
+      display: none;
+    }
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &.swiper-button-disabled {
+      opacity: 0;
+    }
   }
-}
 
-.swiper-button-prev {
-  background-image: escape-svg($carousel-control-prev-icon-bg);
+  .swiper-button-next {
+    right: 0;
+    background-image: escape-svg($carousel-control-next-icon-bg);
+  }
 
-  &::after {
-    content: '';
+  .swiper-button-prev {
+    left: 0;
+    background-image: escape-svg($carousel-control-prev-icon-bg);
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -13,9 +13,13 @@
 // import Angular Toastr bootstrap styles
 @import 'ngx-toastr/toastr-bs5-alert';
 
-// import Swiper default theme
-@import 'swiper/scss';
-@import 'swiper/scss/pagination';
+// import Swiper styles
+@import 'swiper/css';
+@import 'swiper/css/a11y';
+@import 'swiper/css/navigation';
+@import 'swiper/css/pagination';
+
+// import ng-select styles
 @import '@ng-select/ng-select/scss/default.theme';
 
 // STYLING COMPATIBILITY LAYER

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
       ],
       "requisition-management": [
         "projects/requisition-management/src/app/exports"
-      ],
-      "swiper_angular": ["node_modules/swiper/angular"]
+      ]
     },
 
     /* Language & Environment */


### PR DESCRIPTION
### 🚀 Description

This pull request migrates the [Swiper](https://swiperjs.com/) from version 8 to [12.1.4](https://github.com/nolimits4web/swiper/releases/tag/v12.1.4).

Swiper is used for mobile-friendly carousels and sliders: 
* Product images component: a product image gallery carousel in the product detail page
* Product links component: related products (cross-selling, up-selling, accessories, etc.) in a carousel format
* Product list component: product listings in carousel mode when configured

Closes: #1668

---

### 🔍 Detailed Changes

Swiper integration is based on [Swiper Core / API](https://swiperjs.com/swiper-api), not [Swiper Element (WebComponent)](https://swiperjs.com/element).

---

### 📝 Notes

BREAKING CHANGES: 
- Swiper module / swiper/angular removed (replaced with the JavaScript API)
- Migration of all Swiper usages is required
- Lazy loading changed
- Swiper module imports updated

---

### ✅ Open Tasks

- [x] lazy loading of product tiles (triggering the product detail rest requests) not yet implemented again
- [ ] Documentation and Localizations reviewed by the documentation team


---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116577](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116577)