### PR TITLE
fix: enable patch open tender after redirect

### DIFF
--- a/src/app/core/store/customer/basket/basket-payment.effects.spec.ts
+++ b/src/app/core/store/customer/basket/basket-payment.effects.spec.ts
@@ -769,10 +769,6 @@ describe('Basket Payment Effects', () => {
           basket: {
             id: 'BID',
             lineItems: [],
-            payment: {
-              id: 'paypal-payment',
-              capabilities: ['PaypalCheckout'],
-            },
           } as Basket,
         })
       );

--- a/src/app/core/store/customer/basket/basket-payment.effects.ts
+++ b/src/app/core/store/customer/basket/basket-payment.effects.ts
@@ -48,7 +48,7 @@ import {
   updatePaymentInstrumentSuccess,
   updatePaypalCreditCardPaymentInstrument,
 } from './basket.actions';
-import { getCurrentBasket } from './basket.selectors';
+import { getCurrentBasket, getCurrentBasketId } from './basket.selectors';
 
 @Injectable()
 export class BasketPaymentEffects {
@@ -284,10 +284,9 @@ export class BasketPaymentEffects {
       ),
       switchMap(routerState =>
         this.store.pipe(
-          select(getCurrentBasket),
+          select(getCurrentBasketId),
           whenTruthy(),
           take(1),
-          filter(basket => !!basket.payment?.capabilities?.includes('PaypalCheckout')),
           map(() => updateBasketPayment({ params: routerState.queryParams }))
         )
       )


### PR DESCRIPTION
Redirect before payment method handling was broken. The necessary payment details were no longer sent to the ICM after the redirect. The corresponding effect method has a faulty filtering mechanism.
This issue has been fixed by removing the unnecessary filter.


[AB#116764](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116764)