### PR TITLE
chore: use typescript workspace version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
   "git.rebaseWhenSync": true,
   "git.autoStash": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "workbench.iconTheme": "vscode-icons",
 
   // stylelint


### PR DESCRIPTION
### 🚀 Description

If the developer didn't select which typescript version should be used in vs code the current version (6.x) is used.
This leads to many errors displayed in the code because typescript 6.x has strict typescript as default setting.

The vscode setting 'js/ts.tsdk.promptToUseWorkspaceVersion' is added to the vs code settings to ensure the developers use the correct typescript version in their vs code.

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#116837](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116837)