### PR TITLE
fix: correct initialization/hydration of transfered state to feature state

### DIFF
--- a/src/app/core/configurations/ngrx-state-transfer.ts
+++ b/src/app/core/configurations/ngrx-state-transfer.ts
@@ -13,6 +13,8 @@ const STATE_ACTION_TYPE = '[Internal] Import NgRx State';
 
 let transferredState: object;
 
+const hydratedFeatures = new Set<string>();
+
 /**
  * meta reducer for overriding client side state if supplied by server
  */
@@ -23,8 +25,13 @@ export function ngrxStateTransferMeta(reducer: ActionReducer<CoreState>): Action
       return mergeDeep(state, transferredState);
     }
     if (action.type === UPDATE && transferredState) {
-      // re-apply transferred state as it could be overwritten by uninitialized reducers
-      return reducer({ ...state, ...pick(transferredState, ...action.features) }, action);
+      // only re-apply transferred state for features being registered for the first time
+      // subsequent re-registrations must not overwrite state that was updated client-side after hydration
+      const newFeatures = action.features?.filter(f => !hydratedFeatures.has(f)) ?? [];
+      action.features?.forEach(f => hydratedFeatures.add(f));
+      if (newFeatures.length) {
+        return reducer({ ...state, ...pick(transferredState, ...newFeatures) }, action);
+      }
     }
     return reducer(state, action);
   };

--- a/src/app/core/configurations/ngrx-state-transfer.ts
+++ b/src/app/core/configurations/ngrx-state-transfer.ts
@@ -11,26 +11,30 @@ export const NGRX_STATE_SK = makeStateKey<object>('ngrxState');
 
 const STATE_ACTION_TYPE = '[Internal] Import NgRx State';
 
-let transferredState: object;
-
-const hydratedFeatures = new Set<string>();
+let transferredState: Record<string, unknown>;
 
 /**
- * meta reducer for overriding client side state if supplied by server
+ * Meta reducer for hydrating server side state on the client side if supplied by SSR.
+ * Initially (STATE_ACTION_TYPE) all already registered slices are hydrated, then removed from the transferred state.
+ * On subsequent updates (UPDATE), only features that are still in the transferred state are applied, then removed from the transferred state.
+ * This allows to apply the transferred state in parts and only once, e.g. as features are loaded, and prevents transferred state from being lost if the store is updated before a feature is loaded.
  */
 export function ngrxStateTransferMeta(reducer: ActionReducer<CoreState>): ActionReducer<CoreState> {
-  return (state: CoreState, action: Action & { payload: object; features: string[] }) => {
+  return (state: CoreState, action: Action & { payload: Record<string, unknown>; features: string[] }) => {
     if (action.type === STATE_ACTION_TYPE) {
-      transferredState = action.payload;
-      return mergeDeep(state, transferredState);
+      // keep a mutable copy — slices are removed as they're applied
+      transferredState = { ...action.payload };
+      const registered = Object.keys(state ?? {});
+      const applicable = pick(transferredState, ...registered);
+      registered.forEach(k => delete transferredState[k]);
+      return mergeDeep(state, applicable);
     }
-    if (action.type === UPDATE && transferredState) {
-      // only re-apply transferred state for features being registered for the first time
-      // subsequent re-registrations must not overwrite state that was updated client-side after hydration
-      const newFeatures = action.features?.filter(f => !hydratedFeatures.has(f)) ?? [];
-      action.features?.forEach(f => hydratedFeatures.add(f));
-      if (newFeatures.length) {
-        return reducer({ ...state, ...pick(transferredState, ...newFeatures) }, action);
+    if (action.type === UPDATE && transferredState && Object.keys(transferredState).length) {
+      const newFeatures = action.features ?? [];
+      const applicable = pick(transferredState, ...newFeatures);
+      if (Object.keys(applicable).length) {
+        newFeatures.forEach(k => delete transferredState[k]);
+        return reducer({ ...state, ...applicable }, action);
       }
     }
     return reducer(state, action);


### PR DESCRIPTION
### 🚀 Description

In the user management and cost center management section of myAccount, form pages (e.g. edit user, edit cost center) are sometimes empty because the selected user/cost center is missing after the user reloads the list or detail pages. This issue only occurs in an SSR environment.

closes: #1821

---

### 🔍 Detailed Changes

The root cause is a design flaw in [ngrxStateTransferMeta](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dating back to [PR #628](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The original fix addressed lazy feature stores losing their transferred state by re-applying the full [transferredState](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on every [UPDATE](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) action. However, this meant stale server state could overwrite client-side state — which is exactly what caused the empty form pages.

The new approach addresses this more thoroughly:

Don't merge state for unregistered features prematurely. On [STATE_ACTION_TYPE](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), only the slices for already-registered feature reducers are merged. Previously, all transferred state (including for not-yet-loaded lazy features) was merged into the store, where it would be silently dropped by combineReducers on the next action.

Apply each feature's transferred state exactly once. Consumed slices are deleted from [transferredState](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after being applied. This eliminates the need for a deduplication Set — once a feature's state is consumed, it can never be re-applied.

Short-circuit when nothing remains. The [UPDATE](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) handler checks [Object.keys(transferredState).length](vscode-file://vscode-app/c:/Users/shauke/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to skip processing once all slices have been consumed.

This makes the hydration logic self-cleaning and prevents transferred state from ever overwriting state that was updated client-side after initial hydration.

---

### 🔗 Other Information

[AB#116965](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/116965)
