### PR TITLE
refactor: modal dialogs

### DIFF
--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.html
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.html
@@ -1,14 +1,11 @@
-<ng-template #modal let-editModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="cc-buyer-edit-modal-title">{{ modalHeader | translate }}</h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
-  <form #form="ngForm" ishFormSubmit [formGroup]="costCenterBuyerForm" (ngSubmit)="submitCostCenterBuyerForm()">
+<ish-modal-dialog
+  #modal
+  [options]="{ titleText: modalHeader | translate, size: 'lg', ariaLabelledBy: 'cc-buyer-edit-modal-title' }"
+>
+  <form #form="ngForm" body ishFormSubmit [formGroup]="costCenterBuyerForm" (ngSubmit)="submitCostCenterBuyerForm()">
     <div class="modal-body">
       <formly-form [fields]="fields" [form]="costCenterBuyerForm" [model]="model" />
     </div>
-
     <div class="modal-footer">
       <button
         class="btn btn-primary"
@@ -18,9 +15,9 @@
       >
         {{ 'account.costcenter.details.buyers.action.save' | translate }}
       </button>
-      <button class="btn btn-secondary" type="button" (click)="hide()">
+      <button class="btn btn-secondary" type="button" (click)="modal.hide()">
         {{ 'account.cancel.button.label' | translate }}
       </button>
     </div>
   </form>
-</ng-template>
+</ish-modal-dialog>

--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.spec.ts
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.spec.ts
@@ -1,10 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { CostCenterBuyer } from 'ish-core/models/cost-center/cost-center.model';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
 
@@ -23,9 +27,11 @@ describe('Cost Center Buyer Edit Dialog Component', () => {
     appFacade = mock(AppFacade);
     when(appFacade.currencySymbol$(anything())).thenReturn(of('$'));
 
-    organizationManagementFacade = mock(organizationManagementFacade);
+    organizationManagementFacade = mock(OrganizationManagementFacade);
 
     await TestBed.configureTestingModule({
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [CostCenterBuyerEditDialogComponent, MockComponent(ModalDialogComponent)],
       providers: [
         { provide: AppFacade, useFactory: () => instance(appFacade) },
         { provide: OrganizationManagementFacade, useFactory: () => instance(organizationManagementFacade) },
@@ -49,6 +55,7 @@ describe('Cost Center Buyer Edit Dialog Component', () => {
     });
 
     component.costCenterBuyerForm = form;
+    fixture.detectChanges();
     component.show({
       login: 'jlink@test.intershop.de',
       budget: { currency: 'USD', value: 10000 },
@@ -62,8 +69,6 @@ describe('Cost Center Buyer Edit Dialog Component', () => {
   });
 
   it('should display all form input fields for cost center buyer update', () => {
-    fixture.detectChanges();
-
     expect(JSON.stringify(component.fields)).toContain('buyerName');
     expect(JSON.stringify(component.fields)).toContain('budgetValue');
     expect(JSON.stringify(component.fields)).toContain('budgetPeriod');

--- a/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.ts
+++ b/projects/organization-management/src/app/components/cost-center-buyer-edit-dialog/cost-center-buyer-edit-dialog.component.ts
@@ -1,11 +1,11 @@
-import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { CostCenterBuyer } from 'ish-core/models/cost-center/cost-center.model';
 import { PriceHelper } from 'ish-core/models/price/price.helper';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { FormsService } from 'ish-shared/forms/utils/forms.service';
 
 import { OrganizationManagementFacade } from '../../facades/organization-management.facade';
@@ -17,7 +17,6 @@ import { OrganizationManagementFacade } from '../../facades/organization-managem
 })
 export class CostCenterBuyerEditDialogComponent implements OnInit {
   model: { buyerName: string; budgetValue: number; budgetPeriod: string };
-  modal: NgbModalRef;
   modalHeader = 'account.costcenter.details.buyers.action.editbudget.title';
 
   costCenterBuyerForm = new FormGroup({});
@@ -25,10 +24,9 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
 
   buyer: CostCenterBuyer;
 
-  @ViewChild('modal', { static: false }) modalTemplate: TemplateRef<unknown>;
+  @ViewChild('modal', { static: false }) modalDialog: ModalDialogComponent<unknown>;
 
   constructor(
-    private ngbModal: NgbModal,
     private appFacade: AppFacade,
     private organizationManagementFacade: OrganizationManagementFacade
   ) {}
@@ -93,7 +91,9 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
       };
 
       this.organizationManagementFacade.updateCostCenterBuyer(changedBuyer);
-      this.hide();
+      if (this.modalDialog) {
+        this.modalDialog.hide();
+      }
     }
   }
 
@@ -106,13 +106,6 @@ export class CostCenterBuyerEditDialogComponent implements OnInit {
       budgetPeriod: buyer.budgetPeriod,
     };
 
-    this.modal = this.ngbModal.open(this.modalTemplate, { size: 'lg', ariaLabelledBy: 'cc-buyer-edit-modal-title' });
-  }
-
-  /** Close the modal. */
-  hide() {
-    if (this.modal) {
-      this.modal.close();
-    }
+    this.modalDialog.show();
   }
 }

--- a/projects/requisition-management/src/app/components/requisition-reject-dialog/requisition-reject-dialog.component.html
+++ b/projects/requisition-management/src/app/components/requisition-reject-dialog/requisition-reject-dialog.component.html
@@ -1,25 +1,22 @@
-<ng-template #modal let-rejectModal>
-  <div class="modal-content">
-    <div class="modal-header">
-      <h2 class="modal-title" id="requisition-reject-modal-title">
-        {{ 'approval.rejectform.reject_order.heading' | translate }}
-      </h2>
-      <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: 'approval.rejectform.reject_order.heading' | translate,
+    ariaLabelledBy: 'requisition-reject-modal-title',
+  }"
+>
+  <form #form="ngForm" body ishFormSubmit novalidate [formGroup]="rejectForm" (ngSubmit)="submitForm()">
+    <div class="modal-body">
+      <formly-form [fields]="fields" [form]="rejectForm" />
     </div>
 
-    <form #form="ngForm" class="clearfix" ishFormSubmit novalidate [formGroup]="rejectForm" (ngSubmit)="submitForm()">
-      <div class="modal-body">
-        <formly-form [fields]="fields" [form]="rejectForm" />
-      </div>
-
-      <div class="modal-footer">
-        <button class="btn btn-primary" type="submit" [disabled]="rejectForm.invalid && form.submitted">
-          {{ 'approval.rejectform.button.reject.label' | translate }}
-        </button>
-        <button class="btn btn-secondary" type="button" (click)="hide()">
-          {{ 'approval.rejectform.button.cancel.label' | translate }}
-        </button>
-      </div>
-    </form>
-  </div>
-</ng-template>
+    <div class="modal-footer">
+      <button class="btn btn-primary" type="submit" [disabled]="rejectForm.invalid && form.submitted">
+        {{ 'approval.rejectform.button.reject.label' | translate }}
+      </button>
+      <button class="btn btn-secondary" type="button" (click)="modal.hide()">
+        {{ 'approval.rejectform.button.cancel.label' | translate }}
+      </button>
+    </div>
+  </form>
+</ish-modal-dialog>

--- a/projects/requisition-management/src/app/components/requisition-reject-dialog/requisition-reject-dialog.component.spec.ts
+++ b/projects/requisition-management/src/app/components/requisition-reject-dialog/requisition-reject-dialog.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { anything, capture, spy, verify } from 'ts-mockito';
+
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { RequisitionRejectDialogComponent } from './requisition-reject-dialog.component';
 
@@ -8,6 +13,13 @@ describe('Requisition Reject Dialog Component', () => {
   let component: RequisitionRejectDialogComponent;
   let fixture: ComponentFixture<RequisitionRejectDialogComponent>;
   let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [MockComponent(ModalDialogComponent), RequisitionRejectDialogComponent],
+    }).compileComponents();
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RequisitionRejectDialogComponent);
@@ -25,6 +37,7 @@ describe('Requisition Reject Dialog Component', () => {
 
   it('should emit approval comment when submit form was called and the form was valid', () => {
     fixture.detectChanges();
+    component.show();
     component.rejectForm.setValue({
       comment: 'test comment',
     });

--- a/projects/requisition-management/src/app/components/requisition-reject-dialog/requisition-reject-dialog.component.ts
+++ b/projects/requisition-management/src/app/components/requisition-reject-dialog/requisition-reject-dialog.component.ts
@@ -1,15 +1,8 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  OnInit,
-  Output,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
+
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 
 /**
  * The Wishlist Reject Approval Dialog shows the modal to reject a requisition.
@@ -33,14 +26,7 @@ export class RequisitionRejectDialogComponent implements OnInit {
   rejectForm = new FormGroup({});
   fields: FormlyFieldConfig[];
 
-  /**
-   *  A reference to the current modal.
-   */
-  modal: NgbModalRef;
-
-  @ViewChild('modal') modalTemplate: TemplateRef<unknown>;
-
-  constructor(private ngbModal: NgbModal) {}
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   ngOnInit() {
     this.initForm();
@@ -73,20 +59,13 @@ export class RequisitionRejectDialogComponent implements OnInit {
   submitForm() {
     if (this.rejectForm.valid) {
       this.submitRejectRequisition.emit(this.rejectForm.get('comment').value);
-      this.hide();
+      this.modalDialog.hide();
     }
   }
 
   /** Opens the modal. */
   show() {
     this.rejectForm.reset();
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'requisition-reject-modal-title' });
-  }
-
-  /** Close the modal. */
-  hide() {
-    if (this.modal) {
-      this.modal.close();
-    }
+    this.modalDialog.show();
   }
 }

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
@@ -1,10 +1,18 @@
-<ng-template #modal let-addModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="order-template-preferences-title">{{ modalTitle || modalHeader | translate }}</h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
-  <form #form="ngForm" ishFormSubmit novalidate [formGroup]="orderTemplateForm" (ngSubmit)="submitOrderTemplateForm()">
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: modalTitle || modalHeader | translate,
+    ariaLabelledBy: 'order-template-preferences-title',
+  }"
+>
+  <form
+    #form="ngForm"
+    body
+    ishFormSubmit
+    novalidate
+    [formGroup]="orderTemplateForm"
+    (ngSubmit)="submitOrderTemplateForm()"
+  >
     <div class="modal-body">
       <formly-form [fields]="fields" [form]="orderTemplateForm" [model]="model" />
     </div>
@@ -18,9 +26,9 @@
       >
         {{ primaryButton | translate }}
       </button>
-      <button class="btn btn-secondary" type="button" (click)="hide()">
+      <button class="btn btn-secondary" type="button" (click)="modal.hide()">
         {{ 'account.cancel.button.label' | translate }}
       </button>
     </div>
   </form>
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.spec.ts
@@ -1,5 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { anything, capture, spy, verify } from 'ts-mockito';
+
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { OrderTemplatePreferencesDialogComponent } from './order-template-preferences-dialog.component';
 
@@ -7,6 +13,13 @@ describe('Order Template Preferences Dialog Component', () => {
   let component: OrderTemplatePreferencesDialogComponent;
   let fixture: ComponentFixture<OrderTemplatePreferencesDialogComponent>;
   let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [MockComponent(ModalDialogComponent), OrderTemplatePreferencesDialogComponent],
+    }).compileComponents();
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OrderTemplatePreferencesDialogComponent);
@@ -21,10 +34,11 @@ describe('Order Template Preferences Dialog Component', () => {
   });
 
   it('should emit new order template data when submit form was called and the form was valid', () => {
-    fixture.detectChanges();
-    component.model = {
+    component.orderTemplate = {
+      id: '123456789',
       title: 'test order template',
     };
+    fixture.detectChanges();
 
     const emitter = spy(component.submitOrderTemplate);
 

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.ts
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.ts
@@ -1,18 +1,9 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { pick } from 'lodash-es';
 
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { OrderTemplate } from '../../models/order-template/order-template.model';
@@ -45,19 +36,12 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
   model: Partial<OrderTemplate>;
   fields: FormlyFieldConfig[];
 
-  /**
-   *  A reference to the current modal.
-   */
-  modal: NgbModalRef;
-
   /** localization keys, default = for new */
   primaryButton = 'account.order_template.new_from_order.button.create.label';
   private orderTemplateTitle = 'account.order_template.new_order_template.text';
   modalHeader = 'account.order_template.list.button.add_template.label';
 
-  @ViewChild('modal', { static: false }) modalTemplate: TemplateRef<unknown>;
-
-  constructor(private ngbModal: NgbModal) {}
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   ngOnInit() {
     this.fields = [
@@ -99,7 +83,7 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
         title: this.model.title,
       });
 
-      this.hide();
+      this.modalDialog.hide();
     }
   }
 
@@ -107,13 +91,6 @@ export class OrderTemplatePreferencesDialogComponent implements OnInit {
   show() {
     this.orderTemplateForm.reset();
     this.model = pick(this.orderTemplate, 'title');
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'order-template-preferences-title' });
-  }
-
-  /** Close the modal. */
-  hide() {
-    if (this.modal) {
-      this.modal.close();
-    }
+    this.modalDialog.show();
   }
 }

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.html
@@ -1,11 +1,12 @@
-<ng-template #modal let-selectModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="select-order-template-modal-title">{{ headerTranslationKey | translate }}</h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: headerTranslationKey | translate,
+    ariaLabelledBy: 'select-order-template-modal-title',
+  }"
+>
   @if (showForm) {
-    <form #form="ngForm" ishFormSubmit novalidate [formGroup]="formGroup" (ngSubmit)="submitForm()">
+    <form #form="ngForm" body ishFormSubmit novalidate [formGroup]="formGroup" (ngSubmit)="submitForm()">
       <div class="modal-body">
         <ish-select-order-template-form [addMoveProduct]="addMoveProduct" [formGroup]="formGroup" />
       </div>
@@ -19,25 +20,27 @@
       </div>
     </form>
   } @else {
-    <div *ishProductContextAccess="let product = product" class="modal-body">
-      <span
-        data-testing-id="order-template-success-link"
-        [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
-        [ishServerHtml]="
-          successTranslationKey
-            | translate
-              : {
-                  '0': product.name,
-                  '1': selectedOrderTemplateTitle$ | async | ishHtmlEncode,
-                  '2': selectedOrderTemplateRoute$ | async,
-                }
-        "
-      ></span>
-    </div>
-    <div class="modal-footer">
-      <button class="btn btn-secondary" type="button" (click)="hide()">
-        {{ 'store.dialog.button.ok' | translate }}
-      </button>
+    <div body>
+      <div *ishProductContextAccess="let product = product" class="modal-body">
+        <span
+          data-testing-id="order-template-success-link"
+          [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
+          [ishServerHtml]="
+            successTranslationKey
+              | translate
+                : {
+                    '0': product.name,
+                    '1': selectedOrderTemplateTitle$ | async | ishHtmlEncode,
+                    '2': selectedOrderTemplateRoute$ | async,
+                  }
+          "
+        ></span>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" type="button" (click)="hide()">
+          {{ 'store.dialog.button.ok' | translate }}
+        </button>
+      </div>
     </div>
   }
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
 
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
@@ -47,8 +50,12 @@ describe('Select Order Template Modal Component', () => {
     orderTemplateFacadeMock = mock(OrderTemplatesFacade);
 
     await TestBed.configureTestingModule({
-      declarations: [SelectOrderTemplateFormComponent, SelectOrderTemplateModalComponent],
-      imports: [FormlyTestingModule, TranslateModule.forRoot()],
+      declarations: [
+        MockComponent(ModalDialogComponent),
+        MockComponent(SelectOrderTemplateFormComponent),
+        SelectOrderTemplateModalComponent,
+      ],
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
       providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplateFacadeMock) }],
     }).compileComponents();
   });

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
@@ -6,18 +6,17 @@ import {
   Input,
   OnInit,
   Output,
-  TemplateRef,
   ViewChild,
   inject,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
 
@@ -48,14 +47,12 @@ export class SelectOrderTemplateModalComponent implements OnInit {
   });
 
   showForm: boolean;
-  modal: NgbModalRef;
 
   private destroyRef = inject(DestroyRef);
 
-  @ViewChild('modal', { static: false }) modalTemplate: TemplateRef<unknown>;
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   constructor(
-    private ngbModal: NgbModal,
     private orderTemplatesFacade: OrderTemplatesFacade,
     private translate: TranslateService
   ) {}
@@ -102,14 +99,14 @@ export class SelectOrderTemplateModalComponent implements OnInit {
 
   /** close modal */
   hide() {
-    this.modal.close();
+    this.modalDialog.hide();
     this.formGroup.reset();
   }
 
   /** open modal */
   show() {
     this.showForm = true;
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'select-order-template-modal-title' });
+    this.modalDialog.show();
 
     // set default values after init (for example after closing and reopening the modal)
     this.orderTemplateOptions$

--- a/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.html
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.html
@@ -1,51 +1,57 @@
-<ng-template #modal let-selectModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="product-notification-edit-modal-title">
-      @if (product$ | async; as product) {
-        {{ product.name }}
-      }
-    </h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
-  @if (productNotification$ | async; as productNotification) {
-    <form #form="ngForm" ishFormSubmit novalidate [formGroup]="productNotificationForm" (ngSubmit)="submitForm()">
-      <div class="modal-body">
-        <ish-product-image imageType="L" />
-        <ish-product-notification-edit-form
-          [form]="productNotificationForm"
-          [productNotification]="productNotification"
-          [userEmail]="userEmail$ | async"
-        />
-      </div>
-      <div class="modal-footer">
-        <button
-          class="btn btn-primary"
-          data-testing-id="product-notification-edit-dialog-edit"
-          type="submit"
-          [disabled]="productNotificationForm.invalid && form.submitted"
-        >
-          {{ 'product.notification.edit.form.update.button.label' | translate }}
-        </button>
-        <button class="btn btn-secondary" type="button" (click)="hide()">
-          {{ 'product.notification.edit.form.cancel.button.label' | translate }}
-        </button>
-      </div>
-    </form>
-  } @else {
-    <form ishFormSubmit novalidate [formGroup]="productNotificationForm" (ngSubmit)="submitForm()">
-      <div class="modal-body">
-        <ish-product-image imageType="L" />
-        <ish-product-notification-edit-form [form]="productNotificationForm" [userEmail]="userEmail$ | async" />
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-primary" type="submit">
-          {{ 'product.notification.edit.form.create.button.label' | translate }}
-        </button>
-        <button class="btn btn-secondary" type="button" (click)="hide()">
-          {{ 'product.notification.edit.form.cancel.button.label' | translate }}
-        </button>
-      </div>
-    </form>
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: (product$ | async)?.name,
+    ariaLabelledBy: 'product-notification-edit-modal-title',
+  }"
+>
+  @if (inventoryLoaded$ | async) {
+    @if (productNotification$ | async; as productNotification) {
+      <form
+        #form="ngForm"
+        body
+        ishFormSubmit
+        novalidate
+        [formGroup]="productNotificationForm"
+        (ngSubmit)="submitForm()"
+      >
+        <div class="modal-body">
+          <ish-product-image imageType="L" />
+          <ish-product-notification-edit-form
+            [form]="productNotificationForm"
+            [productNotification]="productNotification"
+            [userEmail]="userEmail$ | async"
+          />
+        </div>
+        <div class="modal-footer">
+          <button
+            class="btn btn-primary"
+            data-testing-id="product-notification-edit-dialog-edit"
+            type="submit"
+            [disabled]="productNotificationForm.invalid && form.submitted"
+          >
+            {{ 'product.notification.edit.form.update.button.label' | translate }}
+          </button>
+          <button class="btn btn-secondary" type="button" (click)="hide()">
+            {{ 'product.notification.edit.form.cancel.button.label' | translate }}
+          </button>
+        </div>
+      </form>
+    } @else {
+      <form body ishFormSubmit novalidate [formGroup]="productNotificationForm" (ngSubmit)="submitForm()">
+        <div class="modal-body">
+          <ish-product-image imageType="L" />
+          <ish-product-notification-edit-form [form]="productNotificationForm" [userEmail]="userEmail$ | async" />
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" type="submit">
+            {{ 'product.notification.edit.form.create.button.label' | translate }}
+          </button>
+          <button class="btn btn-secondary" type="button" (click)="hide()">
+            {{ 'product.notification.edit.form.cancel.button.label' | translate }}
+          </button>
+        </div>
+      </form>
+    }
   }
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.spec.ts
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.spec.ts
@@ -1,13 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UntypedFormBuilder } from '@angular/forms';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
+import { FormSubmitDirective } from 'ish-core/directives/form-submit.directive';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { ProductView } from 'ish-core/models/product-view/product-view.model';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { ProductImageComponent } from 'ish-shared/components/product/product-image/product-image.component';
 
 import { ProductNotificationsFacade } from '../../facades/product-notifications.facade';
+import { ProductNotificationEditFormComponent } from '../product-notification-edit-form/product-notification-edit-form.component';
 
 import { ProductNotificationEditDialogComponent } from './product-notification-edit-dialog.component';
 
@@ -28,6 +35,14 @@ describe('Product Notification Edit Dialog Component', () => {
     appFacade = mock(AppFacade);
 
     await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [
+        MockComponent(ModalDialogComponent),
+        MockComponent(ProductImageComponent),
+        MockComponent(ProductNotificationEditFormComponent),
+        MockDirective(FormSubmitDirective),
+        ProductNotificationEditDialogComponent,
+      ],
       providers: [
         { provide: AccountFacade, useFactory: () => instance(accountFacade) },
         { provide: AppFacade, useFactory: () => instance(appFacade) },
@@ -37,7 +52,9 @@ describe('Product Notification Edit Dialog Component', () => {
     }).compileComponents();
 
     when(appFacade.currentCurrency$).thenReturn(of('USD'));
+    when(context.select('product')).thenReturn(of({ name: 'Test Product' } as ProductView));
     when(context.select('inventory', 'inStock')).thenReturn(of(true));
+    when(accountFacade.userEmail$).thenReturn(of('test@test.com'));
   });
 
   beforeEach(() => {
@@ -55,6 +72,7 @@ describe('Product Notification Edit Dialog Component', () => {
   describe('form submit', () => {
     beforeEach(() => {
       fb = TestBed.inject(UntypedFormBuilder);
+      fixture.detectChanges();
     });
 
     it('should emit delete product notification when alert type is delete', () => {

--- a/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.ts
+++ b/src/app/extensions/product-notifications/shared/product-notification-edit-dialog/product-notification-edit-dialog.component.ts
@@ -1,23 +1,14 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DestroyRef,
-  Input,
-  OnInit,
-  TemplateRef,
-  ViewChild,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, Input, OnInit, ViewChild, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { UntypedFormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { Observable, of, shareReplay, switchMap } from 'rxjs';
+import { Observable, map, of, shareReplay, switchMap } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { AppFacade } from 'ish-core/facades/app.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 import { whenTruthy } from 'ish-core/utils/operators';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 
 import { ProductNotificationsFacade } from '../../facades/product-notifications.facade';
 import { ProductNotification } from '../../models/product-notification/product-notification.model';
@@ -45,8 +36,8 @@ import { ProductNotification } from '../../models/product-notification/product-n
 export class ProductNotificationEditDialogComponent implements OnInit {
   @Input() productNotification: ProductNotification;
 
-  modal: NgbModalRef;
   product$: Observable<ProductView>;
+  inventoryLoaded$: Observable<boolean>;
   userEmail$: Observable<string>;
   private currentCurrency: string;
 
@@ -56,10 +47,9 @@ export class ProductNotificationEditDialogComponent implements OnInit {
 
   private destroyRef = inject(DestroyRef);
 
-  @ViewChild('modal', { static: false }) modalTemplate: TemplateRef<unknown>;
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   constructor(
-    private ngbModal: NgbModal,
     private context: ProductContextFacade,
     private accountFacade: AccountFacade,
     private productNotificationsFacade: ProductNotificationsFacade,
@@ -69,6 +59,7 @@ export class ProductNotificationEditDialogComponent implements OnInit {
   ngOnInit() {
     this.product$ = this.context.select('product');
     const productAvailable$ = this.context.select('inventory', 'inStock');
+    this.inventoryLoaded$ = productAvailable$.pipe(map(() => true));
     this.userEmail$ = this.accountFacade.userEmail$;
 
     // determine current currency
@@ -91,14 +82,14 @@ export class ProductNotificationEditDialogComponent implements OnInit {
   // close modal
   hide() {
     this.productNotificationForm.reset();
-    if (this.modal) {
-      this.modal.close();
+    if (this.modalDialog) {
+      this.modalDialog.hide();
     }
   }
 
   // open modal
   show() {
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'product-notification-edit-modal-title' });
+    this.modalDialog.show();
   }
 
   // submit the form

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.html
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.html
@@ -1,44 +1,42 @@
-<ng-template #modal let-reviewModal>
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: 'product.reviews.create.dialog.heading' | translate,
+    ariaLabelledBy: 'product-review-create-modal-title',
+  }"
+>
   <ng-container *ishProductContextAccess="let product = product">
     <form
       #reviewForm="ngForm"
+      body
       class="form-horizontal"
       data-testing-id="create-product-review-form"
       ishFormSubmit
       [formGroup]="form"
       (ngSubmit)="submitForm(product.sku)"
     >
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2 class="modal-title" id="product-review-create-modal-title">
-            {{ 'product.reviews.create.dialog.heading' | translate }}
-          </h2>
-          <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-        </div>
-
-        <div class="modal-body">
-          <div class="d-flex">
-            <ish-product-image imageType="S" [link]="true" />
-            <div>
-              <ish-product-name [link]="false" />
-              <ish-product-id />
-              <ish-product-variation-display />
-            </div>
+      <div class="modal-body">
+        <div class="d-flex">
+          <ish-product-image imageType="S" [link]="true" />
+          <div>
+            <ish-product-name [link]="false" />
+            <ish-product-id />
+            <ish-product-variation-display />
           </div>
-
-          <p>{{ 'product.reviews.create.dialog.description.text' | translate }}</p>
-
-          <formly-form [fields]="fields" [form]="form" [model]="model$ | async" />
         </div>
-        <div class="modal-footer">
-          <button class="btn btn-primary" type="submit" [disabled]="form.invalid && reviewForm.submitted">
-            {{ 'product.reviews.create.dialog.confirm.button.label' | translate }}
-          </button>
-          <button class="btn btn-secondary" type="button" (click)="hide()">
-            {{ 'product.reviews.create.dialog.cancel.button.label' | translate }}
-          </button>
-        </div>
+
+        <p>{{ 'product.reviews.create.dialog.description.text' | translate }}</p>
+
+        <formly-form [fields]="fields" [form]="form" [model]="model$ | async" />
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-primary" type="submit" [disabled]="form.invalid && reviewForm.submitted">
+          {{ 'product.reviews.create.dialog.confirm.button.label' | translate }}
+        </button>
+        <button class="btn btn-secondary" type="button" (click)="modal.hide()">
+          {{ 'product.reviews.create.dialog.cancel.button.label' | translate }}
+        </button>
       </div>
     </form>
   </ng-container>
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.spec.ts
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.spec.ts
@@ -1,9 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
+import { FormSubmitDirective } from 'ish-core/directives/form-submit.directive';
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { User } from 'ish-core/models/user/user.model';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { ProductReviewsFacade } from '../../facades/product-reviews.facade';
 
@@ -33,6 +39,12 @@ describe('Product Review Create Dialog Component', () => {
     when(accountFacade.user$).thenReturn(of({ firstName: 'Patricia', lastName: 'Miller' } as User));
 
     await TestBed.configureTestingModule({
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [
+        MockComponent(ModalDialogComponent),
+        MockDirective(FormSubmitDirective),
+        ProductReviewCreateDialogComponent,
+      ],
       providers: [
         { provide: AccountFacade, useFactory: () => instance(accountFacade) },
         { provide: ProductReviewsFacade, useFactory: () => instance(reviewsFacade) },

--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
@@ -1,10 +1,10 @@
-import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { Observable, map, tap } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 
 import { ProductReviewsFacade } from '../../facades/product-reviews.facade';
 import { ProductReview } from '../../models/product-reviews/product-review.model';
@@ -15,19 +15,13 @@ import { ProductReview } from '../../models/product-reviews/product-review.model
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProductReviewCreateDialogComponent implements OnInit {
-  /**
-   *  A reference to the current modal.
-   */
-  modal: NgbModalRef;
-
-  @ViewChild('modal') modalTemplate: TemplateRef<unknown>;
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   form = new UntypedFormGroup({});
   fields: FormlyFieldConfig[];
   model$: Observable<Partial<ProductReview>>;
 
   constructor(
-    private ngbModal: NgbModal,
     private accountFacade: AccountFacade,
     private reviewFacade: ProductReviewsFacade
   ) {}
@@ -35,8 +29,8 @@ export class ProductReviewCreateDialogComponent implements OnInit {
   ngOnInit() {
     this.model$ = this.accountFacade.user$.pipe(
       tap(user => {
-        if (!user) {
-          this.hide();
+        if (!user && this.modalDialog) {
+          this.modalDialog.hide();
         }
       }),
       map(user => ({ authorFirstName: `${user.firstName} ${user.lastName.charAt(0)}.` }))
@@ -107,21 +101,14 @@ export class ProductReviewCreateDialogComponent implements OnInit {
   /** Opens the modal. */
   show() {
     this.form.reset();
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'product-review-create-modal-title' });
-  }
-
-  /** Close the modal. */
-  hide() {
-    if (this.modal) {
-      this.modal.close();
-    }
+    this.modalDialog.show();
   }
 
   /** Send the review to the server */
   submitForm(sku: string) {
     if (this.form.valid) {
       this.reviewFacade.createProductReview(sku, this.form.value);
-      this.hide();
+      this.modalDialog.hide();
     }
   }
 }

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.html
@@ -1,11 +1,12 @@
-<ng-template #modal let-selectModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="select-wishlist-modal-title">{{ headerTranslationKey | translate }}</h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: headerTranslationKey | translate,
+    ariaLabelledBy: 'select-wishlist-modal-title',
+  }"
+>
   @if (showForm) {
-    <form ishFormSubmit novalidate [formGroup]="formGroup" (ngSubmit)="submitForm()">
+    <form body ishFormSubmit novalidate [formGroup]="formGroup" (ngSubmit)="submitForm()">
       <div class="modal-body">
         <ish-select-wishlist-form [addMoveProduct]="addMoveProduct" [formGroup]="formGroup" />
       </div>
@@ -19,25 +20,27 @@
       </div>
     </form>
   } @else {
-    <div *ishProductContextAccess="let product = product" class="modal-body">
-      <span
-        data-testing-id="wishlist-success-link"
-        [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
-        [ishServerHtml]="
-          successTranslationKey
-            | translate
-              : {
-                  '0': product.name,
-                  '1': (selectedWishlistRoute$ | async),
-                  '2': (selectedWishlistTitle$ | async | ishHtmlEncode),
-                }
-        "
-      ></span>
-    </div>
-    <div class="modal-footer">
-      <button class="btn btn-secondary" type="button" (click)="hide()">
-        {{ 'account.wishlists.add_to_wishlist.confirmation.ok_button.text' | translate }}
-      </button>
+    <div body>
+      <div *ishProductContextAccess="let product = product" class="modal-body">
+        <span
+          data-testing-id="wishlist-success-link"
+          [callbacks]="{ callbackHideDialogModal: callbackHideDialogModal }"
+          [ishServerHtml]="
+            successTranslationKey
+              | translate
+                : {
+                    '0': product.name,
+                    '1': (selectedWishlistRoute$ | async),
+                    '2': (selectedWishlistTitle$ | async | ishHtmlEncode),
+                  }
+          "
+        ></span>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" type="button" (click)="hide()">
+          {{ 'account.wishlists.add_to_wishlist.confirmation.ok_button.text' | translate }}
+        </button>
+      </div>
     </div>
   }
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.spec.ts
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
 
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { WishlistsFacade } from '../../facades/wishlists.facade';
@@ -51,8 +54,12 @@ describe('Select Wishlist Modal Component', () => {
     wishlistFacadeMock = mock(WishlistsFacade);
 
     await TestBed.configureTestingModule({
-      declarations: [SelectWishlistFormComponent, SelectWishlistModalComponent],
-      imports: [FormlyTestingModule, TranslateModule.forRoot()],
+      declarations: [
+        MockComponent(ModalDialogComponent),
+        MockComponent(SelectWishlistFormComponent),
+        SelectWishlistModalComponent,
+      ],
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
       providers: [{ provide: WishlistsFacade, useFactory: () => instance(wishlistFacadeMock) }],
     }).compileComponents();
   });

--- a/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.ts
+++ b/src/app/extensions/wishlists/shared/select-wishlist-modal/select-wishlist-modal.component.ts
@@ -6,18 +6,17 @@ import {
   Input,
   OnInit,
   Output,
-  TemplateRef,
   ViewChild,
   inject,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { Observable, of } from 'rxjs';
 import { filter, map, take, withLatestFrom } from 'rxjs/operators';
 
 import { SelectOption } from 'ish-core/models/select-option/select-option.model';
 import { whenTruthy } from 'ish-core/utils/operators';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 
 import { WishlistsFacade } from '../../facades/wishlists.facade';
 
@@ -49,16 +48,11 @@ export class SelectWishlistModalComponent implements OnInit {
 
   showForm: boolean;
 
-  modal: NgbModalRef;
-
   private destroyRef = inject(DestroyRef);
 
-  @ViewChild('modal') modalTemplate: TemplateRef<unknown>;
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
-  constructor(
-    private ngbModal: NgbModal,
-    private wishlistsFacade: WishlistsFacade
-  ) {}
+  constructor(private wishlistsFacade: WishlistsFacade) {}
 
   ngOnInit() {
     this.wishlistOptions$ = this.wishlistsFacade.wishlistSelectOptions$(this.addMoveProduct === 'move');
@@ -103,14 +97,14 @@ export class SelectWishlistModalComponent implements OnInit {
 
   /** close modal */
   hide() {
-    this.modal.close();
+    this.modalDialog.hide();
     this.formGroup.reset();
   }
 
   /** open modal */
   show() {
     this.showForm = true;
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'select-wishlist-modal-title' });
+    this.modalDialog.show();
 
     this.wishlistsFacade.preferredWishlist$
       .pipe(

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.html
@@ -1,10 +1,11 @@
-<ng-template #modal let-addModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="wishlist-preferences-modal-title">{{ modalHeader | translate }}</h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
-  <form #form="ngForm" ishFormSubmit novalidate [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: modalHeader | translate,
+    ariaLabelledBy: 'wishlist-preferences-modal-title',
+  }"
+>
+  <form #form="ngForm" body ishFormSubmit novalidate [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
     <div class="modal-body">
       <formly-form [fields]="fields" [form]="wishListForm" [model]="model" />
     </div>
@@ -18,9 +19,9 @@
       >
         {{ primaryButton | translate }}
       </button>
-      <button class="btn btn-secondary" type="button" (click)="hide()">
+      <button class="btn btn-secondary" type="button" (click)="modal.hide()">
         {{ 'account.wishlists.wishlist_form.cancel_button.text' | translate }}
       </button>
     </div>
   </form>
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.spec.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent } from 'ng-mocks';
 import { anything, capture, spy, verify } from 'ts-mockito';
+
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { WishlistPreferencesDialogComponent } from './wishlist-preferences-dialog.component';
 
@@ -8,6 +13,13 @@ describe('Wishlist Preferences Dialog Component', () => {
   let component: WishlistPreferencesDialogComponent;
   let fixture: ComponentFixture<WishlistPreferencesDialogComponent>;
   let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [MockComponent(ModalDialogComponent), WishlistPreferencesDialogComponent],
+    }).compileComponents();
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WishlistPreferencesDialogComponent);
@@ -22,11 +34,14 @@ describe('Wishlist Preferences Dialog Component', () => {
   });
 
   it('should emit new wishlist data when submit form was called and the form was valid', () => {
-    fixture.detectChanges();
-    component.model = {
+    component.wishlist = {
+      id: '123456789',
       title: 'test wishlist',
       preferred: true,
     };
+    fixture.detectChanges();
+    component.show();
+    fixture.detectChanges();
 
     const emitter = spy(component.submitWishlist);
 

--- a/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-preferences-dialog/wishlist-preferences-dialog.component.ts
@@ -1,18 +1,9 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { pick } from 'lodash-es';
 
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { Wishlist } from '../../models/wishlist/wishlist.model';
@@ -48,17 +39,13 @@ export class WishlistPreferencesDialogComponent implements OnInit {
   /**
    *  A reference to the current modal.
    */
-  modal: NgbModalRef;
-
   // localization keys, default = for new
 
   primaryButton = 'account.wishlists.new_wishlist_form.create_button.text';
   private wishlistTitle = 'account.wishlists.choose_wishlist.new_wishlist_name.initial_value';
   modalHeader = 'account.wishlists.new_wishlist_dialog.header';
 
-  @ViewChild('modal') modalTemplate: TemplateRef<unknown>;
-
-  constructor(private ngbModal: NgbModal) {}
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   ngOnInit() {
     this.fields = [
@@ -113,7 +100,9 @@ export class WishlistPreferencesDialogComponent implements OnInit {
         title: this.model.title,
         public: false,
       });
-      this.hide();
+      if (this.modalDialog) {
+        this.modalDialog.hide();
+      }
     }
   }
 
@@ -125,13 +114,6 @@ export class WishlistPreferencesDialogComponent implements OnInit {
     } else {
       this.model = pick(this.wishlist, 'title', 'preferred');
     }
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'wishlist-preferences-modal-title' });
-  }
-
-  /** Close the modal. */
-  hide() {
-    if (this.modal) {
-      this.modal.close();
-    }
+    this.modalDialog.show();
   }
 }

--- a/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.html
+++ b/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.html
@@ -1,10 +1,11 @@
-<ng-template #modal let-addModal>
-  <div class="modal-header">
-    <h2 class="modal-title" id="wishlist-sharing-modal-title">{{ modalHeader | translate }}</h2>
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
-  <form #form="ngForm" ishFormSubmit novalidate [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
+<ish-modal-dialog
+  #modal
+  [options]="{
+    titleText: modalHeader | translate,
+    ariaLabelledBy: 'wishlist-sharing-modal-title',
+  }"
+>
+  <form #form="ngForm" body ishFormSubmit novalidate [formGroup]="wishListForm" (ngSubmit)="submitWishlistForm()">
     <div class="modal-body">
       <p aria-hidden="true" class="indicates-required">
         <span class="required">*</span> {{ 'account.required_field.message' | translate }}
@@ -29,9 +30,9 @@
       >
         {{ primaryButton | translate }}
       </button>
-      <button class="btn btn-secondary" type="button" (click)="hide()">
+      <button class="btn btn-secondary" type="button" (click)="modal.hide()">
         {{ 'account.wishlists.wishlist_sharing_form.cancel_button.text' | translate }}
       </button>
     </div>
   </form>
-</ng-template>
+</ish-modal-dialog>

--- a/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.spec.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.spec.ts
@@ -1,6 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { anything, capture, spy, verify } from 'ts-mockito';
+
+import { FormSubmitDirective } from 'ish-core/directives/form-submit.directive';
+import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
+import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
 import { WishlistSharingDialogComponent } from './wishlist-sharing-dialog.component';
 
@@ -8,6 +15,18 @@ describe('Wishlist Sharing Dialog Component', () => {
   let component: WishlistSharingDialogComponent;
   let fixture: ComponentFixture<WishlistSharingDialogComponent>;
   let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormlyTestingModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      declarations: [
+        MockComponent(ModalDialogComponent),
+        MockDirective(FormSubmitDirective),
+        MockDirective(ServerHtmlDirective),
+        WishlistSharingDialogComponent,
+      ],
+    }).compileComponents();
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WishlistSharingDialogComponent);
@@ -23,6 +42,7 @@ describe('Wishlist Sharing Dialog Component', () => {
   });
 
   it('should emit wishlist sharing data when form is submitted and valid', () => {
+    component.show();
     const recipientEmails = 'test@example.com';
     const personalMessage = 'Test message';
 

--- a/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.ts
+++ b/src/app/extensions/wishlists/shared/wishlist-sharing-dialog/wishlist-sharing-dialog.component.ts
@@ -1,17 +1,8 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
+import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 import { SpecialValidators } from 'ish-shared/forms/validators/special-validators';
 
 import { WishlistSharing } from '../../models/wishlist-sharing/wishlist-sharing.model';
@@ -44,17 +35,10 @@ export class WishlistSharingDialogComponent implements OnInit {
   wishListForm = new FormGroup({});
   fields: FormlyFieldConfig[];
 
-  /**
-   *  A reference to the current modal.
-   */
-  modal: NgbModalRef;
-
   primaryButton = 'account.wishlists.wishlist_sharing_form.send_button.text';
   modalHeader = 'account.wishlists.wishlist_sharing_form.heading';
 
-  @ViewChild('modal') modalTemplate: TemplateRef<unknown>;
-
-  constructor(private ngbModal: NgbModal) {}
+  @ViewChild('modal') modalDialog: ModalDialogComponent<unknown>;
 
   ngOnInit() {
     this.fields = [
@@ -102,20 +86,15 @@ export class WishlistSharingDialogComponent implements OnInit {
         message: this.wishListForm.get('personalMessage').value,
       });
 
-      this.hide();
+      if (this.modalDialog) {
+        this.modalDialog.hide();
+      }
     }
   }
 
   /** Opens the modal. */
   show() {
     this.wishListForm.reset();
-    this.modal = this.ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'wishlist-sharing-modal-title' });
-  }
-
-  /** Close the modal. */
-  hide() {
-    if (this.modal) {
-      this.modal.close();
-    }
+    this.modalDialog.show();
   }
 }

--- a/src/app/shared/components/common/modal-dialog/modal-dialog.component.html
+++ b/src/app/shared/components/common/modal-dialog/modal-dialog.component.html
@@ -1,36 +1,40 @@
 <ng-template #template>
-  <div class="modal-header">
-    @if (options.titleText) {
-      <h2 class="modal-title" [id]="'modal-title-' + uuid">
-        @if (options.icon) {
-          <i class="bi bi-{{ options.icon }} {{ options.iconClass }} "></i>
-        }
-        {{ options.titleText }}
-      </h2>
-    }
-    <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
-  </div>
-
-  <div class="modal-body"><ng-content /></div>
-
-  @if (options.confirmText || options.rejectText) {
-    <div class="modal-footer">
-      @if (options.confirmText) {
-        <button
-          class="btn btn-primary"
-          data-testing-id="confirm"
-          type="button"
-          [disabled]="options.confirmDisabled"
-          (click)="confirm()"
-        >
-          {{ options.confirmText }}
-        </button>
+  <ng-content select="[header]">
+    <div class="modal-header">
+      @if (options.titleText) {
+        <h2 class="modal-title" [id]="'modal-title-' + uuid">
+          @if (options.icon) {
+            <i class="bi bi-{{ options.icon }} {{ options.iconClass }} "></i>
+          }
+          {{ options.titleText }}
+        </h2>
       }
-      @if (options.rejectText) {
-        <button class="btn btn-secondary" data-testing-id="reject" type="button" (click)="hide()">
-          {{ options.rejectText }}
-        </button>
-      }
+      <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
     </div>
-  }
+  </ng-content>
+
+  <ng-content select="[body]">
+    <div class="modal-body"><ng-content /></div>
+
+    @if (options.confirmText || options.rejectText) {
+      <div class="modal-footer">
+        @if (options.confirmText) {
+          <button
+            class="btn btn-primary"
+            data-testing-id="confirm"
+            type="button"
+            [disabled]="options.confirmDisabled"
+            (click)="confirm()"
+          >
+            {{ options.confirmText }}
+          </button>
+        }
+        @if (options.rejectText) {
+          <button class="btn btn-secondary" data-testing-id="reject" type="button" (click)="hide()">
+            {{ options.rejectText }}
+          </button>
+        }
+      </div>
+    }
+  </ng-content>
 </ng-template>

--- a/src/app/shared/components/common/modal-dialog/modal-dialog.component.ts
+++ b/src/app/shared/components/common/modal-dialog/modal-dialog.component.ts
@@ -18,44 +18,59 @@ import { Subject, race, take } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 
 export interface ModalOptions extends NgbModalOptions {
-  /**
-   * Modal title string.
-   */
+  /** Modal Title */
   titleText?: string;
-  /**
-   * Optional modal confirm button text.
-   */
+
+  /** Modal confirm button Label. */
   confirmText?: string;
-  /**
-   * Optional modal confirm button disabled.
-   */
+
+  /** Modal confirm button disabled. */
   confirmDisabled?: boolean;
-  /**
-   * Optional modal reject button text.
-   */
+
+  /** Modal reject button Label. */
   rejectText?: string;
-  /**
-   * Optional icon properties to display an icon in front of the title, e.g. 'exclamation-triangle-fill',
-   */
+
+  /** Icon properties to display an icon in front of the title, e.g. 'exclamation-triangle-fill' */
   icon?: string;
-  /**
-   * Optional icon styling classes, e.g. iconClass: 'text-warning pe-2'
-   */
+
+  /**  Icon styling classes, e.g. iconClass: 'text-warning pe-2' */
   iconClass?: string;
 }
 
 /**
- * The Modal Dialog Component displays a generic (ng-bootstrap) modal, that shows a custom title and custom content.
- * It provides an optional footer that includes confirm and reject buttons.
- * It is possible to pass any data on show.
- * The also provided confirmed output emitter will return the previously passed data if the modal gets confirmed.
+ * The Modal Dialog Component displays a generic (ng-bootstrap) modal.
+ * It supports two mutually exclusive usage modes:
  *
- * @see https://ng-bootstrap.github.io/#/components/modal/api#NgbModal
+ * **Mode 1 – Options-driven (simple):**
+ * The dialog header (title, icon, close button) and footer (confirm/reject buttons) are rendered
+ * automatically based on the `[options]` input. Provide your content as plain `ng-content`,
+ * which will be placed inside the modal body.
  *
  * @example
- * <ish-modal-dialog [options]="options" (confirmed)="onConfirmed($event)">
- *   Dummy content
+ * <ish-modal-dialog [options]="{ titleText: 'Confirm', confirmText: 'OK', rejectText: 'Cancel' }"
+ *                   (confirmed)="onConfirmed($event)">
+ *   <p>Are you sure?</p>
  * </ish-modal-dialog>
+ *
+ * ---
+ *
+ * **Mode 2 – Custom sections (advanced):**
+ * For full control, project elements with a `header` and/or `body` attribute.
+ * When provided, these replace the corresponding options-driven sections entirely.
+ *
+ * - `[header]` replaces the entire modal header (title, icon, close button).
+ * - `[body]` replaces the entire modal body AND footer (you must provide your own buttons).
+ *
+ * @example
+ * <!-- Custom body (including footer), options-driven header -->
+ * <ish-modal-dialog [options]="{ titleText: 'Info' }">
+ *   <div body>
+ *     <div class="modal-body">Full control over body and footer.</div>
+ *     <div class="modal-footer"><button (click)="doSomething()">Custom Action</button></div>
+ *   </div>
+ * </ish-modal-dialog>
+ *
+ * @see https://ng-bootstrap.github.io/#/components/modal/api#NgbModal
  */
 @Component({
   selector: 'ish-modal-dialog',
@@ -97,7 +112,7 @@ export class ModalDialogComponent<T> implements OnDestroy {
 
     this.ngbModalRef = this.ngbModal.open(this.modalDialogTemplate, {
       ...this.options,
-      ariaLabelledBy: `modal-title-${this.uuid}`,
+      ariaLabelledBy: this.options.titleText ? `modal-title-${this.uuid}` : this.options.ariaLabelledBy,
     });
 
     race(this.ngbModalRef.dismissed, this.hide$)


### PR DESCRIPTION
### 🚀 Description

This pull request refactors several modal dialog components across the codebase to use a shared `ModalDialogComponent` instead of the previously used `ng-template` and `NgbModal`. The change modernizes the modal implementation, improves consistency, and simplifies the modal logic, particularly for form dialogs. Additionally, the related unit tests have been updated to accommodate the new modal structure.



<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

---

### 🔍 Detailed Changes

**Modal Refactoring and Component Updates:**

* Replaced `ng-template`/`NgbModal` modal implementations with the reusable `ish-modal-dialog` component in the following components: `cost-center-buyer-edit-dialog`, `requisition-reject-dialog`, and `order-template-preferences-dialog`. This includes updating the modal open/close logic and template structure for each dialog. [[1]](diffhunk://#diff-4c164d421f09167f64e65da86764cfd1263a342eddb71e230fe2d2590bbad53cL1-L11) [[2]](diffhunk://#diff-e14258e48ea7b1d7032f509e963e059c02a43aedc5339cf9be89d4418af30cd9L1-R8) [[3]](diffhunk://#diff-ce48eb7fb0efc0122e1eda4695c45665f9cc6961febe2178a8d69d1067c41628L1-R15)
* Updated the TypeScript logic in the affected components to use `@ViewChild('modal') modalDialog: ModalDialogComponent<unknown>` for modal control and replaced direct calls to `NgbModal` with calls to the modal dialog's `show()` and `hide()` methods. [[1]](diffhunk://#diff-6559cd595627cc6d23751439991a8080c0f057fa32a4f2dd4232251f6b8b4393L1-R8) [[2]](diffhunk://#diff-6559cd595627cc6d23751439991a8080c0f057fa32a4f2dd4232251f6b8b4393L20-L31) [[3]](diffhunk://#diff-6559cd595627cc6d23751439991a8080c0f057fa32a4f2dd4232251f6b8b4393L96-R96) [[4]](diffhunk://#diff-6559cd595627cc6d23751439991a8080c0f057fa32a4f2dd4232251f6b8b4393L109-R109) [[5]](diffhunk://#diff-ca1802e0c7bd56ba968c43f2094f403702884d2fb5dcf1ee834c4758df7c76b2L1-R6) [[6]](diffhunk://#diff-ca1802e0c7bd56ba968c43f2094f403702884d2fb5dcf1ee834c4758df7c76b2L36-R29) [[7]](diffhunk://#diff-ca1802e0c7bd56ba968c43f2094f403702884d2fb5dcf1ee834c4758df7c76b2L76-R69) [[8]](diffhunk://#diff-218be52bb55576b463e22d9aee6fafe27a9c61c513006fdb06202c69fe035c3bL1-R6) [[9]](diffhunk://#diff-218be52bb55576b463e22d9aee6fafe27a9c61c513006fdb06202c69fe035c3bL48-R44)

**Template and UX Adjustments:**

* Updated modal action buttons in templates to use `modal.hide()` instead of a local `hide()` method, ensuring consistent closing behavior across dialogs. [[1]](diffhunk://#diff-4c164d421f09167f64e65da86764cfd1263a342eddb71e230fe2d2590bbad53cL21-R23) [[2]](diffhunk://#diff-e14258e48ea7b1d7032f509e963e059c02a43aedc5339cf9be89d4418af30cd9L19-R22) [[3]](diffhunk://#diff-ce48eb7fb0efc0122e1eda4695c45665f9cc6961febe2178a8d69d1067c41628L21-R34)

**Unit Test Updates:**

* Modified and extended unit tests to import the new `ModalDialogComponent` and related modules, and adapted test setup to the new modal structure. This includes using `MockComponent` for the modal dialog and updating test initialization and interaction logic. [[1]](diffhunk://#diff-435228fd7e459d75fe342ab3761a04b25508f995f991cccf7774e97590a46b85L2-R10) [[2]](diffhunk://#diff-435228fd7e459d75fe342ab3761a04b25508f995f991cccf7774e97590a46b85L26-R33) [[3]](diffhunk://#diff-435228fd7e459d75fe342ab3761a04b25508f995f991cccf7774e97590a46b85R57) [[4]](diffhunk://#diff-435228fd7e459d75fe342ab3761a04b25508f995f991cccf7774e97590a46b85L65-L66) [[5]](diffhunk://#diff-8f6452c3bbc209418b70b0d42a4dd88d20e96a9bcffabfedc72f5de3fb3a7791L2-R23) [[6]](diffhunk://#diff-8f6452c3bbc209418b70b0d42a4dd88d20e96a9bcffabfedc72f5de3fb3a7791R40) [[7]](diffhunk://#diff-535a1cac3153b5db721caf073d57d86be0acf5b4458867bf24b01cda94f376a9R2-R23) [[8]](diffhunk://#diff-535a1cac3153b5db721caf073d57d86be0acf5b4458867bf24b01cda94f376a9L24-R41)

These changes collectively improve maintainability, consistency, and testability of modal dialogs throughout the application.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117067](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117067)

[AB#117690](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117690)