### PR TITLE
refactor: remove `this.` when accessing template reference variables

### DIFF
--- a/projects/requisition-management/src/app/pages/requisition-detail/requisition-buyer-approval/requisition-buyer-approval.component.html
+++ b/projects/requisition-management/src/app/pages/requisition-detail/requisition-buyer-approval/requisition-buyer-approval.component.html
@@ -82,7 +82,7 @@
               <dl class="row dl-horizontal dl-separator">
                 <dt class="col-6">{{ 'account.budget.left.label' | translate }}</dt>
                 <dd class="col-6">
-                  {{ this.requisition.userBudget?.remainingBudget | ishPrice }} ({{ leftPercentage | percent }})
+                  {{ requisition.userBudget?.remainingBudget | ishPrice }} ({{ leftPercentage | percent }})
                 </dd>
               </dl>
             }

--- a/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
+++ b/src/app/extensions/order-templates/shared/order-template-preferences-dialog/order-template-preferences-dialog.component.html
@@ -1,6 +1,6 @@
 <ng-template #modal let-addModal>
   <div class="modal-header">
-    <h2 class="modal-title" id="order-template-preferences-title">{{ this.modalTitle || modalHeader | translate }}</h2>
+    <h2 class="modal-title" id="order-template-preferences-title">{{ modalTitle || modalHeader | translate }}</h2>
     <button class="btn-close" type="button" [title]="'dialog.close.text' | translate" (click)="hide()"></button>
   </div>
 

--- a/src/app/extensions/quickorder/shared/direct-order/direct-order.component.html
+++ b/src/app/extensions/quickorder/shared/direct-order/direct-order.component.html
@@ -13,10 +13,7 @@
           class="btn btn-primary"
           type="submit"
           [disabled]="
-            directOrderForm.pristine ||
-            this.directOrderForm.invalid ||
-            (hasQuantityError$ | async) ||
-            (loading$ | async)
+            directOrderForm.pristine || directOrderForm.invalid || (hasQuantityError$ | async) || (loading$ | async)
           "
         >
           {{ 'quickorder.page.add.cart' | translate }}

--- a/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
+++ b/src/app/shared/cms/components/content-design-view-wrapper/content-design-view-wrapper.component.html
@@ -41,12 +41,12 @@
         }
         <!-- slot -->
         @case ('slot') {
-          <div class="name">{{ pagelet.slot(this.slotId).displayName }}</div>
+          <div class="name">{{ pagelet.slot(slotId).displayName }}</div>
           <button
             class="btn"
             type="button"
             title="{{ 'designview.add.link.title' | translate }}"
-            (click)="triggerAction(this.slotId, 'slotAdd')"
+            (click)="triggerAction(slotId, 'slotAdd')"
           >
             <i class="bi bi-plus"></i>
           </button>

--- a/src/app/shared/forms/components/form-control-feedback/form-control-feedback.component.html
+++ b/src/app/shared/forms/components/form-control-feedback/form-control-feedback.component.html
@@ -1,5 +1,5 @@
 @if (control.dirty && control.validator) {
-  @if (this.control.valid) {
+  @if (control.valid) {
     <i class="bi bi-check-lg form-control-feedback"></i>
   } @else {
     <i class="bi bi-x form-control-feedback"></i>


### PR DESCRIPTION
### 🚀 Description

This pull request primarily cleans up template bindings in several Angular components by removing unnecessary uses of the `this` keyword. This results in more concise and idiomatic Angular templates, improving readability and maintainability. No functional changes are introduced.

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117188](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117188)