### PR TITLE
fix: resolve footer lighthouse accessibility issue

### DIFF
--- a/src/styles/components/footer/footer.scss
+++ b/src/styles/components/footer/footer.scss
@@ -25,6 +25,9 @@ footer {
   }
 
   .footer-fix {
+    display: flex;
+    flex-wrap: wrap;
+    row-gap: $space-default;
     margin: ($space-default * 2) 0;
 
     .list-inline-item:not(:last-child) {


### PR DESCRIPTION
Lighthouse accessibility check failed for mobile device because distance between two footer row are to low.

[AB#117285](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117285)