### PR TITLE
feat: add CLA workflow for contributor license agreement

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -31,7 +31,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The below token should have repo scope. It must be manually added by you in the repository's secret.
+          # The below token should have repo scope. You must manually add it in the repository's secret.
           # Here it is populated with the GitHub App installation token created in the previous step.
           # This token is required only if you have configured to store the signatures in a remote repository/organization.
           PERSONAL_ACCESS_TOKEN: ${{ steps.create-token.outputs.token }}
@@ -42,7 +42,7 @@ jobs:
           branch: 'main'
           #allowlist: user1,bot*
 
-          # The followings are the optional inputs. If the optional inputs are not given, then default values will be taken.
+          # The following are the optional inputs. If the optional inputs are not provided, the default values are used.
           remote-organization-name: intershop # Enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository).
           remote-repository-name: intershop-signatures # Enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository).
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
@@ -50,5 +50,5 @@ jobs:
           #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
           #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
           #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - If you don't want this bot to automatically lock the pull request after merging (default - true).
+          #lock-pullrequest-aftermerge: false - If you do not want this bot to automatically lock the pull request after merging (default - true).
           #use-dco-flag: true - If you are using DCO instead of CLA.

--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -15,11 +15,12 @@ permissions:
 
 jobs:
   CLAAssistant:
+    name: CLA Assistant
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Token
-        id: generate-token
+      - name: Create GitHub App Token
         uses: actions/create-github-app-token@v3
+        id: create-token
         with:
           client-id: ${{ secrets.CLA_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
@@ -31,9 +32,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # The below token should have repo scope. It must be manually added by you in the repository's secret.
-          # Here it is populated with the GitHub App installation token generated in the previous step.
+          # Here it is populated with the GitHub App installation token created in the previous step.
           # This token is required only if you have configured to store the signatures in a remote repository/organization.
-          PERSONAL_ACCESS_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.create-token.outputs.token }}
         with:
           path-to-signatures: 'pwa/version1/cla.json'
           path-to-document: 'https://github.com/intershop/intershop-pwa/blob/develop/INTERSHOP_CLA.md' # e.g. a CLA or a DCO document

--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -37,7 +37,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ steps.create-token.outputs.token }}
         with:
           path-to-signatures: 'pwa/version1/cla.json'
-          path-to-document: 'https://github.com/intershop/intershop-pwa/blob/develop/INTERSHOP_CLA.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/intershop/intershop-pwa/blob/12.0.0/INTERSHOP_CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
           #allowlist: user1,bot*

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,53 @@
+name: 'CLA Assistant'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read # 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.CLA_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          repositories: intershop-signatures
+
+      - name: CLA Assistant
+        if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The below token should have repo scope. It must be manually added by you in the repository's secret.
+          # Here it is populated with the GitHub App installation token generated in the previous step.
+          # This token is required only if you have configured to store the signatures in a remote repository/organization.
+          PERSONAL_ACCESS_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          path-to-signatures: 'pwa/version1/cla.json'
+          path-to-document: 'https://github.com/intershop/intershop-pwa/blob/develop/INTERSHOP_CLA.md' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          #allowlist: user1,bot*
+
+          # The followings are the optional inputs. If the optional inputs are not given, then default values will be taken.
+          remote-organization-name: intershop # Enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository).
+          remote-repository-name: intershop-signatures # Enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository).
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - If you don't want this bot to automatically lock the pull request after merging (default - true).
+          #use-dco-flag: true - If you are using DCO instead of CLA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,48 +9,50 @@ kb_everyone
 
 Thank you for your interest in the Intershop PWA project.
 
-We look forward for any kind of contribution.
+We look forward to any kind of contribution.
 
 ## Code of Conduct
 
-We have adopted the [Contributor Covenants](https://www.contributor-covenant.org/) Code of Conduct and we expect project participants to adhere to it. Please read and follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
+We have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct and we expect project participants to adhere to it. Read and follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Non-Code Contributions
 
-You can contribute to the project without being a software developer. You can help by improving the documentation or analyzing the nature of an issue.
+You can contribute to the project without being a software developer. You can help by improving the documentation or analyzing issues.
 
-You have feedback? Please send it to pwa@intershop.de
+For feedback, contact pwa@intershop.de.
 
 ## Contributor License Agreement
 
-When you contribute please be aware that your contribution is covered by the same [license](./LICENSE) as the whole project. In order to contribute you must apply to the [Contributor License Agreement](./INTERSHOP_CLA.md). If you are an employee of a company we also need the approval from your company that you are authorized to do so. This is mainly to protect you as an employee.
+When you contribute, be aware that your contribution is covered by the same [license](./LICENSE) as the whole project. To contribute, you must agree to the [Contributor License Agreement](./INTERSHOP_CLA.md). If you are an employee of a company, we also need your company's approval confirming that you are authorized to do so. This is to protect you as an employee.
 
-Please note that you do not have to do this right now but only once you want to submit your first pull request.
+You do not need to sign now. Sign only when you submit your first pull request.
 
-Please print the contributor license agreement and send it to pwa@intershop.de.
+The CLA signing process is automated. When you open a pull request, the CLA Assistant bot will check whether you have already signed the CLA. If not, it will post a comment on your PR asking you to sign. To sign, simply copy the exact text provided in the bot's comment and post it as a reply to the PR.
 
-If you have any questions feel free to also send them to this email address.
+Your signature will be recorded automatically. You only need to sign once.
+
+For questions, contact pwa@intershop.de.
 
 ## Contribution process
 
 1. Fork the repository
 2. Use the `develop` branch for your edits
 3. Work on changes
-4. Comment the changes
-5. Check whether the changes comply with the the rules (design etc.)
+4. Document your changes
+5. Check whether the changes comply with the rules (design etc.)
 6. Create a pull request
-7. Add as much information as needed
-8. Reference the solved issue
+7. Add all relevant information
+8. Reference the resolved issue
 9. Wait for the review
 10. PR is approved, denied (with explanation) or sent back for further information
-11. We are trying to react as fast as possible to pull-request, issues, feedback and any other community interaction. However, we can’t guarantee a particular timeframe for every answer. We hope you understand and apologize for any inconveniences.
+11. We respond to pull requests, issues, feedback, and other community interactions as quickly as possible. However, we cannot guarantee a particular response time for every inquiry.
 
 ## Commit Message Guidelines
 
-In general we comply with the rules and formats of [Conventional Commits](https://www.conventionalcommits.org).
+In general, we follow the rules and format of [Conventional Commits](https://www.conventionalcommits.org).
 
-We added the commit message linter [commitlint](https://github.com/conventional-changelog/commitlint) to the project to check whether commit messages are correctly formatted.
+The project uses the commit message linter [commitlint](https://github.com/conventional-changelog/commitlint) to check whether commit messages are correctly formatted.
 
-With [commitizen](https://github.com/commitizen/cz-cli) there is also a wizard available to help you fill out all required information when committing.
+The [commitizen](https://github.com/commitizen/cz-cli) wizard is also available to help you fill out all required commit information.
 
-Install with `npm install commitizen -g`. Afterwards you can use it by calling `git cz` when you want to commit something.
+Install it with `npm install commitizen -g`. Use `git cz` to commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ kb_everyone
 
 Thank you for your interest in the Intershop PWA project.
 
-We look forward to any kind of contribution.
+We welcome all kinds of contributions.
 
 ## Code of Conduct
 
@@ -33,7 +33,7 @@ Your signature will be recorded automatically. You only need to sign once.
 
 For questions, contact pwa@intershop.de.
 
-## Contribution process
+## Contribution Process
 
 1. Fork the repository
 2. Use the `develop` branch for your edits
@@ -44,8 +44,9 @@ For questions, contact pwa@intershop.de.
 7. Add all relevant information
 8. Reference the resolved issue
 9. Wait for the review
-10. PR is approved, denied (with explanation) or sent back for further information
-11. We respond to pull requests, issues, feedback, and other community interactions as quickly as possible. However, we cannot guarantee a particular response time for every inquiry.
+10. PR is approved, denied (with explanation), or sent back for further information
+
+We respond to pull requests, issues, feedback, and other community interactions as quickly as possible. However, we cannot guarantee a particular response time for every inquiry.
 
 ## Commit Message Guidelines
 
@@ -55,4 +56,4 @@ The project uses the commit message linter [commitlint](https://github.com/conve
 
 The [commitizen](https://github.com/commitizen/cz-cli) wizard is also available to help you fill out all required commit information.
 
-Install it with `npm install commitizen -g`. Use `git cz` to commit.
+Install it with `npm install commitizen -g` and use `git cz` to commit.

--- a/INTERSHOP_CLA.md
+++ b/INTERSHOP_CLA.md
@@ -7,23 +7,23 @@ kb_guide
 
 # Intershop Contributor License Agreement
 
-Thank you for your interest in contributing to our open source software project ("project PWA storefront" or just "project") made available by Intershop Communications AG ("ISH"). This contributor license agreement ("agreement") sets out the terms governing any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or other works of authorship that you submit or have submitted, in any form and in any manner, to ISH in respect of the project PWA storefront (collectively "Contributions").
+Thank you for your interest in contributing to our open-source software project ("project PWA storefront" or just "project") made available by Intershop Communications AG ("ISH"). This contributor license agreement ("agreement") sets out the terms governing any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or other works of authorship that you submit or have submitted, in any form and in any manner, to ISH with respect to the project PWA storefront (collectively "Contributions").
 
 By signing this agreement, you agree that the following terms apply to all of your Contributions to the project. Except for the licenses granted in this agreement, you retain all of your right, title, and interest in and to your Contributions. You are aware that the project is also covered by the MIT License.
 
-## Contributions and copyright license
+## Contributions and Copyright License
 
-You hereby agree to contribute your works and developments with respect to the ISH PWA storefront project. You hereby grant, and agree to grant, to ISH a non-exclusive, perpetual, irrevocable, worldwide, fully paid, royalty-free, transferable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and such derivative works, with the right to sublicense the foregoing rights to multiple tiers of sub-licensees.
+You hereby agree to contribute your works and developments with respect to the ISH PWA storefront project. You hereby grant, and agree to grant, to ISH a non-exclusive, perpetual, irrevocable, worldwide, fully paid, royalty-free, transferable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and such derivative works, with the right to sublicense the foregoing rights to multiple tiers of sublicensees.
 
-## Moral rights
+## Moral Rights
 
-To the fullest extent permitted under applicable law, you will hereby waive and agree not to assert all of your moral rights in or relating to your Contributions for the benefit of ISH, its assigns, and their respective direct and indirect sub-licensees.
+To the fullest extent permitted under applicable law, you will hereby waive and agree not to assert all of your moral rights in or relating to your Contributions for the benefit of ISH, its assigns, and their respective direct and indirect sublicensees.
 
 ## Claims
 
 You hereby grant, and agree to grant, to ISH the right to claim copyright or license infringements of your Contributions alone or by combination of your Contributions with the results of the project.
 
-## Third party content/rights
+## Third-Party Content/Rights
 
 If your contribution includes or is based on any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information, or other works of authorship that were not authored by you ("Third Party Content"), or if you are aware of any third party intellectual property rights associated with your Contribution ("Third Party Rights"), then you agree to include with the submission of your Contribution full details respecting such Third Party Content and Third Party Rights. This information duty includes the identification of which aspects of your Contribution contain Third Party Content or are associated with Third Party Rights, the owner/author of the Third Party Content and Third Party Rights, where you obtained the Third Party Content and any applicable third party license terms or restrictions respecting the Third Party Content and Third Party Rights.
 
@@ -31,15 +31,15 @@ If your contribution includes or is based on any source code, object code, bug f
 
 You represent that you are the sole author of your Contributions and are legally entitled to grant the foregoing licenses and waivers in respect of the Contributions, except the Third Party Content and Third Party Rights identified by you in accordance with this agreement.
 
-## Behavior standards
+## Behavior Standards
 
-You agree and accept as a contributor in our project the following behavior standards:
+You agree and accept as a contributor to our project the following behavior standards:
 
 - using welcoming and acceptable language
 - being respectful of differing viewpoints and experiences
 - gracefully accepting constructive criticism
 - focusing on what is best for the project
-- showing empathy towards other contributors
+- showing empathy toward other contributors
 
 For example, the following behaviors are unacceptable by contributors:
 
@@ -47,13 +47,13 @@ For example, the following behaviors are unacceptable by contributors:
 - trolling, insulting or derogatory comments, and personal or political attacks
 - public or private harassment
 - publishing others' private information, such as a physical or electronic address or other personal data that will be provided during the project on the platform
-- other conduct which could reasonably be considered inappropriate in a professional environment.
+- other conduct that could reasonably be considered inappropriate in a professional environment.
 
 ## Disclaimer
 
-Your Contributions are provided "as is" without warranties or conditions of any kind, either express or implied, including, without limitation any warranties or conditions of title, non-infringement, merchantability or fitness for a particular purpose. In no event shall you be liable for any claim, damages or other liability arising from or in connection with your Contributions.
+Your Contributions are provided "as is" without warranties or conditions of any kind, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability or fitness for a particular purpose. In no event shall you be liable for any claim, damages or other liability arising from or in connection with your Contributions.
 
-## No obligation of use or incorporation
+## No Obligation of Use or Incorporation
 
 You acknowledge that ISH is in no event obligated to use or incorporate your Contributions into the ISH PWA storefront. The decision to use or incorporate your Contributions will be made at the sole discretion of ISH.
 

--- a/INTERSHOP_CLA.md
+++ b/INTERSHOP_CLA.md
@@ -9,15 +9,15 @@ kb_guide
 
 Thank you for your interest in contributing to our open source software project ("project PWA storefront" or just "project") made available by Intershop Communications AG ("ISH"). This contributor license agreement ("agreement") sets out the terms governing any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or other works of authorship that you submit or have submitted, in any form and in any manner, to ISH in respect of the project PWA storefront (collectively "Contributions").
 
-With your click on the button you agree that the following terms apply to all of your Contributions to the project. Except for the licenses granted in this agreement, you retain all of your right, title and interest in and to your Contributions. You are aware that the project is also covering by the MIT-license.
+By signing this agreement, you agree that the following terms apply to all of your Contributions to the project. Except for the licenses granted in this agreement, you retain all of your right, title, and interest in and to your Contributions. You are aware that the project is also covered by the MIT License.
 
 ## Contributions and copyright license
 
-You hereby grant to contribute your works and developments with respect to ISH PWA storefront project. You hereby grant, and agree to grant, to ISH non-exclusive, perpetual, irrevocable, worldwide, fully paid, royalty free, transferrable, copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and such derivative works, with the right to sublicense the forgoing rights to multiple tiers of sub-licensees.
+You hereby agree to contribute your works and developments with respect to the ISH PWA storefront project. You hereby grant, and agree to grant, to ISH a non-exclusive, perpetual, irrevocable, worldwide, fully paid, royalty-free, transferable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and such derivative works, with the right to sublicense the foregoing rights to multiple tiers of sub-licensees.
 
-## Morale rights
+## Moral rights
 
-To the fullest extent permitted under applicable law, you will hereby waive and agree not to assert, all of your morale rights in or relating to your Contributions for the benefit of ISH, its assigns, and their respective direct and indirect sub-licensees.
+To the fullest extent permitted under applicable law, you will hereby waive and agree not to assert all of your moral rights in or relating to your Contributions for the benefit of ISH, its assigns, and their respective direct and indirect sub-licensees.
 
 ## Claims
 
@@ -25,11 +25,11 @@ You hereby grant, and agree to grant, to ISH the right to claim copyright or lic
 
 ## Third party content/rights
 
-If your contribution includes or is based on any source code, object code, bug fixes, configuration changes, tools, specifications, documentations, data, materials, feedback, information or other works of authorship were not authored by you ("Third Party Content") or if you are aware of any third party intellectual property rights associated with your Contribution ("Third Party Rights") than you agree to include with the submission of your Contribution full details respecting such Third Party Content and Third Party Rights. This information duty includes the identification of which aspects of your Contribution contain Third Party Content or are associated with Third Party Rights, the owner/author of the Third Party Content and Third Party Rights, where you obtained the Third Party Content and any applicable third party license terms or restrictions respecting the Third Party Content and Third Party Rights.
+If your contribution includes or is based on any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information, or other works of authorship that were not authored by you ("Third Party Content"), or if you are aware of any third party intellectual property rights associated with your Contribution ("Third Party Rights"), then you agree to include with the submission of your Contribution full details respecting such Third Party Content and Third Party Rights. This information duty includes the identification of which aspects of your Contribution contain Third Party Content or are associated with Third Party Rights, the owner/author of the Third Party Content and Third Party Rights, where you obtained the Third Party Content and any applicable third party license terms or restrictions respecting the Third Party Content and Third Party Rights.
 
 ## Representations
 
-You represent that you are the sole author of your Contributions and are legally entitled to grant the forgoing licenses and waivers in respect of the Contributions, except the Third Party Content and Third Party Rights identified by you in accordance with this agreement.
+You represent that you are the sole author of your Contributions and are legally entitled to grant the foregoing licenses and waivers in respect of the Contributions, except the Third Party Content and Third Party Rights identified by you in accordance with this agreement.
 
 ## Behavior standards
 
@@ -37,16 +37,16 @@ You agree and accept as a contributor in our project the following behavior stan
 
 - using welcoming and acceptable language
 - being respectful of differing viewpoints and experiences
-- gracefully excepting constructive criticism
+- gracefully accepting constructive criticism
 - focusing on what is best for the project
-- showing emphasis towards other contributors
+- showing empathy towards other contributors
 
 For example, the following behaviors are unacceptable by contributors:
 
-- the use of sexualized language or imagery and unwelcome sexual attention or
-- trolling, insulting/derogatory comments and personal or political attacks
-- public or private harassment…
-- publishing others’ private information, such a physical or electronic address or other personal data which will provided during the project on the platform
+- the use of sexualized language or imagery and unwelcome sexual attention
+- trolling, insulting or derogatory comments, and personal or political attacks
+- public or private harassment
+- publishing others' private information, such as a physical or electronic address or other personal data that will be provided during the project on the platform
 - other conduct which could reasonably be considered inappropriate in a professional environment.
 
 ## Disclaimer
@@ -55,7 +55,7 @@ Your Contributions are provided "as is" without warranties or conditions of any 
 
 ## No obligation of use or incorporation
 
-You acknowledge that ISH is under no event obliged to use or incorporate your Contributions to the ISH PWA storefront. The decision to use or incorporate your Contributions will be made at the sole discretion of ISH.
+You acknowledge that ISH is in no event obligated to use or incorporate your Contributions into the ISH PWA storefront. The decision to use or incorporate your Contributions will be made at the sole discretion of ISH.
 
 ## Disputes
 


### PR DESCRIPTION
### 🚀 Description

This pull request introduces an automated Contributor License Agreement (CLA) signing process using [CLA Assistant Lite](https://github.com/contributor-assistant/github-action), updates the contribution guidelines to reflect this automation, and improves the clarity and correctness of the CLA document and contributing instructions.

---

### 🔍 Detailed Changes

* Added a new GitHub Actions workflow (`.github/workflows/cla.yml`) to automate CLA verification.
* Signatures are stored in a dedicated private repository (used [Create GitHub App Token](https://github.com/actions/create-github-app-token) in workflow).
* Updated `CONTRIBUTING.md` to clarify and streamline the contribution process.
* Revised `INTERSHOP_CLA.md` to improve legal language.

---

### 📝 Notes

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [x] Documentation reviewed by legal department
- [x] Documentation and Localizations reviewed by the documentation team
- [x] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117365](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117365)