### PR TITLE
fix: contact us `NG0205` error + missing translations ++

### DIFF
--- a/e2e/cypress/e2e/pages/footer.module.ts
+++ b/e2e/cypress/e2e/pages/footer.module.ts
@@ -4,6 +4,6 @@ export class FooterModule {
   }
 
   manageCookies() {
-    cy.get('ish-footer').contains('Cookie').click();
+    cy.get('ish-footer').contains('cookie').click();
   }
 }

--- a/src/app/core/utils/translate/fallback-missing-translation-handler.ts
+++ b/src/app/core/utils/translate/fallback-missing-translation-handler.ts
@@ -65,7 +65,8 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
   }
 
   handle(params: MissingTranslationHandlerParams) {
-    if (params.interpolateParams || /^\w+(\.[\w-]+)+$/.test(params.key)) {
+    // to consider localization keys being an actual key they need to have at least 10 characters and the tested dotted format without spaces
+    if (params.key.length >= 10 && /^\w+(\.[\w-]+)+$/.test(params.key)) {
       const currentLang = params.translateService.currentLang;
       /*
        * when changing languages 'currentLang' from the translate service

--- a/src/app/extensions/contact-us/facades/contact-us.facade.ts
+++ b/src/app/extensions/contact-us/facades/contact-us.facade.ts
@@ -3,7 +3,14 @@ import { Store, select } from '@ngrx/store';
 
 import { Contact } from 'ish-core/models/contact/contact.model';
 
-import { createContact, getContactLoading, getContactSubjects, getContactSuccess, loadContact } from '../store/contact';
+import {
+  createContact,
+  getContactLoading,
+  getContactSubjects,
+  getContactSuccess,
+  loadContact,
+  resetContact,
+} from '../store/contact';
 
 @Injectable({ providedIn: 'root' })
 export class ContactUsFacade {
@@ -17,8 +24,9 @@ export class ContactUsFacade {
   contactSuccess$ = this.store.pipe(select(getContactSuccess));
 
   resetContactState() {
-    this.store.dispatch(loadContact());
+    this.store.dispatch(resetContact());
   }
+
   createContact(contact: Contact) {
     this.store.dispatch(createContact({ contact }));
   }

--- a/src/app/extensions/contact-us/pages/contact/contact-page.component.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-page.component.ts
@@ -39,7 +39,7 @@ export class ContactPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    // reset contact page if the user routes to 'contact' again
+    // reset contact success state to show the form again when the user navigates back
     this.contactUsFacade.resetContactState();
   }
 }

--- a/src/app/extensions/contact-us/pages/contact/contact-page.module.ts
+++ b/src/app/extensions/contact-us/pages/contact/contact-page.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ContactUsModule } from '../../contact-us.module';
+import { ContactUsStoreModule } from '../../store/contact-us-store.module';
 
 import { ContactConfirmationComponent } from './contact-confirmation/contact-confirmation.component';
 import { ContactFormComponent } from './contact-form/contact-form.component';
@@ -22,7 +23,7 @@ const contactPageRoutes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(contactPageRoutes), ContactUsModule],
+  imports: [RouterModule.forChild(contactPageRoutes), ContactUsModule, ContactUsStoreModule],
   declarations: [ContactConfirmationComponent, ContactFormComponent, ContactPageComponent],
 })
 export class ContactPageModule {}

--- a/src/app/extensions/contact-us/store/contact/contact.actions.ts
+++ b/src/app/extensions/contact-us/store/contact/contact.actions.ts
@@ -17,3 +17,5 @@ export const createContact = createAction('[Contact] Create Contact Us Request',
 export const createContactFail = createAction('[Contact API] Create Contact Us Request Fail', httpError());
 
 export const createContactSuccess = createAction('[Contact API] Create Contact Us Request Success');
+
+export const resetContact = createAction('[Contact] Reset Contact State');

--- a/src/app/extensions/contact-us/store/contact/contact.reducer.ts
+++ b/src/app/extensions/contact-us/store/contact/contact.reducer.ts
@@ -9,6 +9,7 @@ import {
   loadContact,
   loadContactFail,
   loadContactSuccess,
+  resetContact,
 } from './contact.actions';
 
 export interface ContactState {
@@ -68,6 +69,13 @@ export const contactReducer = createReducer(
     (state): ContactState => ({
       ...state,
       success: true,
+    })
+  ),
+  on(
+    resetContact,
+    (state): ContactState => ({
+      ...state,
+      success: undefined,
     })
   )
 );

--- a/src/app/extensions/contact-us/store/contact/contact.selectors.spec.ts
+++ b/src/app/extensions/contact-us/store/contact/contact.selectors.spec.ts
@@ -14,8 +14,9 @@ import {
   loadContact,
   loadContactFail,
   loadContactSuccess,
+  resetContact,
 } from './contact.actions';
-import { getContactLoading, getContactSubjects } from './contact.selectors';
+import { getContactLoading, getContactSubjects, getContactSuccess } from './contact.selectors';
 
 describe('Contact Selectors', () => {
   let store$: StoreWithSnapshots;
@@ -110,6 +111,23 @@ describe('Contact Selectors', () => {
         expect(getContactLoading(store$.state)).toBeFalse();
         expect(getContactSubjects(store$.state)).toBeEmpty();
       });
+    });
+  });
+
+  describe('resetContact', () => {
+    beforeEach(() => {
+      store$.dispatch(loadContactSuccess({ subjects }));
+      store$.dispatch(createContactSuccess());
+    });
+
+    it('should reset success but keep subjects', () => {
+      expect(getContactSuccess(store$.state)).toBeTrue();
+      expect(getContactSubjects(store$.state)).toEqual(subjects);
+
+      store$.dispatch(resetContact());
+
+      expect(getContactSuccess(store$.state)).toBeUndefined();
+      expect(getContactSubjects(store$.state)).toEqual(subjects);
     });
   });
 });

--- a/src/app/extensions/recently/pages/recently/recently-page.module.ts
+++ b/src/app/extensions/recently/pages/recently/recently-page.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { RecentlyModule } from '../../recently.module';
+import { RecentlyStoreModule } from '../../store/recently-store.module';
 
 import { RecentlyPageComponent } from './recently-page.component';
 
@@ -20,7 +21,7 @@ const recentlyPageRoutes: Routes = [
 ];
 
 @NgModule({
-  imports: [RecentlyModule, RouterModule.forChild(recentlyPageRoutes)],
+  imports: [RecentlyModule, RouterModule.forChild(recentlyPageRoutes), RecentlyStoreModule],
   declarations: [RecentlyPageComponent],
 })
 export class RecentlyPageModule {}

--- a/src/app/shared/components/product/products-list/products-list.component.html
+++ b/src/app/shared/components/product/products-list/products-list.component.html
@@ -3,7 +3,7 @@
     @if (listStyle === 'carousel') {
       <div class="product-list">
         <swiper [config]="swiperConfig">
-          @for (sku of products; track sku) {
+          @for (sku of products; track $index) {
             <ng-template let-data swiperSlide>
               <div [ngClass]="listItemCSSClass">
                 @if (lazyFetch(data.isVisible, sku)) {
@@ -21,7 +21,7 @@
       </div>
     } @else {
       <div class="product-list row">
-        @for (sku of products; track sku) {
+        @for (sku of products; track $index) {
           <div class="product-list-item" [ngClass]="listItemCSSClass">
             <ish-product-item
               ishProductContext

--- a/src/app/shared/formly/extensions/translate-select-options.extension.ts
+++ b/src/app/shared/formly/extensions/translate-select-options.extension.ts
@@ -1,7 +1,7 @@
 import { FormlyExtension, FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
 import { isObservable, of } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 
 /**
  * Extension to translate the props.options and add a placeholder element.
@@ -24,24 +24,44 @@ class TranslateSelectOptionsExtension implements FormlyExtension {
       return;
     }
 
+    let placeholderInitialized = false;
+
     field.expressions = {
       ...(field.expressions || {}),
       'props.options': (isObservable(props.options) ? props.options : of(props.options)).pipe(
-        map(options =>
-          (props.placeholder ? [{ value: '', label: this.translate.instant(props.placeholder) }] : []).concat(
-            options ?? []
-          )
-        ),
-        tap(() => {
-          if (props.placeholder && !field.formControl.value && !field.model[field.key as string]) {
-            field.formControl.setValue('');
+        switchMap(options => {
+          const allOptions = (props.placeholder ? [{ value: '', label: props.placeholder }] : []).concat(options ?? []);
+          const translationKeys = (props.placeholder ? [props.placeholder] : []).concat(
+            props.optionsTranslateDisabled ? [] : (options ?? []).map(o => o.label)
+          );
+
+          if (translationKeys.length === 0) {
+            return of(allOptions);
           }
+
+          return this.translate
+            .get(translationKeys)
+            .pipe(
+              map(translations =>
+                allOptions.map(option =>
+                  props.optionsTranslateDisabled && option.value !== ''
+                    ? option
+                    : { ...option, label: translations[option.label] || option.label }
+                )
+              )
+            );
         }),
-        map(options =>
-          options?.map(option =>
-            props.optionsTranslateDisabled ? option : { ...option, label: this.translate.instant(option.label) }
-          )
-        )
+        tap(() => {
+          if (
+            !placeholderInitialized &&
+            props.placeholder &&
+            !field.formControl.value &&
+            !field.model[field.key as string]
+          ) {
+            field.formControl.setValue('');
+            placeholderInitialized = true;
+          }
+        })
       ),
     };
   }


### PR DESCRIPTION
### 🚀 Description

This pull request introduces several improvements and fixes across the codebase, focusing on enhancing the contact form state management, refining product list rendering, and improving translation handling for select options. The main themes are state management enhancements for the contact form, translation improvements, and minor bug fixes.

---

### 🔍 Detailed Changes

**Contact Form State Management Improvements:**

* Added a new `resetContact` action and corresponding reducer logic to reset the contact form state, ensuring that the contact state is properly cleared when navigating away from the contact page. 
* Ensured the `ContactUsStoreModule` is imported in the contact page module, making sure the store is properly set up for the contact feature.

**Translation and Localization Enhancements:**

* Improved the translation extension for select options by batching translation keys and supporting disabling translation for specific options, resulting in more accurate and efficient translations.
* Updated the fallback missing translation handler to only treat keys as localization keys if they are at least 10 characters long and match the expected format, reducing false positives.

**Bug Fixes and Minor Improvements:**

* Fixed the `trackBy` function in product list templates to use the array index instead of the SKU, preventing potential rendering issues.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117433](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117433)