### PR TITLE
docs: update migration guide 

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -25,6 +25,9 @@ When enabled, a withdrawal link appears in the footer, and the `/withdrawal` rou
 The footer link and route are automatically hidden when the preference is disabled.
 This feature requires ICM version 14.3.0 or higher.
 
+> [!TIP]
+> The [Intershop Academy](https://public.academy.intershop.com/plus/catalog) (free registration required) offers a video tutorial on [how to migrate from version 9.0.0 to version 11.0.0](https://public.academy.intershop.com/plus/catalog/courses/488).
+
 ## From 10.1.0 to 11.0.0
 
 **Angular 18 update**

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -25,9 +25,6 @@ When enabled, a withdrawal link appears in the footer, and the `/withdrawal` rou
 The footer link and route are automatically hidden when the preference is disabled.
 This feature requires ICM version 14.3.0 or higher.
 
-> [!TIP]
-> The [Intershop Academy](https://public.academy.intershop.com/plus/catalog) (free registration required) offers a video tutorial on [how to migrate from version 9.0.0 to version 11.0.0](https://public.academy.intershop.com/plus/catalog/courses/488).
-
 ## From 10.1.0 to 11.0.0
 
 **Angular 18 update**
@@ -167,6 +164,9 @@ For details, see the [PayPal Integration Guide](./paypal.md).
 
 The behavior of the language switch component has changed.
 The component no longer renders when only one language is configured in ICM, and therefore no language switch options are available.
+
+> [!TIP]
+> The [Intershop Academy](https://public.academy.intershop.com/plus/catalog) (free registration required) offers a video tutorial on [how to migrate from version 9.0.0 to version 11.0.0](https://public.academy.intershop.com/plus/catalog/courses/488).
 
 ## From 9.1.0 to 10.0.0
 


### PR DESCRIPTION








### 🚀 Description

This pull request adds a helpful resource to the migration documentation, making it easier for users to access a video tutorial on migrating from version 9.0.0 to 11.0.0.

---

### 🔍 Detailed Changes

Documentation improvement:

* Added a tip in `docs/guides/migrations.md` linking to a free video tutorial on the Intershop Academy for migrating from version 9.0.0 to 11.0.0.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117472](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117472)