### PR TITLE
fix: improve product review caching

### DIFF
--- a/src/app/extensions/rating/services/reviews/reviews.service.spec.ts
+++ b/src/app/extensions/rating/services/reviews/reviews.service.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { ApiService } from 'ish-core/services/api/api.service';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
 import { ProductReview } from '../../models/product-reviews/product-review.model';
 
@@ -31,7 +33,10 @@ describe('Reviews Service', () => {
     when(apiServiceMock.encodeResourceId(anything())).thenCall(id => id);
 
     TestBed.configureTestingModule({
-      providers: [{ provide: ApiService, useFactory: () => instance(apiServiceMock) }],
+      providers: [
+        { provide: ApiService, useFactory: () => instance(apiServiceMock) },
+        provideMockStore({ selectors: [{ selector: getLoggedInCustomer, value: { customerNo: '123' } }] }),
+      ],
     });
     reviewsService = TestBed.inject(ReviewsService);
   });
@@ -40,24 +45,28 @@ describe('Reviews Service', () => {
     expect(reviewsService).toBeTruthy();
   });
 
-  it('should get product reviews when "getProductReviews" is called with isLoggedIn true', done => {
+  it('should get product reviews when "getProductReviews" is called with logged-in user', done => {
     when(apiServiceMock.get(anything(), anything())).thenReturn(of());
     when(apiServiceMock.resolveLinks())
       .thenReturn(() => of([]))
       .thenReturn(() => of([review]));
 
-    reviewsService.getProductReviews(sku, true).subscribe(data => {
+    reviewsService.getProductReviews(sku).subscribe(data => {
       verify(apiServiceMock.get(`products/${sku}/reviews`, anything())).twice();
       expect(data).toHaveProperty('reviews', [{ ...review, status: undefined }]);
       done();
     });
   });
 
-  it('should get product reviews when "getProductReviews" is called with isLoggedIn false', done => {
+  it('should get product reviews when "getProductReviews" is called with anonymous user', done => {
+    const store = TestBed.inject(MockStore);
+    store.overrideSelector(getLoggedInCustomer, undefined);
+    store.refreshState();
+
     when(apiServiceMock.get(anything(), anything())).thenReturn(of());
     when(apiServiceMock.resolveLinks()).thenReturn(() => of([review]));
 
-    reviewsService.getProductReviews(sku, false).subscribe(data => {
+    reviewsService.getProductReviews(sku).subscribe(data => {
       verify(apiServiceMock.get(`products/${sku}/reviews`, anything())).once();
       expect(data).toHaveProperty('reviews', [review]);
       done();
@@ -71,7 +80,7 @@ describe('Reviews Service', () => {
       .thenReturn(() => of([review]))
       .thenReturn(() => of([ownReview]));
 
-    reviewsService.getProductReviews(sku, true).subscribe(data => {
+    reviewsService.getProductReviews(sku).subscribe(data => {
       expect(data.reviews).toHaveLength(2);
       expect(data.reviews).toContainEqual(expect.objectContaining({ id: '1' }));
       expect(data.reviews).toContainEqual(expect.objectContaining({ id: '2', own: true }));
@@ -85,7 +94,7 @@ describe('Reviews Service', () => {
       .thenReturn(() => of([review]))
       .thenReturn(() => of([]));
 
-    reviewsService.getProductReviews(sku, true).subscribe(data => {
+    reviewsService.getProductReviews(sku).subscribe(data => {
       expect(data).toHaveProperty('reviews', [{ ...review, status: undefined }]);
       done();
     });
@@ -95,7 +104,9 @@ describe('Reviews Service', () => {
     when(apiServiceMock.get(anything(), anything())).thenReturn(of());
     when(apiServiceMock.resolveLinks()).thenReturn(() => of(undefined));
 
-    reviewsService.getProductReviews(sku, false).subscribe({
+    TestBed.inject(MockStore).overrideSelector(getLoggedInCustomer, undefined);
+
+    reviewsService.getProductReviews(sku).subscribe({
       error: err => {
         expect(err.message).toContain('productReviews data is required');
         done();
@@ -104,7 +115,7 @@ describe('Reviews Service', () => {
   });
 
   it('should throw error when called without sku', done => {
-    reviewsService.getProductReviews('', false).subscribe({
+    reviewsService.getProductReviews('').subscribe({
       error: err => {
         expect(err.message).toContain('getProductReviews() called without sku');
         done();

--- a/src/app/extensions/rating/services/reviews/reviews.service.spec.ts
+++ b/src/app/extensions/rating/services/reviews/reviews.service.spec.ts
@@ -40,14 +40,75 @@ describe('Reviews Service', () => {
     expect(reviewsService).toBeTruthy();
   });
 
-  it('should get product reviews when "getProductReviews" is called', done => {
+  it('should get product reviews when "getProductReviews" is called with isLoggedIn true', done => {
+    when(apiServiceMock.get(anything(), anything())).thenReturn(of());
+    when(apiServiceMock.resolveLinks())
+      .thenReturn(() => of([]))
+      .thenReturn(() => of([review]));
+
+    reviewsService.getProductReviews(sku, true).subscribe(data => {
+      verify(apiServiceMock.get(`products/${sku}/reviews`, anything())).twice();
+      expect(data).toHaveProperty('reviews', [{ ...review, status: undefined }]);
+      done();
+    });
+  });
+
+  it('should get product reviews when "getProductReviews" is called with isLoggedIn false', done => {
     when(apiServiceMock.get(anything(), anything())).thenReturn(of());
     when(apiServiceMock.resolveLinks()).thenReturn(() => of([review]));
 
-    reviewsService.getProductReviews(sku).subscribe(data => {
+    reviewsService.getProductReviews(sku, false).subscribe(data => {
       verify(apiServiceMock.get(`products/${sku}/reviews`, anything())).once();
       expect(data).toHaveProperty('reviews', [review]);
       done();
+    });
+  });
+
+  it('should add additional own reviews not present in all reviews', done => {
+    const ownReview: ProductReview = { ...review, id: '2', own: true };
+    when(apiServiceMock.get(anything(), anything())).thenReturn(of());
+    when(apiServiceMock.resolveLinks())
+      .thenReturn(() => of([review]))
+      .thenReturn(() => of([ownReview]));
+
+    reviewsService.getProductReviews(sku, true).subscribe(data => {
+      expect(data.reviews).toHaveLength(2);
+      expect(data.reviews).toContainEqual(expect.objectContaining({ id: '1' }));
+      expect(data.reviews).toContainEqual(expect.objectContaining({ id: '2', own: true }));
+      done();
+    });
+  });
+
+  it('should return only all reviews when first call returns reviews and own call returns empty', done => {
+    when(apiServiceMock.get(anything(), anything())).thenReturn(of());
+    when(apiServiceMock.resolveLinks())
+      .thenReturn(() => of([review]))
+      .thenReturn(() => of([]));
+
+    reviewsService.getProductReviews(sku, true).subscribe(data => {
+      expect(data).toHaveProperty('reviews', [{ ...review, status: undefined }]);
+      done();
+    });
+  });
+
+  it('should throw error when first call returns undefined', done => {
+    when(apiServiceMock.get(anything(), anything())).thenReturn(of());
+    when(apiServiceMock.resolveLinks()).thenReturn(() => of(undefined));
+
+    reviewsService.getProductReviews(sku, false).subscribe({
+      error: err => {
+        expect(err.message).toContain('productReviews data is required');
+        done();
+      },
+    });
+  });
+
+  it('should throw error when called without sku', done => {
+    reviewsService.getProductReviews('', false).subscribe({
+      error: err => {
+        expect(err.message).toContain('getProductReviews() called without sku');
+        done();
+      },
     });
   });
 

--- a/src/app/extensions/rating/services/reviews/reviews.service.ts
+++ b/src/app/extensions/rating/services/reviews/reviews.service.ts
@@ -1,7 +1,7 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of, throwError } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 
 import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
@@ -15,23 +15,45 @@ export class ReviewsService {
   constructor(private apiService: ApiService) {}
 
   /**
-   * Gets the reviews for a given product.
+   * Gets the reviews for a given product. If the user is logged in, a second request
+   * fetches the user's own reviews to mark them accordingly and include any that are
+   * not yet publicly visible (e.g. pending approval). Furthermore, the second request
+   * is not cached for logged in users, to ensure that the user always sees their
+   * latest reviews, even if they are not yet approved.
    *
-   * @param sku The product sku.
-   * @returns   The available reviews of a product.
+   * @param sku         The product sku.
+   * @param isLoggedIn  Whether the current user is logged in.
+   * @returns           The available reviews of a product.
    */
-  getProductReviews(sku: string): Observable<ProductReviews> {
+  getProductReviews(sku: string, isLoggedIn: boolean): Observable<ProductReviews> {
     if (!sku) {
       return throwError(() => new Error('getProductReviews() called without sku'));
     }
 
-    const params = new HttpParams().set('attrs', 'own');
+    const params = new HttpParams().set('own', 'false');
     return this.apiService
       .get(`products/${this.apiService.encodeResourceId(sku)}/reviews`, { sendSPGID: true, params })
       .pipe(
         unpackEnvelope<Link>(),
         this.apiService.resolveLinks<ProductReview>(),
-        map(reviews => ProductReviewsMapper.fromData(sku, reviews))
+        map(reviews => ProductReviewsMapper.fromData(sku, reviews)),
+        switchMap(allReviews =>
+          isLoggedIn
+            ? this.apiService
+                .get(`products/${this.apiService.encodeResourceId(sku)}/reviews`, {
+                  sendSPGID: true,
+                  params: new HttpParams().set('own', 'true'),
+                })
+                .pipe(
+                  unpackEnvelope<Link>(),
+                  this.apiService.resolveLinks<ProductReview>(),
+                  map(ownReviews => ({
+                    ...allReviews,
+                    reviews: [...allReviews.reviews, ...ProductReviewsMapper.fromData(sku, ownReviews).reviews],
+                  }))
+                )
+            : of(allReviews)
+        )
       );
   }
 

--- a/src/app/extensions/rating/services/reviews/reviews.service.ts
+++ b/src/app/extensions/rating/services/reviews/reviews.service.ts
@@ -1,10 +1,12 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Store, select } from '@ngrx/store';
 import { Observable, of, throwError } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 
 import { Link } from 'ish-core/models/link/link.model';
 import { ApiService, unpackEnvelope } from 'ish-core/services/api/api.service';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 
 import { ProductReview, ProductReviewCreationType } from '../../models/product-reviews/product-review.model';
 import { ProductReviewsMapper } from '../../models/product-reviews/product-reviews.mapper';
@@ -12,20 +14,22 @@ import { ProductReviews } from '../../models/product-reviews/product-reviews.mod
 
 @Injectable({ providedIn: 'root' })
 export class ReviewsService {
-  constructor(private apiService: ApiService) {}
+  constructor(
+    private apiService: ApiService,
+    private store: Store
+  ) {}
+
+  private currentCustomer$ = this.store.pipe(select(getLoggedInCustomer), take(1));
 
   /**
-   * Gets the reviews for a given product. If the user is logged in, a second request
-   * fetches the user's own reviews to mark them accordingly and include any that are
-   * not yet publicly visible (e.g. pending approval). Furthermore, the second request
-   * is not cached for logged in users, to ensure that the user always sees their
-   * latest reviews, even if they are not yet approved.
+   * Fetches public reviews for a product. For logged-in users, additionally fetches
+   * their own reviews (flagged with `own: true`) which may include non-public entries
+   * pending approval. The own-reviews request bypasses caching to reflect latest state.
    *
-   * @param sku         The product sku.
-   * @param isLoggedIn  Whether the current user is logged in.
-   * @returns           The available reviews of a product.
+   * @param sku  The product SKU.
+   * @returns    The combined product reviews.
    */
-  getProductReviews(sku: string, isLoggedIn: boolean): Observable<ProductReviews> {
+  getProductReviews(sku: string): Observable<ProductReviews> {
     if (!sku) {
       return throwError(() => new Error('getProductReviews() called without sku'));
     }
@@ -38,21 +42,25 @@ export class ReviewsService {
         this.apiService.resolveLinks<ProductReview>(),
         map(reviews => ProductReviewsMapper.fromData(sku, reviews)),
         switchMap(allReviews =>
-          isLoggedIn
-            ? this.apiService
-                .get(`products/${this.apiService.encodeResourceId(sku)}/reviews`, {
-                  sendSPGID: true,
-                  params: new HttpParams().set('own', 'true'),
-                })
-                .pipe(
-                  unpackEnvelope<Link>(),
-                  this.apiService.resolveLinks<ProductReview>(),
-                  map(ownReviews => ({
-                    ...allReviews,
-                    reviews: [...allReviews.reviews, ...ProductReviewsMapper.fromData(sku, ownReviews).reviews],
-                  }))
-                )
-            : of(allReviews)
+          this.currentCustomer$.pipe(
+            switchMap(customer =>
+              customer
+                ? this.apiService
+                    .get(`products/${this.apiService.encodeResourceId(sku)}/reviews`, {
+                      sendSPGID: true,
+                      params: new HttpParams().set('own', 'true'),
+                    })
+                    .pipe(
+                      unpackEnvelope<Link>(),
+                      this.apiService.resolveLinks<ProductReview>(),
+                      map(ownReviews => ({
+                        ...allReviews,
+                        reviews: [...allReviews.reviews, ...ProductReviewsMapper.fromData(sku, ownReviews).reviews],
+                      }))
+                    )
+                : of(allReviews)
+            )
+          )
         )
       );
   }

--- a/src/app/extensions/rating/store/product-reviews/product-reviews.effects.spec.ts
+++ b/src/app/extensions/rating/store/product-reviews/product-reviews.effects.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, of, throwError } from 'rxjs';
-import { anyString, anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { displayInfoMessage, displaySuccessMessage } from 'ish-core/store/core/messages';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { loadProduct } from 'ish-core/store/shopping/products';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 
@@ -39,7 +41,9 @@ describe('Product Reviews Effects', () => {
 
   beforeEach(() => {
     reviewsServiceMock = mock(ReviewsService);
-    when(reviewsServiceMock.getProductReviews(anything())).thenCall((sku: string) => of({ sku, reviews: [] }));
+    when(reviewsServiceMock.getProductReviews(anything(), anything())).thenCall((sku: string) =>
+      of({ sku, reviews: [] })
+    );
     when(reviewsServiceMock.createProductReview(anything(), anything())).thenReturn(of(reviews));
     when(reviewsServiceMock.deleteProductReview(anything(), anything())).thenReturn(of(undefined));
 
@@ -48,6 +52,9 @@ describe('Product Reviews Effects', () => {
         { provide: ReviewsService, useFactory: () => instance(reviewsServiceMock) },
         ProductReviewsEffects,
         provideMockActions(() => actions$),
+        provideMockStore({
+          selectors: [{ selector: getLoggedInCustomer, value: { customerNo: 'customer123' } }],
+        }),
       ],
     });
 
@@ -55,19 +62,18 @@ describe('Product Reviews Effects', () => {
   });
 
   describe('loadProductReviews$', () => {
-    it('should not dispatch actions when encountering loadProductReviews', done => {
+    it('should call the service with sku and isLoggedIn when encountering loadProductReviews', done => {
       const action = loadProductReviews({ sku: '123' });
       actions$ = of(action);
 
       effects.loadProductReviews$.subscribe(() => {
-        const sku = capture(reviewsServiceMock.getProductReviews);
-        expect(sku).toEqual(sku);
+        verify(reviewsServiceMock.getProductReviews('123', true)).once();
         done();
       });
     });
 
     it('should map invalid request to action of type loadProductReviewsFail', () => {
-      when(reviewsServiceMock.getProductReviews(anything())).thenReturn(
+      when(reviewsServiceMock.getProductReviews(anything(), anything())).thenReturn(
         throwError(() => makeHttpError({ message: 'invalid' }))
       );
       const action = loadProductReviews({ sku: '123' });

--- a/src/app/extensions/rating/store/product-reviews/product-reviews.effects.spec.ts
+++ b/src/app/extensions/rating/store/product-reviews/product-reviews.effects.spec.ts
@@ -1,13 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
-import { provideMockStore } from '@ngrx/store/testing';
 import { cold, hot } from 'jasmine-marbles';
 import { Observable, of, throwError } from 'rxjs';
 import { anyString, anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { displayInfoMessage, displaySuccessMessage } from 'ish-core/store/core/messages';
-import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { loadProduct } from 'ish-core/store/shopping/products';
 import { makeHttpError } from 'ish-core/utils/dev/api-service-utils';
 
@@ -41,9 +39,7 @@ describe('Product Reviews Effects', () => {
 
   beforeEach(() => {
     reviewsServiceMock = mock(ReviewsService);
-    when(reviewsServiceMock.getProductReviews(anything(), anything())).thenCall((sku: string) =>
-      of({ sku, reviews: [] })
-    );
+    when(reviewsServiceMock.getProductReviews(anything())).thenCall((sku: string) => of({ sku, reviews: [] }));
     when(reviewsServiceMock.createProductReview(anything(), anything())).thenReturn(of(reviews));
     when(reviewsServiceMock.deleteProductReview(anything(), anything())).thenReturn(of(undefined));
 
@@ -52,9 +48,6 @@ describe('Product Reviews Effects', () => {
         { provide: ReviewsService, useFactory: () => instance(reviewsServiceMock) },
         ProductReviewsEffects,
         provideMockActions(() => actions$),
-        provideMockStore({
-          selectors: [{ selector: getLoggedInCustomer, value: { customerNo: 'customer123' } }],
-        }),
       ],
     });
 
@@ -62,18 +55,18 @@ describe('Product Reviews Effects', () => {
   });
 
   describe('loadProductReviews$', () => {
-    it('should call the service with sku and isLoggedIn when encountering loadProductReviews', done => {
+    it('should call the service with sku when encountering loadProductReviews', done => {
       const action = loadProductReviews({ sku: '123' });
       actions$ = of(action);
 
       effects.loadProductReviews$.subscribe(() => {
-        verify(reviewsServiceMock.getProductReviews('123', true)).once();
+        verify(reviewsServiceMock.getProductReviews('123')).once();
         done();
       });
     });
 
     it('should map invalid request to action of type loadProductReviewsFail', () => {
-      when(reviewsServiceMock.getProductReviews(anything(), anything())).thenReturn(
+      when(reviewsServiceMock.getProductReviews(anything())).thenReturn(
         throwError(() => makeHttpError({ message: 'invalid' }))
       );
       const action = loadProductReviews({ sku: '123' });

--- a/src/app/extensions/rating/store/product-reviews/product-reviews.effects.ts
+++ b/src/app/extensions/rating/store/product-reviews/product-reviews.effects.ts
@@ -1,11 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { concatLatestFrom } from '@ngrx/operators';
-import { Store, select } from '@ngrx/store';
 import { map, mergeMap } from 'rxjs/operators';
 
 import { displayInfoMessage, displaySuccessMessage } from 'ish-core/store/core/messages';
-import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { loadProduct } from 'ish-core/store/shopping/products';
 import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
@@ -27,8 +24,7 @@ import {
 export class ProductReviewsEffects {
   constructor(
     private actions$: Actions,
-    private reviewService: ReviewsService,
-    private store: Store
+    private reviewService: ReviewsService
   ) {}
 
   loadProductReviews$ = createEffect(() =>
@@ -36,9 +32,8 @@ export class ProductReviewsEffects {
       ofType(loadProductReviews),
       mapToPayloadProperty('sku'),
       whenTruthy(),
-      concatLatestFrom(() => this.store.pipe(select(getLoggedInCustomer))),
-      mergeMap(([sku, customer]) =>
-        this.reviewService.getProductReviews(sku, !!customer).pipe(
+      mergeMap(sku =>
+        this.reviewService.getProductReviews(sku).pipe(
           map(reviews => loadProductReviewsSuccess({ reviews })),
           mapErrorToAction(loadProductReviewsFail)
         )

--- a/src/app/extensions/rating/store/product-reviews/product-reviews.effects.ts
+++ b/src/app/extensions/rating/store/product-reviews/product-reviews.effects.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { concatLatestFrom } from '@ngrx/operators';
+import { Store, select } from '@ngrx/store';
 import { map, mergeMap } from 'rxjs/operators';
 
 import { displayInfoMessage, displaySuccessMessage } from 'ish-core/store/core/messages';
+import { getLoggedInCustomer } from 'ish-core/store/customer/user';
 import { loadProduct } from 'ish-core/store/shopping/products';
 import { mapErrorToAction, mapToPayload, mapToPayloadProperty, whenTruthy } from 'ish-core/utils/operators';
 
@@ -24,7 +27,8 @@ import {
 export class ProductReviewsEffects {
   constructor(
     private actions$: Actions,
-    private reviewService: ReviewsService
+    private reviewService: ReviewsService,
+    private store: Store
   ) {}
 
   loadProductReviews$ = createEffect(() =>
@@ -32,8 +36,9 @@ export class ProductReviewsEffects {
       ofType(loadProductReviews),
       mapToPayloadProperty('sku'),
       whenTruthy(),
-      mergeMap(sku =>
-        this.reviewService.getProductReviews(sku).pipe(
+      concatLatestFrom(() => this.store.pipe(select(getLoggedInCustomer))),
+      mergeMap(([sku, customer]) =>
+        this.reviewService.getProductReviews(sku, !!customer).pipe(
           map(reviews => loadProductReviewsSuccess({ reviews })),
           mapErrorToAction(loadProductReviewsFail)
         )


### PR DESCRIPTION
### 🚀 Description

The product review list call is cached. Side effects occur — for example, a customer creates a product review. If the customer leaves this page after creating a review and then returns to the page immediately, the review has disappeared. The reason is the caching of the corresponding REST call.

The REST endpoint has been revised. If the endpoint is called with the query parameter own=true, the REST call is not cached and returns the customer's own review. If the REST call is made without query parameters, a cached list of product reviews is still returned.

The service call to the backend has been updated to reflect the new behavior.


### 🔍 Detailed Changes

If the customer is logged in, an additional REST call for the customer's own product review is executed now. The product review list that is currently displayed consists of cached product reviews from other users and the current user's uncached product reviews.

If the customer is not logged in, only the cached product reviews from other users are executed.

The cache is not broken, because the query parameter of this REST call already existed in older versions. Only the caching behavior has been changed.
refers to problem ticket: [117039](https://dev.azure.com/intershop-com/Products/_workitems/edit/117039)
new behavior available for ICM version 14.4.0. 

[AB#117524](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117524)