### PR TITLE
feat: add CMS include at the top of the registration page

### DIFF
--- a/src/app/pages/registration/registration-page.component.html
+++ b/src/app/pages/registration/registration-page.component.html
@@ -1,3 +1,7 @@
+<div class="marketing-area">
+  <ish-content-include includeId="include.registration.base.top.pagelet2-Include" />
+</div>
+
 <ish-error-message [error]="error$ | async" />
 
 <div data-testing-id="account-create-full-page">

--- a/src/app/pages/registration/registration-page.component.spec.ts
+++ b/src/app/pages/registration/registration-page.component.spec.ts
@@ -8,6 +8,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
+import { ContentIncludeComponent } from 'ish-shared/cms/components/content-include/content-include.component';
 import { ErrorMessageComponent } from 'ish-shared/components/common/error-message/error-message.component';
 import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testing.module';
 
@@ -30,6 +31,7 @@ describe('Registration Page Component', () => {
     activatedRoute = mock(ActivatedRoute);
     await TestBed.configureTestingModule({
       declarations: [
+        MockComponent(ContentIncludeComponent),
         MockComponent(ErrorMessageComponent),
         MockComponent(LazyAddressDoctorComponent),
         RegistrationPageComponent,


### PR DESCRIPTION
### 🚀 Description

Add CMS include at the top of the registration page to be able to show the demo shop disclaimer message.

⚠️ Waits for availability of headless and demo data, see "Notes" below. ⚠️

---

### 🔍 Detailed Changes

---

### 📝 Notes

Reguires:
* icm-as-customization-headless:4.2.1
* icm-as-customization-demodata:4.3.2 (optional)

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117868](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117868)

[AB#119204](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119204)