### PR TITLE
refactor: use the bootstrap breadcrumb for breadcrumb component

### DIFF
--- a/e2e/cypress/e2e/pages/breadcrumb.module.ts
+++ b/e2e/cypress/e2e/pages/breadcrumb.module.ts
@@ -1,5 +1,5 @@
 export class BreadcrumbModule {
   get items() {
-    return cy.get('li.breadcrumbs-list');
+    return cy.get('li.breadcrumb-item');
   }
 }

--- a/e2e/cypress/e2e/specs/shopping/browse-products-from-indexed-page.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/shopping/browse-products-from-indexed-page.b2c.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('Browsing User', () => {
     it('should navigate to family page to check sibling products', () => {
       at(ProductDetailPage, page => {
         page.breadcrumb.items.should('have.length', 4);
-        page.breadcrumb.items.eq(2).should('have.text', `${_.category.name}/`).click();
+        page.breadcrumb.items.eq(2).should('have.text', `${_.category.name}`).click();
       });
 
       at(FamilyPage, page => {

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
@@ -23,7 +23,7 @@
         </li>
       }
     }
-    @for (item of trail$ | async; track item.key; let last = $last) {
+    @for (item of trail$ | async; track $index; let last = $last) {
       <li
         class="breadcrumb-item"
         [attr.aria-current]="last && !item.link ? 'page' : null"

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
@@ -1,40 +1,38 @@
 <!-- tabindex is necessary to be a valid focus target for the <ish-skip-content-link> component -->
 <nav
-  class="breadcrumbs row"
+  class="breadcrumbs"
   id="nav-breadcrumbs"
   tabindex="-1"
   [attr.aria-label]="'breadcrumbs.aria_label' | translate"
+  [ngStyle]="separator ? { '--bs-breadcrumb-divider': '\'' + separator + '\'' } : {}"
 >
-  <ol class="breadcrumbs-list">
+  <ol class="breadcrumb">
     @if (showHome) {
-      <li class="breadcrumbs-list breadcrumbs-list-home">
+      <li class="breadcrumb-item breadcrumbs-list-home">
         <a class="breadcrumbs-list-link breadcrumbs-list-link-home" rel="home" routerLink="/home">{{
           'common.home.link' | translate
-        }}</a
-        ><span class="breadcrumb-list-separator">{{ separator }}</span>
+        }}</a>
       </li>
     }
     @if (account) {
-      <li class="breadcrumbs-list">
-        @if ((trail$ | async)?.length) {
-          <a class="breadcrumbs-list-link" routerLink="/account">{{ 'account.my_account.link' | translate }}</a
-          ><span class="breadcrumb-list-separator">{{ separator }}</span>
-        } @else {
-          {{ 'account.my_account.link' | translate }}
-        }
-      </li>
+      @if ((trail$ | async)?.length) {
+        <li class="breadcrumb-item">
+          <a class="breadcrumbs-list-link" routerLink="/account">{{ 'account.my_account.link' | translate }}</a>
+        </li>
+      } @else {
+        <li class="breadcrumb-item active">
+          <span aria-current="page">{{ 'account.my_account.link' | translate }}</span>
+        </li>
+      }
     }
     @for (item of trail$ | async; track item.key; let index = $index; let last = $last) {
-      <li class="breadcrumbs-list" [ngClass]="{ 'breadcrumbs-list-active': last }">
+      <li class="breadcrumb-item" [ngClass]="{ active: last }">
         @if (item.link) {
           <a class="breadcrumbs-list-link" [queryParams]="item.linkParams" [routerLink]="item.link">{{
             item.text || (item.key | translate)
           }}</a>
         } @else {
-          <div aria-current="location">{{ item.text || (item.key | translate) }}</div>
-        }
-        @if (!last) {
-          <span aria-hidden="true" class="breadcrumb-list-separator">{{ separator }}</span>
+          <span aria-current="page">{{ item.text || (item.key | translate) }}</span>
         }
       </li>
     }

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
@@ -4,7 +4,7 @@
   id="nav-breadcrumbs"
   tabindex="-1"
   [attr.aria-label]="'breadcrumbs.aria_label' | translate"
-  [ngStyle]="separator ? { '--bs-breadcrumb-divider': '\'' + separator + '\'' } : {}"
+  [ngStyle]="dividerStyle"
 >
   <ol class="breadcrumb">
     @if (showHome) {

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.html
@@ -8,31 +8,31 @@
 >
   <ol class="breadcrumb">
     @if (showHome) {
-      <li class="breadcrumb-item breadcrumbs-list-home">
-        <a class="breadcrumbs-list-link breadcrumbs-list-link-home" rel="home" routerLink="/home">{{
-          'common.home.link' | translate
-        }}</a>
+      <li class="breadcrumb-item">
+        <a rel="home" routerLink="/home">{{ 'common.home.link' | translate }}</a>
       </li>
     }
     @if (account) {
       @if ((trail$ | async)?.length) {
         <li class="breadcrumb-item">
-          <a class="breadcrumbs-list-link" routerLink="/account">{{ 'account.my_account.link' | translate }}</a>
+          <a routerLink="/account">{{ 'account.my_account.link' | translate }}</a>
         </li>
       } @else {
-        <li class="breadcrumb-item active">
-          <span aria-current="page">{{ 'account.my_account.link' | translate }}</span>
+        <li aria-current="page" class="breadcrumb-item active">
+          {{ 'account.my_account.link' | translate }}
         </li>
       }
     }
-    @for (item of trail$ | async; track item.key; let index = $index; let last = $last) {
-      <li class="breadcrumb-item" [ngClass]="{ active: last }">
+    @for (item of trail$ | async; track item.key; let last = $last) {
+      <li
+        class="breadcrumb-item"
+        [attr.aria-current]="last && !item.link ? 'page' : null"
+        [ngClass]="{ active: last && !item.link }"
+      >
         @if (item.link) {
-          <a class="breadcrumbs-list-link" [queryParams]="item.linkParams" [routerLink]="item.link">{{
-            item.text || (item.key | translate)
-          }}</a>
+          <a [queryParams]="item.linkParams" [routerLink]="item.link">{{ item.text || (item.key | translate) }}</a>
         } @else {
-          <span aria-current="page">{{ item.text || (item.key | translate) }}</span>
+          {{ item.text || (item.key | translate) }}
         }
       </li>
     }

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.spec.ts
@@ -33,6 +33,10 @@ describe('Breadcrumb Component', () => {
     translate.set('common.home.link', 'Home');
   });
 
+  function breadcrumbItemTexts(): string[] {
+    return Array.from(element.querySelectorAll('li.breadcrumb-item')).map(li => (li.textContent ?? '').trim());
+  }
+
   it('should be created', () => {
     expect(component).toBeTruthy();
     expect(element).toBeTruthy();
@@ -43,13 +47,13 @@ describe('Breadcrumb Component', () => {
     it('should render trail from home and trail with translation keys if set', () => {
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'KEY' }, { key: 'KEY2' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"Home KEY  KEY2 "`);
+      expect(breadcrumbItemTexts()).toEqual(['Home', 'KEY', 'KEY2']);
     });
 
     it('should render trail from home and trail with text if set', () => {
       when(appFacade.breadcrumbData$).thenReturn(of([{ text: 'TEXT' }, { text: 'TEXT2' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"Home TEXT  TEXT2 "`);
+      expect(breadcrumbItemTexts()).toEqual(['Home', 'TEXT', 'TEXT2']);
     });
 
     it('should render trail from home and with link if set', () => {
@@ -60,7 +64,7 @@ describe('Breadcrumb Component', () => {
         ])
       );
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"HomeL1L2"`);
+      expect(breadcrumbItemTexts()).toEqual(['Home', 'L1', 'L2']);
     });
   });
 
@@ -70,15 +74,14 @@ describe('Breadcrumb Component', () => {
       component.account = true;
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'account.order_history.link' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"My Account Orders "`);
+      expect(breadcrumbItemTexts()).toEqual(['My Account', 'Orders']);
     });
 
     it('should render breadcrumbtrail from home and account and trail when account is active', () => {
       component.account = true;
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'account.order_history.link' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"HomeMy Account Orders "`);
-      expect(element.textContent).toContain('My Account');
+      expect(breadcrumbItemTexts()).toEqual(['Home', 'My Account', 'Orders']);
     });
   });
 });

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.spec.ts
@@ -43,13 +43,13 @@ describe('Breadcrumb Component', () => {
     it('should render trail from home and trail with translation keys if set', () => {
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'KEY' }, { key: 'KEY2' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"Home/KEY/KEY2"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"HomeKEYKEY2"`);
     });
 
     it('should render trail from home and trail with text if set', () => {
       when(appFacade.breadcrumbData$).thenReturn(of([{ text: 'TEXT' }, { text: 'TEXT2' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"Home/TEXT/TEXT2"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"HomeTEXTTEXT2"`);
     });
 
     it('should render trail from home and with link if set', () => {
@@ -60,7 +60,7 @@ describe('Breadcrumb Component', () => {
         ])
       );
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"Home/L1/L2"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"HomeL1L2"`);
     });
   });
 
@@ -70,14 +70,14 @@ describe('Breadcrumb Component', () => {
       component.account = true;
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'account.order_history.link' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"My Account/Orders"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"My AccountOrders"`);
     });
 
     it('should render breadcrumbtrail from home and account and trail when account is active', () => {
       component.account = true;
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'account.order_history.link' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"Home/My Account/Orders"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"HomeMy AccountOrders"`);
       expect(element.textContent).toContain('My Account');
     });
   });

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.spec.ts
@@ -43,13 +43,13 @@ describe('Breadcrumb Component', () => {
     it('should render trail from home and trail with translation keys if set', () => {
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'KEY' }, { key: 'KEY2' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"HomeKEYKEY2"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"Home KEY  KEY2 "`);
     });
 
     it('should render trail from home and trail with text if set', () => {
       when(appFacade.breadcrumbData$).thenReturn(of([{ text: 'TEXT' }, { text: 'TEXT2' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"HomeTEXTTEXT2"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"Home TEXT  TEXT2 "`);
     });
 
     it('should render trail from home and with link if set', () => {
@@ -70,14 +70,14 @@ describe('Breadcrumb Component', () => {
       component.account = true;
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'account.order_history.link' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"My AccountOrders"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"My Account Orders "`);
     });
 
     it('should render breadcrumbtrail from home and account and trail when account is active', () => {
       component.account = true;
       when(appFacade.breadcrumbData$).thenReturn(of([{ key: 'account.order_history.link' }]));
       fixture.detectChanges();
-      expect(element.textContent).toMatchInlineSnapshot(`"HomeMy AccountOrders"`);
+      expect(element.textContent).toMatchInlineSnapshot(`"HomeMy Account Orders "`);
       expect(element.textContent).toContain('My Account');
     });
   });

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.ts
@@ -28,4 +28,17 @@ export class BreadcrumbComponent implements OnInit {
   ngOnInit() {
     this.trail$ = this.appFacade.breadcrumbData$;
   }
+
+  /**
+   * Bootstrap divider override. A provided separator (including an empty string to remove the divider)
+   * sets the '--bs-breadcrumb-divider' custom property; otherwise the Bootstrap default is used.
+   */
+  get dividerStyle(): Record<string, string> {
+    if (typeof this.separator !== 'string') {
+      return {};
+    }
+    // escape backslashes and single quotes so the value stays a valid quoted CSS string
+    const escaped = this.separator.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    return { '--bs-breadcrumb-divider': `'${escaped}'` };
+  }
 }

--- a/src/app/shared/components/common/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/components/common/breadcrumb/breadcrumb.component.ts
@@ -17,7 +17,7 @@ import { BreadcrumbItem } from 'ish-core/models/breadcrumb-item/breadcrumb-item.
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BreadcrumbComponent implements OnInit {
-  @Input() separator = '/';
+  @Input() separator: string;
   @Input() showHome = true;
   @Input() account: boolean;
 

--- a/src/styles/global/breadcrumbs.scss
+++ b/src/styles/global/breadcrumbs.scss
@@ -1,34 +1,28 @@
 /******* GLOBAL BREADCRUMBS *********/
 
 .breadcrumbs {
-  padding: 0 $space-default;
-
   @media (max-width: $screen-xs-max) {
     display: none;
   }
 
   ol {
-    padding: 0;
     margin: 0;
-    list-style: none;
   }
 
   li {
-    float: left;
     font-size: 12px;
     text-transform: uppercase;
 
-    span {
-      margin: 0 ($space-default * 0.5);
-    }
-
     a {
-      font-size: 12px;
       color: $text-color-tertiary;
 
       &:hover {
         color: $text-color-quaternary;
       }
+    }
+
+    &.active {
+      color: $text-color-primary;
     }
   }
 }


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

This pull request refactors the breadcrumb component to use Bootstrap 5's breadcrumb and improves accessibility.

---

### 🔍 Detailed Changes

Replace custom breadcrumb markup and manual separator elements with the Bootstrap breadcrumb. The separator remains configurable via the `separator` input.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#117990](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/117990)