### PR TITLE
fix: change captcha v3 token fetching mechanism

### DIFF
--- a/src/app/core/facades/app.facade.ts
+++ b/src/app/core/facades/app.facade.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { NavigationCancel, NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 import { combineLatest, merge, noop } from 'rxjs';
@@ -32,16 +32,13 @@ import { whenTruthy } from 'ish-core/utils/operators';
 export class AppFacade {
   constructor(
     private store: Store,
-    private router: Router,
-    private appRef: ApplicationRef
+    private router: Router
   ) {
     this.routingInProgress$.subscribe(noop);
 
     store.pipe(select(getICMBaseURL)).subscribe(icmBaseUrl => (this.icmBaseUrl = icmBaseUrl));
   }
   icmBaseUrl: string;
-
-  appBecameStable$ = this.appRef.isStable.pipe(whenTruthy(), take(1));
 
   headerType$ = this.store.pipe(select(getHeaderType));
   deviceType$ = this.store.pipe(select(getDeviceType));

--- a/src/app/core/utils/paypal/adapters/paypal-google-pay/paypal-google-pay.adapter.spec.ts
+++ b/src/app/core/utils/paypal/adapters/paypal-google-pay/paypal-google-pay.adapter.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Injectable } from '@angular/core';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed, fakeAsync, flush } from '@angular/core/testing';
 import { noop, of, throwError } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
@@ -269,7 +269,7 @@ describe('Paypal Google Pay Adapter', () => {
 
     it('should call processPaypalOrderCreation on checkout facade', fakeAsync(() => {
       adapter.testOnGooglePayButtonClicked();
-      tick();
+      flush();
 
       verify(checkoutFacade.processPaypalOrderCreation()).once();
     }));
@@ -289,7 +289,7 @@ describe('Paypal Google Pay Adapter', () => {
   describe('startOrderCreation()', () => {
     it('should call processPaypalOrderCreation on checkout facade', fakeAsync(() => {
       adapter.testStartOrderCreation();
-      tick();
+      flush();
 
       verify(checkoutFacade.processPaypalOrderCreation()).once();
     }));

--- a/src/app/core/utils/paypal/paypal-config/paypal-config.service.spec.ts
+++ b/src/app/core/utils/paypal/paypal-config/paypal-config.service.spec.ts
@@ -51,7 +51,6 @@ describe('Paypal Config Service', () => {
         },
       })
     );
-    when(appFacade.appBecameStable$).thenReturn(of(true));
     when(scriptLoader.load(anything(), anything())).thenReturn(
       of({ src: 'https://www.paypal.com/sdk/js', loaded: true })
     );

--- a/src/app/extensions/captcha/exports/lazy-captcha/lazy-captcha.component.spec.ts
+++ b/src/app/extensions/captcha/exports/lazy-captcha/lazy-captcha.component.spec.ts
@@ -29,7 +29,6 @@ describe('Lazy Captcha Component', () => {
     when(captchaFacade.captchaVersion$).thenReturn(of(3 as const));
     when(captchaFacade.captchaSiteKey$).thenReturn(of('captchaSiteKeyASDF'));
     when(captchaFacade.captchaActive$(anyString())).thenReturn(of(true));
-    when(appFacade.appBecameStable$).thenReturn(of(true));
 
     await TestBed.configureTestingModule({
       providers: [

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.spec.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockDirective } from 'ng-mocks';
@@ -61,7 +61,9 @@ describe('Captcha V3 Component', () => {
 });
 
 @Component({
-  template: `<form [formGroup]="form"><ish-captcha-v3 [parentForm]="form" /></form>`,
+  template: `<form [formGroup]="form">
+    <ish-captcha-v3 [parentForm]="form" /><button type="submit">Submit</button>
+  </form>`,
 })
 class WrapperComponent {
   @ViewChild(CaptchaV3Component) captchaComponent: CaptchaV3Component;
@@ -99,22 +101,24 @@ describe('Captcha V3 Component', () => {
 
   it('should block initial submit and fetch a token', fakeAsync(() => {
     const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+    const submitButton: HTMLButtonElement = formElement.querySelector('button[type="submit"]');
     const ngSubmitSpy = jest.fn();
     formElement.addEventListener('submit', ngSubmitSpy);
 
-    formElement.requestSubmit();
-    tick();
+    submitButton.click();
+    flush();
 
     expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
   }));
 
   it('should re-trigger submit after token is set', fakeAsync(() => {
     const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+    const submitButton: HTMLButtonElement = formElement.querySelector('button[type="submit"]');
     let submitCount = 0;
     formElement.addEventListener('submit', () => submitCount++);
 
-    formElement.requestSubmit();
-    tick();
+    submitButton.click();
+    flush();
 
     // First submit is blocked, second submit passes through after token is ready
     expect(submitCount).toBeGreaterThanOrEqual(1);
@@ -123,20 +127,22 @@ describe('Captcha V3 Component', () => {
 
   it('should set captcha token value in the parent form', fakeAsync(() => {
     const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+    const submitButton: HTMLButtonElement = formElement.querySelector('button[type="submit"]');
 
     expect(wrapper.form.get('captcha').value).toBeEmpty();
 
-    formElement.requestSubmit();
-    tick();
+    submitButton.click();
+    flush();
 
     expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
   }));
 
   it('should fetch a fresh token on every submit', fakeAsync(() => {
     const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+    const submitButton: HTMLButtonElement = formElement.querySelector('button[type="submit"]');
 
-    formElement.requestSubmit();
-    tick();
+    submitButton.click();
+    flush();
 
     expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
 
@@ -144,8 +150,8 @@ describe('Captcha V3 Component', () => {
     wrapper.form.get('captcha').setValue('');
     when(recaptchaV3Service.execute('testAction')).thenReturn(of('mock-token-456'));
 
-    formElement.requestSubmit();
-    tick();
+    submitButton.click();
+    flush();
 
     expect(wrapper.form.get('captcha').value).toEqual('mock-token-456');
   }));

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.spec.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.spec.ts
@@ -1,13 +1,13 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControl, FormGroup } from '@angular/forms';
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockDirective } from 'ng-mocks';
-import { RECAPTCHA_V3_SITE_KEY, RecaptchaV3Module } from 'ng-recaptcha-2';
+import { RECAPTCHA_V3_SITE_KEY, ReCaptchaV3Service, RecaptchaV3Module } from 'ng-recaptcha-2';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
 import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
-import { AppFacade } from 'ish-core/facades/app.facade';
 import { findAllDataTestingIDs } from 'ish-core/utils/dev/html-query-utils';
 
 import { CaptchaV3Component } from './captcha-v3.component';
@@ -16,19 +16,13 @@ describe('Captcha V3 Component', () => {
   let component: CaptchaV3Component;
   let fixture: ComponentFixture<CaptchaV3Component>;
   let element: HTMLElement;
-  let appFacade: AppFacade;
   const captchaSiteKey = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
 
   beforeEach(async () => {
-    appFacade = mock(AppFacade);
-    when(appFacade.appBecameStable$).thenReturn(of(true));
     await TestBed.configureTestingModule({
       declarations: [CaptchaV3Component, MockDirective(ServerHtmlDirective)],
       imports: [RecaptchaV3Module, TranslateModule.forRoot()],
-      providers: [
-        { provide: AppFacade, useFactory: () => instance(appFacade) },
-        { provide: RECAPTCHA_V3_SITE_KEY, useValue: captchaSiteKey },
-      ],
+      providers: [{ provide: RECAPTCHA_V3_SITE_KEY, useValue: captchaSiteKey }],
     }).compileComponents();
   });
 
@@ -56,4 +50,103 @@ describe('Captcha V3 Component', () => {
       ]
     `);
   });
+
+  it('should set captchaAction validators on init', () => {
+    fixture.detectChanges();
+    const captchaAction = component.parentForm.get('captchaAction');
+    captchaAction.setValue('');
+    captchaAction.updateValueAndValidity();
+    expect(captchaAction.valid).toBeFalse();
+  });
+});
+
+@Component({
+  template: `<form [formGroup]="form"><ish-captcha-v3 [parentForm]="form" /></form>`,
+})
+class WrapperComponent {
+  @ViewChild(CaptchaV3Component) captchaComponent: CaptchaV3Component;
+  form = new FormGroup({
+    captcha: new FormControl(''),
+    captchaAction: new FormControl('testAction'),
+  });
+}
+
+describe('Captcha V3 Component', () => {
+  let wrapperFixture: ComponentFixture<WrapperComponent>;
+  let wrapper: WrapperComponent;
+  let recaptchaV3Service: ReCaptchaV3Service;
+  const captchaSiteKey = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
+  beforeEach(async () => {
+    recaptchaV3Service = mock(ReCaptchaV3Service);
+    when(recaptchaV3Service.execute('testAction')).thenReturn(of('mock-token-123'));
+
+    await TestBed.configureTestingModule({
+      declarations: [CaptchaV3Component, MockDirective(ServerHtmlDirective), WrapperComponent],
+      imports: [ReactiveFormsModule, TranslateModule.forRoot()],
+      providers: [
+        { provide: RECAPTCHA_V3_SITE_KEY, useValue: captchaSiteKey },
+        { provide: ReCaptchaV3Service, useFactory: () => instance(recaptchaV3Service) },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    wrapperFixture = TestBed.createComponent(WrapperComponent);
+    wrapper = wrapperFixture.componentInstance;
+    wrapperFixture.detectChanges();
+  });
+
+  it('should block initial submit and fetch a token', fakeAsync(() => {
+    const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+    const ngSubmitSpy = jest.fn();
+    formElement.addEventListener('submit', ngSubmitSpy);
+
+    formElement.requestSubmit();
+    tick();
+
+    expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
+  }));
+
+  it('should re-trigger submit after token is set', fakeAsync(() => {
+    const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+    let submitCount = 0;
+    formElement.addEventListener('submit', () => submitCount++);
+
+    formElement.requestSubmit();
+    tick();
+
+    // First submit is blocked, second submit passes through after token is ready
+    expect(submitCount).toBeGreaterThanOrEqual(1);
+    expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
+  }));
+
+  it('should set captcha token value in the parent form', fakeAsync(() => {
+    const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+
+    expect(wrapper.form.get('captcha').value).toBeEmpty();
+
+    formElement.requestSubmit();
+    tick();
+
+    expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
+  }));
+
+  it('should fetch a fresh token on every submit', fakeAsync(() => {
+    const formElement: HTMLFormElement = wrapperFixture.nativeElement.querySelector('form');
+
+    formElement.requestSubmit();
+    tick();
+
+    expect(wrapper.form.get('captcha').value).toEqual('mock-token-123');
+
+    // Reset captcha and submit again
+    wrapper.form.get('captcha').setValue('');
+    when(recaptchaV3Service.execute('testAction')).thenReturn(of('mock-token-456'));
+
+    formElement.requestSubmit();
+    tick();
+
+    expect(wrapper.form.get('captcha').value).toEqual('mock-token-456');
+  }));
 });

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
@@ -1,14 +1,13 @@
 // eslint-disable-next-line max-classes-per-file
-import { ChangeDetectionStrategy, Component, DestroyRef, Input, NgModule, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, Input, NgModule, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { RECAPTCHA_V3_SITE_KEY, ReCaptchaV3Service, RecaptchaV3Module } from 'ng-recaptcha-2';
-import { timer } from 'rxjs';
-import { filter, switchMap, take } from 'rxjs/operators';
+import { EMPTY, fromEvent } from 'rxjs';
+import { catchError, filter, switchMap } from 'rxjs/operators';
 
 import { DirectivesModule } from 'ish-core/directives.module';
-import { AppFacade } from 'ish-core/facades/app.facade';
 import { whenTruthy } from 'ish-core/utils/operators';
 
 import {
@@ -29,47 +28,59 @@ import {
 export class CaptchaV3Component implements OnInit {
   @Input({ required: true }) parentForm: FormGroup;
 
-  private destroyRef = inject(DestroyRef);
+  private tokenReady = false;
 
   constructor(
-    private recaptchaV3Service: ReCaptchaV3Service,
-    private appFacade: AppFacade
+    private destroyRef: DestroyRef,
+    private elementRef: ElementRef,
+    private recaptchaV3Service: ReCaptchaV3Service
   ) {}
 
   ngOnInit() {
     this.parentForm.get('captchaAction').setValidators([Validators.required]);
 
-    // as soon as the app is getting stable the form requests a captcha token every 2 minutes
     if (!SSR) {
-      this.appFacade.appBecameStable$
-        .pipe(
-          take(1),
-          switchMap(() =>
-            timer(0, 2 * (60 - 3) * 1000).pipe(
-              switchMap(() => this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value))
-            )
-          ),
-          whenTruthy(),
-          takeUntilDestroyed(this.destroyRef)
-        )
-        .subscribe(token => {
-          this.parentForm.get('captcha').setValue(token);
-          this.parentForm.get('captcha').updateValueAndValidity();
-        });
+      // Intercept form submit in capture phase: block until a fresh token is available
+      const formElement = this.elementRef.nativeElement.closest('form');
 
-      // if the captcha is set to undefined from outside request a captcha token
-      this.parentForm
-        .get('captcha')
-        .valueChanges.pipe(
-          filter(token => token === undefined),
-          switchMap(() => this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value)),
-          whenTruthy(),
-          takeUntilDestroyed(this.destroyRef)
-        )
-        .subscribe(token => {
-          this.parentForm.get('captcha').setValue(token);
-          this.parentForm.get('captcha').updateValueAndValidity();
-        });
+      if (formElement) {
+        const captureOptions: AddEventListenerOptions = { capture: true };
+        let pendingSubmitter: HTMLElement | undefined;
+        fromEvent<SubmitEvent>(formElement, 'submit', captureOptions)
+          .pipe(
+            filter(event => {
+              if (this.tokenReady) {
+                // Token is ready — let the submit propagate to Angular's (ngSubmit)
+                this.tokenReady = false;
+                return false;
+              }
+              pendingSubmitter = (event.submitter as HTMLElement) || undefined;
+
+              // Block the submit until we have a fresh token
+              event.preventDefault();
+              event.stopPropagation();
+              return true;
+            }),
+            switchMap(() =>
+              this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value).pipe(
+                whenTruthy(),
+                catchError(() => {
+                  pendingSubmitter = undefined;
+                  return EMPTY;
+                })
+              )
+            ),
+            takeUntilDestroyed(this.destroyRef)
+          )
+          .subscribe(token => {
+            this.parentForm.get('captcha').setValue(token);
+            this.parentForm.get('captcha').updateValueAndValidity();
+            this.tokenReady = true;
+            // Re-trigger submit — this time it will pass through
+            formElement.requestSubmit(pendingSubmitter);
+            pendingSubmitter = undefined;
+          });
+      }
     }
   }
 }

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
@@ -1,11 +1,21 @@
 // eslint-disable-next-line max-classes-per-file
-import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, Input, NgModule, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Input,
+  NgModule,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { RECAPTCHA_V3_SITE_KEY, ReCaptchaV3Service, RecaptchaV3Module } from 'ng-recaptcha-2';
-import { EMPTY, fromEvent } from 'rxjs';
-import { catchError, filter, switchMap } from 'rxjs/operators';
+import { EMPTY, fromEvent, race, timer } from 'rxjs';
+import { catchError, exhaustMap, filter, map, tap } from 'rxjs/operators';
 
 import { DirectivesModule } from 'ish-core/directives.module';
 import { whenTruthy } from 'ish-core/utils/operators';
@@ -25,69 +35,78 @@ import {
   templateUrl: './captcha-v3.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CaptchaV3Component implements OnInit {
+export class CaptchaV3Component implements OnInit, AfterViewInit {
   @Input({ required: true }) parentForm: FormGroup;
 
   private tokenReady = false;
 
+  private destroyRef = inject(DestroyRef);
+
   constructor(
-    private destroyRef: DestroyRef,
     private elementRef: ElementRef<HTMLElement>,
     private recaptchaV3Service: ReCaptchaV3Service
   ) {}
 
   ngOnInit() {
     this.parentForm.get('captchaAction').setValidators([Validators.required]);
+  }
 
-    if (!SSR) {
-      // Intercept form submit in capture phase: block until a fresh token is available
-      const formElement = this.elementRef.nativeElement.closest('form');
-
-      if (formElement) {
-        const captureOptions: AddEventListenerOptions = { capture: true };
-        let pendingSubmitter: HTMLElement | undefined;
-        fromEvent<SubmitEvent>(formElement, 'submit', captureOptions)
-          .pipe(
-            filter(event => {
-              if (this.tokenReady) {
-                // Token is ready — let the submit propagate to Angular's (ngSubmit)
-                this.tokenReady = false;
-                return false;
-              }
-
-              // Let invalid submits propagate normally so validation UX (e.g. focus first invalid field) is not delayed
-              if (this.parentForm.invalid) {
-                return false;
-              }
-
-              pendingSubmitter = (event.submitter as HTMLElement) || undefined;
-
-              // Block the submit until we have a fresh token
-              event.preventDefault();
-              event.stopPropagation();
-              return true;
-            }),
-            switchMap(() =>
-              this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value).pipe(
-                whenTruthy(),
-                catchError(() => {
-                  pendingSubmitter = undefined;
-                  return EMPTY;
-                })
-              )
-            ),
-            takeUntilDestroyed(this.destroyRef)
-          )
-          .subscribe(token => {
-            this.parentForm.get('captcha').setValue(token);
-            this.parentForm.get('captcha').updateValueAndValidity();
-            this.tokenReady = true;
-            // Re-trigger submit — this time it will pass through
-            formElement.requestSubmit(pendingSubmitter);
-            pendingSubmitter = undefined;
-          });
-      }
+  ngAfterViewInit() {
+    if (SSR) {
+      return;
     }
+
+    const formElement = this.elementRef.nativeElement.closest('form');
+    if (!formElement) {
+      return;
+    }
+
+    // Intercept form submit in capture phase: block until a fresh reCAPTCHA token is obtained,
+    // then re-trigger the submit so Angular's (ngSubmit) fires with the token in place.
+    let pendingSubmitter: HTMLElement;
+    fromEvent<SubmitEvent>(formElement, 'submit', { capture: true })
+      .pipe(
+        filter(event => this.interceptSubmit(event)),
+        tap(event => {
+          pendingSubmitter = event.submitter;
+          event.preventDefault();
+          event.stopPropagation();
+        }),
+        exhaustMap(() => this.requestToken()),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(token => {
+        this.applyTokenAndResubmit(token, formElement, pendingSubmitter);
+        pendingSubmitter = undefined;
+      });
+  }
+
+  private interceptSubmit(_event: SubmitEvent): boolean {
+    if (this.tokenReady) {
+      this.tokenReady = false;
+      return false;
+    }
+    // Clear previous captcha errors so they don't block a retry
+    this.parentForm.get('captcha').setErrors(undefined);
+    return this.parentForm.valid;
+  }
+
+  private requestToken() {
+    const token$ = this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value).pipe(whenTruthy());
+    const timeout$ = timer(5000).pipe(
+      map(() => {
+        throw new Error('reCAPTCHA token request timed out');
+      })
+    );
+
+    return race(token$, timeout$).pipe(catchError(() => EMPTY));
+  }
+
+  private applyTokenAndResubmit(token: string, formElement: HTMLFormElement, submitter: HTMLElement) {
+    this.parentForm.get('captcha').setValue(token);
+    this.parentForm.get('captcha').updateValueAndValidity();
+    this.tokenReady = true;
+    formElement.requestSubmit(submitter);
   }
 }
 

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
@@ -14,11 +14,10 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { RECAPTCHA_V3_SITE_KEY, ReCaptchaV3Service, RecaptchaV3Module } from 'ng-recaptcha-2';
-import { EMPTY, fromEvent, race, timer } from 'rxjs';
-import { catchError, exhaustMap, filter, map, tap } from 'rxjs/operators';
+import { fromEvent, race, timer } from 'rxjs';
+import { exhaustMap, filter, map, tap } from 'rxjs/operators';
 
 import { DirectivesModule } from 'ish-core/directives.module';
-import { whenTruthy } from 'ish-core/utils/operators';
 
 import {
   SitekeyProviderService,
@@ -92,14 +91,10 @@ export class CaptchaV3Component implements OnInit, AfterViewInit {
   }
 
   private requestToken() {
-    const token$ = this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value).pipe(whenTruthy());
-    const timeout$ = timer(5000).pipe(
-      map(() => {
-        throw new Error('reCAPTCHA token request timed out');
-      })
+    return race(
+      this.recaptchaV3Service.execute(this.parentForm.get('captchaAction').value),
+      timer(2000).pipe(map(() => ''))
     );
-
-    return race(token$, timeout$).pipe(catchError(() => EMPTY));
   }
 
   private applyTokenAndResubmit(token: string, formElement: HTMLFormElement, submitter: HTMLElement) {

--- a/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
+++ b/src/app/extensions/captcha/shared/captcha-v3/captcha-v3.component.ts
@@ -32,7 +32,7 @@ export class CaptchaV3Component implements OnInit {
 
   constructor(
     private destroyRef: DestroyRef,
-    private elementRef: ElementRef,
+    private elementRef: ElementRef<HTMLElement>,
     private recaptchaV3Service: ReCaptchaV3Service
   ) {}
 
@@ -54,6 +54,12 @@ export class CaptchaV3Component implements OnInit {
                 this.tokenReady = false;
                 return false;
               }
+
+              // Let invalid submits propagate normally so validation UX (e.g. focus first invalid field) is not delayed
+              if (this.parentForm.invalid) {
+                return false;
+              }
+
               pendingSubmitter = (event.submitter as HTMLElement) || undefined;
 
               // Block the submit until we have a fresh token


### PR DESCRIPTION
Until now, the Captcha v3 token has always been retrieved from the Captcha service when the web forms are initialised. This is problematic for several reasons. The token is only valid for 2 minutes and contains user interaction data. 
As a result of the refactoring, the token is now only generated when the valid form is submitted.

Closes: #2075 

[AB#118264](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118264)