### PR TITLE
fix: reset form directive on opening a dialog

### DIFF
--- a/src/app/shared/components/common/modal-dialog/modal-dialog.component.ts
+++ b/src/app/shared/components/common/modal-dialog/modal-dialog.component.ts
@@ -2,6 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  ContentChild,
   DestroyRef,
   EventEmitter,
   Inject,
@@ -13,6 +14,7 @@ import {
   inject,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroupDirective } from '@angular/forms';
 import { NgbModal, NgbModalOptions, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { Subject, race, take } from 'rxjs';
 import { v4 as uuid } from 'uuid';
@@ -87,6 +89,7 @@ export class ModalDialogComponent<T> implements OnDestroy {
   @Output() readonly shown = new EventEmitter<T>();
 
   @ViewChild('template') modalDialogTemplate: TemplateRef<unknown>;
+  @ContentChild(FormGroupDirective) private formDirective: FormGroupDirective;
 
   // visible-for-testing
   ngbModalRef: NgbModalRef;
@@ -109,6 +112,8 @@ export class ModalDialogComponent<T> implements OnDestroy {
    */
   show(data?: T) {
     this.data = data ? data : undefined;
+    // Reset the form's submitted state so validation errors don't persist across modal open/close cycles.
+    this.formDirective?.resetForm();
 
     this.ngbModalRef = this.ngbModal.open(this.modalDialogTemplate, {
       ...this.options,


### PR DESCRIPTION
### 🚀 Description

This pull request enhances the `ModalDialogComponent` to better handle embedded forms by ensuring that form validation errors do not persist when the modal is reopened. The main changes focus on integrating Angular's form handling and resetting the form state each time the modal is shown.

<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

---

### 🔍 Detailed Changes

<!-- Describe the changes in detail -->

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team
- [ ] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#118297](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118297)