### PR TITLE
fix: scrollable and fullscreen modal styling

### DIFF
--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -37,6 +37,11 @@ The Design View and Preview Context features have been reworked so that they can
 Previously, the Design View was initialized by a special `PreviewContextID=DESIGNVIEW` query parameter value, which prevented real Preview Context data from being used at the same time.
 Now, the Design View is activated via its own `DesignView` query parameter, and the `PreviewContextID` query parameter is used exclusively for Preview Context data.
 
+**Modal fullscreen and scrollable styling**
+
+The custom `.modal-fullscreen` and `.modal-dialog-scrollable` SCSS overrides have been removed in favor of the native ng-bootstrap modal behavior.
+You can now use the built-in options `fullscreen: true` and `scrollable: true`, which apply standard Bootstrap styling.
+
 ## From 11.0.0 to 11.1.0
 
 **New footer styling**

--- a/src/app/pages/product/product-images/product-images.component.html
+++ b/src/app/pages/product/product-images/product-images.component.html
@@ -51,11 +51,13 @@
     #zoomDialog
     [options]="{
       scrollable: true,
-      modalDialogClass: 'modal-fullscreen',
+      fullscreen: true,
     }"
   >
-    @for (imageView of zoomImages; track imageView; let i = $index) {
-      <ish-product-image imageType="ZOOM" [id]="getZoomImageAnchorId(i)" [imageView]="imageView" />
-    }
+    <div class="text-center">
+      @for (imageView of zoomImages; track imageView; let i = $index) {
+        <ish-product-image imageType="ZOOM" [id]="getZoomImageAnchorId(i)" [imageView]="imageView" />
+      }
+    </div>
   </ish-modal-dialog>
 }

--- a/src/styles/global/modals.scss
+++ b/src/styles/global/modals.scss
@@ -9,7 +9,6 @@
   }
 
   .modal-header {
-    align-items: center;
     justify-content: space-between;
     min-height: 50px;
 
@@ -25,49 +24,6 @@
       display: inline-block;
       width: auto;
       margin-bottom: 0;
-    }
-  }
-}
-
-// fullscreen modal styling (similar to Bootstrap 5)
-// use `modalDialogClass: 'modal-fullscreen'` instead of `size`
-.modal-fullscreen {
-  min-width: 100%;
-  margin: 0;
-
-  .modal-content {
-    min-height: 100vh;
-    padding-top: 50px; // for the fixed header
-    border: none;
-  }
-
-  // the fixed header in fullscreen is needed for mobile devices
-  // otherwise the header will not always be reachable to close the dialog
-  .modal-header {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    width: 100%;
-    min-height: 50px;
-    background-color: $color-inverse;
-  }
-
-  .modal-body {
-    align-self: center;
-  }
-}
-
-.modal-dialog-scrollable {
-  min-height: 100vh;
-
-  .modal-body {
-    // Hide scrollbar for Firefox
-    scrollbar-width: none;
-
-    /* Hide scrollbar for WebKit browsers */
-    &::-webkit-scrollbar {
-      display: none;
     }
   }
 }


### PR DESCRIPTION
### 🚀 Description

This pull request updates modal dialog styling to use native [ng-bootstrap modal](https://ng-bootstrap.github.io/#/components/modal/api) instead of custom SCSS overrides. It also updates the product images zoom modal to use the `fullscreen` option and cleans up related styles.

---

### 🔍 Detailed Changes

Removed custom `.modal-fullscreen` and `.modal-dialog-scrollable` SCSS overrides. Now, use `fullscreen: true` and `scrollable: true` options for fullscreen and scrollable modals.

---

### 📝 Notes

---

### ✅ Open Tasks

- [x] Visual changes approved by VD / IAD (check: modal header, pdp zoom now with scrollbar)

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#118338](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118338)