### PR TITLE
fix: route product master variation filtering to ICM service

### DIFF
--- a/src/app/core/store/shopping/products/products.effects.spec.ts
+++ b/src/app/core/store/shopping/products/products.effects.spec.ts
@@ -359,6 +359,43 @@ describe('Products Effects', () => {
         done();
       });
     });
+
+    it('should skip Sparque and use the ICM products service for master listings', done => {
+      const action = loadProductsForFilter({
+        id: {
+          type: 'master',
+          value: '201807231',
+          filters: { MasterSKU: ['201807231'], Hard_disk_drive_capacity: ['1TB'] },
+        },
+        searchParameter: { MasterSKU: ['201807231'], Hard_disk_drive_capacity: ['1TB'] },
+      });
+
+      actions$ = of(action);
+      effects.loadFilteredProducts$.pipe(toArray()).subscribe(() => {
+        // skipSparque must be true so that the ICM products service is used (SPARQUE cannot handle master listings)
+        verify(productsServiceProviderMock.get(true)).once();
+        done();
+      });
+    });
+
+    it('should not emit loadFilterSuccess for master listings even when Sparque is enabled', done => {
+      when(productsServiceProviderMock.isSparqueSearchEnabled()).thenReturn(of(true));
+
+      const action = loadProductsForFilter({
+        id: {
+          type: 'master',
+          value: '201807231',
+          filters: { MasterSKU: ['201807231'], Hard_disk_drive_capacity: ['1TB'] },
+        },
+        searchParameter: { MasterSKU: ['201807231'], Hard_disk_drive_capacity: ['1TB'] },
+      });
+
+      actions$ = of(action);
+      effects.loadFilteredProducts$.pipe(toArray()).subscribe(actions => {
+        expect(actions.some(a => a.type === loadFilterSuccess.type)).toBeFalse();
+        done();
+      });
+    });
   });
 
   describe('loadProductVariations$', () => {

--- a/src/app/core/store/shopping/products/products.effects.ts
+++ b/src/app/core/store/shopping/products/products.effects.ts
@@ -202,7 +202,8 @@ export class ProductsEffects {
           switchMap(pageSize =>
             this.productsServiceProvider
               // TODO: (Sparque handling) remove this additional parameter once the category navigation will be handled by Sparque
-              .get(Object.keys(searchParameter).includes('productFilter'))
+              // master variation listings are master-scoped and not handled by SPARQUE yet (no keyword), so use the ICM service
+              .get('productFilter' in searchParameter || id.type === 'master')
               .getFilteredProducts(searchParameter, pageSize, sorting, ((page || 1) - 1) * pageSize)
               .pipe(
                 concatLatestFrom(() => this.productsServiceProvider.isSparqueSearchEnabled()),
@@ -225,7 +226,7 @@ export class ProductsEffects {
                       )
                     ),
                   ];
-                  if (isSparque) {
+                  if (isSparque && id.type !== 'master') {
                     actions.push(
                       productFilter?.length
                         ? loadFilterSuccess({


### PR DESCRIPTION
### 🚀 Description

This pull request ensures that master-scoped product listings use the correct service provider and that SPARQUE-specific actions are only dispatched when appropriate.

---

### 🔍 Detailed Changes

Changed the condition for selecting the product service provider to ensure that master variation listings always use the ICM service, since these are not yet handled by SPARQUE.

---

### 📝 Notes

<!-- Anything important that is not obvious from the code itself

  - Breaking changes?
  - Required ICM version?
  - Migrations required?
  - Feature flags / configuration changes?
  - Known limitations?
-->

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->

[AB#118433](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118433)
