### PR TITLE
fix: prevent false-positive missing-translation errors in SSR

### DIFF
--- a/src/app/core/utils/translate/fallback-missing-translation-handler.ts
+++ b/src/app/core/utils/translate/fallback-missing-translation-handler.ts
@@ -69,10 +69,14 @@ export class FallbackMissingTranslationHandler implements MissingTranslationHand
     if (params.key.length >= 10 && /^\w+(\.[\w-]+)+$/.test(params.key)) {
       const currentLang = params.translateService.currentLang;
       /*
-       * when changing languages 'currentLang' from the translate service
-       * is out of sync -- double check before reporting
+       * When changing languages 'currentLang' from the translate service is out of sync with its loaded
+       * translations -- only report a missing translation when the translations for the current language
+       * are actually loaded but the key is genuinely absent. While the translations are still loading
+       * (e.g. during SSR or a language switch) the language's translations object is not yet available,
+       * so reporting would be a false positive.
        */
-      if (!params.translateService.translations?.[currentLang]?.[params.key]) {
+      const translations = params.translateService.translations?.[currentLang];
+      if (translations && !translations[params.key]) {
         this.reportMissingTranslation(currentLang, params.key);
       }
 


### PR DESCRIPTION
### 🚀 Description

This pull request refines the logic for reporting missing translations to prevent false positives during language loading or switching. Now, missing translations are only reported if the translations for the current language are fully loaded and the specific key is genuinely absent.

---

### 🔍 Detailed Changes

Updated `FallbackMissingTranslationHandler` in `fallback-missing-translation-handler.ts` to only report missing translations when the translations for the current language are loaded and the key is actually missing, reducing false positives during SSR or language switches.

---

### 📝 Notes

> **Note:** Also fixed on `upgrade/angular-19` (same place, ngx-translate 18 API). This PR
> brings the equivalent fix to `develop` so it's covered until the upgrade lands.

---

### ✅ Open Tasks


---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#118485](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118485)