### PR TITLE
fix(NGINX): bad array subscript error parsing wastatistics

### DIFF
--- a/nginx/cache_clearer.sh
+++ b/nginx/cache_clearer.sh
@@ -108,7 +108,7 @@ while true; do
         continue
     fi
 
-    SITES_CACHEIDS=$(cat /tmp/wastatistics_output | grep  '\-Site' | awk -F ' ' '{print $2 ":" $4}')
+    SITES_CACHEIDS=$(cat /tmp/wastatistics_output | grep '\-Site' | awk -F ' ' '{if ($2 ~ /-Site$/ && $4 ~ /^[0-9]+$/) print $2 ":" $4}')
     # echo " Site - Cache IDS: $SITES_CACHEIDS"
 
     SITES_TO_CLEAR=()


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->
When ICM enables page cache keyword processing for one of its sites, the cache clearer script fails to parse the wastatistics response for the current cache IDs with: 

```
./cache_clearer.sh: line 120: SITE_CACHE_MAP: bad array subscript
./cache_clearer.sh: line 127: SITE_CACHE_MAP["$SITE"]: bad array subscript
```


### Workaround

Disable keyword processing for all sites.
Note that a  selective cache clearing for specific keywords is not processed by the nginx pwa cache clearing.  See also [docs/guides/nginx-startup.md#cache-clearing](https://github.com/intershop/intershop-pwa/blob/develop/docs/guides/nginx-startup.md#cache-clearing)

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#118553](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118553)