### PR TITLE
fix: move order template item

### DIFF
--- a/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-line-item/account-order-template-detail-line-item.component.html
+++ b/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-line-item/account-order-template-detail-line-item.component.html
@@ -24,7 +24,7 @@
           data-testing-id="move-order-template"
           type="button"
           [title]="'account.order_template.table.options.move_to_template' | translate"
-          (click)="moveDialog.show()"
+          (click)="emitMoveClicked()"
         >
           <i class="bi bi-arrows-move"></i>
         </button>
@@ -50,9 +50,3 @@
     <ish-product-price />
   </div>
 </div>
-
-<ish-select-order-template-modal
-  #moveDialog
-  addMoveProduct="move"
-  (submitEmitter)="moveItemToOtherOrderTemplate(orderTemplateItemData.sku, $event)"
-/>

--- a/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-line-item/account-order-template-detail-line-item.component.spec.ts
+++ b/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-line-item/account-order-template-detail-line-item.component.spec.ts
@@ -17,7 +17,6 @@ import { ProductQuantityComponent } from 'ish-shared/components/product/product-
 import { ProductVariationDisplayComponent } from 'ish-shared/components/product/product-variation-display/product-variation-display.component';
 
 import { OrderTemplatesFacade } from '../../../facades/order-templates.facade';
-import { SelectOrderTemplateModalComponent } from '../../../shared/select-order-template-modal/select-order-template-modal.component';
 
 import { AccountOrderTemplateDetailLineItemComponent } from './account-order-template-detail-line-item.component';
 
@@ -41,7 +40,6 @@ describe('Account Order Template Detail Line Item Component', () => {
         MockComponent(ProductPriceComponent),
         MockComponent(ProductQuantityComponent),
         MockComponent(ProductVariationDisplayComponent),
-        MockComponent(SelectOrderTemplateModalComponent),
         MockPipe(DatePipe),
       ],
       imports: [MockComponent(ProductImageComponent), ReactiveFormsModule, TranslateModule.forRoot()],

--- a/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-line-item/account-order-template-detail-line-item.component.ts
+++ b/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-line-item/account-order-template-detail-line-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { map } from 'rxjs';
 
@@ -15,6 +15,8 @@ import { OrderTemplate, OrderTemplateItem } from '../../../models/order-template
 export class AccountOrderTemplateDetailLineItemComponent implements OnInit {
   @Input() orderTemplateItemData: OrderTemplateItem;
   @Input() currentOrderTemplate: OrderTemplate;
+
+  @Output() readonly moveClicked = new EventEmitter<string>();
 
   checkBox = new FormControl();
 
@@ -40,22 +42,8 @@ export class AccountOrderTemplateDetailLineItemComponent implements OnInit {
     });
   }
 
-  moveItemToOtherOrderTemplate(sku: string, orderTemplateMoveData: { id: string; title: string }) {
-    if (orderTemplateMoveData.id) {
-      this.orderTemplatesFacade.moveItemToOrderTemplate(
-        this.currentOrderTemplate.id,
-        orderTemplateMoveData.id,
-        sku,
-        this.context.get('quantity')
-      );
-    } else {
-      this.orderTemplatesFacade.moveItemToNewOrderTemplate(
-        this.currentOrderTemplate.id,
-        orderTemplateMoveData.title,
-        sku,
-        this.context.get('quantity')
-      );
-    }
+  emitMoveClicked() {
+    this.moveClicked.emit(this.orderTemplateItemData.id);
   }
 
   private updateProductQuantity(sku: string, quantity: number) {

--- a/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-page.component.html
+++ b/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-page.component.html
@@ -54,6 +54,7 @@
                   [propagateIndex]="i"
                   [quantity]="item.desiredQuantity.value"
                   [sku]="item.sku"
+                  (moveClicked)="showMoveDialog($event)"
                 />
               </div>
             }
@@ -73,3 +74,11 @@
 @if (orderTemplateLoading$ | async) {
   <ish-loading />
 }
+
+<ng-container ishProductContext [sku]="moveItem?.sku">
+  <ish-select-order-template-modal
+    #moveDialog
+    addMoveProduct="move"
+    (submitEmitter)="moveItemToOtherOrderTemplate($event)"
+  />
+</ng-container>

--- a/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-page.component.spec.ts
+++ b/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-page.component.spec.ts
@@ -14,6 +14,7 @@ import { FormlyTestingModule } from 'ish-shared/formly/dev/testing/formly-testin
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
 import { OrderTemplate } from '../../models/order-template/order-template.model';
+import { SelectOrderTemplateModalComponent } from '../../shared/select-order-template-modal/select-order-template-modal.component';
 
 import { AccountOrderTemplateDetailLineItemComponent } from './account-order-template-detail-line-item/account-order-template-detail-line-item.component';
 import { AccountOrderTemplateDetailPageComponent } from './account-order-template-detail-page.component';
@@ -42,6 +43,7 @@ describe('Account Order Template Detail Page Component', () => {
         MockComponent(AccountOrderTemplateDetailLineItemComponent),
         MockComponent(ErrorMessageComponent),
         MockComponent(ProductAddToBasketComponent),
+        MockComponent(SelectOrderTemplateModalComponent),
         MockDirective(ProductContextDirective),
       ],
       providers: [{ provide: OrderTemplatesFacade, useFactory: () => instance(orderTemplatesFacade) }],
@@ -78,6 +80,7 @@ describe('Account Order Template Detail Page Component', () => {
         [
           "ish-error-message",
           "ish-in-place-edit",
+          "ish-select-order-template-modal",
         ]
       `);
     });
@@ -93,6 +96,7 @@ describe('Account Order Template Detail Page Component', () => {
           "ish-in-place-edit",
           "ish-account-order-template-detail-line-item",
           "ish-product-add-to-basket",
+          "ish-select-order-template-modal",
         ]
       `);
     });

--- a/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-page.component.ts
+++ b/src/app/extensions/order-templates/pages/account-order-template-detail/account-order-template-detail-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
@@ -8,7 +8,8 @@ import { HttpError } from 'ish-core/models/http-error/http-error.model';
 import { mapToProperty, whenTruthy } from 'ish-core/utils/operators';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
-import { OrderTemplate } from '../../models/order-template/order-template.model';
+import { OrderTemplate, OrderTemplateItem } from '../../models/order-template/order-template.model';
+import { SelectOrderTemplateModalComponent } from '../../shared/select-order-template-modal/select-order-template-modal.component';
 
 @Component({
   selector: 'ish-account-order-template-detail-page',
@@ -26,7 +27,10 @@ export class AccountOrderTemplateDetailPageComponent implements OnInit {
   model: { title: string };
   fields: FormlyFieldConfig[];
 
+  @ViewChild('moveDialog') moveDialog: SelectOrderTemplateModalComponent;
+
   private currentOrderTemplate: OrderTemplate;
+  moveItem: OrderTemplateItem;
 
   private destroyRef = inject(DestroyRef);
 
@@ -42,6 +46,7 @@ export class AccountOrderTemplateDetailPageComponent implements OnInit {
 
     this.orderTemplate$.pipe(whenTruthy(), takeUntilDestroyed(this.destroyRef)).subscribe(orderTemplate => {
       this.currentOrderTemplate = orderTemplate;
+      this.moveItem = undefined;
       this.model = { title: orderTemplate.title };
       this.fields = this.getFields();
     });
@@ -80,5 +85,30 @@ export class AccountOrderTemplateDetailPageComponent implements OnInit {
     this.orderTemplate$
       .pipe(whenTruthy(), take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe(orderTemplate => (this.model = { ...this.model, title: orderTemplate.title }));
+  }
+
+  showMoveDialog(orderTemplateItemId: string) {
+    this.moveItem = this.currentOrderTemplate.items.find(item => item.id === orderTemplateItemId);
+    if (this.moveItem) {
+      this.moveDialog.show();
+    }
+  }
+
+  moveItemToOtherOrderTemplate(orderTemplateMoveData: { id: string; title: string }) {
+    if (orderTemplateMoveData.id) {
+      this.orderTemplatesFacade.moveItemToOrderTemplate(
+        this.currentOrderTemplate.id,
+        orderTemplateMoveData.id,
+        this.moveItem.sku,
+        this.moveItem.desiredQuantity.value
+      );
+    } else {
+      this.orderTemplatesFacade.moveItemToNewOrderTemplate(
+        this.currentOrderTemplate.id,
+        orderTemplateMoveData.title,
+        this.moveItem.sku,
+        this.moveItem.desiredQuantity.value
+      );
+    }
   }
 }

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.spec.ts
@@ -66,6 +66,7 @@ describe('Select Order Template Modal Component', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement;
     when(orderTemplateFacadeMock.currentOrderTemplate$).thenReturn(of(orderTemplateDetails));
+    when(orderTemplateFacadeMock.orderTemplates$).thenReturn(of([orderTemplateDetails]));
     when(orderTemplateFacadeMock.orderTemplatesSelectOptions$(anything())).thenReturn(
       of([{ value: orderTemplateDetails.id, label: orderTemplateDetails.title }])
     );
@@ -197,17 +198,22 @@ describe('Select Order Template Modal Component', () => {
     });
 
     it('should return correct route of new order template', done => {
+      when(orderTemplateFacadeMock.orderTemplates$).thenReturn(
+        of([{ ...orderTemplateDetails, title: 'New Ordertemplate Title' }])
+      );
       startup();
       updateOrderTemplateAndNew();
 
       component.selectedOrderTemplateRoute$.subscribe(r => {
         expect(r).toBe('route://account/order-templates/.SKsEQAE4FIAAAFuNiUBWx0d');
+        done();
       });
-      done();
     });
 
     it('should wait for the created order template and not emit an "undefined" route', done => {
-      when(orderTemplateFacadeMock.currentOrderTemplate$).thenReturn(of(undefined, orderTemplateDetails));
+      when(orderTemplateFacadeMock.orderTemplates$).thenReturn(
+        of([], [{ ...orderTemplateDetails, title: 'New Ordertemplate Title' }])
+      );
       startup();
       updateOrderTemplateAndNew();
 

--- a/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
+++ b/src/app/extensions/order-templates/shared/select-order-template-modal/select-order-template-modal.component.ts
@@ -148,9 +148,12 @@ export class SelectOrderTemplateModalComponent implements OnInit {
     const selectedValue = this.formGroup.value.orderTemplate;
 
     if (selectedValue === 'new' || !selectedValue) {
-      return this.orderTemplatesFacade.currentOrderTemplate$.pipe(
+      const title = this.formGroup.value.newOrderTemplate;
+      return this.orderTemplatesFacade.orderTemplates$.pipe(
+        // pick the most recently created template matching the title since titles are not unique
+        map(templates => templates.filter(t => t.title === title).sort((a, b) => b.creationDate - a.creationDate)[0]),
         whenTruthy(),
-        map(currentOrderTemplate => `route://account/order-templates/${currentOrderTemplate.id}`),
+        map(template => `route://account/order-templates/${template.id}`),
         take(1)
       );
     } else {

--- a/src/app/extensions/order-templates/store/order-template/order-template.actions.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.actions.ts
@@ -67,7 +67,7 @@ export const addProductToOrderTemplateFail = createAction(
 
 export const addProductToNewOrderTemplate = createAction(
   '[Order Templates] Add Product To New Order Template',
-  payload<{ title: string; sku: string; quantity?: number }>()
+  payload<{ title: string; sku: string; quantity?: number; suppressSelect?: boolean }>()
 );
 
 export const moveItemToOrderTemplate = createAction(

--- a/src/app/extensions/order-templates/store/order-template/order-template.effects.spec.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.effects.spec.ts
@@ -467,6 +467,14 @@ describe('Order Template Effects', () => {
       const expected$ = cold('-(bcd)-(bcd)-(bcd)', { b: completion1, c: completion2, d: completion3 });
       expect(effects.addProductToNewOrderTemplate$).toBeObservable(expected$);
     });
+    it('should not dispatch selectOrderTemplate when suppressSelect is true', () => {
+      const action = addProductToNewOrderTemplate({ ...payload, suppressSelect: true });
+      const completion1 = createOrderTemplateSuccess({ orderTemplate });
+      const completion2 = addProductToOrderTemplate({ orderTemplateId: orderTemplate.id, sku: payload.sku });
+      actions$ = hot('-a----a----a', { a: action });
+      const expected$ = cold('-(bc)-(bc)-(bc)', { b: completion1, c: completion2 });
+      expect(effects.addProductToNewOrderTemplate$).toBeObservable(expected$);
+    });
     it('should map failed calls to actions of type CreateOrderTemplateFail', () => {
       const error = makeHttpError({ message: 'invalid' });
       when(orderTemplateServiceMock.createOrderTemplate(anything())).thenReturn(throwError(() => error));
@@ -506,6 +514,7 @@ describe('Order Template Effects', () => {
         title: payload1.target.title,
         sku: payload1.target.sku,
         quantity: payload1.target.quantity,
+        suppressSelect: true,
       });
       const completion2 = removeItemFromOrderTemplate({
         orderTemplateId: payload1.source.id,

--- a/src/app/extensions/order-templates/store/order-template/order-template.effects.ts
+++ b/src/app/extensions/order-templates/store/order-template/order-template.effects.ts
@@ -203,7 +203,7 @@ export class OrderTemplateEffects {
                 sku: payload.sku,
                 quantity: payload.quantity,
               }),
-              selectOrderTemplate({ id: orderTemplate.id }),
+              ...(payload.suppressSelect ? [] : [selectOrderTemplate({ id: orderTemplate.id })]),
             ]),
             mapErrorToAction(createOrderTemplateFail)
           )
@@ -222,6 +222,7 @@ export class OrderTemplateEffects {
               title: payload.target.title,
               sku: payload.target.sku,
               quantity: payload.target.quantity,
+              suppressSelect: true,
             }),
             removeItemFromOrderTemplate({
               orderTemplateId: payload.source.id,

--- a/src/app/shared/components/common/in-place-edit/in-place-edit.component.scss
+++ b/src/app/shared/components/common/in-place-edit/in-place-edit.component.scss
@@ -1,5 +1,7 @@
+@import 'variables';
+
 .btn-link {
-  padding: 3px;
+  padding: $space-default * 0.5;
   font-size: 16px;
 
   &.btn-lg {


### PR DESCRIPTION
### 🚀 Description

This pull request fixes 2 issues regarding the "move item to another order template" functionality:
- After moving an item the link and the button in the confirmation dialog doesn't work properly
- After moving an item the a new order template the underlying order template changed unintentionally, see also

- Related Ticket/Issue: Closes #1666 


<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->


---

### 🔍 Detailed Changes

1. 
Problem: The `ish-select-order-template-modal` lived inside the line-item component, which is rendered inside a @for loop. When a move succeeds, the item is removed from the store, the @for re-renders, the component is destroyed, and the modal's Angular bindings die — making the OK button unresponsive.

Solution: Moved the modal out of the @for loop to the page component level. Since the modal now lives at the page level, it survives the store update that removes the item from the list. The user sees the updated source template (item removed) AND can navigate to the target template via the success message link.

2. 
After moving an item the a new order template the underlying order template changed because the newly create order template was selected in the state. An optianal parameter suppressSelect has been added to addProductToNewOrderTemplate action to prevent this behavior. The source template stays displayed.

3.
Enlarge the padding of the in-place editing pencil icon


---

### 📝 Notes

<!-- Anything important that is not obvious from the code itself

  - Breaking changes?
  - Required ICM version?
  - Migrations required?
  - Feature flags / configuration changes?
  - Known limitations?
-->

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team
- [x] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#118586](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118586)