### PR TITLE
fix: introduce x-captcha-token for usage of captcha with sso

### DIFF
--- a/src/app/core/identity-provider/auth0.identity-provider.spec.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.spec.ts
@@ -1,9 +1,10 @@
 import { APP_BASE_HREF } from '@angular/common';
+import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router, provideRouter } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { OAuthService } from 'angular-oauth2-oidc';
-import { of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { anything, capture, instance, mock, resetCalls, spy, verify, when } from 'ts-mockito';
 
 import { Customer } from 'ish-core/models/customer/customer.model';
@@ -158,5 +159,70 @@ describe('Auth0 Identity Provider', () => {
       verify(apiTokenService.removeApiToken()).once();
       expect(router.url).not.toContain('/account');
     }));
+  });
+
+  describe('intercept', () => {
+    let handler: HttpHandler;
+
+    class MockHandler extends HttpHandler {
+      handle = () => EMPTY;
+    }
+
+    beforeEach(() => {
+      handler = mock(MockHandler);
+    });
+
+    it('should set Bearer token as Authorization header when user is logged in via SSO', () => {
+      const req = new HttpRequest('GET', 'https://example.com/api/resource');
+
+      auth0IdentityProvider.intercept(req, instance(handler));
+
+      const interceptedReq = capture(handler.handle).last()[0] as HttpRequest<unknown>;
+      expect(interceptedReq.headers.get('Authorization')).toBe(`Bearer ${idToken}`);
+    });
+
+    it('should delegate to apiTokenService when no ID token is available', () => {
+      when(oAuthService.getIdToken()).thenReturn(undefined);
+      const req = new HttpRequest('GET', 'https://example.com/api/resource');
+
+      auth0IdentityProvider.intercept(req, instance(handler));
+
+      verify(apiTokenService.intercept(anything(), anything())).once();
+    });
+
+    it('should move CAPTCHA Authorization header to X-Captcha-Token and set Bearer token', () => {
+      const captchaValue = 'CAPTCHA recaptcha_token=abc123 action=contact';
+      const req = new HttpRequest('GET', 'https://example.com/api/resource', {
+        headers: new HttpHeaders().set('Authorization', captchaValue),
+      });
+
+      auth0IdentityProvider.intercept(req, instance(handler));
+
+      const interceptedReq = capture(handler.handle).last()[0] as HttpRequest<unknown>;
+      expect(interceptedReq.headers.get('Authorization')).toBe(`Bearer ${idToken}`);
+      expect(interceptedReq.headers.get('X-Captcha-Token')).toBe(captchaValue);
+    });
+
+    it('should move CAPTCHA V2 Authorization header to X-Captcha-Token and set Bearer token', () => {
+      const captchaValue = 'CAPTCHA g-recaptcha-response=token123 foo=bar';
+      const req = new HttpRequest('GET', 'https://example.com/api/resource', {
+        headers: new HttpHeaders().set('Authorization', captchaValue),
+      });
+
+      auth0IdentityProvider.intercept(req, instance(handler));
+
+      const interceptedReq = capture(handler.handle).last()[0] as HttpRequest<unknown>;
+      expect(interceptedReq.headers.get('Authorization')).toBe(`Bearer ${idToken}`);
+      expect(interceptedReq.headers.get('X-Captcha-Token')).toBe(captchaValue);
+    });
+
+    it('should not modify request for processtoken endpoint', () => {
+      const req = new HttpRequest('POST', 'https://example.com/api/users/processtoken', {});
+
+      auth0IdentityProvider.intercept(req, instance(handler));
+
+      const interceptedReq = capture(handler.handle).last()[0] as HttpRequest<unknown>;
+      expect(interceptedReq.headers.has('Authorization')).toBeFalse();
+    });
   });
 });

--- a/src/app/core/identity-provider/auth0.identity-provider.ts
+++ b/src/app/core/identity-provider/auth0.identity-provider.ts
@@ -253,14 +253,25 @@ export class Auth0IdentityProvider implements IdentityProvider {
       return this.apiTokenService.intercept(req, next);
     }
 
-    const newRequest =
+    if (
       this.oauthService.getIdToken() &&
       !req.url.endsWith('users/processtoken') &&
       !req.headers.has(ApiService.TOKEN_HEADER_KEY)
-        ? req.clone({
-            headers: req.headers.set(ApiService.AUTHORIZATION_HEADER_KEY, `Bearer ${this.oauthService.getIdToken()}`),
-          })
-        : req;
-    return next.handle(newRequest);
+    ) {
+      let headers = req.headers;
+
+      // move existing CAPTCHA authorization to X-Captcha-Token header
+      const existingAuth = headers.get(ApiService.AUTHORIZATION_HEADER_KEY);
+      if (existingAuth?.startsWith('CAPTCHA ')) {
+        headers = headers.set('X-Captcha-Token', existingAuth).delete(ApiService.AUTHORIZATION_HEADER_KEY);
+      }
+
+      // set Bearer token as Authorization header
+      headers = headers.set(ApiService.AUTHORIZATION_HEADER_KEY, `Bearer ${this.oauthService.getIdToken()}`);
+
+      return next.handle(req.clone({ headers }));
+    }
+
+    return next.handle(req);
   }
 }

--- a/src/app/core/models/customer/customer.model.ts
+++ b/src/app/core/models/customer/customer.model.ts
@@ -41,7 +41,7 @@ export type CustomerRegistrationType = {
 } & Captcha &
   CustomerUserType;
 
-export interface SsoRegistrationType {
+export interface SsoRegistrationType extends Captcha {
   companyInfo: { companyName1: string; companyName2?: string; taxationID: string };
   budgetPriceType?: PriceType;
   address: Address;

--- a/src/app/core/store/customer/sso-registration/sso-registration.effects.ts
+++ b/src/app/core/store/customer/sso-registration/sso-registration.effects.ts
@@ -35,6 +35,8 @@ export class SsoRegistrationEffects {
               taxationID: data.companyInfo.taxationID,
             },
             userId: data.userId,
+            captcha: data.captcha,
+            captchaAction: data.captchaAction,
           })
           .pipe(
             concatMap(createUserResponse => [

--- a/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
+++ b/src/app/pages/registration/services/registration-form-configuration/registration-form-configuration.service.ts
@@ -181,6 +181,8 @@ export class RegistrationFormConfigurationService {
         address,
         userId: registrationConfig.userId,
         subscribedToNewsletter: formValue.newsletterSubscription,
+        captcha: formValue.captcha,
+        captchaAction: formValue.captchaAction,
       });
     } else {
       const customer: Customer = {


### PR DESCRIPTION
This PR enables using CAPTCHA-protected REST calls while authenticated via SSO by preventing the CAPTCHA payload from being overwritten when the Auth0 interceptor sets the Authorization: Bearer <idToken> header.

Fixes: #1334

**Changes:**

- Extend SSO registration payloads to carry captcha and captchaAction through the registration flow.
- Update Auth0IdentityProvider.intercept() to move an existing Authorization: CAPTCHA ... header into X-Captcha-Token, then set Authorization: Bearer <idToken>.
- Add unit tests covering the new interceptor behavior (Bearer injection, CAPTCHA header move, and users/processtoken passthrough).