### PR TITLE
fix: mix of smaller issues

### DIFF
--- a/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.html
+++ b/src/app/extensions/order-templates/pages/account-order-template/account-order-template-list/account-order-template-list.component.html
@@ -61,13 +61,6 @@
               />
             </a>
           }
-          <a
-            class="btn-tool"
-            data-testing-id="order-template-details-edit"
-            [routerLink]="'/account/order-templates/' + orderTemplate.id"
-            [title]="'account.order_template.edit.heading' | translate"
-            ><i class="bi bi-pencil-fill"></i
-          ></a>
           <button
             class="btn-tool btn-link"
             data-testing-id="delete-order-template"

--- a/src/app/extensions/quickorder/shared/direct-order/direct-order.component.ts
+++ b/src/app/extensions/quickorder/shared/direct-order/direct-order.component.ts
@@ -82,7 +82,9 @@ export class DirectOrderComponent implements OnInit, AfterViewInit {
         },
         validation: {
           messages: {
-            validProduct: () => this.translate.get('quickorder.page.error.invalid.product', { 0: this.model.sku }),
+            // the message keeps showing the SKU that previously failed while the user is typing
+            validProduct: () =>
+              this.translate.get('quickorder.page.error.invalid.product', { 0: this.context.get('sku') }),
           },
         },
       },

--- a/src/app/extensions/quickorder/shared/formly/quickorder-repeat-field/quickorder-repeat-field.component.html
+++ b/src/app/extensions/quickorder/shared/formly/quickorder-repeat-field/quickorder-repeat-field.component.html
@@ -13,7 +13,7 @@
         class="btn-tool btn-link m-2"
         title="{{ 'quickorder.page.remove.row' | translate }}"
         type="button"
-        (click)="remove(i); updateContexts()"
+        (click)="removeRow(i)"
       >
         <i class="bi bi-trash-fill"></i>
       </button>

--- a/src/app/extensions/quickorder/shared/formly/quickorder-repeat-field/quickorder-repeat-field.component.ts
+++ b/src/app/extensions/quickorder/shared/formly/quickorder-repeat-field/quickorder-repeat-field.component.ts
@@ -3,11 +3,14 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   QueryList,
   ViewChildren,
+  inject,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FieldArrayType } from '@ngx-formly/core';
-import { debounceTime, map } from 'rxjs/operators';
+import { debounceTime, take } from 'rxjs/operators';
 
 import { ProductContextDirective } from 'ish-core/directives/product-context.directive';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
@@ -27,6 +30,8 @@ import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 export class QuickorderRepeatFieldComponent extends FieldArrayType implements AfterViewInit {
   @ViewChildren(ProductContextDirective) contexts: QueryList<{ context: ProductContextFacade }>;
 
+  private readonly destroyRef = inject(DestroyRef);
+
   constructor(private cdRef: ChangeDetectorRef) {
     super();
   }
@@ -39,26 +44,37 @@ export class QuickorderRepeatFieldComponent extends FieldArrayType implements Af
     for (let i = 0; i < rows; i++) {
       this.add(this.model.length, { sku: '', quantity: 1 });
     }
-    this.updateContexts();
+    this.updateContextsOnNextRender();
+  }
+
+  removeRow(index: number) {
+    this.remove(index);
+    this.updateContextsOnNextRender();
   }
 
   /**
    * Set the form control field to the according product context and handle its behavior.
    */
-  updateContexts() {
+  private updateContexts() {
     this.contexts.forEach((context: { context: ProductContextFacade }, index) => {
       const field = this.field.fieldGroup[index].fieldGroup[0];
-      const formControl = field.formControl;
 
-      context.context.connect('sku', formControl.valueChanges.pipe(debounceTime(500)));
-      formControl.setAsyncValidators(() =>
-        context.context
-          .select('product')
-          .pipe(
-            map(product => (product.failed && formControl.value?.trim() !== '' ? { validProduct: false } : undefined))
-          )
-      );
+      // only wire up rows that are not connected yet to avoid duplicate subscriptions
+      if (field.props.productContext === context.context) {
+        return;
+      }
+
+      // expose the product context to the field so its configured validators can access it
+      field.props.productContext = context.context;
+      context.context.connect('sku', field.formControl.valueChanges.pipe(debounceTime(500)));
     });
     this.cdRef.markForCheck();
+  }
+
+  /**
+   * Rows are rendered asynchronously, so wait for the next rendered-rows change before wiring up the contexts.
+   */
+  private updateContextsOnNextRender() {
+    this.contexts.changes.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => this.updateContexts());
   }
 }

--- a/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.html
+++ b/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.html
@@ -3,7 +3,7 @@
   ishFormSubmit
   [attr.aria-label]="'quickorder.page.form.label' | translate"
   [formGroup]="quickOrderForm"
-  (ngSubmit)="onAddProducts()"
+  (ngSubmit)="onAddProducts(quickOrderIDForm)"
 >
   <div class="list-header d-sm-flex">
     <div class="col-md-8 list-header-item no-seperator">{{ 'quickorder.page.product.id' | translate }}</div>

--- a/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.spec.ts
+++ b/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroupDirective } from '@angular/forms';
 import { TranslatePipe, provideTranslateService } from '@ngx-translate/core';
 import { anyNumber, anyString, instance, mock, verify, when } from 'ts-mockito';
 
@@ -74,7 +75,7 @@ describe('Quickorder Add Products Form Component', () => {
       addProducts: [validProducts[0], invalidProducts[0], invalidProducts[1], validProducts[1], invalidProducts[2]],
     };
     component.quickOrderForm.patchValue(component.model);
-    component.onAddProducts();
+    component.onAddProducts(instance(mock(FormGroupDirective)));
 
     verify(shoppingFacade.addProductToBasket(validProducts[0].sku, validProducts[0].quantity)).once();
     verify(shoppingFacade.addProductToBasket(validProducts[1].sku, validProducts[1].quantity)).once();

--- a/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.ts
+++ b/src/app/extensions/quickorder/shared/quickorder-add-products-form/quickorder-add-products-form.component.ts
@@ -1,8 +1,11 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup, FormGroupDirective } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { filter, map, take } from 'rxjs/operators';
 
+import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ShoppingFacade } from 'ish-core/facades/shopping.facade';
 import { SkuQuantityType } from 'ish-core/models/product/product.helper';
 
@@ -38,7 +41,7 @@ export class QuickorderAddProductsFormComponent implements OnInit {
     this.initModel();
   }
 
-  onAddProducts() {
+  onAddProducts(form: FormGroupDirective) {
     const products = this.model.addProducts.filter((p: SkuQuantityType) => !!p.sku && !!p.quantity);
     if (products.length === 0 || this.hasValidationError()) {
       return;
@@ -46,6 +49,7 @@ export class QuickorderAddProductsFormComponent implements OnInit {
     products.forEach(product => {
       this.shoppingFacade.addProductToBasket(product.sku, product.quantity);
     });
+    form?.resetForm();
     this.reset();
   }
 
@@ -105,12 +109,29 @@ export class QuickorderAddProductsFormComponent implements OnInit {
                   return !this.model.addProducts.find((p: SkuQuantityType) => p.sku && p.quantity);
                 },
               },
+              asyncValidators: {
+                // the product context per row is provided by the quickorder repeat field (see field.props.productContext)
+                validProduct: (control: AbstractControl, field: FormlyFieldConfig) => {
+                  const context: ProductContextFacade = field.props?.productContext;
+                  const sku: string = control.value?.trim();
+                  if (!context || !sku) {
+                    return of(true);
+                  }
+                  // wait until the product for the entered sku has settled, then complete the validation
+                  return context.select('product').pipe(
+                    filter(product => product?.sku?.trim() === sku),
+                    take(1),
+                    map(product => !product.failed)
+                  );
+                },
+              },
               validation: {
                 messages: {
                   required: 'quickorder.page.quantityWithoutSKU',
-                  validProduct: (_, field) =>
+                  // the message keeps showing the SKU that previously failed while the user is typing a correction
+                  validProduct: (_error: unknown, field: FormlyFieldConfig) =>
                     this.translate.get('quickorder.page.error.invalid.product', {
-                      0: this.model.addProducts[parseInt(field.parent.key.toString(), 10)].sku,
+                      0: (field.props?.productContext as ProductContextFacade)?.get('sku'),
                     }),
                 },
               },

--- a/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
+++ b/src/app/shared/formly-address-forms/components/formly-customer-address-form/formly-customer-address-form.component.ts
@@ -99,18 +99,22 @@ export class FormlyCustomerAddressFormComponent implements OnInit, OnChanges {
   }
 
   submitForm() {
-    if (this.form.valid) {
-      // build address from form data and send it to the parent
-      let formAddress: Address = this.form.value.address;
-      if (this.address) {
-        // update form values in the original address
-        formAddress = { ...this.address, mainDivisionCode: '', ...formAddress };
-      }
-      if (this.extension) {
-        formAddress = { ...formAddress, email: this.extensionForm.get('email')?.value };
-      }
-      this.save.emit(formAddress);
+    if (this.form.invalid) {
+      this.form.get('address')?.updateValueAndValidity();
+      this.extensionForm.updateValueAndValidity();
+      return;
     }
+
+    // build address from form data and send it to the parent
+    let formAddress: Address = this.form.value.address;
+    if (this.address) {
+      // update form values in the original address
+      formAddress = { ...this.address, mainDivisionCode: '', ...formAddress };
+    }
+    if (this.extension) {
+      formAddress = { ...formAddress, email: this.extensionForm.get('email')?.value };
+    }
+    this.save.emit(formAddress);
   }
 
   emitCancelForm() {

--- a/src/app/shared/formly/types/search-select-field/search-select-field.component.html
+++ b/src/app/shared/formly/types/search-select-field/search-select-field.component.html
@@ -8,5 +8,6 @@
   [items]="props.options | formlySelectOptions: field | async"
   [labelForId]="id"
   [ngClass]="props.inputClass"
+  [placeholder]="props.placeholder"
   [virtualScroll]="props.virtualScroll || false"
 />

--- a/src/environments/environment.b2b.ts
+++ b/src/environments/environment.b2b.ts
@@ -13,10 +13,10 @@ export const environment: Environment = {
     'businessCustomerRegistration',
     'costCenters',
     'maps',
+    'orderTemplates',
     'punchout',
     'quickorder',
     'quoting',
-    'orderTemplates',
   ],
 
   ...overrides,

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -1,3 +1,4 @@
+/* eslint-disable perfectionist/sort-union-types */
 import { Auth0Config } from 'ish-core/identity-provider/auth0.identity-provider';
 import { CookieConsentOptions } from 'ish-core/models/cookies/cookies.model';
 import { PaypalClientConfig } from 'ish-core/models/paypal-client-config/paypal-client-config';
@@ -27,33 +28,32 @@ export interface Environment {
 
   /* FEATURE TOGGLES */
   features: (
-    | 'addressDoctor'
-    | 'businessCustomerRegistration'
     | 'compare'
     | 'contactUs'
-    | 'copilot'
-    | 'costCenters'
     | 'extraConfiguration'
-    | 'guestCheckout'
-    | 'legacyEncoding'
-    /* B2B features */
-    | 'maps'
-    | 'orderTemplates'
     | 'productNotifications'
-    | 'punchout'
-    | 'quickorder'
-    | 'quoting'
-    /* B2C features */
     | 'rating'
     | 'recently'
-    /* ICM compatibility - a.o. to be used with the ICMCompatibilityInterceptor */
-    // | 'messageToMerchant'
     | 'saveLanguageSelection'
-    /* Third-party Integrations */
     | 'stickyHeader'
     | 'storeLocator'
-    | 'tracking'
+    /* B2B features */
+    | 'businessCustomerRegistration'
+    | 'costCenters'
+    | 'orderTemplates'
+    | 'punchout'
+    | 'quoting'
+    | 'quickorder'
+    /* B2C features */
+    | 'guestCheckout'
     | 'wishlists'
+    /* ICM compatibility - a.o. to be used with the ICMCompatibilityInterceptor */
+    | 'legacyEncoding'
+    /* Third-party Integrations */
+    | 'addressDoctor'
+    | 'copilot'
+    | 'maps'
+    | 'tracking'
   )[];
 
   /* ADDITIONAL FEATURE CONFIGURATIONS */


### PR DESCRIPTION
### 🚀 Description


This pull request introduces several enhancements and fixes across the codebase, with a focus on quick order and address forms.


---

### 🔍 Detailed Changes

1. fix: empty placeholder of ng-select form field — Restores the placeholder text so an `ng-select` form field no longer appears blank when nothing is selected, e.g. the preferred invoice select field on myAccount addresses page.

2. fix: validation display in address fields — Corrects how validation feedback is shown on address form fields so errors are displayed properly, e.g. fixes missing validation info for city and postal code

3. fix: error message in quick order forms — Ensures the correct error message is shown in the quick order forms after the user changes the sku value.

4. refactor: remove edit icon button from order template list — Removes the redundant edit icon button from the order template list view.

5. refactor: feature toggle order - fix the order of the feature toggles in the environment.model.ts file

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#118746](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/118746)