### PR TITLE
chore: enable hot module replacement in development

### DIFF
--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -77,6 +77,7 @@ grecaptcha
 heapsnapshot
 helpdesk
 hiper
+hostnames
 hoverable
 iban
 icecat

--- a/angular.json
+++ b/angular.json
@@ -112,7 +112,8 @@
               "buildTarget": "intershop-pwa:build:production"
             },
             "development": {
-              "buildTarget": "intershop-pwa:build:development"
+              "buildTarget": "intershop-pwa:build:development",
+              "hmr": true
             },
             "b2b": {
               "buildTarget": "intershop-pwa:build:b2b"
@@ -226,7 +227,8 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "buildTarget": "organization-management:build"
+            "buildTarget": "organization-management:build",
+            "hmr": true
           }
         }
       }
@@ -273,7 +275,8 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "buildTarget": "requisition-management:build"
+            "buildTarget": "requisition-management:build",
+            "hmr": true
           }
         }
       }

--- a/angular.json
+++ b/angular.json
@@ -110,7 +110,8 @@
               "buildTarget": "intershop-pwa:build:production"
             },
             "development": {
-              "buildTarget": "intershop-pwa:build:development"
+              "buildTarget": "intershop-pwa:build:development",
+              "hmr": true
             },
             "b2b": {
               "buildTarget": "intershop-pwa:build:b2b"
@@ -224,7 +225,8 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "buildTarget": "organization-management:build"
+            "buildTarget": "organization-management:build",
+            "hmr": true
           }
         }
       }
@@ -271,7 +273,8 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "buildTarget": "requisition-management:build"
+            "buildTarget": "requisition-management:build",
+            "hmr": true
           }
         }
       }

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -103,6 +103,13 @@ The order template and wishlist selection modals have been reworked for a more c
 The `ProductRatingStarComponent` has been removed and the ng-bootstrap's `NgbRating` component is used instead.
 If you customized or extended the `ProductRatingStarComponent` component in your project, either skip the according commit or migrate to `NgbRating` as well.
 
+**Hot Module Replacement (HMR) in development**
+
+HMR has been enabled for the `serve` targets in `angular.json` via `"hmr": true`.
+Running `ng serve` now applies style changes (global and component SCSS) in place without a full page reload, preserving the current application state.
+Template and TypeScript changes still trigger a full live-reload as before.
+The setting only affects the development `serve` configuration and has no impact on production builds or SSR.
+
 ## From 11.1.0 to 11.2.0
 
 **Extended Withdrawal functionality**

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -60,6 +60,13 @@ The experimental Angular Service Worker integration has been removed, as it was 
 The `@angular/service-worker` dependency, the `ngsw-config.json` file, the `serviceWorker`/`ngswConfigPath` options in _angular.json_, the `node schematics/customization/service-worker` customization, and the related `serviceWorker` Docker build argument no longer exist.
 The Web App Manifest (installability) is unaffected and remains available.
 
+**Hot Module Replacement (HMR) in development**
+
+HMR has been enabled for the `serve` targets in `angular.json` via `"hmr": true`.
+Running `ng serve` now applies style changes (global and component SCSS) in place without a full page reload, preserving the current application state.
+Template and TypeScript changes still trigger a full live-reload as before.
+The setting only affects the dev server (`ng serve`) and has no impact on production builds or SSR.
+
 ## From 12.0.0 to 12.1.0
 
 **Generative Engine Optimization (GEO)**

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,16 +7,6 @@ if (PRODUCTION_MODE) {
   enableProdMode();
 }
 
-function bootstrap(): void {
-  platformBrowser()
-    .bootstrapModule(AppModule)
-    .catch(err => console.error(err));
-}
-
-// bootstrap immediately when the DOM is already parsed (e.g. on HMR re-execution),
-// otherwise wait for the initial DOMContentLoaded event
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', bootstrap);
-} else {
-  bootstrap();
-}
+platformBrowser()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,16 @@ if (PRODUCTION_MODE) {
   enableProdMode();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function bootstrap(): void {
   platformBrowser()
     .bootstrapModule(AppModule)
     .catch(err => console.error(err));
-});
+}
+
+// bootstrap immediately when the DOM is already parsed (e.g. on HMR re-execution),
+// otherwise wait for the initial DOMContentLoaded event
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+} else {
+  bootstrap();
+}


### PR DESCRIPTION
### 🚀 Description

This pull request enables Hot Module Replacement (HMR) for development builds, improving the development workflow by allowing **style changes** to be applied without a full page reload and preserving application state. It also documents this change.

---

### 🔍 Detailed Changes

The style HMR alone (no template HMR) is genuinely useful here because:

- SCSS is where iterative work happens. With a large theme setup (src/styles/themes/... plus per-component styles), designers/devs tweak spacing, colors, and layout constantly. Instant in-place style updates without losing app state (open modals, filled forms, scroll position, cart contents) is a real productivity win.
- No downside vs. before. For template/TS changes you get the same full reload you already had without hmr. So you're strictly adding capability, not trading anything away.
- It's dev-only. The hmr: true lives under the development serve configuration, so it never touches production builds or SSR.

---

### 📝 Notes

The CLI's HMR runtime destroys and re-bootstraps the app on component
style/template changes by re-executing the entry module. The legacy
DOMContentLoaded wrapper (copied from the Angular Universal starter back in
2017) prevented re-bootstrap because the event never fires again on an HMR
re-run, leaving the page blank without an error.

Replace it with the canonical direct bootstrap, which is the current Angular
standard. The entry is emitted as a deferred module script, so the DOM
(including ish-root) is already parsed when it runs in production, and it
re-bootstraps correctly on HMR.

---


### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119240](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119240)