### PR TITLE
docs: add versioning policy documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ kb_sync_latest_only
 
 ### Maintenance
 
+- [Concept - Versioning Policy](./concepts/versioning-policy.md)
 - [Guide - Updating Dependencies](./guides/updating-pwa.md)
 - [Guide - Determining the PWA Version](./guides/determine-pwa-version.md)
 

--- a/docs/concepts/versioning-policy.md
+++ b/docs/concepts/versioning-policy.md
@@ -1,5 +1,5 @@
 <!--
-kb_concept
+kb_concepts
 kb_pwa
 kb_everyone
 kb_sync_latest_only
@@ -15,11 +15,11 @@ kb_sync_latest_only
 
 The PWA versioning system follows semantic versioning principles to communicate the nature and scope of each release in a consistent and predictable way.
 
-Due to the full availability of the [PWA source code in GitHub](https://github.com/intershop/intershop-pwa), PATCH releases are usually not created, since new bug fixes can easily be consumed by any project via `git cherry-pick` from the `develop` branch or the pull request branch. 
+Due to the full availability of the [PWA source code in GitHub](https://github.com/intershop/intershop-pwa), PATCH releases are usually not created, since new bug fixes can easily be consumed by any project via `git cherry-pick` from the `develop` branch or the pull request branch.
 Publishing such changes within a PATCH release is not necessary, since projects need to integrate the changes as a merged commit either way.
 There is no “just incrementing a dependency version” concept due to the Intershop PWA not being a library, but rather a blueprint to start a custom storefront project.
 
-The Intershop PWA is not maintained in multiple versions with subsequent new MINOR or PATCH releases to parallel versions. 
+The Intershop PWA is not maintained in multiple versions with subsequent new MINOR or PATCH releases to parallel versions.
 Rather, it follows a linear path of released versions that uses a MAJOR or MINOR release to signal the scope of contained changes.
 
 > [!TIP]
@@ -41,18 +41,18 @@ The Intershop PWA follows the versioning format **MAJOR.MINOR.PATCH**.
 | **MINOR**   | Release must be **backward compatible**                                                 | Only non-breaking changes         | Functionality, improvements, bug fixes                                |
 | **PATCH**   | **Not used** in current release process; always `0`                                     |                                   |                                                                       |
 
-The version number primarily signals upgrade impact, not the functional type of change. 
+The version number primarily signals upgrade impact, not the functional type of change.
 It reflects upgrade effort and scope.
 
 ## Breaking Changes
 
 A breaking change is defined as _“a change in one part of a software system that potentially causes other components to fail“_ ([Wiktionary](https://en.wiktionary.org/wiki/breaking_change#English)).
 
-Projects upgrade by incorporating code changes from higher PWA versions into their source code. 
+Projects upgrade by incorporating code changes from higher PWA versions into their source code.
 They do not simply “consume” a newer PWA version by updating a version number.
 
-Each project has its own customizations, ranging from minimal to extensive. 
-A project that uses the PWA without code-level customizations (for example, only updating CSS styles) can upgrade to any version, including major versions, without much adaptation effort. 
+Each project has its own customizations, ranging from minimal to extensive.
+A project that uses the PWA without code-level customizations (for example, only updating CSS styles) can upgrade to any version, including major versions, without much adaptation effort.
 In such cases, there are no breaking changes because nothing conflicts during migration.
 
 The definition of a breaking change refers primarily to whether changes in the standard PWA code require project teams to manually adapt their customizations when upgrading (e.g., custom code no longer compiles or behaves correctly without adaptation).

--- a/docs/concepts/versioning-policy.md
+++ b/docs/concepts/versioning-policy.md
@@ -1,0 +1,50 @@
+# Versioning Policy
+
+# Introduction
+
+The PWA versioning system follows semantic versioning principles to communicate the nature and scope of each release in a consistent and predictable way
+
+Due to the full availability of the [PWA source code in GitHub](https://github.com/intershop/intershop-pwa), PATCH releases are usually not created, since new bug fixes can easily be consumed by any project via `git cherry-pick` from the `develop`branch or the pull request branch. It is not actually necessary to publish such changes within a PATCH release, since projects need to integrate the changes as a merged commit either way. There is no “ just incrementing a dependency version” concept, due to the nature of the Intershop PWA - not being a library, but rather a blueprint to start a custom storefront project.
+
+The Intershop PWA is not maintained in multiple versions with subsequent new MINOR or PATCH releases to parallel versions; rather, it follows a linear path of released versions that use a MAJOR or MINOR release to signal the scope of contained changes.
+
+> [!TIP]
+> GitHub provides very convenient means of creating patches for commits or pull requests, making it even easier than `git cherry-pick` to get a desired bug fix or changed functionality into a project.
+>
+> To automatically generate a patch file just append `.patch` to the GitHub commit or pull request URL.
+>
+> Commit: `https://github.com/intershop/intershop-pwa/commit/e3b092fa2c7122f0a68f6ea0ba0bddb3dd162308.patch`
+>
+> Pull Request: `https://github.com/intershop/intershop-pwa/pull/2002.patch`
+
+# Versioning Scheme
+
+The Intershop PWA follows the versioning format **MAJOR.MINOR.PATCH**.
+
+| **Version** | **Meaning**                                                                             | **Allowed changes**               | **Includes**                                                               |
+| ----------- | --------------------------------------------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------- |
+| **MAJOR**   | Release **can contain breaking changes **or be **strategically important** (marketing). | breaking and non-breaking changes | - functionality - improvements - bug fixes - major code convention changes |
+| **MINOR**   | Release must be **backward compatible**                                                 | only non-breaking changes         | - functionality - improvements - bug fixes                                 |
+| **PATCH**   | **Not used** in current release process; always `0`                                     |                                   |                                                                            |
+
+The **version number** primarily **signals upgrade impact**, not the functional type of change. It serves as a **signal about upgrade effort and scope**.
+
+# Breaking Changes
+
+A breaking change is defined as _“a change in one part of a software system that potentially causes other components to fail“_ ([Wiktionary](https://en.wiktionary.org/wiki/breaking_change#English)).
+
+Projects upgrade by incorporating code changes from higher PWA versions into their source code - they do not simply “consume” a newer PWA version by updating a version number.
+
+Each project has its own customizations, ranging from minimal to extensive. A project that uses the PWA without code-level customizations - for example, only updating CSS styles - can upgrade to any version, including major versions, without much adaptation effort. In such cases, there are no breaking changes because nothing conflicts during migration.
+
+The definition of a breaking change refers primarily to whether changes in the standard PWA code require project teams to manually adapt their customizations when upgrading (e.g., custom code no longer compiles or behaves correctly without changes on their end).
+
+The **breaking changes** listed below represent typical customization points where project-specific modifications are most likely to conflict with changes made in the standard PWA:
+
+- Angular upgrade to a major version (systematic code changes across the codebase)
+- Breaking changes in dependencies (e.g., Bootstrap)
+- Removal of support for specific older REST API endpoints; e.g., the PWA uses a new version of an ICM REST API endpoint **and** removes the existing fallback to the older endpoint version.
+- Feature removal or major feature rework
+- Public signatures that require code adaptations
+- Changes in the routing structure (route paths; e.g., SEO-critical: deep links, sitemaps, query parameter conventions)
+- Required configuration, environment, or deployment changes (configuration keys, environment variable names, feature toggle identifiers)

--- a/docs/concepts/versioning-policy.md
+++ b/docs/concepts/versioning-policy.md
@@ -1,49 +1,67 @@
+<!--
+kb_concept
+kb_pwa
+kb_everyone
+kb_sync_latest_only
+-->
+
 # Versioning Policy
 
-# Introduction
+- [Introduction](#introduction)
+- [Versioning Scheme](#versioning-scheme)
+- [Breaking Changes](#breaking-changes)
 
-The PWA versioning system follows semantic versioning principles to communicate the nature and scope of each release in a consistent and predictable way
+## Introduction
 
-Due to the full availability of the [PWA source code in GitHub](https://github.com/intershop/intershop-pwa), PATCH releases are usually not created, since new bug fixes can easily be consumed by any project via `git cherry-pick` from the `develop`branch or the pull request branch. It is not actually necessary to publish such changes within a PATCH release, since projects need to integrate the changes as a merged commit either way. There is no “ just incrementing a dependency version” concept, due to the nature of the Intershop PWA - not being a library, but rather a blueprint to start a custom storefront project.
+The PWA versioning system follows semantic versioning principles to communicate the nature and scope of each release in a consistent and predictable way.
 
-The Intershop PWA is not maintained in multiple versions with subsequent new MINOR or PATCH releases to parallel versions; rather, it follows a linear path of released versions that use a MAJOR or MINOR release to signal the scope of contained changes.
+Due to the full availability of the [PWA source code in GitHub](https://github.com/intershop/intershop-pwa), PATCH releases are usually not created, since new bug fixes can easily be consumed by any project via `git cherry-pick` from the `develop` branch or the pull request branch. 
+Publishing such changes within a PATCH release is not necessary, since projects need to integrate the changes as a merged commit either way.
+There is no “just incrementing a dependency version” concept due to the Intershop PWA not being a library, but rather a blueprint to start a custom storefront project.
+
+The Intershop PWA is not maintained in multiple versions with subsequent new MINOR or PATCH releases to parallel versions. 
+Rather, it follows a linear path of released versions that uses a MAJOR or MINOR release to signal the scope of contained changes.
 
 > [!TIP]
 > GitHub provides very convenient means of creating patches for commits or pull requests, making it even easier than `git cherry-pick` to get a desired bug fix or changed functionality into a project.
 >
-> To automatically generate a patch file just append `.patch` to the GitHub commit or pull request URL.
+> To automatically generate a patch file, just append `.patch` to the GitHub commit or pull request URL.
 >
 > Commit: `https://github.com/intershop/intershop-pwa/commit/e3b092fa2c7122f0a68f6ea0ba0bddb3dd162308.patch`
 >
 > Pull Request: `https://github.com/intershop/intershop-pwa/pull/2002.patch`
 
-# Versioning Scheme
+## Versioning Scheme
 
 The Intershop PWA follows the versioning format **MAJOR.MINOR.PATCH**.
 
-| **Version** | **Meaning**                                                                             | **Allowed changes**               | **Includes**                                                               |
-| ----------- | --------------------------------------------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------- |
-| **MAJOR**   | Release **can contain breaking changes **or be **strategically important** (marketing). | breaking and non-breaking changes | - functionality - improvements - bug fixes - major code convention changes |
-| **MINOR**   | Release must be **backward compatible**                                                 | only non-breaking changes         | - functionality - improvements - bug fixes                                 |
-| **PATCH**   | **Not used** in current release process; always `0`                                     |                                   |                                                                            |
+| **Version** | **Meaning**                                                                             | **Allowed Changes**               | **Includes**                                                          |
+| ----------- | --------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------- |
+| **MAJOR**   | Release **can contain breaking changes** or be **strategically important** (marketing). | Breaking and non-breaking changes | Functionality, improvements, bug fixes, major code convention changes |
+| **MINOR**   | Release must be **backward compatible**                                                 | Only non-breaking changes         | Functionality, improvements, bug fixes                                |
+| **PATCH**   | **Not used** in current release process; always `0`                                     |                                   |                                                                       |
 
-The **version number** primarily **signals upgrade impact**, not the functional type of change. It serves as a **signal about upgrade effort and scope**.
+The version number primarily signals upgrade impact, not the functional type of change. 
+It reflects upgrade effort and scope.
 
-# Breaking Changes
+## Breaking Changes
 
 A breaking change is defined as _“a change in one part of a software system that potentially causes other components to fail“_ ([Wiktionary](https://en.wiktionary.org/wiki/breaking_change#English)).
 
-Projects upgrade by incorporating code changes from higher PWA versions into their source code - they do not simply “consume” a newer PWA version by updating a version number.
+Projects upgrade by incorporating code changes from higher PWA versions into their source code. 
+They do not simply “consume” a newer PWA version by updating a version number.
 
-Each project has its own customizations, ranging from minimal to extensive. A project that uses the PWA without code-level customizations - for example, only updating CSS styles - can upgrade to any version, including major versions, without much adaptation effort. In such cases, there are no breaking changes because nothing conflicts during migration.
+Each project has its own customizations, ranging from minimal to extensive. 
+A project that uses the PWA without code-level customizations (for example, only updating CSS styles) can upgrade to any version, including major versions, without much adaptation effort. 
+In such cases, there are no breaking changes because nothing conflicts during migration.
 
-The definition of a breaking change refers primarily to whether changes in the standard PWA code require project teams to manually adapt their customizations when upgrading (e.g., custom code no longer compiles or behaves correctly without changes on their end).
+The definition of a breaking change refers primarily to whether changes in the standard PWA code require project teams to manually adapt their customizations when upgrading (e.g., custom code no longer compiles or behaves correctly without adaptation).
 
 The **breaking changes** listed below represent typical customization points where project-specific modifications are most likely to conflict with changes made in the standard PWA:
 
 - Angular upgrade to a major version (systematic code changes across the codebase)
 - Breaking changes in dependencies (e.g., Bootstrap)
-- Removal of support for specific older REST API endpoints; e.g., the PWA uses a new version of an ICM REST API endpoint **and** removes the existing fallback to the older endpoint version.
+- Removal of support for specific older REST API endpoints (e.g., the PWA uses a new version of an ICM REST API endpoint **and** removes the existing fallback to the older endpoint version).
 - Feature removal or major feature rework
 - Public signatures that require code adaptations
 - Changes in the routing structure (route paths; e.g., SEO-critical: deep links, sitemaps, query parameter conventions)


### PR DESCRIPTION
### 🚀 Description

There is no public documentation that explains the PWA versioning concept.

---

### 🔍 Detailed Changes

There is a documentation about the PWA versioning that explains which types of changes lead to major and minor version updates.

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119308](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119308)

[AB#119314](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119314)