### PR TITLE
feat: add initial esbuild build pipeline

### DIFF
--- a/.github/lighthouse/Dockerfile.esbuild
+++ b/.github/lighthouse/Dockerfile.esbuild
@@ -1,0 +1,27 @@
+FROM node:22.22.0-alpine AS build
+
+ENV CI=true
+ENV NODE_OPTIONS=--max-old-space-size=8192
+
+WORKDIR /workspace
+
+COPY package.json package-lock.json ./
+RUN npm ci --prefer-offline --no-audit --ignore-scripts
+RUN find node_modules -path '*/esbuild/install.js' | xargs -rt -n 1 node
+
+COPY . .
+RUN npm run postinstall
+RUN npm run build:ssr:esbuild
+
+FROM node:22.22.0-alpine
+
+ENV LOGLEVEL=error
+ENV NODE_ENV=production
+
+WORKDIR /workspace
+
+COPY --from=build /workspace/dist/esbuild ./dist/esbuild
+
+EXPOSE 4200
+
+CMD ["node", "dist/esbuild/server/server.mjs"]

--- a/.github/lighthouse/docker-compose.yml
+++ b/.github/lighthouse/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: intershophub/intershop-pwa-ssr
     build:
       context: ../../.
+      dockerfile: .github/lighthouse/Dockerfile.esbuild
     environment:
       ICM_BASE_URL: 'https://develop.icm.intershop.de'
 

--- a/.github/workflows/lighthouse-performance-baseline.yml
+++ b/.github/workflows/lighthouse-performance-baseline.yml
@@ -7,6 +7,13 @@ on:
       - develop
     paths:
       - src/**
+      - .github/lighthouse/**
+      - .github/workflows/lighthouse-performance-baseline.yml
+      - angular.json
+      - package.json
+      - package-lock.json
+      - server*.ts
+      - tsconfig*.json
 
 concurrency:
   group: ${{ github.workflow }}

--- a/angular.json
+++ b/angular.json
@@ -185,6 +185,21 @@
                 }
               ]
             },
+            "ssr": {
+              "server": "src/main.server.ts",
+              "ssr": {
+                "entry": "server.esbuild.ts"
+              },
+              "tsConfig": "tsconfig.esbuild-ssr.json",
+              "define": {
+                "PWA_VERSION": "\"11.2.0 esbuild phase 2\"",
+                "PRODUCTION_MODE": "true",
+                "SERVICE_WORKER": "false",
+                "NGRX_RUNTIME_CHECKS": "false",
+                "THEME": "\"b2b\"",
+                "SSR": "globalThis.ngServerMode"
+              }
+            },
             "b2b": {}
           }
         },

--- a/angular.json
+++ b/angular.json
@@ -204,27 +204,6 @@
           }
         },
         "serve": {
-          "builder": "@angular-builders/custom-webpack:dev-server",
-          "options": {
-            "buildTarget": "intershop-pwa:build"
-          },
-          "defaultConfiguration": "b2b,development",
-          "configurations": {
-            "production": {
-              "buildTarget": "intershop-pwa:build:production"
-            },
-            "development": {
-              "buildTarget": "intershop-pwa:build:development"
-            },
-            "b2b": {
-              "buildTarget": "intershop-pwa:build:b2b"
-            },
-            "b2c": {
-              "buildTarget": "intershop-pwa:build:b2c"
-            }
-          }
-        },
-        "serve-esbuild": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "buildTarget": "intershop-pwa:build-esbuild"

--- a/angular.json
+++ b/angular.json
@@ -101,6 +101,93 @@
             "b2c": {}
           }
         },
+        "build-esbuild": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/esbuild",
+            "index": "src/index.html",
+            "browser": "src/main.ts",
+            "polyfills": ["src/polyfills.ts"],
+            "tsConfig": "tsconfig.app.json",
+            "assets": [
+              "src/assets",
+              {
+                "glob": "favicon.ico",
+                "input": "src/assets/themes/b2b/img/",
+                "output": "/"
+              }
+            ],
+            "styles": ["src/styles/themes/b2b/style.scss"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["src/styles/themes/b2b"]
+            },
+            "sourceMap": true,
+            "allowedCommonJsDependencies": ["localforage"],
+            "define": {
+              "PWA_VERSION": "\"11.2.0 esbuild phase 1\"",
+              "PRODUCTION_MODE": "false",
+              "SERVICE_WORKER": "false",
+              "NGRX_RUNTIME_CHECKS": "true",
+              "THEME": "\"b2b\"",
+              "SSR": "false"
+            },
+            "fileReplacements": [
+              {
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.b2b.ts"
+              }
+            ]
+          },
+          "defaultConfiguration": "b2b,production",
+          "configurations": {
+            "production": {
+              "outputHashing": "all",
+              "namedChunks": false,
+              "extractLicenses": true,
+              "define": {
+                "PWA_VERSION": "\"11.2.0 esbuild phase 1\"",
+                "PRODUCTION_MODE": "true",
+                "SERVICE_WORKER": "false",
+                "NGRX_RUNTIME_CHECKS": "false",
+                "THEME": "\"b2b\"",
+                "SSR": "false"
+              },
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "1.6mb",
+                  "maximumError": "2mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "5kb",
+                  "maximumError": "10kb"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.b2b.ts"
+                },
+                {
+                  "replace": "src/app/core/store/store-devtools.module.ts",
+                  "with": "src/app/core/store/store-devtools.module.production.ts"
+                }
+              ]
+            },
+            "development": {
+              "optimization": false,
+              "tsConfig": "tsconfig.app-no-checks.json",
+              "budgets": [
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
+                }
+              ]
+            },
+            "b2b": {}
+          }
+        },
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
@@ -119,6 +206,24 @@
             },
             "b2c": {
               "buildTarget": "intershop-pwa:build:b2c"
+            }
+          }
+        },
+        "serve-esbuild": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "buildTarget": "intershop-pwa:build-esbuild"
+          },
+          "defaultConfiguration": "b2b,development",
+          "configurations": {
+            "production": {
+              "buildTarget": "intershop-pwa:build-esbuild:production"
+            },
+            "development": {
+              "buildTarget": "intershop-pwa:build-esbuild:development"
+            },
+            "b2b": {
+              "buildTarget": "intershop-pwa:build-esbuild:b2b"
             }
           }
         },

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ kb_sync_latest_only
 ### Developing
 
 - [Guide - Development Environment](./guides/development.md)
+- [Guide - Esbuild Migration](./guides/esbuild-migration.md)
 - [Guide - Angular Component Development](./guides/angular-component-development.md)
 - [Concept - Styling](./concepts/styling-behavior.md)
 - [Concept - Testing](./concepts/testing.md)

--- a/docs/guides/esbuild-migration.md
+++ b/docs/guides/esbuild-migration.md
@@ -1,0 +1,67 @@
+<!--
+kb_guide
+kb_pwa
+kb_everyone
+kb_sync_latest_only
+-->
+
+# Esbuild Migration
+
+## Current Scope
+
+The first migration phase provides separate esbuild browser build and development server targets based on the Angular `application` and `dev-server` builders.
+
+This phase intentionally does not migrate custom webpack features.
+It currently covers the B2B browser application only.
+Server-side rendering and service workers are disabled for the esbuild targets and will be migrated separately.
+Webpack compatibility is not a goal.
+
+## Build and Serve
+
+Build the development configuration:
+
+```bash
+npx ng run intershop-pwa:build-esbuild:development
+```
+
+Start the development server:
+
+```bash
+npm run start:esbuild
+```
+
+Build the production configuration:
+
+```bash
+npm run build:esbuild
+```
+
+Serve the production configuration with the Angular development server:
+
+```bash
+npx ng run intershop-pwa:serve-esbuild:production
+```
+
+Build output is written to `dist/esbuild/browser`.
+Each build replaces the previous output.
+To serve the generated files with SPA fallback, run:
+
+```bash
+npx serve -s dist/esbuild/browser -l 4200
+```
+
+## Implemented Compatibility Changes
+
+- Font URLs no longer use webpack's `~` resolver syntax.
+- Dynamically imported JSON localization files use their default export.
+- Build-time constants required by the browser application are defined by the esbuild target.
+
+## Known Limitations
+
+- The production browser application still expects configuration, locale, and hydration data from SSR. A standalone production CSR deployment is not supported in this phase.
+- The build reports existing Sass `@import` deprecations.
+- The production initial bundle currently exceeds its warning budget.
+- CSS optimization skips selectors that it cannot process.
+
+Both development and production browser builds compile successfully.
+Full production runtime validation will be possible after the SSR target has been migrated.

--- a/docs/guides/esbuild-migration.md
+++ b/docs/guides/esbuild-migration.md
@@ -9,11 +9,11 @@ kb_sync_latest_only
 
 ## Current Scope
 
-The first migration phase provides separate esbuild browser build and development server targets based on the Angular `application` and `dev-server` builders.
+The migration provides separate esbuild browser and server-side rendering targets based on the Angular `application` and `dev-server` builders.
 
-This phase intentionally does not migrate custom webpack features.
-It currently covers the B2B browser application only.
-Server-side rendering and service workers are disabled for the esbuild targets and will be migrated separately.
+The current scope intentionally does not migrate custom webpack features.
+It covers the B2B application only.
+Service workers remain disabled for the esbuild targets.
 Webpack compatibility is not a goal.
 
 ## Build and Serve
@@ -42,7 +42,19 @@ Serve the production configuration with the Angular development server:
 npx ng run intershop-pwa:serve-esbuild:production
 ```
 
-Build output is written to `dist/esbuild/browser`.
+Build the production configuration with server-side rendering:
+
+```bash
+npm run build:ssr:esbuild
+```
+
+Start the generated server-side rendering build:
+
+```bash
+npm run start:ssr:esbuild
+```
+
+Browser output is written to `dist/esbuild/browser` and server output to `dist/esbuild/server`.
 Each build replaces the previous output.
 To serve the generated files with SPA fallback, run:
 
@@ -55,13 +67,17 @@ npx serve -s dist/esbuild/browser -l 4200
 - Font URLs no longer use webpack's `~` resolver syntax.
 - Dynamically imported JSON localization files use their default export.
 - Build-time constants required by the browser application are defined by the esbuild target.
+- The SSR build initializes the existing `SSR` constant separately for its browser and server bundles.
+- The existing Express and Angular `CommonEngine` server is reused with the esbuild output paths.
 
 ## Known Limitations
 
-- The production browser application still expects configuration, locale, and hydration data from SSR. A standalone production CSR deployment is not supported in this phase.
+- A standalone production CSR deployment is not supported because the production application expects configuration, locale, and hydration data from SSR.
+- Custom webpack features and service workers have not been migrated.
 - The build reports existing Sass `@import` deprecations.
 - The production initial bundle currently exceeds its warning budget.
 - CSS optimization skips selectors that it cannot process.
 
-Both development and production browser builds compile successfully.
-Full production runtime validation will be possible after the SSR target has been migrated.
+The production SSR build compiles successfully.
+Runtime rendering, hydration, localization, styling, and the browser console were validated for the English and French home pages.
+The Lighthouse performance baseline and comparison workflows run against the esbuild SSR build.

--- a/package.json
+++ b/package.json
@@ -47,10 +47,12 @@
     "synchronize-lazy-components": "ng g lazy-components",
     "build:watch": "npm run build client -- --watch",
     "build": "node scripts/build-pwa",
+    "build:esbuild": "ng run intershop-pwa:build-esbuild",
     "build:multi": "node scripts/build-multi-pwa",
     "analyze": "npm run build client -- --stats-json && npx webpack-bundle-analyzer --host 0.0.0.0 dist/browser/stats.json dist/browser",
     "serve": "node dist/server/main.js",
     "start": "npm-run-all build serve",
+    "start:esbuild": "ng run intershop-pwa:serve-esbuild",
     "dev:ssr": "ng run intershop-pwa:serve-ssr",
     "xliff": "node scripts/convert-to-xliff.js",
     "audit": "better-npm-audit audit"

--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
     "build:watch": "npm run build client -- --watch",
     "build": "node scripts/build-pwa",
     "build:esbuild": "ng run intershop-pwa:build-esbuild",
+    "build:ssr:esbuild": "ng run intershop-pwa:build-esbuild:production,ssr",
     "build:multi": "node scripts/build-multi-pwa",
     "analyze": "npm run build client -- --stats-json && npx webpack-bundle-analyzer --host 0.0.0.0 dist/browser/stats.json dist/browser",
     "serve": "node dist/server/main.js",
     "start": "npm-run-all build serve",
     "start:esbuild": "ng run intershop-pwa:serve-esbuild",
+    "start:ssr:esbuild": "node dist/esbuild/server/server.mjs",
     "dev:ssr": "ng run intershop-pwa:serve-ssr",
     "xliff": "node scripts/convert-to-xliff.js",
     "audit": "better-npm-audit audit"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "analyze": "npm run build client -- --stats-json && npx webpack-bundle-analyzer --host 0.0.0.0 dist/browser/stats.json dist/browser",
     "serve": "node dist/server/main.js",
     "start": "npm-run-all build serve",
-    "start:esbuild": "ng run intershop-pwa:serve-esbuild",
+    "start:esbuild": "ng serve",
     "start:ssr:esbuild": "node dist/esbuild/server/server.mjs",
     "dev:ssr": "ng run intershop-pwa:serve-ssr",
     "xliff": "node scripts/convert-to-xliff.js",

--- a/server.esbuild.ts
+++ b/server.esbuild.ts
@@ -1,0 +1,9 @@
+import { join } from 'node:path';
+
+globalThis.ngServerMode = true;
+
+process.env.BROWSER_FOLDER ??= join(process.cwd(), 'dist', 'esbuild', 'browser');
+
+process.env.INDEX_FILE ??= join(process.cwd(), 'dist', 'esbuild', 'server', 'index.server.html');
+
+void import('./server').then(({ run }) => run());

--- a/server.ts
+++ b/server.ts
@@ -129,6 +129,8 @@ const DIST_FOLDER = join(process.cwd(), 'dist');
 
 const BROWSER_FOLDER = process.env.BROWSER_FOLDER || join(process.cwd(), 'dist', 'browser');
 
+const INDEX_FILE = process.env.INDEX_FILE || join(BROWSER_FOLDER, 'index.html');
+
 // The Express app is exported so that it can be used by serverless Functions.
 // eslint-disable-next-line complexity
 export function app() {
@@ -518,7 +520,7 @@ export function app() {
     commonEngine
       .render({
         url: `${req.protocol}://${req.headers.host}${req.originalUrl}`,
-        documentFilePath: join(BROWSER_FOLDER, 'index.html'),
+        documentFilePath: INDEX_FILE,
         publicPath: BROWSER_FOLDER,
         inlineCriticalCss: false,
         providers: [
@@ -646,7 +648,7 @@ if (/^(on|1|true|yes)$/i.test(process.env.PROMETHEUS)) {
   });
 }
 
-function run() {
+export function run() {
   const http = require('http');
   http.createServer(app()).listen(PORT);
   collectDefaultMetrics({ prefix: 'pwa_' });
@@ -666,11 +668,11 @@ function run() {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __non_webpack_require__: NodeJS.Require;
 
-const mainModule = __non_webpack_require__.main;
+const mainModule = typeof __non_webpack_require__ === 'undefined' ? undefined : __non_webpack_require__.main;
 
 const moduleFilename = mainModule?.filename || '';
 
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
+if (mainModule && (moduleFilename === __filename || moduleFilename.includes('iisnode'))) {
   run();
 }
 

--- a/src/app/core/internationalization.module.ts
+++ b/src/app/core/internationalization.module.ts
@@ -39,11 +39,11 @@ import { TranslationGenerator } from './utils/translate/translations-generator';
         useFactory: (lang: string) => {
           switch (lang) {
             case 'en_US':
-              return import('../../assets/i18n/en_US.json');
+              return import('../../assets/i18n/en_US.json').then(module => module.default);
             case 'fr_FR':
-              return import('../../assets/i18n/fr_FR.json');
+              return import('../../assets/i18n/fr_FR.json').then(module => module.default);
             case 'de_DE':
-              return import('../../assets/i18n/de_DE.json');
+              return import('../../assets/i18n/de_DE.json').then(module => module.default);
           }
         },
       },

--- a/src/main.server.ts
+++ b/src/main.server.ts
@@ -4,11 +4,17 @@
 import { enableProdMode } from '@angular/core';
 import '@angular/localize/init';
 
+import { AppServerModule } from './app/app.server.module';
+
 if (PRODUCTION_MODE) {
   enableProdMode();
 }
 
-export { AppServerModule } from './app/app.server.module';
+export { AppServerModule };
+
+export default AppServerModule;
+
 export { environment } from './environments/environment';
+
 export { HYBRID_MAPPING_TABLE, ICM_WEB_URL, ICM_CONFIG_MATCH } from './hybrid/default-url-mapping-table';
 export { APP_BASE_HREF } from '@angular/common';

--- a/src/styles/global/fonts/roboto.scss
+++ b/src/styles/global/fonts/roboto.scss
@@ -8,8 +8,8 @@
   src:
     local('Roboto Regular '),
     local('Roboto-Regular'),
-    /*  Super Modern Browsers*/ url('~typeface-roboto/files/roboto-latin-400.woff2') format('woff2'),
-    /* Modern Browsers*/ url('~typeface-roboto/files/roboto-latin-400.woff') format('woff');
+    /*  Super Modern Browsers*/ url('typeface-roboto/files/roboto-latin-400.woff2') format('woff2'),
+    /* Modern Browsers*/ url('typeface-roboto/files/roboto-latin-400.woff') format('woff');
   font-display: swap;
 }
 
@@ -21,8 +21,8 @@
   src:
     local('Roboto Bold '),
     local('Roboto-Bold'),
-    /*  Super Modern Browsers*/ url('~typeface-roboto/files/roboto-latin-700.woff2') format('woff2'),
-    /* Modern Browsers*/ url('~typeface-roboto/files/roboto-latin-700.woff') format('woff');
+    /*  Super Modern Browsers*/ url('typeface-roboto/files/roboto-latin-700.woff2') format('woff2'),
+    /* Modern Browsers*/ url('typeface-roboto/files/roboto-latin-700.woff') format('woff');
   font-display: swap;
 }
 
@@ -34,8 +34,8 @@
   src:
     local('Roboto Condensed Regular '),
     local('Roboto Condensed-Regular'),
-    /*  Super Modern Browsers*/ url('~typeface-roboto-condensed/files/roboto-condensed-latin-400.woff2') format('woff2'),
-    /* Modern Browsers*/ url('~typeface-roboto-condensed/files/roboto-condensed-latin-400.woff') format('woff');
+    /*  Super Modern Browsers*/ url('typeface-roboto-condensed/files/roboto-condensed-latin-400.woff2') format('woff2'),
+    /* Modern Browsers*/ url('typeface-roboto-condensed/files/roboto-condensed-latin-400.woff') format('woff');
   font-display: swap;
 }
 
@@ -47,7 +47,7 @@
   src:
     local('Roboto Condensed Bold '),
     local('Roboto Condensed-Bold'),
-    /*  Super Modern Browsers*/ url('~typeface-roboto-condensed/files/roboto-condensed-latin-700.woff2') format('woff2'),
-    /* Modern Browsers*/ url('~typeface-roboto-condensed/files/roboto-condensed-latin-700.woff') format('woff');
+    /*  Super Modern Browsers*/ url('typeface-roboto-condensed/files/roboto-condensed-latin-700.woff2') format('woff2'),
+    /* Modern Browsers*/ url('typeface-roboto-condensed/files/roboto-condensed-latin-700.woff') format('woff');
   font-display: swap;
 }

--- a/tsconfig.esbuild-ssr.json
+++ b/tsconfig.esbuild-ssr.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "outDir": "./node_modules/.out-tsc/esbuild-ssr",
+    "types": ["node"]
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts",
+    "src/main.server.ts",
+    "server.esbuild.ts"
+  ],
+  "include": ["src/typings.d.ts"]
+}


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements -->

- [x] The PR title follows the Conventional Commits specification.
- [x] The `feature` label indicates the type of the PR.
- [x] The `BREAKING CHANGES` label indicates the changed local development workflow.
- [ ] The migrations guide is fully up to date and reviewed.
- [ ] Unit tests for the changes added/updated (no unit tests added for the build configuration yet).
- [x] Integration/performance workflow updated for the esbuild SSR build.
- [ ] Manual testing performed on a demo system with SSR in the required browsers/devices.
- [x] No new user-facing texts were introduced; localization approval is not applicable.
- [ ] Documentation approved by the documentation team.
- [x] No intended visual changes; VD/IAD approval is not applicable.
- [x] Open checklist tasks are listed in the Open Tasks section.

### 🚀 Description

This draft introduces the first runnable Angular esbuild build path for the Intershop PWA. It provides browser and SSR production builds, localization compatibility, an esbuild-based `ng serve` development workflow, and Lighthouse performance workflow support.

The work intentionally establishes a small, functioning baseline before custom Webpack features are migrated individually. Webpack compatibility is not a goal of the migration.

---

### 🔍 Detailed Changes

- Added an Angular `application` target for esbuild browser and SSR builds.
- Added dedicated npm scripts and output paths under `dist/esbuild`.
- Reused the existing Express and Angular `CommonEngine` server through a small esbuild SSR entry point.
- Adjusted localization JSON imports to consume their default exports with esbuild.
- Replaced Webpack-specific font URL syntax with bundler-independent relative URLs.
- Configured the build-time constants required by browser and server bundles.
- Changed the standard `ng serve` target to use Angular's official dev server with the esbuild application target.
- Removed the redundant `serve-esbuild` target; `npm run start:esbuild` is now an alias for `ng serve`.
- Updated the Lighthouse baseline infrastructure and workflow paths for the esbuild SSR build.
- Added an esbuild migration guide describing the current scope and limitations.

---

### 📝 Notes

- **Breaking development workflow change:** `ng serve` now uses esbuild instead of the Custom Webpack dev server. The PR is therefore labeled `BREAKING CHANGES` for visibility.
- No specific ICM version is required by this migration phase.
- No runtime feature flag is introduced. The production esbuild build remains available through dedicated build scripts.
- The current esbuild scope supports the B2B application only.
- Custom Webpack features, theme/customization replacements, and service workers have not yet been migrated.
- Standalone production CSR deployment is currently unsupported because production expects configuration, localization, and hydration data from SSR.
- Existing Sass deprecations, CSS optimization warnings, and the production bundle-size warning remain visible.
- Local validation covered production browser and SSR builds, English and French localization, styling, browser console checks, SSR responses, and `ng serve` rebuild/live reload.

---

### ✅ Open Tasks

- [ ] Update the migration guide to replace the removed `serve-esbuild:production` command with the current `ng serve` workflow.
- [ ] Decide whether additional automated tests are required for the Angular build configuration.
- [ ] Run and document the required SSR demo-system checks across the relevant browsers/devices.
- [ ] Documentation reviewed and approved by the documentation team.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119311](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119311)