### PR TITLE
docs: add Helm Chart deployment configuration examples for SSO identity provider

### DIFF
--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -81,6 +81,7 @@ hostnames
 hoverable
 iban
 icecat
+identityprovider
 iframes
 iisnode
 includeid

--- a/docs/guides/authentication_sso.md
+++ b/docs/guides/authentication_sso.md
@@ -20,7 +20,7 @@ After setting up the ICM side with the identity provider, an implementation for 
 
 The Intershop PWA contains a working example implementation for SSO with [Auth0](https://auth0.com/) that can be used for B2B and B2C.
 
-For development purposes the configuration can be added to the Angular CLI environment files:
+For development purposes the configuration can be added to the Angular CLI `environment.ts` files:
 
 ```typescript
   identityProvider: 'Auth0',
@@ -36,6 +36,8 @@ For development purposes the configuration can be added to the Angular CLI envir
 For production, this configuration should be provided to the SSR process via environment variables (see [Building and Running Server-Side Rendering][ssr-startup]).
 The usage of identity providers can also be set in the multi-channel configuration (see [Building and Running nginx Docker Image][nginx-startup]).
 
+Example for the Auth0 identity provider configuration via `docker-compose.yaml` file:
+
 ```yaml
 pwa:
   environment:
@@ -45,6 +47,19 @@ pwa:
         type: auth0
         domain: some-domain.auth0.com
         clientID: ASDF12345
+```
+
+Example for the Auth0 identity provider configuration via [PWA Helm Chart](https://github.com/intershop/helm-charts/tree/main/charts/pwa):
+
+```yaml
+environment:
+  - name: IDENTITY_PROVIDER
+    value: 'Auth0'
+  - name: IDENTITY_PROVIDERS
+    value: |
+      {
+        "Auth0": {"type": "auth0", "domain": "some-domain.auth0.com", "clientID": "ASDF12345"}
+      }
 ```
 
 ## SSO with Auth0 for PWA
@@ -72,6 +87,23 @@ Use the configuration fields `domain` and `clientID` for configuring the provide
 | SSO                     | /forgotPassword/updatePassword | Redirect to SSO provider    |
 
 ## Further References
+
+Example for an Auth0 identity provider configuration via [ICM Helm Chart](https://github.com/intershop/helm-charts/tree/main/charts/icm-as):
+
+```yaml
+icm-as:
+  environment:
+    ISH_ENV_IDENTITYPROVIDER: |
+      intershop.identityProvider.remote = supported,
+      intershop.authentication.identityprovider.localICM.type=local,
+      intershop.authentication.identityprovider.auth0.type=oidc,
+      intershop.authentication.identityprovider.auth0.name=Auth0 SSO ICM,
+      intershop.authentication.identityprovider.auth0.configuration={"issuer": "https://some-domain.auth0.com"",""client_id": "ASDF12345"",""client_secret": "53CR37"},
+      intershop.authentication.inSPIRED-inTRONICS-Anonymous.externalname=inTRONICS,
+      intershop.authentication.inSPIRED-inTRONICS-Anonymous.identityproviders=auth0"," localICM,
+      intershop.authentication.inSPIRED-inTRONICS_Business-Anonymous.externalname=inTRONICS-b2b,
+      intershop.authentication.inSPIRED-inTRONICS_Business-Anonymous.identityproviders=auth0"," localICM
+```
 
 - PWA
   - [Concept - Authentication](../concepts/authentication.md)


### PR DESCRIPTION
### 🚀 Description

This pull request adds documentation and configuration examples for integrating Auth0 as an identity provider, including examples for both PWA and ICM Helm charts. It also adds `identityprovider` to the `.vscode/intershop.txt` hostnames file and clarifies references to Angular environment files.

**Documentation improvements for Auth0 identity provider integration:**

* Added example configuration for Auth0 identity provider using `docker-compose.yaml` in `docs/guides/authentication_sso.md`.
* Added example configuration for Auth0 identity provider using the PWA Helm Chart in `docs/guides/authentication_sso.md`.
* Added example configuration for Auth0 identity provider using the ICM Helm Chart in `docs/guides/authentication_sso.md`.
* Clarified that development configuration should be added to Angular CLI `environment.ts` files.

**Other changes:**

* Added `identityprovider` to the `.vscode/intershop.txt` hostnames list.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119328](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119328)