### PR TITLE
fix: prevent console error on product review tab

### DIFF
--- a/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
+++ b/src/app/extensions/rating/shared/product-review-create-dialog/product-review-create-dialog.component.ts
@@ -4,6 +4,7 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { Observable, map, tap } from 'rxjs';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
+import { whenTruthy } from 'ish-core/utils/operators';
 import { ModalDialogComponent } from 'ish-shared/components/common/modal-dialog/modal-dialog.component';
 
 import { ProductReviewsFacade } from '../../facades/product-reviews.facade';
@@ -34,6 +35,7 @@ export class ProductReviewCreateDialogComponent implements OnInit {
           this.modalDialog.hide();
         }
       }),
+      whenTruthy(),
       map(user => ({ authorFirstName: `${user.firstName} ${user.lastName.charAt(0)}.` }))
     );
 


### PR DESCRIPTION
### 🚀 Description

Fixes a console.error introduced by commit [73ba82c](vscode-file://vscode-app/c:/Users/suschneider/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html), where the "Write a Review" dialog did not open for anonymous users on the product reviews page.

---

### 🔍 Detailed Changes

Re-added the `filter(user => !!user)` guard in the `model$` stream of `ProductReviewCreateDialogComponent` to prevent the mapping step from running for anonymous users.

**Root cause:**

In v11.2.0 the dialog content was wrapped in an `<ng-template #modal>`. `<ng-template>` is lazily instantiated — its view (and subscriptions like `model$ | async`) is only created when the template is explicitly rendered via `this.ngbModal.open(this.modalTemplate)` inside `show()`. At that point the user was guaranteed to be logged in, since only logged-in users can trigger `show()`.

In v12.0.0 the content was moved into `<ish-modal-dialog>` via content projection (`<ng-content>`). Angular eagerly instantiates projected content as soon as the host component is created — regardless of whether `ModalDialogComponent` internally wraps it in an `<ng-template>`. As a result, `model$ | async` now subscribes immediately when `ProductReviewCreateDialogComponent` enters the DOM (which happens for *all* users viewing the product reviews section). For anonymous users, `accountFacade.user$` emits `undefined`, causing the subsequent `map(user => ...user.firstName...)` to throw a `TypeError`.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->

[AB#119502](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119502)