### PR TITLE
fix: add configured quantities of retail set products to quote

### DIFF
--- a/src/app/extensions/quoting/shared/product-add-to-quote/product-add-to-quote.component.spec.ts
+++ b/src/app/extensions/quoting/shared/product-add-to-quote/product-add-to-quote.component.spec.ts
@@ -7,6 +7,7 @@ import { instance, mock, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { ProductRetailSet } from 'ish-core/models/product/product.model';
 
 import { ProductAddToQuoteComponent } from './product-add-to-quote.component';
 
@@ -74,5 +75,15 @@ describe('Product Add To Quote Component', () => {
     tick(500);
 
     expect(location.path()).toMatchInlineSnapshot(`"/addProductToQuoteRequest?sku=dummy&quantity=5"`);
+  }));
+
+  it('should route to addToQuote URL with quantity 1 for retail sets', fakeAsync(() => {
+    when(context.get('product')).thenReturn({ type: 'RetailSet' } as ProductRetailSet);
+    fixture.detectChanges();
+    component.addToQuote();
+
+    tick(500);
+
+    expect(location.path()).toMatchInlineSnapshot(`"/addProductToQuoteRequest?sku=dummy&quantity=1"`);
   }));
 });

--- a/src/app/extensions/quoting/shared/product-add-to-quote/product-add-to-quote.component.ts
+++ b/src/app/extensions/quoting/shared/product-add-to-quote/product-add-to-quote.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { ProductHelper } from 'ish-core/models/product/product.model';
 import { GenerateLazyComponent } from 'ish-core/utils/module-loader/generate-lazy-component.decorator';
 
 /**
@@ -38,8 +39,10 @@ export class ProductAddToQuoteComponent implements OnInit {
   }
 
   addToQuote() {
+    const product = this.context.get('product');
+    const quantity = ProductHelper.isRetailSet(product) ? 1 : this.context.get('quantity');
     this.router.navigate(['/addProductToQuoteRequest'], {
-      queryParams: { sku: this.context.get('sku'), quantity: this.context.get('quantity') },
+      queryParams: { sku: this.context.get('sku'), quantity },
     });
   }
 }


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

Clicking “Add to Quote Request” for a retail set passes summed children quantity instead of one set.

When using the “Add to Quote Request” function for retail sets, the product quantities configured in the backend are transferred to the quote.

---

### 🔍 Detailed Changes

`ProductAddToQuoteComponent` detect retail set via `ProductHelper.isRetailSet()`and use quantity 1 for adding retail set to quote.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119524](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119524)