### PR TITLE
feat: forward PAYONE credit card type to ICM

### DIFF
--- a/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.spec.ts
+++ b/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.spec.ts
@@ -56,6 +56,7 @@ describe('Payment Payone Creditcard Component', () => {
     const response = {
       pseudocardpan: 'token',
       truncatedcardpan: '41111XXXX111',
+      cardtype: 'V',
       status: 'VALID',
     };
 
@@ -71,6 +72,7 @@ describe('Payment Payone Creditcard Component', () => {
     const response = {
       pseudocardpan: 'token',
       truncatedcardpan: '41111XXXX111',
+      cardtype: 'V',
       status: 'INVALID',
     };
 

--- a/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.ts
+++ b/src/app/pages/checkout-payment/payment-payone-creditcard/payment-payone-creditcard.component.ts
@@ -82,6 +82,7 @@ export class PaymentPayoneCreditcardComponent implements OnChanges, OnDestroy, O
       status: string;
       pseudocardpan: string;
       truncatedcardpan: string;
+      cardtype: string;
     }) {
       thisComp.submitCallback(response);
     };
@@ -166,12 +167,13 @@ export class PaymentPayoneCreditcardComponent implements OnChanges, OnDestroy, O
   }
 
   // visible-for-testing
-  submitCallback(response: { status: string; pseudocardpan: string; truncatedcardpan: string }) {
+  submitCallback(response: { status: string; pseudocardpan: string; truncatedcardpan: string; cardtype: string }) {
     if (response.status === 'VALID' && !this.payoneCreditCardForm.invalid) {
       this.submitPayment.emit({
         parameters: [
           { name: 'pseudocardpan', value: response.pseudocardpan },
           { name: 'truncatedcardpan', value: response.truncatedcardpan },
+          { name: 'cardtype', value: response.cardtype },
         ],
         saveAllowed: this.paymentMethod.saveAllowed && this.payoneCreditCardForm.get('saveForLater').value,
       });


### PR DESCRIPTION
### 🚀 Description

  - forwarded the cardtype that is send by payone to the icm

- Related Ticket/Issue: Closes #113733

---

### 🔍 Detailed Changes

just added cardtype to the forwarded fields send from payone to icm

### 📝 Notes

nothing special to mention here
---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119525](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119525)

[AB#119526](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119526)