### PR TITLE
refactor: do not show withdrawal verification status in MyAccount

### DIFF
--- a/src/app/pages/account-order/account-order/account-order.component.html
+++ b/src/app/pages/account-order/account-order/account-order.component.html
@@ -71,11 +71,7 @@
             <dt>{{ 'account.orderdetails.withdrawal_status.label' | translate }}</dt>
             <dd data-testing-id="withdrawal-status">
               <span class="badge text-bg-secondary">
-                @if (order.withdrawal?.status === 'CREATED') {
-                  {{ 'withdrawal.status.label.received' | translate }}
-                } @else {
-                  {{ 'withdrawal.status.label.approved' | translate }}
-                }
+                {{ 'withdrawal.status.label.received' | translate }}
               </span>
             </dd>
             @if (order.withdrawal?.withdrawalCreationDate) {

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -1599,6 +1599,5 @@
   "wishlist.table.header.price": "Preis",
   "wishlist.table.options.move_to_another_wishlist": "In andere Liste verschieben",
   "wishlist.table.options.remove": "Entfernen",
-  "withdrawal.status.label.approved": "Genehmigt",
   "withdrawal.status.label.received": "Erhalten"
 }

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -1599,6 +1599,5 @@
   "wishlist.table.header.price": "Price",
   "wishlist.table.options.move_to_another_wishlist": "Move to other list",
   "wishlist.table.options.remove": "Remove",
-  "withdrawal.status.label.approved": "Approved",
   "withdrawal.status.label.received": "Received"
 }

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -1599,6 +1599,5 @@
   "wishlist.table.header.price": "Prix",
   "wishlist.table.options.move_to_another_wishlist": "Déplacer vers une autre liste",
   "wishlist.table.options.remove": "Supprimer",
-  "withdrawal.status.label.approved": "Approuvée",
   "withdrawal.status.label.received": "Reçue"
 }


### PR DESCRIPTION
### 🚀 Description

The withdrawal approval flow (merchant approving a customer's withdrawal request) is not yet fully implemented in ICM. Until it is, there is no value in differentiating between CREATED and VERIFIED withdrawal statuses in the UI. Both states now display withdrawal.status.label.received. This is a temporary frontend-only change that will be reverted once the approval flow is introduced.

The related ADO ticket is #119351.


### 📝 Notes

Based on commit 4e5ae51.
Requires ICM version 14.4.

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119669](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119669)

[AB#119670](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119670)