### PR TITLE
ci(Lighthouse): add performance measurement for mobile without cookie banner

### DIFF
--- a/.github/lighthouse/configurations/performance-mobile-no-banner.lighthouserc.json
+++ b/.github/lighthouse/configurations/performance-mobile-no-banner.lighthouserc.json
@@ -1,0 +1,64 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 5,
+      "puppeteerScript": "./.github/lighthouse/scripts/set-consent-cookie.js",
+      "puppeteerLaunchOptions": {
+        "args": [
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          "--disable-dev-shm-usage",
+          "--disable-gpu",
+          "--disable-background-timer-throttling",
+          "--disable-backgrounding-occluded-windows",
+          "--disable-renderer-backgrounding",
+          "--disable-web-security",
+          "--disable-features=TranslateUI",
+          "--disable-ipc-flooding-protection"
+        ]
+      },
+      "url": [
+        "http://localhost:4200/home",
+        "http://localhost:4200/search/notebook",
+        "http://localhost:4200/computers-ctgComputers",
+        "http://localhost:4200/computers/notebooks-and-pcs/notebooks-ctgComputers.1835.151",
+        "http://localhost:4200/computers/notebooks-and-pcs/notebooks/microsoft-surface-book-2-256gb-152-prd201807231-04-ctgComputers.1835.151",
+        "http://localhost:4200/quick-order",
+        "http://localhost:4200/page/page.helpdesk.pagelet2-Page",
+        "http://localhost:4200/page/page.demodisclaimer",
+        "http://localhost:4200/compare"
+      ],
+      "settings": {
+        "formFactor": "mobile",
+        "throttlingMethod": "devtools",
+        "disableStorageReset": true,
+        "skipAudits": ["uses-http2"],
+        "onlyCategories": ["performance"]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage",
+      "outputDir": ".lighthouseci"
+    }
+  },
+  "pages": {
+    "http://localhost:4200/home": ["Home"],
+    "http://localhost:4200/search/notebook": ["Search"],
+    "http://localhost:4200/computers-ctgComputers": ["Category"],
+    "http://localhost:4200/computers/notebooks-and-pcs/notebooks-ctgComputers.1835.151": [
+      "Product List"
+    ],
+    "http://localhost:4200/computers/notebooks-and-pcs/notebooks/microsoft-surface-book-2-256gb-152-prd201807231-04-ctgComputers.1835.151": [
+      "Product Detail"
+    ],
+    "http://localhost:4200/quick-order": ["Quick Order"],
+    "http://localhost:4200/page/page.helpdesk.pagelet2-Page": ["Helpdesk"],
+    "http://localhost:4200/page/page.demodisclaimer": ["Demo Disclaimer"],
+    "http://localhost:4200/compare": ["Product Comparison"]
+  }
+}

--- a/.github/lighthouse/scripts/lighthouse-performance-baseline.js
+++ b/.github/lighthouse/scripts/lighthouse-performance-baseline.js
@@ -4,15 +4,16 @@ const fs = require('fs');
 
 const { collectUrlScores, formatScore, loadPagesConfiguration, normalizeUrl } = require('./lighthouse-utils');
 
-function renderPagePerformanceTable(pages, deskBase, mobBase) {
-  let md = `| Page | Desktop | Mobile |\n`;
-  md += `|:---|---:|---:|\n`;
+function renderPagePerformanceTable(pages, deskBase, mobBase, mobNoBannerBase) {
+  let md = `| Page | Desktop | Mobile | Mobile (returning user) |\n`;
+  md += `|:---|---:|---:|---:|\n`;
 
   for (const url of Object.keys(pages)) {
     const row = [
       pages[url][0] || normalizeUrl(url),
       formatScore(deskBase.get(url)?.performance, deskBase.get(url)?.reportUrl),
       formatScore(mobBase.get(url)?.performance, mobBase.get(url)?.reportUrl),
+      formatScore(mobNoBannerBase.get(url)?.performance, mobNoBannerBase.get(url)?.reportUrl),
     ];
     md += `| ${row.join(' | ')} |\n`;
   }
@@ -24,10 +25,11 @@ function renderPagePerformanceTable(pages, deskBase, mobBase) {
   const pages = loadPagesConfiguration('.github/lighthouse/configurations/performance-desktop.lighthouserc.json');
   const desktopBaselineScores = collectUrlScores('lighthouse-desktop-baseline');
   const mobileBaselineScores = collectUrlScores('lighthouse-mobile-baseline');
+  const mobileNoBannerBaselineScores = collectUrlScores('lighthouse-mobile-no-banner-baseline');
 
   let body = '### Lighthouse Performance Score\n\n';
 
-  body += renderPagePerformanceTable(pages, desktopBaselineScores, mobileBaselineScores);
+  body += renderPagePerformanceTable(pages, desktopBaselineScores, mobileBaselineScores, mobileNoBannerBaselineScores);
 
   body += '> Click on scores to view detailed Lighthouse reports (links are valid for some days).\n';
   body += '> Detailed reports are also available as workflow artifacts.\n';

--- a/.github/lighthouse/scripts/lighthouse-performance-compare.js
+++ b/.github/lighthouse/scripts/lighthouse-performance-compare.js
@@ -10,9 +10,9 @@ const {
   normalizeUrl,
 } = require('./lighthouse-utils');
 
-function renderPagePerformanceTable(pages, deskBase, deskCurr, mobBase, mobCurr) {
-  let md = `| Page | | Desktop | Δ | | Mobile | Δ |\n`;
-  md += `|:---|---|---:|---:|---|---:|---:|\n`;
+function renderPagePerformanceTable(pages, deskBase, deskCurr, mobBase, mobCurr, mobNoBannerBase, mobNoBannerCurr) {
+  let md = `| Page | | Desktop | Δ | | Mobile | Δ | | Mobile (returning user) | Δ |\n`;
+  md += `|:---|---|---:|---:|---|---:|---:|---|---:|---:|\n`;
 
   for (const url of Object.keys(pages)) {
     const row = [
@@ -23,6 +23,9 @@ function renderPagePerformanceTable(pages, deskBase, deskCurr, mobBase, mobCurr)
       '',
       formatScore(mobCurr.get(url)?.performance, mobCurr.get(url)?.reportUrl),
       formatDelta(mobCurr.get(url)?.performance, mobBase.get(url)?.performance, 3),
+      '',
+      formatScore(mobNoBannerCurr.get(url)?.performance, mobNoBannerCurr.get(url)?.reportUrl),
+      formatDelta(mobNoBannerCurr.get(url)?.performance, mobNoBannerBase.get(url)?.performance, 3),
     ];
     md += `| ${row.join(' | ')} |\n`;
   }
@@ -36,6 +39,8 @@ function renderPagePerformanceTable(pages, deskBase, deskCurr, mobBase, mobCurr)
   const desktopCurrentScores = collectUrlScores('lighthouse-desktop-current');
   const mobileBaselineScores = collectUrlScores('lighthouse-mobile-baseline');
   const mobileCurrentScores = collectUrlScores('lighthouse-mobile-current');
+  const mobileNoBannerBaselineScores = collectUrlScores('lighthouse-mobile-no-banner-baseline');
+  const mobileNoBannerCurrentScores = collectUrlScores('lighthouse-mobile-no-banner-current');
 
   let body = '### Lighthouse Performance Score Comparison\n\n';
 
@@ -44,7 +49,9 @@ function renderPagePerformanceTable(pages, deskBase, deskCurr, mobBase, mobCurr)
     desktopBaselineScores,
     desktopCurrentScores,
     mobileBaselineScores,
-    mobileCurrentScores
+    mobileCurrentScores,
+    mobileNoBannerBaselineScores,
+    mobileNoBannerCurrentScores
   );
 
   body += '> Click on scores to view detailed Lighthouse reports (links are valid for some days).\n';

--- a/.github/lighthouse/scripts/set-consent-cookie.js
+++ b/.github/lighthouse/scripts/set-consent-cookie.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/**
+ * LHCI puppeteer hook: seeds a valid `cookieConsent` cookie before each audit so
+ * the cookie banner is not displayed, measuring the returning/consented-user
+ * experience. Keep the payload in sync with `cookieConsentVersion` and the
+ * configured options in `src/environments/environment.model.ts`.
+ */
+module.exports = async (browser, context) => {
+  const page = await browser.newPage();
+  await page.setCookie({
+    name: 'cookieConsent',
+    // encoded to mirror how the app writes/reads the cookie (CookiesService uses encode/decodeURIComponent)
+    value: encodeURIComponent(JSON.stringify({ enabledOptions: ['required', 'functional', 'tracking'], version: 1 })),
+    url: context.url,
+  });
+  await page.close();
+};

--- a/.github/workflows/lighthouse-performance-baseline.yml
+++ b/.github/workflows/lighthouse-performance-baseline.yml
@@ -65,9 +65,10 @@ jobs:
             curl -sk "$url" >/dev/null
           done
 
-      - name: Run Lighthouse CI performance audits (desktop + mobile)
+      - name: Run Lighthouse CI performance audits (desktop + mobile + mobile no-banner)
         env:
           LHCI_COLLECT__CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: |
           echo "Lighthouse CI (desktop)"
           npx lhci autorun --config=.github/lighthouse/configurations/performance-desktop.lighthouserc.json
@@ -77,6 +78,10 @@ jobs:
           npx lhci autorun --config=.github/lighthouse/configurations/performance-mobile.lighthouserc.json
           mv .lighthouseci lighthouse-mobile-baseline
 
+          echo "Lighthouse CI (mobile, no cookie banner)"
+          npx lhci autorun --config=.github/lighthouse/configurations/performance-mobile-no-banner.lighthouserc.json
+          mv .lighthouseci lighthouse-mobile-no-banner-baseline
+
       - name: Upload baseline Lighthouse reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -85,6 +90,7 @@ jobs:
           path: |
             lighthouse-desktop-baseline
             lighthouse-mobile-baseline
+            lighthouse-mobile-no-banner-baseline
           if-no-files-found: warn
 
       - name: Generate performance baseline markdown

--- a/.github/workflows/lighthouse-performance-compare.yml
+++ b/.github/workflows/lighthouse-performance-compare.yml
@@ -66,9 +66,10 @@ jobs:
             curl -sk "$url" >/dev/null
           done
 
-      - name: Run Lighthouse CI performance audits (desktop + mobile)
+      - name: Run Lighthouse CI performance audits (desktop + mobile + mobile no-banner)
         env:
           LHCI_COLLECT__CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: |
           echo "Lighthouse CI (desktop)"
           npx lhci autorun --config=.github/lighthouse/configurations/performance-desktop.lighthouserc.json
@@ -78,6 +79,10 @@ jobs:
           npx lhci autorun --config=.github/lighthouse/configurations/performance-mobile.lighthouserc.json
           mv .lighthouseci lighthouse-mobile-current
 
+          echo "Lighthouse CI (mobile, no cookie banner)"
+          npx lhci autorun --config=.github/lighthouse/configurations/performance-mobile-no-banner.lighthouserc.json
+          mv .lighthouseci lighthouse-mobile-no-banner-current
+
       - name: Upload current Lighthouse reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -86,6 +91,7 @@ jobs:
           path: |
             lighthouse-desktop-current
             lighthouse-mobile-current
+            lighthouse-mobile-no-banner-current
           if-no-files-found: warn
 
       - name: Download baseline Lighthouse reports


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

This pull request expands the Lighthouse CI performance auditing setup to include a new "mobile, no cookie banner" scenario, which simulates a returning or consented user by pre-seeding the cookie consent. The changes ensure that both the baseline and comparison workflows run and report on this scenario, and update the reporting scripts to include the new results in the generated markdown tables.

These changes provide better visibility into the performance impact of the cookie banner and help track user experience improvements for returning/consented users.

**The realism caveat you should know about**
The returning user (no-banner) column isn't a pure "same page minus banner" isolation. To keep the consent cookie alive through Lighthouse's storage wipe, that config also has disableStorageReset: true, which additionally preserves cache/storage across the 5 runs. So it measures a returning user with a warmer cache, not solely "banner removed." That's actually a fair representation of a real returning visitor — but it means a few of those extra points come from cache warmth, not the banner alone.

<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

---

### 🔍 Detailed Changes

**Lighthouse CI Configuration and Workflow Updates:**

* Added `.github/lighthouse/configurations/performance-mobile-no-banner.lighthouserc.json` to define a new Lighthouse CI configuration for mobile audits with the cookie consent banner suppressed, targeting the returning/consented user experience.
* Updated both `lighthouse-performance-baseline.yml` and `lighthouse-performance-compare.yml` workflows to run this new configuration, store results in `lighthouse-mobile-no-banner-baseline` and `lighthouse-mobile-no-banner-current`, and upload them as artifacts. [[1]](diffhunk://#diff-7bdbe5407eb91952b1c7a606101c16ba92664ad56ed395760cc81dab9d17ea19L59-R62) [[2]](diffhunk://#diff-7bdbe5407eb91952b1c7a606101c16ba92664ad56ed395760cc81dab9d17ea19R72-R75) [[3]](diffhunk://#diff-7bdbe5407eb91952b1c7a606101c16ba92664ad56ed395760cc81dab9d17ea19R84) [[4]](diffhunk://#diff-ad0ef1e77eb9dab0787c947befad817d320e6f15300ffcb4991fb9e8fafe3a55L60-R63) [[5]](diffhunk://#diff-ad0ef1e77eb9dab0787c947befad817d320e6f15300ffcb4991fb9e8fafe3a55R73-R76) [[6]](diffhunk://#diff-ad0ef1e77eb9dab0787c947befad817d320e6f15300ffcb4991fb9e8fafe3a55R85)

**Cookie Consent Automation:**

* Added `.github/lighthouse/scripts/set-consent-cookie.js`, a Puppeteer script that seeds the `cookieConsent` cookie before each audit to suppress the cookie banner, ensuring performance measurements reflect a returning/consented user.

**Reporting Script Enhancements:**

* Updated `.github/lighthouse/scripts/lighthouse-performance-baseline.js` and `.github/lighthouse/scripts/lighthouse-performance-compare.js` to include the "Mobile (returning user)" column in the markdown tables, showing scores and deltas for the new scenario. [[1]](diffhunk://#diff-d093b0497963261596921fb18fcc8711cbf774a9b26dbe461d2f17a3afad4010L7-R16) [[2]](diffhunk://#diff-d093b0497963261596921fb18fcc8711cbf774a9b26dbe461d2f17a3afad4010R28-R32) [[3]](diffhunk://#diff-b8d52866d424ddd979fbfabc454c90015a286b61824c2d61f085ec7b963811abL13-R15) [[4]](diffhunk://#diff-b8d52866d424ddd979fbfabc454c90015a286b61824c2d61f085ec7b963811abR26-R28) [[5]](diffhunk://#diff-b8d52866d424ddd979fbfabc454c90015a286b61824c2d61f085ec7b963811abR42-R43) [[6]](diffhunk://#diff-b8d52866d424ddd979fbfabc454c90015a286b61824c2d61f085ec7b963811abL47-R54)

---

### 📝 Notes

Why is it useful to measure performance for the first-visit and the returning user experience in mobile?

**Why to measure the first-visit experience?**
Google's Core Web Vitals field data (CrUX) — the numbers that actually affect ranking — are collected from real users, -including first-time visitors who see the banner. If the banner is your field LCP, hiding it in the lab means your green lab score diverges from the field data Google penalizes you on.
It can mask the actual problem. The banner-as-LCP finding is itself a genuine performance issue for new visitors. If you suppress it and stop looking, you've hidden the very thing worth fixing.

**Why to measure the returning user experience**
Most real users navigating the shop have already consented — the banner appears once, then not again for a year — so the consented state is the representative steady-state for the majority of page views. And the whole point of your LHCI runs is to catch when your code/content/images regress across PRs. If a one-time overlay dominates LCP, your metric is measuring the banner, not the page, and it masks real regressions in the actual content. Suppressing it gives a cleaner, more stable, more actionable signal. Consistent across runs = fair

<!-- Anything important that is not obvious from the code itself

  - Breaking changes?
  - Required ICM version?
  - Migrations required?
  - Feature flags / configuration changes?
  - Known limitations?
-->

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team
- [ ] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119705](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119705)

[AB#119729](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119729)