### PR TITLE
perf: render cookie banner during SSR to improve mobile LCP

### DIFF
--- a/e2e/cypress/e2e/specs/system/cookie-consent.b2c.e2e-spec.ts
+++ b/e2e/cypress/e2e/specs/system/cookie-consent.b2c.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('Cookie Consent', () => {
 
     it('should see cookie banner', () => {
       at(HomePage, () => {
-        cy.get('.cookies-banner').should('contain', 'cookies');
+        cy.get('.cookies-banner').should('be.visible').and('contain', 'cookies');
       });
     });
 
@@ -22,7 +22,7 @@ describe('Cookie Consent', () => {
         cy.getCookies().then(cookies => {
           expect(cookies[cookies.length - 1]).to.have.property('name', 'cookieConsent');
           cy.wait(500);
-          cy.get('.cookies-banner').should('not.exist');
+          cy.get('.cookies-banner').should('not.be.visible');
         });
       });
     });

--- a/src/app/shell/application/cookies-banner/cookies-banner.component.html
+++ b/src/app/shell/application/cookies-banner/cookies-banner.component.html
@@ -1,43 +1,44 @@
-@if (showBanner) {
-  <div
-    class="cookies-banner"
-    role="region"
-    [attr.aria-label]="'cookies.banner.title' | translate"
-    [class.bottom-out]="transitionBanner === 'bottom-out'"
-    (transitionend)="setCookiesConsent($event)"
-  >
-    <div class="d-lg-flex justify-content-between align-items-center">
-      <div class="cookies-banner-text" [ishServerHtml]="'cookies.banner.text' | translate"></div>
-      <div class="d-md-flex flex-nowrap justify-content-end">
-        <!-- Accept All -->
-        <button
-          class="btn btn-light text-nowrap ms-lg-2"
-          data-testing-id="acceptAllButton"
-          type="button"
-          [title]="'cookies.banner.accept_all.tooltip' | translate"
-          (click)="acceptAll()"
-        >
-          {{ 'cookies.banner.accept_all' | translate }}
-        </button>
-        <!-- Accept Essential -->
-        <button
-          class="btn btn-outline-light text-nowrap me-lg-0"
-          type="button"
-          [title]="'cookies.banner.accept_only_required.tooltip' | translate"
-          (click)="acceptOnlyRequired()"
-        >
-          {{ 'cookies.banner.accept_only_required' | translate }}
-        </button>
-        <!-- Set Preferences -->
-        <button
-          class="btn btn-link text-nowrap me-lg-0"
-          routerLink="/cookies"
-          type="button"
-          [title]="'cookies.banner.set_preferences.tooltip' | translate"
-        >
-          {{ 'cookies.banner.set_preferences' | translate }}
-        </button>
-      </div>
+<div
+  class="cookies-banner"
+  role="region"
+  [attr.aria-label]="'cookies.banner.title' | translate"
+  [class.bottom-out]="transitionBanner === 'bottom-out'"
+  (transitionend)="setCookiesConsent($event)"
+>
+  <div class="d-lg-flex justify-content-between align-items-center">
+    <div class="cookies-banner-text" [ishServerHtml]="'cookies.banner.text' | translate"></div>
+    <div class="d-md-flex flex-nowrap justify-content-end">
+      <!-- Accept All -->
+      <button
+        class="btn btn-light text-nowrap ms-lg-2"
+        data-testing-id="acceptAllButton"
+        type="button"
+        [disabled]="!interactive()"
+        [title]="'cookies.banner.accept_all.tooltip' | translate"
+        (click)="acceptAll()"
+      >
+        {{ 'cookies.banner.accept_all' | translate }}
+      </button>
+      <!-- Accept Essential -->
+      <button
+        class="btn btn-outline-light text-nowrap me-lg-0"
+        type="button"
+        [disabled]="!interactive()"
+        [title]="'cookies.banner.accept_only_required.tooltip' | translate"
+        (click)="acceptOnlyRequired()"
+      >
+        {{ 'cookies.banner.accept_only_required' | translate }}
+      </button>
+      <!-- Set Preferences -->
+      <button
+        class="btn btn-link text-nowrap me-lg-0"
+        routerLink="/cookies"
+        type="button"
+        [disabled]="!interactive()"
+        [title]="'cookies.banner.set_preferences.tooltip' | translate"
+      >
+        {{ 'cookies.banner.set_preferences' | translate }}
+      </button>
     </div>
   </div>
-}
+</div>

--- a/src/app/shell/application/cookies-banner/cookies-banner.component.ts
+++ b/src/app/shell/application/cookies-banner/cookies-banner.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectionStrategy, Component, OnInit, TransferState } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Inject,
+  OnInit,
+  Renderer2,
+  TransferState,
+  afterNextRender,
+  signal,
+} from '@angular/core';
 
 import { COOKIE_CONSENT_VERSION } from 'ish-core/configurations/state-keys';
 import { CookieConsentSettings } from 'ish-core/models/cookies/cookies.model';
@@ -6,6 +16,10 @@ import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
 
 /**
  * Cookies Banner Component
+ *
+ * The banner markup is always rendered (also during SSR) but kept hidden by default. It is revealed via the
+ * 'show-cookie-banner' root class, which is set pre-hydration by an inline script in index.html when no consent
+ * cookie exists, so first-time visitors see the banner at FCP instead of waiting for Angular to bootstrap.
  */
 @Component({
   selector: 'ish-cookies-banner',
@@ -14,32 +28,39 @@ import { CookiesService } from 'ish-core/utils/cookies/cookies.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CookiesBannerComponent implements OnInit {
-  showBanner = false;
   transitionBanner: string = undefined;
+  // The banner buttons require client-side JS, so they stay disabled until the component hydrates.
+  protected interactive = signal(false);
   private cookiesConsentFor: string[] = undefined;
 
   constructor(
     private transferState: TransferState,
-    private cookiesService: CookiesService
-  ) {}
+    private cookiesService: CookiesService,
+    private renderer: Renderer2,
+    @Inject(DOCUMENT) private document: Document
+  ) {
+    afterNextRender(() => this.interactive.set(true));
+  }
 
   ngOnInit() {
-    this.showBannerIfNecessary();
+    this.reconcileBannerVisibility();
   }
 
   /**
-   * show banner if:
-   * - consent not yet given
-   * - consent outdated
+   * Reconcile the pre-hydration reveal with the authoritative consent version:
+   * show if consent is missing or outdated, otherwise hide.
    */
-  private showBannerIfNecessary() {
+  private reconcileBannerVisibility() {
     if (!SSR) {
       const cookieConsentSettings = JSON.parse(
         this.cookiesService.get('cookieConsent') || 'null'
       ) as CookieConsentSettings;
       const cookieConsentVersion = this.transferState.get<number>(COOKIE_CONSENT_VERSION, 1);
-      if (!cookieConsentSettings || cookieConsentSettings.version < cookieConsentVersion) {
-        this.showBanner = true;
+      const showBanner = !cookieConsentSettings || cookieConsentSettings.version < cookieConsentVersion;
+      if (showBanner) {
+        this.renderer.addClass(this.document.documentElement, 'show-cookie-banner');
+      } else {
+        this.renderer.removeClass(this.document.documentElement, 'show-cookie-banner');
       }
     }
   }

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,12 @@
     <link href="assets/themes/b2b/img/logo_apple_167x167.png" rel="apple-touch-icon" sizes="167x167" />
     <link href="assets/themes/b2b/manifest.webmanifest" rel="manifest" />
     <meta content="#006b99" name="theme-color" />
+    <!-- Reveal the SSR-rendered cookies banner at FCP when no consent cookie exists yet; see the cookies-banner component. -->
+    <script>
+      if (!/(?:^|; )cookieConsent=/.test(document.cookie)) {
+        document.documentElement.classList.add('show-cookie-banner');
+      }
+    </script>
   </head>
   <body>
     <ish-root>Intershop Progressive Web App is loading ...</ish-root>

--- a/src/styles/components/cookies.scss
+++ b/src/styles/components/cookies.scss
@@ -2,6 +2,9 @@
   position: fixed;
   bottom: 0;
   z-index: 1000;
+
+  // hidden by default; revealed pre-hydration via the root class set in index.html when no consent cookie exists
+  display: none;
   width: 100%;
   padding: $space-default $space-default $space-default * 0.5;
   color: $text-color-inverse;
@@ -35,6 +38,10 @@
       width: 100%;
     }
   }
+}
+
+.show-cookie-banner .cookies-banner {
+  display: block;
 }
 
 .cookies-modal {


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

The cookie consent banner is the Largest Contentful Paint (LCP) element on many mobile pages. Previously it was client‑only (rendered after Angular bootstrapped/hydrated), so it appeared at ~8–9s on mobile while FCP was ~2–3s. This hurt LCP on every banner‑dominated page for first‑time visitors and lead to a bad lighthouse performance scores.

Now we render the real cookie banner during SSR but keep it hidden, then a tiny inline script in reveals it at FCP for visitors without a consent cookie — moving the banner's paint from ~8s (post‑hydration) to FCP with no cache fragmentation. Its buttons render disabled during SSR and are enabled once hydrated, so a pre‑hydration click gives clear "not ready" feedback instead of silently failing.

<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

---

### 🔍 Detailed Changes

Render the real banner during server‑side rendering, hidden by default, and reveal it before hydration for new visitors.

- App shell HTML: added a tiny inline script in the document head that adds a "show cookie banner" class to the root html element when no consent cookie exists. It runs at parse time, so the banner is revealed at first contentful paint.
- Cookies styles: the banner is now hidden by default and only shown when that root class is present. Consented visitors never see it and get no layout or LCP cost; the served HTML stays byte‑identical for everyone, so there is no cache fragmentation.
- Banner component: the markup now always renders (the client‑only condition was removed); a browser‑side reconcile step compares the pre‑hydration reveal against the authoritative consent version and shows the banner only if consent is missing or outdated. It reuses the existing component, so localization, theming and consent‑write logic are unchanged — a single source of truth.
- Buttons disabled until interactive: because the buttons need client‑side JavaScript, they render disabled during SSR and are enabled once the component has hydrated. This turns a confusing dead click during the pre‑hydration window into clear not‑ready feedback, and the server and initial client DOM match so there is no hydration mismatch.
- E2E: updated the cookie‑consent assertions since the banner is now always in the DOM (checking it is not visible instead of not present).
---

### 📝 Notes

Pending Tasks:

- CSP note for adopters: the inline reveal script is fine with the default (no CSP) setup; hardened or PCI deployments using a strict script‑src would need to whitelist it via a hash or externalize it.
- Separate follow‑up: the image‑LCP pages (home, category, product detail, demo disclaimer) need their own optimization (fetch priority, preload, avoid lazy‑loading the hero image) — not part of this change.
- Minor UX: disabled buttons briefly show the framework's reduced opacity during the pre‑hydration window; this can be overridden in the banner styles if undesired.
-  Migration note

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team
- [ ] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#119752](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119752)

[AB#119776](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119776)