### PR TITLE
fix: add `ADDITIONAL_HEADERS` to error responses as well (e.g. CSP headers)

### DIFF
--- a/nginx/templates/add-header.conf.tmpl
+++ b/nginx/templates/add-header.conf.tmpl
@@ -4,6 +4,6 @@
 
 {{- range $headers }}
   {{- range $key, $val := (.) }}
-    add_header {{ $key }} "{{ $val }}";
+    add_header {{ $key }} "{{ $val }}" always;
   {{- end}}
 {{- end }}


### PR DESCRIPTION


* without this fix e.g. CSP headers are not set to error responses

<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

The `add_header` directive of the `ADDITIONAL_HEADERS` implementation in nginx only applies to successful responses (2xx and 3xx) by default. To include 4xx/5xx responses, you need the `always` keyword.

---

### 🔍 Detailed Changes

Now the additional headers (e.g. CSP, HSTS, etc.) will also be sent on 4xx and 5xx responses.

The `always` keyword is the correct approach for security headers like CSP, HSTS, X-Frame-Options, etc. — you want those on every response regardless of status code. Without it, a 404 or 500 page could be missing security headers, which is exactly the kind of gap attackers look for.

The only theoretical concern would be if you had a header that should intentionally differ on error pages, but that's not a realistic scenario for the generic additional-headers mechanism here.

---

### 📝 Notes

This missing functionality is the reason why the quick fix for #2156 only works for deployments without multi channel configuration.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120007](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120007)