### PR TITLE
fix: sanitize hash character in product variation slugs

### DIFF
--- a/src/app/core/routing/product/product.route.spec.ts
+++ b/src/app/core/routing/product/product.route.spec.ts
@@ -105,12 +105,13 @@ describe('Product Route', () => {
           { value: 'SSD - (HDD)' },
           { value: 'Cobalt Blue & Yellow' },
           { value: '500 r/min' },
+          { value: 'RED (#FF0000)' },
         ],
       } as VariationProduct);
 
       it('should include attribute values in slug when product is a variation', () => {
         expect(generateProductUrl(product, undefined)).toMatchInlineSnapshot(
-          `"/some-example-name-ssd-hdd-cobalt-blue-yellow-500-r/min-prdA"`
+          `"/some-example-name-ssd-hdd-cobalt-blue-yellow-500-r/min-red-ff0000-prdA"`
         );
       });
     });

--- a/src/app/core/utils/routing.ts
+++ b/src/app/core/utils/routing.ts
@@ -34,7 +34,7 @@ export function addGlobalGuard(
  * RegEx that finds reserved characters that should not be contained in non functional parts of routes/URLs (e.g product slugs for SEO)
  */
 // not-dead-code
-export const reservedCharactersRegEx = /[ &()=%]/g;
+export const reservedCharactersRegEx = /[ &()=%#]/g;
 
 /**
  * Sanitize slug data (remove reserved characters, clean up obsolete '-', lower case, capitalize identifiers)


### PR DESCRIPTION
### 🚀 Description

Variation attribute values containing a hash (e.g. color codes like "#FF0000") leaked the raw `#` into the generated SEO product slug. The browser interpreted everything after the `#` as a URL fragment, so the path no longer contained the `prd<SKU>` segment and the product route matcher failed to resolve the product.

---

### 🔍 Detailed Changes

Switching product variations whose attribute value contains a `#` (for example color codes such as `#FF0000`) produced a broken URL. The raw `#` ended up in the SEO slug, e.g.: `https://<server>/mastersku-red-#ff0000-variationsku` where the browser treats `#ff0000-variationsku` as a URL fragment, so the router only sees the path up to `...red-`. That path no longer
contains the `prd<SKU>` segment, the product route matcher fails, and the product does not load.

The `#` is added to `reservedCharactersRegEx` so it is normalized to `-` during slug sanitization. 

The slug is purely decorative (SEO); the product is resolved from the `prd<SKU>` segment, which is now preserved.

---

### 📝 Notes

Why not percent-encode to `%23` instead?

- The slug pipeline is deliberately normalized (lowercase, dashes, reserved characters stripped); injecting `%`-encoded sequences fights that design.
- `sanitizeSlugData` already strips `%`, so encoding before sanitizing would corrupt the value.
- Stripping `#` is consistent with the existing handling of `&()=%` and spaces, and requires no special-casing.

---

### ✅ Open Tasks

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120041](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120041)