### PR TITLE
fix: use quantity one for add to order template of a retail set

### DIFF
--- a/src/app/extensions/order-templates/shared/product-add-to-order-template/product-add-to-order-template.component.spec.ts
+++ b/src/app/extensions/order-templates/shared/product-add-to-order-template/product-add-to-order-template.component.spec.ts
@@ -5,6 +5,7 @@ import { anyNumber, anyString, instance, mock, verify, when } from 'ts-mockito';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { ProductRetailSet } from 'ish-core/models/product/product.model';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
 import { SelectOrderTemplateModalComponent } from '../select-order-template-modal/select-order-template-modal.component';
@@ -17,6 +18,7 @@ describe('Product Add To Order Template Component', () => {
   let element: HTMLElement;
   let orderTemplateFacade: OrderTemplatesFacade;
   let accountFacade: AccountFacade;
+  let productContext: ProductContextFacade;
 
   const orderTemplateDetails = [
     {
@@ -43,9 +45,9 @@ describe('Product Add To Order Template Component', () => {
     orderTemplateFacade = mock(OrderTemplatesFacade);
     when(orderTemplateFacade.orderTemplates$).thenReturn(of(orderTemplateDetails));
     accountFacade = mock(AccountFacade);
-    const productContext = mock(ProductContextFacade);
+    productContext = mock(ProductContextFacade);
     when(productContext.get('sku')).thenReturn('test sku');
-    when(productContext.get('quantity')).thenReturn(1);
+    when(productContext.get('quantity')).thenReturn(5);
 
     await TestBed.configureTestingModule({
       declarations: [MockComponent(SelectOrderTemplateModalComponent), ProductAddToOrderTemplateComponent],
@@ -79,5 +81,19 @@ describe('Product Add To Order Template Component', () => {
     fixture.detectChanges();
     component.addProductToOrderTemplate({ id: undefined, title: 'Test Order Template' });
     verify(orderTemplateFacade.addProductToNewOrderTemplate(anyString(), anyString(), anyNumber())).once();
+  });
+
+  it('should call orderTemplateFacade to add retail set product with quantity 1 to order template', () => {
+    when(productContext.get('product')).thenReturn({ type: 'RetailSet' } as ProductRetailSet);
+    fixture.detectChanges();
+    component.addProductToOrderTemplate({ id: 'testid', title: 'Test Order Template' });
+    verify(orderTemplateFacade.addProductToOrderTemplate('testid', 'test sku', 1)).once();
+  });
+
+  it('should call orderTemplateFacade to add retail set product with quantity 1 to new order template', () => {
+    when(productContext.get('product')).thenReturn({ type: 'RetailSet' } as ProductRetailSet);
+    fixture.detectChanges();
+    component.addProductToOrderTemplate({ id: undefined, title: 'Test Order Template' });
+    verify(orderTemplateFacade.addProductToNewOrderTemplate('Test Order Template', 'test sku', 1)).once();
   });
 });

--- a/src/app/extensions/order-templates/shared/product-add-to-order-template/product-add-to-order-template.component.ts
+++ b/src/app/extensions/order-templates/shared/product-add-to-order-template/product-add-to-order-template.component.ts
@@ -6,6 +6,7 @@ import { take } from 'rxjs/operators';
 
 import { AccountFacade } from 'ish-core/facades/account.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
+import { ProductHelper } from 'ish-core/models/product/product.model';
 import { GenerateLazyComponent } from 'ish-core/utils/module-loader/generate-lazy-component.decorator';
 
 import { OrderTemplatesFacade } from '../../facades/order-templates.facade';
@@ -65,18 +66,12 @@ export class ProductAddToOrderTemplateComponent implements OnInit {
   }
 
   addProductToOrderTemplate(orderTemplate: { id: string; title: string }) {
+    const product = this.context.get('product');
+    const quantity = ProductHelper.isRetailSet(product) ? 1 : this.context.get('quantity');
     if (!orderTemplate.id) {
-      this.orderTemplatesFacade.addProductToNewOrderTemplate(
-        orderTemplate.title,
-        this.context.get('sku'),
-        this.context.get('quantity')
-      );
+      this.orderTemplatesFacade.addProductToNewOrderTemplate(orderTemplate.title, this.context.get('sku'), quantity);
     } else {
-      this.orderTemplatesFacade.addProductToOrderTemplate(
-        orderTemplate.id,
-        this.context.get('sku'),
-        this.context.get('quantity')
-      );
+      this.orderTemplatesFacade.addProductToOrderTemplate(orderTemplate.id, this.context.get('sku'), quantity);
     }
   }
 }


### PR DESCRIPTION
### 🚀 Description

Clicking “Add to Order Template” for a retail set passes summed children quantity instead of one set.

When using the “Add to Order Template” function for retail sets, the product quantities configured in the backend are transferred to the quote.

---

### 🔍 Detailed Changes

`ProductAddToOrderTemplateComponent` detect retail set via `ProductHelper.isRetailSet()`and use quantity 1 for adding retail set to order template.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120071](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120071)