### PR TITLE
ci(Lighthouse): use trusted certificates for Lighthouse performance tests

### DIFF
--- a/.github/lighthouse/configurations/performance-desktop.lighthouserc.json
+++ b/.github/lighthouse/configurations/performance-desktop.lighthouserc.json
@@ -15,7 +15,7 @@
       ],
       "settings": {
         "preset": "desktop",
-        "chromeFlags": "--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu --headless=new --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-web-security --disable-features=TranslateUI --disable-ipc-flooding-protection --allow-insecure-localhost",
+        "chromeFlags": "--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu --headless=new --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-web-security --disable-features=TranslateUI --disable-ipc-flooding-protection",
         "onlyCategories": ["performance"]
       }
     },

--- a/.github/lighthouse/configurations/performance-mobile.lighthouserc.json
+++ b/.github/lighthouse/configurations/performance-mobile.lighthouserc.json
@@ -16,7 +16,7 @@
       "settings": {
         "formFactor": "mobile",
         "throttlingMethod": "devtools",
-        "chromeFlags": "--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu --headless=new --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-web-security --disable-features=TranslateUI --disable-ipc-flooding-protection --allow-insecure-localhost",
+        "chromeFlags": "--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu --headless=new --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-web-security --disable-features=TranslateUI --disable-ipc-flooding-protection",
         "onlyCategories": ["performance"]
       }
     },

--- a/.github/lighthouse/scripts/setup-trusted-certificate.sh
+++ b/.github/lighthouse/scripts/setup-trusted-certificate.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+certificate_directory="${GITHUB_WORKSPACE:-$(pwd)}/.github/lighthouse/certs"
+nss_database="sql:${HOME}/.pki/nssdb"
+temporary_directory="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${temporary_directory}"
+}
+trap cleanup EXIT
+
+mkdir -p "${certificate_directory}" "${HOME}/.pki/nssdb"
+rm -f "${certificate_directory}"/*
+
+openssl req -quiet -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
+  -keyout "${temporary_directory}/ca-key.pem" \
+  -out "${certificate_directory}/ca-cert.pem" \
+  -subj '/CN=Intershop Lighthouse CI CA' \
+  -addext 'basicConstraints=critical,CA:TRUE' \
+  -addext 'keyUsage=critical,keyCertSign,cRLSign' \
+  -addext 'subjectKeyIdentifier=hash'
+
+openssl req -quiet -new -newkey rsa:2048 -sha256 -nodes \
+  -keyout "${certificate_directory}/key.pem" \
+  -out "${temporary_directory}/server.csr" \
+  -subj '/CN=localhost'
+
+cat >"${temporary_directory}/server.ext" <<'EOF'
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+EOF
+
+openssl x509 -req -sha256 -days 1 \
+  -in "${temporary_directory}/server.csr" \
+  -CA "${certificate_directory}/ca-cert.pem" \
+  -CAkey "${temporary_directory}/ca-key.pem" \
+  -CAcreateserial \
+  -out "${certificate_directory}/cert.pem" \
+  -extfile "${temporary_directory}/server.ext"
+
+openssl verify \
+  -CAfile "${certificate_directory}/ca-cert.pem" \
+  -verify_hostname localhost \
+  "${certificate_directory}/cert.pem"
+
+# Trust the temporary CA for command-line clients using Ubuntu's system store.
+sudo cp "${certificate_directory}/ca-cert.pem" \
+  /usr/local/share/ca-certificates/intershop-lighthouse-ci-ca.crt
+sudo update-ca-certificates
+
+# Chrome on Linux reads locally administered roots from the user's NSS database.
+if [[ ! -f "${HOME}/.pki/nssdb/cert9.db" ]]; then
+  certutil -N --empty-password -d "${nss_database}"
+fi
+
+certutil -D -d "${nss_database}" -n 'Intershop Lighthouse CI CA' 2>/dev/null || true
+certutil -A \
+  -d "${nss_database}" \
+  -n 'Intershop Lighthouse CI CA' \
+  -t 'C,,' \
+  -i "${certificate_directory}/ca-cert.pem"
+
+certutil -V \
+  -d "${nss_database}" \
+  -n 'Intershop Lighthouse CI CA' \
+  -u L

--- a/.github/workflows/lighthouse-performance-baseline.yml
+++ b/.github/workflows/lighthouse-performance-baseline.yml
@@ -41,14 +41,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate self-signed TLS certificate for HTTP/2
+      - name: Install certificate trust tooling
         run: |
-          mkdir -p .github/lighthouse/certs
-          openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
-            -keyout .github/lighthouse/certs/key.pem \
-            -out .github/lighthouse/certs/cert.pem \
-            -days 365 -subj '/CN=localhost' \
-            -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+          sudo apt-get update
+          sudo apt-get install --yes libnss3-tools
+
+      - name: Generate and trust TLS certificate for HTTP/2
+        run: bash .github/lighthouse/scripts/setup-trusted-certificate.sh
 
       - name: Run docker compose to start SSR and nginx
         uses: hoverkraft-tech/compose-action@v3
@@ -62,8 +61,23 @@ jobs:
           urls=$(jq -r '.ci.collect.url[]' .github/lighthouse/configurations/performance-desktop.lighthouserc.json)
           for url in $urls; do
             echo "Warming up $url"
-            curl -sk "$url" >/dev/null
+            curl --fail --silent --show-error "$url" >/dev/null
           done
+
+      - name: Verify trusted Chrome HTTPS and HTTP/2
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        run: |
+          http_version=$(curl --fail --silent --show-error --output /dev/null --write-out '%{http_version}' https://localhost:4200/home)
+          test "$http_version" = '2'
+
+          "$CHROME_PATH" \
+            --headless=new \
+            --no-sandbox \
+            --disable-dev-shm-usage \
+            --dump-dom \
+            https://localhost:4200/home >chrome-home.html
+          grep --quiet '<ish-root' chrome-home.html
 
       - name: Run Lighthouse CI performance audits (desktop + mobile)
         env:

--- a/.github/workflows/lighthouse-performance-compare.yml
+++ b/.github/workflows/lighthouse-performance-compare.yml
@@ -42,14 +42,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate self-signed TLS certificate for HTTP/2
+      - name: Install certificate trust tooling
         run: |
-          mkdir -p .github/lighthouse/certs
-          openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
-            -keyout .github/lighthouse/certs/key.pem \
-            -out .github/lighthouse/certs/cert.pem \
-            -days 365 -subj '/CN=localhost' \
-            -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+          sudo apt-get update
+          sudo apt-get install --yes libnss3-tools
+
+      - name: Generate and trust TLS certificate for HTTP/2
+        run: bash .github/lighthouse/scripts/setup-trusted-certificate.sh
 
       - name: Run docker compose to start SSR and nginx
         uses: hoverkraft-tech/compose-action@v3
@@ -63,8 +62,23 @@ jobs:
           urls=$(jq -r '.ci.collect.url[]' .github/lighthouse/configurations/performance-desktop.lighthouserc.json)
           for url in $urls; do
             echo "Warming up $url"
-            curl -sk "$url" >/dev/null
+            curl --fail --silent --show-error "$url" >/dev/null
           done
+
+      - name: Verify trusted Chrome HTTPS and HTTP/2
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        run: |
+          http_version=$(curl --fail --silent --show-error --output /dev/null --write-out '%{http_version}' https://localhost:4200/home)
+          test "$http_version" = '2'
+
+          "$CHROME_PATH" \
+            --headless=new \
+            --no-sandbox \
+            --disable-dev-shm-usage \
+            --dump-dom \
+            https://localhost:4200/home >chrome-home.html
+          grep --quiet '<ish-root' chrome-home.html
 
       - name: Run Lighthouse CI performance audits (desktop + mobile)
         env:


### PR DESCRIPTION
### 🚀 Description

This pull request improves the reliability and security of Lighthouse CI performance testing by introducing automated generation and trust of self-signed TLS certificates, updating Chrome launch flags, and enhancing verification steps in the GitHub Actions workflows. The changes ensure that Chrome and command-line tools trust the test certificates, enabling proper HTTP/2 and HTTPS support during CI runs.

**Certificate management and trust automation:**

* Added a new script (`.github/lighthouse/scripts/setup-trusted-certificate.sh`) that generates a temporary self-signed CA and server certificate, installs the CA into both the system and Chrome's NSS trust stores, and verifies the setup. This ensures Chrome and system tools trust the test certificates in CI.
* Updated the Lighthouse performance workflow files (`lighthouse-performance-baseline.yml` and `lighthouse-performance-compare.yml`) to install necessary tooling (`libnss3-tools`) and use the new script for certificate generation and trust, replacing the previous manual OpenSSL steps. [[1]](diffhunk://#diff-7bdbe5407eb91952b1c7a606101c16ba92664ad56ed395760cc81dab9d17ea19L44-R50) [[2]](diffhunk://#diff-ad0ef1e77eb9dab0787c947befad817d320e6f15300ffcb4991fb9e8fafe3a55L45-R51)

**Workflow enhancements and verification:**

* Added explicit verification steps in the workflows to check that Chrome and `curl` can access the test site via HTTPS with HTTP/2, and that the page renders as expected. This increases confidence in the test environment's correctness. [[1]](diffhunk://#diff-7bdbe5407eb91952b1c7a606101c16ba92664ad56ed395760cc81dab9d17ea19L65-R81) [[2]](diffhunk://#diff-ad0ef1e77eb9dab0787c947befad817d320e6f15300ffcb4991fb9e8fafe3a55L66-R82)
* Improved `curl` commands to use `--fail --silent --show-error` for better error handling and visibility during test warm-up. [[1]](diffhunk://#diff-7bdbe5407eb91952b1c7a606101c16ba92664ad56ed395760cc81dab9d17ea19L65-R81) [[2]](diffhunk://#diff-ad0ef1e77eb9dab0787c947befad817d320e6f15300ffcb4991fb9e8fafe3a55L66-R82)

**Configuration updates:**

* Removed the `--allow-insecure-localhost` Chrome flag from Lighthouse configuration files, as it's no longer needed now that the test certificates are trusted. [[1]](diffhunk://#diff-f3f8ddcc0396730af6026069461f45e6fd98d228dec55048efd472e823840be0L18-R18) [[2]](diffhunk://#diff-9d0052a001b7a755fb8a2fa71e2c801298c437aaeaa1ff39529282fabf34d9ebL19-R19)

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120134](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120134)