### PR TITLE
perf: prevent `ishServerHtml` replacement during SSR hydration

### DIFF
--- a/src/app/core/directives/server-html.directive.ts
+++ b/src/app/core/directives/server-html.directive.ts
@@ -24,6 +24,7 @@ import { LinkParser } from 'ish-core/utils/link-parser';
 export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnChanges {
   @Input() callbacks: Record<string, (event?: MouseEvent) => void>;
 
+  private initialized = false;
   private renderer = inject(Renderer2);
 
   constructor(
@@ -34,7 +35,15 @@ export class ServerHtmlDirective implements AfterContentInit, AfterViewInit, OnC
   ) {}
 
   @Input() set ishServerHtml(val: string) {
-    const element = this.elementRef.nativeElement;
+    const element = this.elementRef.nativeElement as HTMLElement;
+    const reuseServerContent = !SSR && !this.initialized && element.hasChildNodes();
+    this.initialized = true;
+
+    // Keep the DOM nodes produced by SSR so hydration does not turn unchanged HTML into a new LCP candidate.
+    if (reuseServerContent) {
+      return;
+    }
+
     while (element.firstChild) {
       element.removeChild(element.firstChild);
     }


### PR DESCRIPTION
### 🚀 Description

This pull request introduces an improvement to the `ServerHtmlDirective` to optimize how server-rendered HTML is handled on the client side, especially in the context of SSR (Server-Side Rendering) and hydration. The main change is to prevent unnecessary DOM updates when server-rendered content is already present, which can help avoid issues like creating new LCP (Largest Contentful Paint) candidates.

---

### 🔍 Detailed Changes

Enhancement to SSR hydration handling:

* Added a private `initialized` flag to `ServerHtmlDirective` and updated the `ishServerHtml` setter to detect if server-rendered content is already present. If so, and if SSR is not active, the directive now skips re-rendering the content on the initial pass, preserving the original DOM nodes for hydration and preventing unnecessary DOM manipulation. [[1]](diffhunk://#diff-24c9fafd0f010321f5389958e687be2a8f17ddcfba23fb4faedab094429a7b51R27) [[2]](diffhunk://#diff-24c9fafd0f010321f5389958e687be2a8f17ddcfba23fb4faedab094429a7b51L37-R46)

---

### 🔗 Other Information

[AB#120143](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120143)