### PR TITLE
feat: render all product detail tabs in DOM for SEO

### DIFF
--- a/src/app/pages/product/product-detail-info/product-detail-info.component.html
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.html
@@ -5,6 +5,7 @@
       class="nav-tabs w-100"
       ngbNav
       [attr.aria-label]="'product.detail.information.tabs.aria_label' | translate"
+      [destroyOnHide]="false"
       [(activeId)]="active"
     >
       <!-- Description -->

--- a/src/app/pages/product/product-detail-info/product-detail-info.component.spec.ts
+++ b/src/app/pages/product/product-detail-info/product-detail-info.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe, provideTranslateService } from '@ngx-translate/core';
-import { MockDirective } from 'ng-mocks';
+import { MockComponent, MockDirective } from 'ng-mocks';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 
@@ -9,6 +9,8 @@ import { ServerHtmlDirective } from 'ish-core/directives/server-html.directive';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
+
+import { LazyProductReviewsComponent } from '../../../extensions/rating/exports/lazy-product-reviews/lazy-product-reviews.component';
 
 import { ProductDetailInfoComponent } from './product-detail-info.component';
 
@@ -26,7 +28,11 @@ describe('Product Detail Info Component', () => {
 
     await TestBed.configureTestingModule({
       imports: [FeatureToggleModule.forTesting('rating'), NgbNavModule, TranslatePipe],
-      declarations: [MockDirective(ServerHtmlDirective), ProductDetailInfoComponent],
+      declarations: [
+        MockComponent(LazyProductReviewsComponent),
+        MockDirective(ServerHtmlDirective),
+        ProductDetailInfoComponent,
+      ],
       providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }, provideTranslateService()],
     }).compileComponents();
   });

--- a/templates/webpack/webpack.custom.ts
+++ b/templates/webpack/webpack.custom.ts
@@ -289,6 +289,8 @@ export default (config: Configuration, angularJsonConfig: CustomWebpackBrowserSc
             /\bcarousel\b/,
             /\bslide\b/,
             /\bnav-tabs\b/,
+            /\btab-content\b/,
+            /\btab-pane\b/,
             /\bnav-link\b/,
             /\bpopover\b/,
             /\btable\b/,


### PR DESCRIPTION
### 🚀 Description

Improves the SEO of the product detail page by rendering the content of all tabs into the source markup, instead of only the active one.

Before: During SSR, only the active tab's content was present in the rendered HTML. As a result, the content of the other tabs was not part of the source code and therefore not crawlable by search engines.

---

### 🔍 Detailed Changes

---

### 📝 Notes

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team
- [ ] Visual changes approved by VD / IAD

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->
