### PR TITLE
feat(Agent readiness): introduce `llms.txt` support

### DIFF
--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -90,6 +90,7 @@ installable
 interpolatable
 intershop
 intershophub
+intershoppwa
 intronics
 ismediaobject
 isrest
@@ -103,6 +104,7 @@ keyvalue
 klausen
 lessthan
 lhci
+llms
 logformat
 loglevel
 luarocks

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,3 +98,7 @@ kb_sync_latest_only
 - [Guide - Address Check with Address Doctor](./guides/address-doctor.md)
 - [Guide - E-Mail Marketing/Newsletter Subscription](./guides/newsletter-subscription.md)
 - [Guide - Well-Known Resources](./guides/well-known-resources.md)
+
+## Agent Readiness
+
+- [Guide - llms.txt](./guides/llms-txt.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,6 @@ kb_sync_latest_only
 - [Concept - Configuration](./concepts/configuration.md)
   - [Guide - Propagating Environment Variables](./guides/propagating-environment-variables.md)
 - [Concept - Localization](./concepts/localization.md)
-- [Concept - SEO](./concepts/search-engine-optimization.md)
 - [Guide - Forms](./guides/forms.md)
 - [Guide - Formly](./guides/formly.md)
 - [Guide - Field Library](./guides/field-library.md)
@@ -98,6 +97,10 @@ kb_sync_latest_only
 - [Guide - Address Check with Address Doctor](./guides/address-doctor.md)
 - [Guide - E-Mail Marketing/Newsletter Subscription](./guides/newsletter-subscription.md)
 - [Guide - Well-Known Resources](./guides/well-known-resources.md)
+
+## Search Engine Optimization
+
+- [Concept - SEO](./concepts/search-engine-optimization.md)
 
 ## Agent Readiness
 

--- a/docs/guides/llms-txt.md
+++ b/docs/guides/llms-txt.md
@@ -9,7 +9,8 @@ kb_sync_latest_only
 
 - [Overview](#overview)
 - [File Location and Naming](#file-location-and-naming)
-- [Single Channel Setup](#single-channel-setup)
+- [Discoverability (`rel="describedby"`)](#discoverability-reldescribedby)
+- [Single-Channel Setup](#single-channel-setup)
 - [Multi-Channel Setup](#multi-channel-setup)
 - [Multi-Base-Href Setup](#multi-base-href-setup)
 - [Behavior by Configuration](#behavior-by-configuration)
@@ -18,17 +19,19 @@ kb_sync_latest_only
 ## Overview
 
 `llms.txt` is a proposed standard (see [llmstxt.org](https://llmstxt.org/)) that provides a curated, LLM-friendly index of a website at `/llms.txt`.
-It helps large language models and AI agents discover the most relevant pages of a store without crawling the full HTML site.
+It helps large language models and AI agents discover the most relevant pages of a store without having to crawl the full HTML site.
 
-It is served as static content by the NGINX layer and does not require server-side rendering.
+The PWA follows the [v2 revision of the proposal (August 2026)](https://llmstxt.org/changes.html).
+
+It is served as static content by the Nginx layer and does not require server-side rendering.
 
 ## File Location and Naming
 
-The content files live in the `nginx/llms/` folder.
+The content files are located in the `nginx/llms/` folder.
 Each file is named after the channel it belongs to, following the pattern `<channel>_llms.txt`.
 
-This naming ties every file to a channel from the [multi-channel configuration](./multi-site-configurations.md), so the correct file is served automatically for each domain.
-If no file matches a domain's channel, NGINX falls back to `nginx/llms/default_llms.txt`.
+This naming links every file to a channel from the [multi-channel configuration](./multi-site-configurations.md), so the correct file is served automatically for each domain.
+If no file matches a domain's channel, Nginx falls back to `nginx/llms/default_llms.txt`.
 For example:
 
 | Channel                            | File                                                   |
@@ -37,16 +40,32 @@ For example:
 | `inSPIRED-inTRONICS_Business-Site` | `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt` |
 | `inSPIRED-inTRONICS-Site`          | `nginx/llms/inSPIRED-inTRONICS-Site_llms.txt`          |
 
-## Single Channel Setup
+## Discoverability (`rel="describedby"`)
 
-For the default configuration in [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), where every host maps to channel `default`, the file is:
+The [v2 revision](https://llmstxt.org/changes.html) adds a way for agents to find the `llms.txt` file that covers a page without guessing the URL: the page links to it with the `rel="describedby"` link relation.
+
+The PWA declares this once in [`src/index.html`](../../src/index.html), so every route of the single-page application advertises it — in both client-side and server-side rendered responses:
+
+```html
+<link href="/llms.txt" rel="describedby" />
+```
+
+The root-relative `/llms.txt` href intentionally ignores the `<base href>`, so it always resolves to the domain root file that Nginx serves for the current channel — including in [Multi-Base-Href Setups](#multi-base-href-setup) where the base href becomes `/en`, `/de`, and so on.
+
+> [!NOTE]
+> The `rel="alternate" type="text/markdown"` relation from v2 points to a Markdown version of an individual page.
+> The PWA does not publish per-page Markdown versions of its content, so this relation is intentionally omitted.
+
+## Single-Channel Setup
+
+For the default configuration in [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), where every host maps to the `default` channel, the file is:
 
 ```
 nginx/llms/default_llms.txt
 ```
 
-It is served at `/llms.txt` for every domain.
-If you explicitly define the `default` channel, the matching multi-channel configuration looks as follows:
+It is served at `/llms.txt` for all domains.
+If you explicitly define the `default` channel, the corresponding multi-channel configuration is as follows:
 
 ```yaml
 MULTI_CHANNEL: |
@@ -54,14 +73,15 @@ MULTI_CHANNEL: |
     channel: default
 ```
 
-But setting `MULTI_CHANNEL` is optional for this case.
+However, setting `MULTI_CHANNEL` is optional for this case.
 
 > [!NOTE]
-> The `default` channel does not correspond to a real storefront, so `nginx/llms/default_llms.txt` is a neutral placeholder without store-specific links.
-> A concrete deployment should map its domains to real channels and provide the corresponding `<channel>_llms.txt` files.
+> The `default` channel does not correspond to a real storefront.
+> Therefore, `nginx/llms/default_llms.txt` is a neutral placeholder without store-specific links.
+> In a concrete deployment, map its domains to real channels and provide the corresponding `<channel>_llms.txt` files.
 
-Alternatively, set the single channel to a specific named channel instead of `default`.
-In that case, `/llms.txt` serves that channel's file, for example `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`:
+Alternatively, set the single channel to a specific, named channel instead of `default`.
+In that case, `/llms.txt` serves that channel's file — for example, `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`:
 
 ```yaml
 MULTI_CHANNEL: |
@@ -71,12 +91,12 @@ MULTI_CHANNEL: |
 
 ## Multi-Channel Setup
 
-If a single deployment serves multiple domains with different channels or themes (for example, a B2B and a B2C storefront), provide one file per channel, so every domain serves its own `/llms.txt`:
+If a single deployment serves multiple domains with different channels or themes (for example, a B2B and a B2C storefront), provide one file per channel, so that every domain serves its own `/llms.txt`:
 
 - `https://intershoppwa.azurewebsites.net/llms.txt` serves the B2B channel file `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`.
 - `https://intershoppwa-b2c.azurewebsites.net/llms.txt` serves the B2C channel file `nginx/llms/inSPIRED-inTRONICS-Site_llms.txt`.
 
-The matching multi-channel configuration looks as follows:
+The corresponding multi-channel configuration is as follows:
 
 ```yaml
 MULTI_CHANNEL: |
@@ -88,12 +108,16 @@ MULTI_CHANNEL: |
 
 ## Multi-Base-Href Setup
 
-A single domain can also serve several channels under different base href paths (for example `/en`, `/de`, `/fr`, and `/b2c`), configured as a list in the [multi-channel configuration](./multi-site-configurations.md).
-In this case there is only **one** `/llms.txt` at the domain root, and it uses the channel of the **first** list entry.
-As everywhere, a missing channel file falls back to `nginx/llms/default_llms.txt`.
+A single domain can also serve several channels under different base href paths (for example `/en`, `/de`, `/fr`, and `/b2c`), as configured in a list in the [multi-channel configuration](./multi-site-configurations.md).
+In this case, there is only **one** `/llms.txt` at the domain root, and it uses the channel of the **first** list entry.
+As with all other setups, a missing channel file falls back to `nginx/llms/default_llms.txt`.
 
-For example, with a list whose first entry uses `inSPIRED-inTRONICS_Business-Site`, the domain root serves `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`.
+For example, if the first list entry uses `inSPIRED-inTRONICS_Business-Site`, the domain root serves `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`.
 The individual base href paths (such as `/b2c`) do **not** get their own `llms.txt`.
+
+> [!NOTE]
+> When the base href paths represent different languages (for example `/en`, `/de`, `/fr` with distinct `lang` values), this affects localization.
+> Because only the domain root serves `/llms.txt` and it always uses the **first** list entry's channel, there is a single file whose language is effectively determined by the first entry.
 
 The matching multi-channel configuration looks as follows:
 
@@ -114,9 +138,9 @@ MULTI_CHANNEL: |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | No `MULTI_CHANNEL` set                    | Falls back to `nginx/multi-channel.yaml` (channel `default`) and serves `default_llms.txt` at `/llms.txt`.               |
 | Single channel (`channel: default`)       | Serves `default_llms.txt` at `/llms.txt`.                                                                                |
-| Multiple domains/channels                 | Each domain serves its own channel file (e.g. B2B and B2C get different `llms.txt`).                                     |
-| Multi-base-href (`/en`, `/de`, `/b2c`, …) | One `/llms.txt` at the domain root, using the first list entry's channel. Base-href sub-paths do not get their own file. |
-| Missing channel file                      | Falls back to `default_llms.txt`, otherwise `404`.                                                                       |
+| Multiple domains/channels                 | Each domain serves its own channel file (e.g., B2B and B2C channels get different `llms.txt` files).                     |
+| Multi base href (`/en`, `/de`, `/b2c`, …) | One `/llms.txt` at the domain root, using the first list entry's channel. Base-href sub-paths do not get their own file. |
+| Missing channel file                      | Falls back to `default_llms.txt`, otherwise, returns `404`.                                                              |
 
 ## Further References
 

--- a/docs/guides/llms-txt.md
+++ b/docs/guides/llms-txt.md
@@ -1,0 +1,126 @@
+<!--
+kb_guide
+kb_pwa
+kb_everyone
+kb_sync_latest_only
+-->
+
+# llms.txt
+
+- [Overview](#overview)
+- [File Location and Naming](#file-location-and-naming)
+- [Single Channel Setup](#single-channel-setup)
+- [Multi-Channel Setup](#multi-channel-setup)
+- [Multi-Base-Href Setup](#multi-base-href-setup)
+- [Behavior by Configuration](#behavior-by-configuration)
+- [Further References](#further-references)
+
+## Overview
+
+`llms.txt` is a proposed standard (see [llmstxt.org](https://llmstxt.org/)) that provides a curated, LLM-friendly index of a website at `/llms.txt`.
+It helps large language models and AI agents discover the most relevant pages of a store without crawling the full HTML site.
+
+It is served as static content by the NGINX layer and does not require server-side rendering.
+
+## File Location and Naming
+
+The content files live in the `nginx/llms/` folder.
+Each file is named after the channel it belongs to, following the pattern `<channel>_llms.txt`.
+
+This naming ties every file to a channel from the [multi-channel configuration](./multi-site-configurations.md), so the correct file is served automatically for each domain.
+If no file matches a domain's channel, NGINX falls back to `nginx/llms/default_llms.txt`.
+For example:
+
+| Channel                            | File                                                   |
+| ---------------------------------- | ------------------------------------------------------ |
+| `default`                          | `nginx/llms/default_llms.txt`                          |
+| `inSPIRED-inTRONICS_Business-Site` | `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt` |
+| `inSPIRED-inTRONICS-Site`          | `nginx/llms/inSPIRED-inTRONICS-Site_llms.txt`          |
+
+## Single Channel Setup
+
+For the default configuration in [`nginx/multi-channel.yaml`](../../nginx/multi-channel.yaml), where every host maps to channel `default`, the file is:
+
+```
+nginx/llms/default_llms.txt
+```
+
+It is served at `/llms.txt` for every domain.
+If you explicitly define the `default` channel, the matching multi-channel configuration looks as follows:
+
+```yaml
+MULTI_CHANNEL: |
+  .+:
+    channel: default
+```
+
+But setting `MULTI_CHANNEL` is optional for this case.
+
+> [!NOTE]
+> The `default` channel does not correspond to a real storefront, so `nginx/llms/default_llms.txt` is a neutral placeholder without store-specific links.
+> A concrete deployment should map its domains to real channels and provide the corresponding `<channel>_llms.txt` files.
+
+Alternatively, set the single channel to a specific named channel instead of `default`.
+In that case, `/llms.txt` serves that channel's file, for example `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`:
+
+```yaml
+MULTI_CHANNEL: |
+  intershoppwa\..+:
+    channel: inSPIRED-inTRONICS_Business-Site
+```
+
+## Multi-Channel Setup
+
+If a single deployment serves multiple domains with different channels or themes (for example, a B2B and a B2C storefront), provide one file per channel, so every domain serves its own `/llms.txt`:
+
+- `https://intershoppwa.azurewebsites.net/llms.txt` serves the B2B channel file `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`.
+- `https://intershoppwa-b2c.azurewebsites.net/llms.txt` serves the B2C channel file `nginx/llms/inSPIRED-inTRONICS-Site_llms.txt`.
+
+The matching multi-channel configuration looks as follows:
+
+```yaml
+MULTI_CHANNEL: |
+  intershoppwa\..+:
+    channel: inSPIRED-inTRONICS_Business-Site
+  intershoppwa-b2c\..+:
+    channel: inSPIRED-inTRONICS-Site
+```
+
+## Multi-Base-Href Setup
+
+A single domain can also serve several channels under different base href paths (for example `/en`, `/de`, `/fr`, and `/b2c`), configured as a list in the [multi-channel configuration](./multi-site-configurations.md).
+In this case there is only **one** `/llms.txt` at the domain root, and it uses the channel of the **first** list entry.
+As everywhere, a missing channel file falls back to `nginx/llms/default_llms.txt`.
+
+For example, with a list whose first entry uses `inSPIRED-inTRONICS_Business-Site`, the domain root serves `nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt`.
+The individual base href paths (such as `/b2c`) do **not** get their own `llms.txt`.
+
+The matching multi-channel configuration looks as follows:
+
+```yaml
+MULTI_CHANNEL: |
+  .+:
+    - baseHref: /en
+      channel: inSPIRED-inTRONICS_Business-Site
+      lang: en_US
+    - baseHref: /b2c
+      channel: inSPIRED-inTRONICS-Site
+      theme: b2c
+```
+
+## Behavior by Configuration
+
+| Configuration                             | Result                                                                                                                   |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| No `MULTI_CHANNEL` set                    | Falls back to `nginx/multi-channel.yaml` (channel `default`) and serves `default_llms.txt` at `/llms.txt`.               |
+| Single channel (`channel: default`)       | Serves `default_llms.txt` at `/llms.txt`.                                                                                |
+| Multiple domains/channels                 | Each domain serves its own channel file (e.g. B2B and B2C get different `llms.txt`).                                     |
+| Multi-base-href (`/en`, `/de`, `/b2c`, …) | One `/llms.txt` at the domain root, using the first list entry's channel. Base-href sub-paths do not get their own file. |
+| Missing channel file                      | Falls back to `default_llms.txt`, otherwise `404`.                                                                       |
+
+## Further References
+
+- [The /llms.txt file proposal](https://llmstxt.org/)
+- [Guide - Building and Running nginx Docker Image](./nginx-startup.md)
+- [Guide - Multi-Site Configurations](./multi-site-configurations.md)
+- [Concept - Search Engine Optimization (SEO)](../concepts/search-engine-optimization.md)

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -69,8 +69,8 @@ The setting only affects the dev server (`ng serve`) and has no impact on produc
 
 **llms.txt integration**
 
-The Intershop PWA now serves an [`llms.txt`](https://llmstxt.org/) file, an LLM-friendly site index, as static content via the NGINX container (see [Guide - llms.txt](./llms-txt.md)).
-The content files are located in _nginx/llms/_ and are named per channel following the pattern _<channel>_llms.txt_, with a neutral _default_llms.txt_ used as fallback file.
+The Intershop PWA now serves an [llms.txt](https://llmstxt.org/) file, an LLM-friendly site index, as static content via the NGINX container (see [Guide - llms.txt](./llms-txt.md)).
+The content files are located in _nginx/llms/_ and are named per channel following the pattern _`<channel>_llms.txt`_, with a neutral _default_llms.txt_ used as fallback file.
 Every project based on the Intershop PWA - whether newly set up or migrated - needs to rename these files to match its storefront channels and replace the demo content with links relevant to its shop.
 
 ## From 12.0.0 to 12.1.0

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -67,6 +67,12 @@ Running `ng serve` now applies style changes (global and component SCSS) in plac
 Template and TypeScript changes still trigger a full live-reload as before.
 The setting only affects the dev server (`ng serve`) and has no impact on production builds or SSR.
 
+**llms.txt integration**
+
+The Intershop PWA now serves an [`llms.txt`](https://llmstxt.org/) file, an LLM-friendly site index, as static content via the NGINX container (see [Guide - llms.txt](./llms-txt.md)).
+The content files are located in _nginx/llms/_ and are named per channel following the pattern _<channel>_llms.txt_, with a neutral _default_llms.txt_ used as fallback file.
+Every project based on the Intershop PWA - whether newly set up or migrated - needs to rename these files to match its storefront channels and replace the demo content with links relevant to its shop.
+
 ## From 12.0.0 to 12.1.0
 
 **Generative Engine Optimization (GEO)**

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -67,6 +67,7 @@ COPY docker-entrypoint.d/*.sh /docker-entrypoint.d/
 RUN chmod 700 /docker-entrypoint.d/*.sh
 COPY *.yaml /
 COPY 50x.html /usr/share/nginx/html/
+COPY llms /etc/nginx/conf.d/llms/
 
 COPY cache_clearer.sh /
 RUN chmod 700 /cache_clearer.sh

--- a/nginx/llms/default_llms.txt
+++ b/nginx/llms/default_llms.txt
@@ -1,8 +1,3 @@
-# Intershop PWA
+# No content available
 
-> This is the default `llms.txt` served by the Intershop Progressive Web App (PWA) when the requested domain is not mapped to a storefront channel. It intentionally contains no store-specific content or links.
-
-Notes for agents:
-
-- No storefront channel is configured for this domain, so there is no curated page index to expose here.
-- A concrete deployment maps its domains to channels in the multi-channel configuration and provides a channel-specific file named `<channel>_llms.txt` with the relevant links.
+> No llms.txt content is currently available for this site. There is no curated, machine-readable page index to consume at this location.

--- a/nginx/llms/default_llms.txt
+++ b/nginx/llms/default_llms.txt
@@ -1,0 +1,8 @@
+# Intershop PWA
+
+> This is the default `llms.txt` served by the Intershop Progressive Web App (PWA) when the requested domain is not mapped to a storefront channel. It intentionally contains no store-specific content or links.
+
+Notes for agents:
+
+- No storefront channel is configured for this domain, so there is no curated page index to expose here.
+- A concrete deployment maps its domains to channels in the multi-channel configuration and provides a channel-specific file named `<channel>_llms.txt` with the relevant links.

--- a/nginx/llms/inSPIRED-inTRONICS-Site_llms.txt
+++ b/nginx/llms/inSPIRED-inTRONICS-Site_llms.txt
@@ -1,0 +1,65 @@
+# inSPIRED - inTRONICS (Intershop PWA B2C Demo Store)
+
+> inSPIRED inTRONICS is a demonstration B2C storefront built on the Intershop Progressive Web App (PWA) on top of Intershop Commerce Management (ICM). It sells consumer electronics and IT equipment (computers, conferencing, networking, servers) to private customers. This is a demo shop: all products, prices, and content are exemplary and non-binding. Do not treat any content as a real commercial offer.
+
+Important notes for agents:
+
+- This is a demonstration environment. Contents are of exemplary nature only. Intershop Communications AG gives no guarantee for correctness, completeness, or up-to-dateness, and the data must not be reused.
+- Prices, promotions, and availability are context-dependent (login and customer status). Values shown to anonymous agents may differ from those shown to authenticated customers.
+- This is the B2C storefront for private customers. A separate B2B storefront for business customers is available at https://intershoppwa.azurewebsites.net/
+- The store is available in English (default), German (append ;lang=de_DE to a route) and French (;lang=fr_FR).
+- Transactional actions (cart, checkout, payment) require authentication and are out of scope for read-only discovery.
+- Most links below point to a clean Markdown mirror (the HTML page URL with .md appended). Remove the .md suffix to reach the equivalent human-readable HTML page.
+
+## Main pages
+
+- [Home](https://intershoppwa-b2c.azurewebsites.net/home.md): Storefront landing page with featured products and top categories.
+- [Help](https://intershoppwa-b2c.azurewebsites.net/page/page.helpdesk.pagelet2-Page.md): Customer help and support overview.
+- [Contact us](https://intershoppwa-b2c.azurewebsites.net/contact.md): Contact form.
+- [Store finder](https://intershoppwa-b2c.azurewebsites.net/store-finder.md): Physical store locations.
+- [Product comparison](https://intershoppwa-b2c.azurewebsites.net/compare.md): Side-by-side comparison of selected products.
+
+## Localized versions
+
+The store serves three locales. Language is selected via a matrix URL parameter.
+
+- [English store (default)](https://intershoppwa-b2c.azurewebsites.net/home.md): Primary English storefront.
+- [German store (Deutsch)](https://intershoppwa-b2c.azurewebsites.net/home.md;lang=de_DE): Full storefront in German.
+- [French store (Français)](https://intershoppwa-b2c.azurewebsites.net/home.md;lang=fr_FR): Full storefront in French.
+
+## Featured Products
+
+- [Microsoft Surface Hub](https://intershoppwa-b2c.azurewebsites.net/microsoft-surface-hub-prd201807181.md): Featured large-format collaboration display.
+- [Microsoft Surface Book 2](https://intershoppwa-b2c.azurewebsites.net/microsoft-surface-book-2-256gb-13.5%22-prd201807231-01.md): Featured detachable notebook.
+- [Microsoft Surface Pro Set Burgundy](https://intershoppwa-b2c.azurewebsites.net/microsoft-surface-pro-set-burgundy-prd201807198.md): Featured 2-in-1 tablet set.
+
+## Product Categories
+
+- [Computers](https://intershoppwa-b2c.azurewebsites.net/computers-ctgComputers.md): Desktops, notebooks, tablets, monitors and related hardware.
+- [Conferencing](https://intershoppwa-b2c.azurewebsites.net/conferencing-ctgpresentation-conferencing.md): Presentation and conferencing equipment.
+- [Networks](https://intershoppwa-b2c.azurewebsites.net/networks-ctgnetworks.md): Networking hardware and accessories.
+- [Servers](https://intershoppwa-b2c.azurewebsites.net/servers-ctgservers.md): Server systems and infrastructure.
+- [Specials](https://intershoppwa-b2c.azurewebsites.net/specials-ctgspecials.md): Current special offers and promotions.
+
+## Account and ordering
+
+- [Sign in](https://intershoppwa-b2c.azurewebsites.net/login.md): Authentication for registered customers.
+- [Register](https://intershoppwa-b2c.azurewebsites.net/register.md): Create a new customer account.
+- [Shopping cart](https://intershoppwa-b2c.azurewebsites.net/basket.md): Current cart contents (session and authentication dependent).
+
+## Policies
+
+- [Demo disclaimer](https://intershoppwa-b2c.azurewebsites.net/page/page.demodisclaimer.md): Notice that this is a non-binding demonstration shop.
+- [Legal notice](https://www.intershop.com/legal-notice): Company and legal information (imprint).
+- [Privacy policy](https://www.intershop.com/privacy-policy): How personal data is processed.
+- [Terms & conditions](https://www.intershop.com/terms-of-use): Terms of use for the store.
+- [Withdrawal from contract](https://intershoppwa-b2c.azurewebsites.net/withdrawal.md): Right of withdrawal information.
+
+## About Intershop
+
+- [About Intershop](https://www.intershop.com): Company behind the platform (Intershop Communications AG, Jena, Germany).
+- [Intershop PWA on GitHub](https://github.com/intershop/intershop-pwa): Open-source source code of this storefront.
+
+## Optional
+
+- [B2B storefront for business customers](https://intershoppwa.azurewebsites.net/): Separate business-facing channel.

--- a/nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt
+++ b/nginx/llms/inSPIRED-inTRONICS_Business-Site_llms.txt
@@ -1,0 +1,66 @@
+# inSPIRED - inTRONICS Business (Intershop PWA B2B Demo Store)
+
+> inSPIRED inTRONICS Business is a demonstration B2B storefront built on the Intershop Progressive Web App (PWA) on top of Intershop Commerce Management (ICM). It sells consumer electronics and IT equipment (computers, conferencing, networking, servers) to business customers. This is a demo shop: all products, prices, and content are exemplary and non-binding. Do not treat any content as a real commercial offer.
+
+Important notes for agents:
+
+- This is a demonstration environment. Contents are of exemplary nature only. Intershop Communications AG gives no guarantee for correctness, completeness, or up-to-dateness, and the data must not be reused.
+- Prices, promotions, and availability are context-dependent (customer type, login, organization, and role). Values shown to anonymous agents may differ from those shown to authenticated business customers.
+- This is the B2B storefront. A separate B2C storefront for private customers is available at https://intershoppwa-b2c.azurewebsites.net/
+- The store is available in English (default), German (append ;lang=de_DE to a route) and French (;lang=fr_FR).
+- Transactional actions (cart, checkout, payment) require authentication and are out of scope for read-only discovery.
+- Most links below point to a clean Markdown mirror (the HTML page URL with .md appended). Remove the .md suffix to reach the equivalent human-readable HTML page.
+
+## Main pages
+
+- [Home](https://intershoppwa.azurewebsites.net/home.md): Storefront landing page with featured products and top categories.
+- [Help](https://intershoppwa.azurewebsites.net/page/page.helpdesk.pagelet2-Page.md): Customer help and support overview.
+- [Contact us](https://intershoppwa.azurewebsites.net/contact.md): Contact form.
+- [Store finder](https://intershoppwa.azurewebsites.net/store-finder.md): Physical store locations.
+- [Quick order](https://intershoppwa.azurewebsites.net/quick-order.md): Add products in bulk by SKU for fast reordering (B2B).
+- [Product comparison](https://intershoppwa.azurewebsites.net/compare.md): Side-by-side comparison of selected products.
+
+## Localized versions
+
+The store serves three locales. Language is selected via a matrix URL parameter.
+
+- [English store (default)](https://intershoppwa.azurewebsites.net/home.md): Primary English storefront.
+- [German store (Deutsch)](https://intershoppwa.azurewebsites.net/home.md;lang=de_DE): Full storefront in German.
+- [French store (Français)](https://intershoppwa.azurewebsites.net/home.md;lang=fr_FR): Full storefront in French.
+
+## Featured Products
+
+- [Microsoft Surface Hub](https://intershoppwa.azurewebsites.net/microsoft-surface-hub-prd201807181.md): Featured large-format collaboration display.
+- [Microsoft Surface Book 2](https://intershoppwa.azurewebsites.net/microsoft-surface-book-2-256gb-13.5%22-prd201807231-01.md): Featured detachable notebook.
+- [Microsoft Surface Pro Set Burgundy](https://intershoppwa.azurewebsites.net/microsoft-surface-pro-set-burgundy-prd201807198.md): Featured 2-in-1 tablet set.
+
+## Product Categories
+
+- [Computers](https://intershoppwa.azurewebsites.net/computers-ctgComputers.md): Desktops, notebooks, tablets, monitors and related hardware.
+- [Conferencing](https://intershoppwa.azurewebsites.net/conferencing-ctgpresentation-conferencing.md): Presentation and conferencing equipment.
+- [Networks](https://intershoppwa.azurewebsites.net/networks-ctgnetworks.md): Networking hardware and accessories.
+- [Servers](https://intershoppwa.azurewebsites.net/servers-ctgservers.md): Server systems and infrastructure.
+- [Specials](https://intershoppwa.azurewebsites.net/specials-ctgspecials.md): Current special offers and promotions.
+
+## Account and ordering
+
+- [Sign in](https://intershoppwa.azurewebsites.net/login.md): Authentication for registered customers.
+- [Register](https://intershoppwa.azurewebsites.net/register.md): Create a new customer account.
+- [Shopping cart](https://intershoppwa.azurewebsites.net/basket.md): Current cart contents (session and authentication dependent).
+
+## Policies
+
+- [Demo disclaimer](https://intershoppwa.azurewebsites.net/page/page.demodisclaimer.md): Notice that this is a non-binding demonstration shop.
+- [Legal notice](https://www.intershop.com/legal-notice): Company and legal information (imprint).
+- [Privacy policy](https://www.intershop.com/privacy-policy): How personal data is processed.
+- [Terms & conditions](https://www.intershop.com/terms-of-use): Terms of use for the store.
+- [Withdrawal from contract](https://intershoppwa.azurewebsites.net/withdrawal.md): Right of withdrawal information.
+
+## About Intershop
+
+- [About Intershop](https://www.intershop.com): Company behind the platform (Intershop Communications AG, Jena, Germany).
+- [Intershop PWA on GitHub](https://github.com/intershop/intershop-pwa): Open-source source code of this storefront.
+
+## Optional
+
+- [B2C storefront for private customers](https://intershoppwa-b2c.azurewebsites.net/): Separate consumer-facing channel.

--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -202,6 +202,19 @@ server {
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
     }
+
+    # llms.txt (LLM-friendly site index) - served per channel, falls back to the default file
+    {{- $llmsChannel := "default" }}
+    {{- if (has $mapping "channel") }}{{ $llmsChannel = $mapping.channel }}{{ else if gt (len $mapping) 0 }}{{ $llmsChannel = (index $mapping 0).channel }}{{ end }}
+    location = /llms.txt {
+        allow all;
+        auth_basic off;
+
+        default_type text/plain;
+        charset utf-8;
+        root /etc/nginx/conf.d/llms;
+        try_files /{{ $llmsChannel }}_llms.txt /default_llms.txt =404;
+    }
   {{ if (has $mapping "channel") }}
     location / {
         {{- tmpl.Exec "LOCATION_TEMPLATE" $mapping }}

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
     <link href="assets/themes/b2b/img/logo_apple_180x180.png" rel="apple-touch-icon" sizes="180x180" />
     <link href="assets/themes/b2b/img/logo_apple_167x167.png" rel="apple-touch-icon" sizes="167x167" />
     <link href="assets/themes/b2b/manifest.webmanifest" rel="manifest" />
+    <link href="/llms.txt" rel="describedby" />
     <meta content="#006b99" name="theme-color" />
   </head>
   <body>


### PR DESCRIPTION
### 🚀 Description

This pull request introduces support for the [llms.txt](https://llmstxt.org/) file, providing a curated, LLM-friendly index of the storefront at `/llms.txt` for AI agents and large language models. 

- Supports single-channel, multi-channel, and multi-base-href deployments (see guide `docs/guides/llms-txt.md`). 
- Files are named according to the channel name `<channel>_llms.txt` and placed in `/nginx/llms/`.
- Files are served as static content by the NGINX layer.

---


### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [x] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information


[AB119225](https://dev.azure.com/intershop-com/Products/_workitems/edit/119225)
<!-- An automatically created ticket in Azure will be linked here (keep this section) -->
