### PR TITLE
fix: hard coded channel name in recommendation email subject

### DIFF
--- a/src/app/core/facades/app.facade.ts
+++ b/src/app/core/facades/app.facade.ts
@@ -48,6 +48,7 @@ export class AppFacade {
   availableLocales$ = this.store.pipe(select(getAvailableLocales));
   currentCurrency$ = this.store.pipe(select(getCurrentCurrency));
   serverConfigurationLoaded$ = this.store.pipe(select(isServerConfigurationLoaded));
+  channelName$ = this.store.pipe(select(getServerConfigParameter<string>('channel.displayName')));
 
   generalError$ = this.store.pipe(select(getGeneralError));
   generalErrorType$ = this.store.pipe(select(getGeneralErrorType));

--- a/src/app/core/models/server-config/server-config.mapper.spec.ts
+++ b/src/app/core/models/server-config/server-config.mapper.spec.ts
@@ -14,6 +14,7 @@ describe('Server Config Mapper', () => {
             displayName: null,
           },
           basket: { acceleration: true, id: 'basket' },
+          channel: { id: 'channel', displayName: 'inTRONICS Business' },
           general: { id: 'general', locales: ['en_US', 'de_DE'] },
           services: {
             id: 'services',
@@ -34,6 +35,9 @@ describe('Server Config Mapper', () => {
             },
             "basket": {
               "acceleration": true,
+            },
+            "channel": {
+              "displayName": "inTRONICS Business",
             },
             "general": {
               "locales": [

--- a/src/app/pages/product/product-detail-actions/product-detail-actions.component.html
+++ b/src/app/pages/product/product-detail-actions/product-detail-actions.component.html
@@ -1,4 +1,5 @@
 @if (product$ | async; as product) {
+  @let channelName = channelName$ | async;
   <div class="row product-details-top-line justify-content-end">
     <div class="col-lg-12">
       <ul class="share-tools">
@@ -29,7 +30,11 @@
         <li>
           <a
             href="mailto:
-          ?subject={{ 'email.recommended_product.heading' | translate: { '0': channelName } }}
+          ?subject={{
+              channelName
+                ? ('email.recommended_product.heading' | translate: { '0': channelName })
+                : ('email.recommended_product.heading.no_channel' | translate)
+            }}
           &body={{ 'email.recommended_product.text' | translate: { '0': product.name + '%0A', '1': document.URL } }}"
             [title]="'product.email_a_friend.link' | translate"
           >

--- a/src/app/pages/product/product-detail-actions/product-detail-actions.component.spec.ts
+++ b/src/app/pages/product/product-detail-actions/product-detail-actions.component.spec.ts
@@ -4,6 +4,7 @@ import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { anyString, instance, mock, when } from 'ts-mockito';
 
+import { AppFacade } from 'ish-core/facades/app.facade';
 import { ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { FeatureToggleModule } from 'ish-core/feature-toggle.module';
 import { createProductView } from 'ish-core/models/product-view/product-view.model';
@@ -19,13 +20,20 @@ describe('Product Detail Actions Component', () => {
   let translate: TranslateService;
   let element: HTMLElement;
   let context: ProductContextFacade;
+  let appFacade: AppFacade;
 
   beforeEach(async () => {
     context = mock(ProductContextFacade);
+    appFacade = mock(AppFacade);
+    when(appFacade.channelName$).thenReturn(of('inTRONICS Business'));
     await TestBed.configureTestingModule({
       imports: [FeatureToggleModule.forTesting('compare'), TranslatePipe],
       declarations: [MockComponent(LazyProductSendToCompareComponent), ProductDetailActionsComponent],
-      providers: [{ provide: ProductContextFacade, useFactory: () => instance(context) }, provideTranslateService()],
+      providers: [
+        { provide: AppFacade, useFactory: () => instance(appFacade) },
+        { provide: ProductContextFacade, useFactory: () => instance(context) },
+        provideTranslateService(),
+      ],
     }).compileComponents();
   });
 

--- a/src/app/pages/product/product-detail-actions/product-detail-actions.component.ts
+++ b/src/app/pages/product/product-detail-actions/product-detail-actions.component.ts
@@ -2,6 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { AppFacade } from 'ish-core/facades/app.facade';
 import { ProductContextDisplayProperties, ProductContextFacade } from 'ish-core/facades/product-context.facade';
 import { ProductView } from 'ish-core/models/product-view/product-view.model';
 
@@ -12,18 +13,18 @@ import { ProductView } from 'ish-core/models/product-view/product-view.model';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProductDetailActionsComponent implements OnInit {
-  // TODO: to be removed once channelName information available in system
-  channelName = 'inTRONICS';
-
+  channelName$: Observable<string>;
   product$: Observable<ProductView>;
 
   constructor(
     @Inject(DOCUMENT) public document: Document,
-    private context: ProductContextFacade
+    private context: ProductContextFacade,
+    private appFacade: AppFacade
   ) {}
 
   ngOnInit() {
     this.product$ = this.context.select('product');
+    this.channelName$ = this.appFacade.channelName$;
   }
 
   configuration$(key: keyof ProductContextDisplayProperties) {

--- a/src/assets/i18n/de_DE.json
+++ b/src/assets/i18n/de_DE.json
@@ -1109,6 +1109,7 @@
   "designview.edit.link.title": "Bearbeiten",
   "dialog.close.text": "Schließen",
   "email.recommended_product.heading": "Ich habe bei {{0}} etwas für dich gefunden",
+  "email.recommended_product.heading.no_channel": "Ich habe etwas für dich gefunden",
   "email.recommended_product.text": "Sieh mal, was ich für dich gefunden habe. {{0}}\n{{1}}",
   "email.wishlist_sharing.heading": "Ich habe meine Wunschliste mit dir geteilt.",
   "email.wishlist_sharing.text": "Schau dir meine Wunschliste an:",

--- a/src/assets/i18n/en_US.json
+++ b/src/assets/i18n/en_US.json
@@ -1109,6 +1109,7 @@
   "designview.edit.link.title": "Edit",
   "dialog.close.text": "Close",
   "email.recommended_product.heading": "I found an item for you at {{0}}",
+  "email.recommended_product.heading.no_channel": "I found an item for you",
   "email.recommended_product.text": "Take a look at what I found for you. {{0}}\n{{1}}",
   "email.wishlist_sharing.heading": "I shared my wishlist with you.",
   "email.wishlist_sharing.text": "Take a look at my wishlist:",

--- a/src/assets/i18n/fr_FR.json
+++ b/src/assets/i18n/fr_FR.json
@@ -1109,6 +1109,7 @@
   "designview.edit.link.title": "Modifier",
   "dialog.close.text": "Fermer",
   "email.recommended_product.heading": "J’ai trouvé un article pour vous sur {{0}}",
+  "email.recommended_product.heading.no_channel": "J’ai trouvé un article pour vous",
   "email.recommended_product.text": "Allez voir ce que j’ai trouvé pour vous. {{0}}\n{{1}}",
   "email.wishlist_sharing.heading": "J’ai partagé ma liste de souhaits avec toi.",
   "email.wishlist_sharing.text": "Jetez un coup d’oeil à ma liste de souhaits :",


### PR DESCRIPTION
### 🚀 Description

The channel name in the Recommandation eMail subject is always inTRONICS.

---

### 🔍 Detailed Changes

Consume the newly available `channel.displayName` from the `/configurations` REST resource and use it in the "email a friend" mailto subject on the product detail page, replacing the previously hard-coded `channelName = 'inTRONICS'` placeholder.

---

### 📝 Notes

- Requires the ICM `/configurations` response to include `data.channel.displayName`. 
- No breaking changes, no migration required, no feature flag.
---

### ✅ Open Tasks

- [ ] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

[AB#120195](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120195)