### PR TITLE
fix(nginx): avoid caching multi-site redirects

### DIFF
--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -226,8 +226,10 @@ server {
         allow all;
         auth_basic off;
         {{ $first := index $mapping 0 -}}
-        rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" permanent;
-        rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri?" permanent;
+        # The target depends on the active multi-site configuration. Do not let browsers
+        # cache it when the same host is later used for a different PWA configuration.
+        rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" redirect;
+        rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri?" redirect;
     }
     location ^~ /sitemap_ {
         {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $first }}


### PR DESCRIPTION
## Summary

Use temporary redirects for fallback multi-site routing so browsers do not retain a redirect after the active PWA mapping changes.

Extracted from the esbuild migration branch because this behavior is independent of the build-system migration.

[AB#120554](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120554)