### PR TITLE
fix: preserve first quantity update

### DIFF
--- a/e2e/cypress/e2e/pages/checkout/cart.page.ts
+++ b/e2e/cypress/e2e/pages/checkout/cart.page.ts
@@ -102,7 +102,6 @@ export class CartPage {
             .find('input[data-testing-id="quantity"]:visible')
             .eq(idx)
             .click()
-            .wait(1000)
             .type('{selectAll}')
             .type(num.toString())
             .wait(1500),

--- a/src/app/core/facades/product-context.facade.spec.ts
+++ b/src/app/core/facades/product-context.facade.spec.ts
@@ -224,6 +224,19 @@ describe('Product Context Facade', () => {
     }));
 
     describe('quantity handling', () => {
+      it('should emit a quantity change made immediately after subscribing', fakeAsync(() => {
+        context.set('sku', () => '123');
+        tick(DEBOUNCE_TIME);
+        const updates: number[] = [];
+        context.validDebouncedQuantityUpdate$().subscribe(quantity => updates.push(quantity));
+
+        context.set('quantity', () => 20);
+        tick(800);
+
+        expect(updates).toEqual([20]);
+        discardPeriodicTasks();
+      }));
+
       it('should start with min order quantity for product', fakeAsync(() => {
         context.set('sku', () => '123');
         tick(DEBOUNCE_TIME);

--- a/src/app/core/facades/product-context.facade.ts
+++ b/src/app/core/facades/product-context.facade.ts
@@ -559,10 +559,10 @@ export class ProductContextFacade extends RxState<ProductContext> implements OnD
 
   validDebouncedQuantityUpdate$(time = 800) {
     return this.select('quantity').pipe(
+      skip(1),
       debounceTime(time),
       filter(() => !this.get('hasQuantityError')),
-      distinctUntilChanged(),
-      skip(1)
+      distinctUntilChanged()
     );
   }
 


### PR DESCRIPTION
## Summary

Skip the initial quantity emission before debouncing so a real quantity change made immediately after subscription is not discarded.

Includes a focused regression test and removes the Cypress timing workaround.

Extracted from the esbuild migration branch because the RxJS behavior is independent of the build-system migration.

[AB#120555](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120555)