### PR TITLE
fix: move custom npm properties out of package.json config 

### DIFF
--- a/.czrc
+++ b/.czrc
@@ -1,0 +1,3 @@
+{
+  "path": "./node_modules/@commitlint/cz-commitlint"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -16,7 +16,7 @@
       }
     },
     {
-      "files": ["*.json", ".*.json", "*.code-snippets", "*.webmanifest"],
+      "files": ["*.json", ".*.json", "*.code-snippets", "*.webmanifest", ".czrc"],
       "options": {
         "parser": "json",
         "printWidth": 80

--- a/.vscode/intershop.txt
+++ b/.vscode/intershop.txt
@@ -39,6 +39,7 @@ crosssells
 customfield
 cxml
 cybersource
+czrc
 dateness
 datepicker
 decamelize

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY templates/webpack/* /workspace/templates/webpack/
 ARG testing=false
 ENV TESTING=${testing}
 ARG activeThemes=
-RUN if [ ! -z "${activeThemes}" ]; then npm pkg set config.active-themes="${activeThemes}"; fi
+RUN if [ ! -z "${activeThemes}" ]; then npm pkg set activeThemes="${activeThemes}"; fi
 RUN npm run build:multi client -- --deploy-url=DEPLOY_URL_PLACEHOLDER
 COPY tsconfig.server.json server.ts /workspace/
 COPY babel.config.js /workspace/

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -17,6 +17,16 @@ Please be aware that npm 11 no longer runs dependencies' lifecycle scripts (prei
 Packages that need to run such scripts must be explicitly allow‑listed (`allowScripts` in the `package.json`).
 `npm install` will warn about missing allow-listing for custom dependencies.
 
+**Custom `config` properties moved out of `package.json`**
+
+npm 11 warns about custom keys in the `package.json` `config` section (`npm warn Unknown env config ...`) because the legacy `npm_config_*` environment injection is deprecated and will be removed in the next major npm version.
+Therefore the two custom `config` properties have been relocated:
+
+- `config.commitizen.path` moved to a new [`.czrc`](../../.czrc) file.
+- `config.active-themes` moved to the top-level `activeThemes` property in the [`package.json`](../../package.json). The build-time override environment variable changed from `npm_config_active_themes` to `ACTIVE_THEMES` (used by `npm run build:multi`).
+
+Custom code or Docker build arguments that referenced `config.active-themes` (for example via `npm pkg set config.active-themes=...`) must be updated to use `activeThemes`.
+
 **TypeScript 5.8/5.9 update**
 
 TypeScript has been updated to version 5.8 (required by Angular 20) and to 5.9 together with the Angular 20 upgrade.

--- a/docs/guides/ssr-startup.md
+++ b/docs/guides/ssr-startup.md
@@ -27,7 +27,7 @@ All `configuration` options must be in the format `--configuration=<theme>,(prod
 
 ## Building Multiple Themes
 
-The `package.json` property `config.active-themes` determines which themes should be built when running `npm run build:multi`.
+The `package.json` property `activeThemes` determines which themes should be built when running `npm run build:multi`.
 This will build server and client bundles for all active themes and supply them in the `dist` folder.
 The SSR process for each theme can be run individually using the generated scripts `dist/<theme>/run-standalone`.
 

--- a/package.json
+++ b/package.json
@@ -231,12 +231,7 @@
       "npm run sort-i18n"
     ]
   },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/@commitlint/cz-commitlint"
-    },
-    "active-themes": "b2b,b2c"
-  },
+  "activeThemes": "b2b,b2c",
   "allowScripts": {
     "esbuild": true,
     "fsevents": true,

--- a/schematics/customization/add/index.js
+++ b/schematics/customization/add/index.js
@@ -51,9 +51,9 @@ execSync('npx prettier --write angular.json');
 // replace in package.json
 const packageJson = parse(fs.readFileSync('./package.json', { encoding: 'UTF-8' }));
 if (setDefault) {
-  packageJson.config['active-themes'] = theme;
+  packageJson.activeThemes = theme;
 } else {
-  packageJson.config['active-themes'] = `${packageJson.config['active-themes']},${theme}`;
+  packageJson.activeThemes = `${packageJson.activeThemes},${theme}`;
 }
 fs.writeFileSync('./package.json', stringify(packageJson, null, 2));
 execSync('npx prettier --write package.json');

--- a/scripts/build-multi-pwa.js
+++ b/scripts/build-multi-pwa.js
@@ -1,9 +1,7 @@
 const { sync: spawnSync } = require('cross-spawn');
 const { readFileSync, writeFileSync } = require('fs');
 
-const configurations = (
-  process.env.npm_config_active_themes || JSON.parse(readFileSync('package.json')).config['active-themes']
-)
+const configurations = (process.env.ACTIVE_THEMES || JSON.parse(readFileSync('package.json')).activeThemes)
   .split(',')
   .map((theme, index) => ({ theme, port: 4000 + index }));
 


### PR DESCRIPTION
<!-- Checklist - Please check if your PR fulfills the following requirements:

  - ✏️ The PR title follows the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)
  - 🏷️ A label indicates the type of the PR (e.g. "bug", "feature", "documentation", etc.)
  - 🏷️ A label indicates if the PR introduces "BREAKING CHANGES"
  - The migrations guide is updated for breaking changes, new features or other important information (if applicable)
  - Unit Tests for the changes added/updated (for bug fixes / features)
  - Integration tests added/updated (for features)
  - Manual testing performed on a demo system with SSR (several browsers/devices, if necessary)
  - ✅ All texts are localized and they have been approved by the documentation team
  - ✅ Documentation or relevant guides added/updated if needed and they have been approved by the documentation team
  - ✅ Visual changes have been approved by VD / IAD (if applicable)
  - Open checklist task are added to the Open Tasks section of the PR
-->

### 🚀 Description

This pull request updates the project's configuration management to align with changes in npm 11, specifically moving custom configuration properties out of the `package.json`'s `config` section. The most important changes involve relocating the `commitizen` configuration to a new `.czrc` file, moving the `active-themes` property to a top-level `activeThemes` property in `package.json`, and updating related documentation and scripts to reference the new structure.



<!-- Short summary of the changes and/or motivation

  - What has been changed?
  - Why was it changed?
  - Reference a related issue if applicable (or remove the "Closes" line)
-->

---

### 🔍 Detailed Changes

After running the application, e.g. with npm run start there have been 2 npm warnings:

npm warn Unknown cli config "active-themes" (intershop-pwa:active-themes). This will stop working in the next major version of npm.
npm warn Unknown cli config "commitizen_path" (intershop-pwa:commitizen_path). This will stop working in the next major version of npm.

That is why the package.json config has been restructured:

**Configuration Restructuring:**

* Moved `commitizen` configuration from `package.json` to a new `.czrc` file for compatibility with npm 11. (`.czrc`, `package.json`) [[1]](diffhunk://#diff-9a4f4c5d4e611c2a9c60292f63f6356d0e6a580ae69079b3b6a62a7e03efdb7fR1-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L234-R234)
* Relocated `config.active-themes` from under `config` in `package.json` to a new top-level `activeThemes` property. (`package.json`)

**Script and Code Updates:**

* Updated scripts and code to reference the new `activeThemes` property and environment variable (`ACTIVE_THEMES`) instead of the old `config.active-themes` and `npm_config_active_themes`. (`Dockerfile`, `schematics/customization/add/index.js`, `scripts/build-multi-pwa.js`) [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R22) [[2]](diffhunk://#diff-401246ad0b0b76c7e2ff7172b5788e35b31479c96250f271e73277625213a73eL54-R56) [[3]](diffhunk://#diff-c3e6d96fe0bdd6acb873c16b19b35d9060bdb3a42fb03c09113907c1491f3599L4-R4)

---

### 📝 Notes

<!-- Anything important that is not obvious from the code itself

  - Breaking changes?
  - Required ICM version?
  - Migrations required?
  - Feature flags / configuration changes?
  - Known limitations?
-->

---

### ✅ Open Tasks

<!-- Add open tasks that need to be resolved before merging the PR (remove what does not apply) -->

- [ ] Documentation and Localizations reviewed by the documentation team

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120635](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120635)