### PR TITLE
fix(nginx): avoid caching multi-site redirects

### DIFF
--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -226,8 +226,8 @@ server {
         allow all;
         auth_basic off;
         {{ $first := index $mapping 0 -}}
-        rewrite ^/$ "$thescheme://$http_host{{ $first.baseHref }}/home" permanent;
-        rewrite ^(.*)$ "$thescheme://$http_host{{ $first.baseHref }}$request_uri?" permanent;
+        rewrite ^/$ "$thescheme://$http_host{{ $first.baseHref }}/home" redirect;
+        rewrite ^(.*)$ "$thescheme://$http_host{{ $first.baseHref }}$request_uri?" redirect;
     }
     location ^~ /sitemap_ {
         {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $first }}


### PR DESCRIPTION
### 🚀 Description

Chrome can retain a permanent multi-site redirect after the configuration on the same hostname changes. For example, visiting http://localhost:4200/home with `/en` as the first configured site redirects to http://localhost:4200/en/home. After switching to a configuration that no longer uses `/en`, Chrome can reuse the cached redirect and continue opening the old URL without consulting NGINX.

Return temporary redirects for the default multi-site fallback so the response no longer declares the configured destination permanent.

### 🔍 Detailed Changes

- Change the two fallback rewrite rules from `permanent` (HTTP 301) to `redirect` (HTTP 302).
- Preserve the existing redirect destinations and path handling.
- Apply this only when no multi-site mapping handles `/`.

### 📝 Notes

The author manually reproduced the issue in Chrome on `develop` and verified that this fix resolves it there. Firefox and Edge did not exhibit the issue during their testing.

This change does not clear previously cached 301 redirects. HTTP 302 responses can still be cached when explicit cache settings allow it.

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120776](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120776)