### PR TITLE
fix: use forwarded protocol for multi-channel baseHref redirects to preserve https behind ingress

### DIFF
--- a/nginx/templates/multi-channel.conf.tmpl
+++ b/nginx/templates/multi-channel.conf.tmpl
@@ -226,8 +226,8 @@ server {
         allow all;
         auth_basic off;
         {{ $first := index $mapping 0 -}}
-        rewrite ^/$ "$scheme://$http_host{{ $first.baseHref }}/home" permanent;
-        rewrite ^(.*)$ "$scheme://$http_host{{ $first.baseHref }}$request_uri?" permanent;
+        rewrite ^/$ "$thescheme://$http_host{{ $first.baseHref }}/home" permanent;
+        rewrite ^(.*)$ "$thescheme://$http_host{{ $first.baseHref }}$request_uri?" permanent;
     }
     location ^~ /sitemap_ {
         {{- tmpl.Exec "LOCATION_TEMPLATE_FOR_SITEMAP" $first }}


### PR DESCRIPTION
### 🚀 Description


The location / block that redirects unprefixed paths to the configured baseHref (e.g. /home -> /b2b/home) built the Location header with nginx's built-in $scheme. When TLS is terminated at the ingress and nginx is reached over plain HTTP, $scheme resolves to "http", so the 301 Location header returned the wrong protocol and broke iframe/mixed-content contexts.

Use the existing $thescheme variable, which honors the X-Forwarded-Proto header and only falls back to $scheme when absent, so redirects keep the original external protocol.

---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120846](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120846)