### PR TITLE
fix(SSR): return 406 instead of 404 for Accept header mismatch in SSR

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -486,14 +486,15 @@ export function app() {
     if (req.headers.accept) {
       const accept = req.headers.accept.toLowerCase();
       if (!accept.includes('html') && ['css', 'image', 'json', 'javascript'].some(inc => accept.includes(inc))) {
+        // 406 (not 404) so NGINX does not cache it and poison the shared HTML page cache entry
         logger.warn(
           {
             ...getBaseLogData(req),
-            http: { request: { mime_type: accept }, response: { status_code: 404 } },
+            http: { request: { mime_type: accept }, response: { status_code: 406 } },
           },
-          'RES 404 - Accept header mismatch'
+          'RES 406 - Accept header mismatch'
         );
-        return res.sendStatus(404);
+        return res.sendStatus(406);
       }
     }
 


### PR DESCRIPTION
### 🚀 Description

SSR returned `404 Not Found` for requests whose `Accept` header asks for a
non-HTML representation (`json`, `css`, `image`, `javascript`) but not `html`.
This response is cached by NGINX and poisons the shared page cache, causing
valid pages (e.g. `/`, `/home`) to serve `404` to normal browser users.

### Problem

- `server.ts` rejects non-HTML `Accept` requests with `res.sendStatus(404)`.
- NGINX caches responses with `proxy_cache_key $scheme://$host$uri$c_uri`,
  which **does not vary by `Accept` header**, and caches `404` via  `proxy_cache_valid 404`.
- Because HTML and non-HTML variants share one cache entry, a crawler sending
  `Accept: application/json` to a valid URL replaces the cached `200` with a
  `404`. Real users then receive the cached `404` until the negative-cache TTL
  (default 60 min) expires or the pod restarts.

The `User-Agent` is irrelevant; only the `Accept` header triggers this.

### Fix

Return **`406 Not Acceptable`** instead of `404` for the `Accept` header
mismatch. `406` is the semantically correct status (the resource exists but
not in an acceptable representation) and is **not** in the NGINX cacheable set
(`200`, `302`, `404`), so these responses are no longer cached and can no
longer poison the HTML page cache.

### Reproduction

With caching disabled (`CACHE_DURATION_NGINX_OK=0m`, `CACHE_DURATION_NGINX_NF=0`):

```bash
# HTML accept -> 200
curl -sk -H 'Accept: text/html,application/json' -o /dev/null -w '%{http_code}\n' 'https://<host>/'

# JSON accept -> was 404 (now 406)
curl -sk -H 'Accept: application/json' -o /dev/null -w '%{http_code}\n' 'https://<host>/'
```
---

### 🔗 Other Information

<!-- An automatically created ticket in Azure will be linked here (keep this section) -->


[AB#120853](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/120853)